### PR TITLE
[feature] emit an error event when uploading a file fails.

### DIFF
--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -61,6 +61,8 @@ export default class Multipart extends Plugin {
 
           this.core.log(`Download ${file.name} from ${file.uploadURL}`)
           return resolve(file)
+        } else {
+          this.core.emitter.emit('upload-error', file.id, uploadURL);
         }
 
         // var upload = {}


### PR DESCRIPTION
Error event is not thrown when uploading a file fails. So is not possible to make a custom actions from my JS code when this occurs.