### PR TITLE
Fix `make install` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ $(eval $(call npm_script_targets))
 
 # These npm run scripts are available, without needing to be mentioned in `package.json`
 install:
-	npm run install
+	npm install


### PR DESCRIPTION
The `make install` is failing because it is calling `npm run install` instead of `npm install`.

This PR simply fixes this.