### PR TITLE
Tus10 auto-retry the upload when back online

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -322,6 +322,7 @@ class Uppy {
     } else {
       this.emit('is-online')
       if (this.wasOffline) {
+        this.emit('back-online')
         this.emit('informer', 'Connected!', 'success', 3000)
         this.wasOffline = false
       }

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -140,6 +140,17 @@ export default class Tus10 extends Plugin {
         upload.start()
       })
 
+      this.core.emitter.on('core:retry-started', () => {
+        const files = this.core.getState().files
+        if (files[file.id].progress.uploadComplete ||
+          !files[file.id].progress.uploadStarted ||
+          files[file.id].isPaused
+            ) {
+          return
+        }
+        upload.start()
+      })
+
       upload.start()
       this.core.emitter.emit('core:upload-started', file.id, upload)
     })
@@ -261,6 +272,10 @@ export default class Tus10 extends Plugin {
       this.core.log('Tus is uploading...')
       const files = this.core.getState().files
       this.selectForUpload(files)
+    })
+
+    this.core.emitter.on('back-online', () => {
+      this.core.emitter.emit('core:retry-started')
     })
   }
 

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -16,7 +16,8 @@ export default class Tus10 extends Plugin {
     // set default options
     const defaultOptions = {
       resume: true,
-      allowPause: true
+      allowPause: true,
+      autoRetry: true
     }
 
     // merge default options with the ones set by user
@@ -274,9 +275,11 @@ export default class Tus10 extends Plugin {
       this.selectForUpload(files)
     })
 
-    this.core.emitter.on('back-online', () => {
-      this.core.emitter.emit('core:retry-started')
-    })
+    if (this.opts.autoRetry) {
+      this.core.emitter.on('back-online', () => {
+        this.core.emitter.emit('core:retry-started')
+      })
+    }
   }
 
   addResumableUploadsCapabilityFlag () {


### PR DESCRIPTION
This PR adds the option (default `true`) to "auto-retry" uploads when the use is back online.

Only the uploads already started, not completed and not paused are retried.