### PR TITLE
Clear Informer timeout before setting a new one

### DIFF
--- a/src/plugins/Informer.js
+++ b/src/plugins/Informer.js
@@ -14,6 +14,7 @@ export default class Informer extends Plugin {
     this.type = 'progressindicator'
     this.id = 'Informer'
     this.title = 'Informer'
+    this.timeoutID = undefined
 
     // set default options
     const defaultOptions = {}
@@ -30,10 +31,14 @@ export default class Informer extends Plugin {
       }
     })
 
-    if (duration === 0) return
+    window.clearTimeout(this.timeoutID)
+    if (duration === 0) {
+      this.timeoutID = undefined
+      return
+    }
 
     // hide the informer after `duration` milliseconds
-    setTimeout(() => {
+    this.timeoutID = setTimeout(() => {
       const newInformer = Object.assign({}, this.core.getState().informer, {
         isHidden: true
       })


### PR DESCRIPTION
If the following scenario happens to quickly:
1. Internet Offline (Informer should be shown "forever")
2. Internet Online (Informer should be shown for 3 seconds)
3. Internet Offline (Informer should be shown forever)

The "disappear timeout" of the "2. Internet Online" hides the "3. Internet Offline" (whereas it should be shown forever).

This PR fixes this by storing and clearing the current `timeoutID` on a new event.