### PR TITLE
Parse `src` folder with `yo-yoify-standalone` before parsing with Babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 
 dist/
 lib/
+lib.yoyoified/
 
 website/db.json
 website/*.log

--- a/bin/build-yoyoified-lib.js
+++ b/bin/build-yoyoified-lib.js
@@ -1,0 +1,25 @@
+const path = require('path')
+const chalk = require('chalk')
+const mkdirp = require('mkdirp')
+const glob = require('glob')
+const yoyoify = require('yo-yoify-standalone')
+
+const DIST_DIR = 'lib.yoyoified'
+const SRC_DIR = 'src'
+
+const DOC_PATTERN = '**/*.js'
+
+const fileList = glob.sync(SRC_DIR + '/' + DOC_PATTERN)
+
+fileList.forEach((srcPath) => {
+  const distPath = srcPath.replace(SRC_DIR, DIST_DIR)
+
+  mkdirp.sync(path.dirname(distPath))
+
+  yoyoify(srcPath, distPath)
+
+  console.info(chalk.green('✓ Yo-yoified:'), srcPath, '-->', chalk.magenta(distPath))
+
+  // const parseCommand = `cat ${srcPath} | ./yo-yoify-cli.js | babel --out-file ${distPath}`
+  // execSync(parseCommand)
+})

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tape": "4.6.3",
     "uppy-server": "0.0.7",
     "watchify": "3.7.0",
-    "yo-yoify": "arturi/yo-yoify#6bf1e0d84c09c01d4a89ee9cb4da680e4aca8da6"
+    "yo-yoify": "arturi/yo-yoify#6bf1e0d84c09c01d4a89ee9cb4da680e4aca8da6",
+    "yo-yoify-standalone": "0.1.0"
   },
   "dependencies": {
     "drag-drop": "2.13.2",
@@ -88,8 +89,9 @@
     "build:gzip": "node ./bin/gzip.js",
     "size": "echo 'JS Bundle mingz:' && cat ./dist/uppy.min.js | gzip | wc -c && echo 'CSS Bundle mingz:' && cat ./dist/uppy.min.css | gzip | wc -c",
     "build:bundle:fullpath": "env OUT=uppy-fp.js ./bin/build-bundle --full-paths",
-    "build:js": "npm-run-all build:bundle build:lib",
+    "build:js": "npm-run-all build:bundle build:lib:yoyoified",
     "build:lib": "babel --version && babel src --source-maps -d lib",
+    "build:lib:yoyoified": "babel --version && node bin/build-yoyoified-lib.js && babel lib.yoyoified --source-maps -d lib",
     "build": "npm-run-all --parallel build:js build:css --serial build:gzip size",
     "clean": "rm -rf lib && rm -rf dist",
     "docs": "cd website && node node_modules/documentation/bin/documentation.js readme ../src/index.js --readme-file=src/api/docs.md --section 'Uppy Core & Plugins' -q --github -c doc-order.json",


### PR DESCRIPTION
With this patch, `bin/build-yoyoified-lib.js` is run before our usual `babel src --source-maps -d lib`. It parses all the scripts in `src`, transforming template strings to direct `document` calls.

Makes things faster, solves #158. We were already using yo-yoify transform on website examples and when developing, just not for `lib` folder, which is published to NPM :scream: