### PR TITLE
ETA with leading zeros

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -373,9 +373,12 @@ export function prettyETA (seconds) {
 
   // Only display hours and minutes if they are greater than 0 but always
   // display minutes if hours is being displayed
+  // Display a leading zero if the there is a preceding unit: 1m 05s, but 5s
   const hoursStr = time.hours ? time.hours + 'h ' : ''
-  const minutesStr = (time.hours || time.minutes) ? time.minutes + 'm ' : ''
-  const secondsStr = time.seconds + 's'
+  const minutesVal = time.hours ? ('0' + time.minutes).substr(-2) : time.minutes
+  const minutesStr = minutesVal ? minutesVal + 'm ' : ''
+  const secondsVal = minutesVal ? ('0' + time.seconds).substr(-2) : time.seconds
+  const secondsStr = secondsVal + 's'
 
   return `${hoursStr}${minutesStr}${secondsStr}`
 }

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -373,11 +373,11 @@ export function prettyETA (seconds) {
 
   // Only display hours and minutes if they are greater than 0 but always
   // display minutes if hours is being displayed
-  const hoursStr = time.hours ? time.hours + 'h' : ''
-  const minutesStr = (time.hours || time.minutes) ? time.minutes + 'm' : ''
+  const hoursStr = time.hours ? time.hours + 'h ' : ''
+  const minutesStr = (time.hours || time.minutes) ? time.minutes + 'm ' : ''
   const secondsStr = time.seconds + 's'
 
-  return `${hoursStr} ${minutesStr} ${secondsStr}`
+  return `${hoursStr}${minutesStr}${secondsStr}`
 }
 
 export function makeCachingFunction () {


### PR DESCRIPTION
This is related to #65: the time string is making some "jumps" when it passes from `1m 10s` to `1m 9s`.

This PR adds a leading `0` to all "trailing" units:
`1m 9s` becomes `1m 09s`, but `9s` stays as it is