### PR TITLE
Fix Dashboard modal close button position.

### DIFF
--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -74,7 +74,7 @@
 .UppyDashboard-close {
   @include reset-button;
   display: none;
-  position: absolute;
+  position: fixed;
   top: 12px;
   right: 12px;
   cursor: pointer;


### PR DESCRIPTION
When the page was scrolled down, the modal close button was
invisible (off-screen). This patch sets the close button to `fixed`
positioning so it's always in the same place on the screen
regardless of scroll, just like the modal background.