### PR TITLE
Multipart File Selection Bug

### DIFF
--- a/src/plugins/Formtag.js
+++ b/src/plugins/Formtag.js
@@ -23,17 +23,33 @@ export default class Formtag extends Plugin {
         var fields   = document.querySelectorAll(self.opts.selector);
         var files    = [];
         var selected = [];
-        for (var i in fields) {
-          for (var j in fields[i].files) {
-            var file = fields[i].files.item(j);
-            if (file) {
-              selected.push({
-                from: 'Formtag',
-                file: fields[i].files.item(j)
-              });
-            }
-          }
-        }
+
+        [].forEach.call(fields, function(field, i) {
+          [].forEach.call(field.files, function(file, j) {
+            selected.push({
+              from: 'Formtag',
+              file: file
+            })
+          })
+        });
+
+        // console.log(fields.length);
+        // for (var i in fields) {
+        //   console.log('i');
+        //   // console.log('i: ', i);
+        //   for (var j in fields[i].files) {
+        //     console.log('j');
+        //     // console.log('i, j', i, j);
+        //     console.log(fields[i].files);
+        //     var file = fields[i].files.item(j);
+        //     if (file) {
+        //       selected.push({
+        //         from: 'Formtag',
+        //         file: fields[i].files.item(j)
+        //       });
+        //     }
+        //   }
+        // }
         self.setProgress(100);
         console.log({
           selected:selected,

--- a/src/plugins/Formtag.js
+++ b/src/plugins/Formtag.js
@@ -24,8 +24,8 @@ export default class Formtag extends Plugin {
         var files    = [];
         var selected = [];
 
-        [].forEach.call(fields, function(field, i) {
-          [].forEach.call(field.files, function(file, j) {
+        [].forEach.call(fields, (field, i) => {
+          [].forEach.call(field.files, (file, j) => {
             selected.push({
               from: 'Formtag',
               file: file

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -5,9 +5,9 @@
 # Uppy versions, auto updated by update.js
 uppy_version: 0.0.1
 
-uppy_dev_size: "78.96"
-uppy_min_size: "78.96"
-uppy_gz_size: "78.96"
+uppy_dev_size: "79.86"
+uppy_min_size: "79.86"
+uppy_gz_size: "79.86"
 
 # Theme
 google_analytics: UA-63083-12


### PR DESCRIPTION
Hey Kevin, think this fixed the multipart file uploading.  I switched from using `for i in x` to running `.forEach`.

`document.querySelectorAll` does not return a javascript `Array` object, so they do not have the higher-order function methods like `map, filter, forEach`, so you need to use `[].forEach.call(fields, ...)`

I didn't want to push to master in case I'm missing something. try it out and let me know!