### PR TITLE
Accept a DOM element in `target:` option.

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -399,6 +399,31 @@ function prettyETA (seconds) {
 //   }
 // }
 
+/**
+ * Check if an object is a DOM element. Duck-typing based on `nodeType`.
+ *
+ * @param {*} obj
+ */
+function isDOMElement (obj) {
+  return obj && typeof obj === 'object' && obj.nodeType === Node.ELEMENT_NODE
+}
+
+/**
+ * Find a DOM element.
+ *
+ * @param {Node|string} element
+ * @return {Node|null}
+ */
+function findDOMElement (element) {
+  if (typeof element === 'string') {
+    return document.querySelector(element)
+  }
+
+  if (typeof element === 'object' && isDOMElement(element)) {
+    return element
+  }
+}
+
 module.exports = {
   generateFileID,
   toArray,
@@ -423,5 +448,6 @@ module.exports = {
   // makeWorker,
   // makeCachingFunction,
   copyToClipboard,
-  prettyETA
+  prettyETA,
+  findDOMElement
 }

--- a/src/plugins/Dashboard/ActionBrowseTagline.js
+++ b/src/plugins/Dashboard/ActionBrowseTagline.js
@@ -1,6 +1,11 @@
 const html = require('yo-yo')
 
 module.exports = (props) => {
+  const input = html`
+    <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
+           onchange=${props.handleInputChange} />
+  `
+
   return html`
     <span>
       ${props.acquirers.length === 0
@@ -10,11 +15,9 @@ module.exports = (props) => {
       <button type="button"
               class="UppyDashboard-browse"
               onclick=${(ev) => {
-                const input = document.querySelector(`${props.container} .UppyDashboard-input`)
                 input.click()
               }}>${props.i18n('browse')}</button>
-      <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
-             onchange=${props.handleInputChange} />
+      ${input}
     </span>
   `
 }

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -77,7 +77,6 @@ module.exports = function Dashboard (props) {
           files: props.files,
           handleInputChange: handleInputChange,
           acquirers: props.acquirers,
-          container: props.container,
           panelSelectorPrefix: props.panelSelectorPrefix,
           showPanel: props.showPanel,
           i18n: props.i18n
@@ -98,7 +97,6 @@ module.exports = function Dashboard (props) {
             acquirers: props.acquirers,
             files: props.files,
             handleInputChange: handleInputChange,
-            container: props.container,
             showFileCard: props.showFileCard,
             showProgressDetails: props.showProgressDetails,
             totalProgress: props.totalProgress,

--- a/src/plugins/Dashboard/FileList.js
+++ b/src/plugins/Dashboard/FileList.js
@@ -12,7 +12,6 @@ module.exports = (props) => {
           <h3 class="UppyDashboard-dropFilesTitle">
             ${ActionBrowseTagline({
               acquirers: props.acquirers,
-              container: props.container,
               handleInputChange: props.handleInputChange,
               i18n: props.i18n
             })}

--- a/src/plugins/Dashboard/Tabs.js
+++ b/src/plugins/Dashboard/Tabs.js
@@ -11,7 +11,6 @@ module.exports = (props) => {
         <h3 class="UppyDashboardTabs-title">
         ${ActionBrowseTagline({
           acquirers: props.acquirers,
-          container: props.container,
           handleInputChange: props.handleInputChange,
           i18n: props.i18n
         })}
@@ -19,6 +18,11 @@ module.exports = (props) => {
       </div>
     `
   }
+
+  const input = html`
+    <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
+           onchange=${props.handleInputChange} />
+  `
 
   return html`<div class="UppyDashboardTabs">
     <nav>
@@ -28,14 +32,12 @@ module.exports = (props) => {
                   role="tab"
                   tabindex="0"
                   onclick=${(ev) => {
-                    const input = document.querySelector(`${props.container} .UppyDashboard-input`)
                     input.click()
                   }}>
             ${localIcon()}
             <h5 class="UppyDashboardTab-name">${props.i18n('localDisk')}</h5>
           </button>
-          <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
-                 onchange=${props.handleInputChange} />
+          ${input}
         </li>
         ${props.acquirers.map((target) => {
           return html`<li class="UppyDashboardTab">

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -111,7 +111,7 @@ module.exports = class DashboardUI extends Plugin {
       })
     })
 
-    return this.opts.target
+    return this.target
   }
 
   hideAllPanels () {

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -380,7 +380,6 @@ module.exports = class DashboardUI extends Plugin {
       progressindicators: progressindicators,
       autoProceed: this.core.opts.autoProceed,
       id: this.id,
-      container: this.opts.target,
       hideModal: this.hideModal,
       showProgressDetails: this.opts.showProgressDetails,
       inline: this.opts.inline,

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -5,6 +5,7 @@ const Dashboard = require('./Dashboard')
 const { getSpeed } = require('../../core/Utils')
 const { getETA } = require('../../core/Utils')
 const { prettyETA } = require('../../core/Utils')
+const { findDOMElement } = require('../../core/Utils')
 const prettyBytes = require('prettier-bytes')
 const { defaultTabIcon } = require('./icons')
 
@@ -169,7 +170,7 @@ module.exports = class DashboardUI extends Plugin {
     // const dashboardEl = document.querySelector(`${this.opts.target} .UppyDashboard`)
 
     // Modal open button
-    const showModalTrigger = document.querySelector(this.opts.trigger)
+    const showModalTrigger = findDOMElement(this.opts.trigger)
     if (!this.opts.inline && showModalTrigger) {
       showModalTrigger.addEventListener('click', this.showModal)
     } else {

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -112,7 +112,7 @@ module.exports = class DragDrop extends Plugin {
 
   render (state) {
     const onSelect = (ev) => {
-      const input = document.querySelector(`${this.target} .UppyDragDrop-input`)
+      const input = this.target.querySelector('.UppyDragDrop-input')
       input.click()
     }
 
@@ -166,7 +166,7 @@ module.exports = class DragDrop extends Plugin {
     const plugin = this
     this.target = this.mount(target, plugin)
 
-    dragDrop(`${this.target} .UppyDragDrop-container`, (files) => {
+    dragDrop(this.target.querySelector('.UppyDragDrop-container'), (files) => {
       this.handleDrop(files)
       this.core.log(files)
     })

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -2,6 +2,15 @@ const yo = require('yo-yo')
 // const nanoraf = require('nanoraf')
 
 /**
+ * Check if an object is a DOM element. Duck-typing based on `nodeType`.
+ *
+ * @param {*} obj
+ */
+function isDOMElement (obj) {
+  return obj && typeof obj === 'object' && obj.nodeType === Node.ELEMENT_NODE
+}
+
+/**
  * Boilerplate that all Plugins share - and should not be used
  * directly. It also shows which methods final plugins should implement/override,
  * this deciding on structure.
@@ -68,16 +77,23 @@ module.exports = class Plugin {
   mount (target, plugin) {
     const callerPluginName = plugin.id
 
-    if (typeof target === 'string') {
+    let targetElement
+    if (isDOMElement(target)) {
+      this.core.log(`Installing ${callerPluginName} to a DOM element`)
+      targetElement = target
+    } else if (typeof target === 'string') {
       this.core.log(`Installing ${callerPluginName} to ${target}`)
+      targetElement = document.querySelector(target)
+    }
 
+    if (targetElement) {
       // clear everything inside the target container
       if (this.opts.replaceTargetContent) {
-        document.querySelector(target).innerHTML = ''
+        targetElement.innerHTML = ''
       }
 
       this.el = plugin.render(this.core.state)
-      document.querySelector(target).appendChild(this.el)
+      targetElement.appendChild(this.el)
 
       return target
     } else {

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -1,14 +1,6 @@
 const yo = require('yo-yo')
 // const nanoraf = require('nanoraf')
-
-/**
- * Check if an object is a DOM element. Duck-typing based on `nodeType`.
- *
- * @param {*} obj
- */
-function isDOMElement (obj) {
-  return obj && typeof obj === 'object' && obj.nodeType === Node.ELEMENT_NODE
-}
+const { findDOMElement } = require('../core/Utils')
 
 /**
  * Boilerplate that all Plugins share - and should not be used
@@ -67,7 +59,7 @@ module.exports = class Plugin {
   }
 
   /**
-   * Check if supplied `target` is a `string` or an `object`.
+   * Check if supplied `target` is a DOM element or an `object`.
    * If it’s an object — target is a plugin, and we search `plugins`
    * for a plugin with same name and return its target.
    *
@@ -77,16 +69,11 @@ module.exports = class Plugin {
   mount (target, plugin) {
     const callerPluginName = plugin.id
 
-    let targetElement
-    if (isDOMElement(target)) {
-      this.core.log(`Installing ${callerPluginName} to a DOM element`)
-      targetElement = target
-    } else if (typeof target === 'string') {
-      this.core.log(`Installing ${callerPluginName} to ${target}`)
-      targetElement = document.querySelector(target)
-    }
+    const targetElement = findDOMElement(target)
 
     if (targetElement) {
+      this.core.log(`Installing ${callerPluginName} to a DOM element`)
+
       // clear everything inside the target container
       if (this.opts.replaceTargetContent) {
         targetElement.innerHTML = ''

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -95,7 +95,7 @@ module.exports = class Plugin {
       this.el = plugin.render(this.core.state)
       targetElement.appendChild(this.el)
 
-      return target
+      return targetElement
     } else {
       // TODO: is instantiating the plugin really the way to roll
       // just to get the plugin name?


### PR DESCRIPTION
This patch accepts a DOM element in the `target` option for Plugins. It does this by checking for the `.nodeType` property when an object is passed to `this.mount()`. Another way would be to do `object instanceof Node`, but that doesn't work if the target node is in an `<iframe>`.

This needs a few more things:

 - [x] Some plugins store the return value of the `mount` method in `this.target`, and use it inside a larger css selector, expecting it to be a string. This could be fixed by always returning the target DOM element, instead of a selector, from the `mount` method. Plugins can then do `this.target.querySelector('.sel')` instead of `document.querySelector(this.target + ' .sel')` to find elements.
 - [x] Probably good for consistency if other options that currently take query selectors can also take DOM elements?