### PR TITLE
Reorder status bar items order

### DIFF
--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -14,7 +14,7 @@ export default (props) => {
       <div class="UppyDashboard-statusBarContent">
         ${props.isUploadStarted && !props.isAllComplete
           ? !props.isAllPaused
-            ? html`<span>${pauseResumeButtons(props)} Uploading... ${props.complete} / ${props.inProgress}・${props.totalProgress || 0}%・${props.totalETA}・↑ ${props.totalSpeed}/s</span>`
+            ? html`<span>${pauseResumeButtons(props)} Uploading... ${props.totalProgress || 0}%・${props.complete} / ${props.inProgress}・${props.totalETA}・↑ ${props.totalSpeed}/s</span>`
             : html`<span>${pauseResumeButtons(props)} Paused・${props.totalProgress}%</span>`
           : null
           }


### PR DESCRIPTION
`Uploading... 1/3 - 20% - (...)` feels like the first of 3 files is uploading (whereas it means that one file is completely uploaded)
This commit changes it to `Uploading... 20% - 1/3 - (...)` to try to make this clearer.