### PR TITLE
[fix] Multipart upload

### DIFF
--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -35,7 +35,7 @@ export default class Multipart extends Plugin {
 
       Object.keys(file.meta).forEach((item) => {
         console.log(file.meta, file.meta[item])
-        formPost.append(file.meta, file.meta[item])
+        formPost.append(item, file.meta[item])
       })
 
       const xhr = new XMLHttpRequest()


### PR DESCRIPTION
When appending data with the file on Multipart, the key of the parameter was not passed correctly. Thus, description and resize data are not available in the backend.