### PR TITLE
After an upload failure return information from the backend for being…

### DIFF
--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -62,7 +62,12 @@ export default class Multipart extends Plugin {
           this.core.log(`Download ${file.name} from ${file.uploadURL}`)
           return resolve(file)
         } else {
-          this.core.emitter.emit('core:upload-error', file.id)
+          // OPTION 1: return the full XHR object
+          this.core.emitter.emit('core:upload-error', file.id, xhr);
+
+          // OPTION 2: return the payload of the XHR object
+          this.core.emitter.emit('core:upload-error', file.id, xhr.response);
+
           return reject('Upload error')
         }
 

--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -62,12 +62,7 @@ export default class Multipart extends Plugin {
           this.core.log(`Download ${file.name} from ${file.uploadURL}`)
           return resolve(file)
         } else {
-          // OPTION 1: return the full XHR object
-          this.core.emitter.emit('core:upload-error', file.id, xhr);
-
-          // OPTION 2: return the payload of the XHR object
-          this.core.emitter.emit('core:upload-error', file.id, xhr.response);
-
+          this.core.emitter.emit('core:upload-error', file.id, xhr)
           return reject('Upload error')
         }
 


### PR DESCRIPTION
Greetings. I have found this problem in a project: after uploading a file and getting an error I require some information returned from the backend for managing the error. I think returning the XHR object (payload, code error...) or its payload would provide more flexibility to Uppy.