### PR TITLE
Implement reading audio+video from Webcam.

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -146,6 +146,23 @@ function getFileType (file) {
   // return mime.lookup(file.name)
 }
 
+// TODO Check which types are actually supported in browsers. Chrome likes webm
+// from my testing, but we may need more.
+// We could use a library but they tend to contain dozens of KBs of mappings,
+// most of which will go unused, so not sure if that's worth it.
+const mimeToExtensions = {
+  'video/ogg': 'ogv',
+  'audio/ogg': 'ogg',
+  'video/webm': 'webm',
+  'audio/webm': 'webm',
+  'video/mp4': 'mp4',
+  'audio/mp3': 'mp3'
+}
+
+function getFileTypeExtension (mimeType) {
+  return mimeToExtensions[mimeType] || null
+}
+
 // returns [fileName, fileExt]
 function getFileNameAndExtension (fullFileName) {
   var re = /(?:\.([^.]+))?$/
@@ -436,6 +453,7 @@ module.exports = {
   isTouchDevice,
   getFileNameAndExtension,
   truncateString,
+  getFileTypeExtension,
   getFileType,
   secondsToTime,
   dataURItoBlob,

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -255,6 +255,11 @@ function createImageThumbnail (imgDataURI, newWidth) {
   })
 }
 
+function supportsMediaRecorder () {
+  return typeof MediaRecorder === 'function' && !!MediaRecorder.prototype &&
+    typeof MediaRecorder.prototype.start === 'function'
+}
+
 function dataURItoBlob (dataURI, opts, toFile) {
   // get the base64 data
   var data = dataURI.split(',')[1]
@@ -450,6 +455,7 @@ module.exports = {
   readFile,
   createImageThumbnail,
   getProportionalImageHeight,
+  supportsMediaRecorder,
   isTouchDevice,
   getFileNameAndExtension,
   truncateString,

--- a/src/plugins/Webcam/CameraScreen.js
+++ b/src/plugins/Webcam/CameraScreen.js
@@ -1,30 +1,9 @@
 const html = require('yo-yo')
-const CameraIcon = require('./CameraIcon')
-const RecordStartIcon = require('./RecordStartIcon')
-const RecordStopIcon = require('./RecordStopIcon')
+const SnapshotButton = require('./SnapshotButton')
+const RecordButton = require('./RecordButton')
 
-function RecordButton ({ recording, onStartRecording, onStopRecording }) {
-  if (recording) {
-    return html`
-      <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
-        type="button"
-        title="Stop Recording"
-        aria-label="Stop Recording"
-        onclick=${onStopRecording}>
-        ${RecordStopIcon()}
-      </button>
-    `
-  }
-
-  return html`
-    <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
-      type="button"
-      title="Begin Recording"
-      aria-label="Begin Recording"
-      onclick=${onStartRecording}>
-      ${RecordStartIcon()}
-    </button>
-  `
+function isModeAvailable (modes, mode) {
+  return modes.indexOf(mode) !== -1
 }
 
 module.exports = (props) => {
@@ -37,6 +16,14 @@ module.exports = (props) => {
     video = html`<video class="UppyWebcam-video" autoplay src="${src}"></video>`
   }
 
+  const shouldShowRecordButton = props.supportsRecording && (
+    isModeAvailable(props.modes, 'video-only') ||
+    isModeAvailable(props.modes, 'audio-only') ||
+    isModeAvailable(props.modes, 'video-audio')
+  )
+
+  const shouldShowSnapshotButton = isModeAvailable(props.modes, 'picture')
+
   return html`
     <div class="UppyWebcam-container" onload=${(el) => {
       props.onFocus()
@@ -48,14 +35,8 @@ module.exports = (props) => {
         ${video}
       </div>
       <div class='UppyWebcam-buttonContainer'>
-        ${props.supportsRecording ? RecordButton(props) : null}
-        <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
-          type="button"
-          title="Take a snapshot"
-          aria-label="Take a snapshot"
-          onclick=${props.onSnapshot}>
-          ${CameraIcon()}
-        </button>
+        ${shouldShowRecordButton ? RecordButton(props) : null}
+        ${shouldShowSnapshotButton ? SnapshotButton(props) : null}
       </div>
       <canvas class="UppyWebcam-canvas" style="display: none;"></canvas>
     </div>

--- a/src/plugins/Webcam/CameraScreen.js
+++ b/src/plugins/Webcam/CameraScreen.js
@@ -1,5 +1,31 @@
 const html = require('yo-yo')
 const CameraIcon = require('./CameraIcon')
+const RecordStartIcon = require('./RecordStartIcon')
+const RecordStopIcon = require('./RecordStopIcon')
+
+function RecordButton ({ recording, onStartRecording, onStopRecording }) {
+  if (recording) {
+    return html`
+      <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
+        type="button"
+        title="Stop Recording"
+        aria-label="Stop Recording"
+        onclick=${onStopRecording}>
+        ${RecordStopIcon()}
+      </button>
+    `
+  }
+
+  return html`
+    <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
+      type="button"
+      title="Begin Recording"
+      aria-label="Begin Recording"
+      onclick=${onStartRecording}>
+      ${RecordStartIcon()}
+    </button>
+  `
+}
 
 module.exports = (props) => {
   const src = props.src || ''
@@ -14,7 +40,7 @@ module.exports = (props) => {
   return html`
     <div class="UppyWebcam-container" onload=${(el) => {
       props.onFocus()
-      document.querySelector('.UppyWebcam-stopRecordBtn').focus()
+      document.querySelector('.UppyWebcam-recordButton').focus()
     }} onunload=${(el) => {
       props.onStop()
     }}>
@@ -22,7 +48,8 @@ module.exports = (props) => {
         ${video}
       </div>
       <div class='UppyWebcam-buttonContainer'>
-        <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-stopRecordBtn"
+        ${RecordButton(props)}
+        <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
           type="button"
           title="Take a snapshot"
           aria-label="Take a snapshot"

--- a/src/plugins/Webcam/CameraScreen.js
+++ b/src/plugins/Webcam/CameraScreen.js
@@ -48,7 +48,7 @@ module.exports = (props) => {
         ${video}
       </div>
       <div class='UppyWebcam-buttonContainer'>
-        ${RecordButton(props)}
+        ${props.supportsRecording ? RecordButton(props) : null}
         <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
           type="button"
           title="Take a snapshot"

--- a/src/plugins/Webcam/RecordButton.js
+++ b/src/plugins/Webcam/RecordButton.js
@@ -1,0 +1,27 @@
+const html = require('yo-yo')
+const RecordStartIcon = require('./RecordStartIcon')
+const RecordStopIcon = require('./RecordStopIcon')
+
+module.exports = function RecordButton ({ recording, onStartRecording, onStopRecording }) {
+  if (recording) {
+    return html`
+      <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
+        type="button"
+        title="Stop Recording"
+        aria-label="Stop Recording"
+        onclick=${onStopRecording}>
+        ${RecordStopIcon()}
+      </button>
+    `
+  }
+
+  return html`
+    <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
+      type="button"
+      title="Begin Recording"
+      aria-label="Begin Recording"
+      onclick=${onStartRecording}>
+      ${RecordStartIcon()}
+    </button>
+  `
+}

--- a/src/plugins/Webcam/RecordStartIcon.js
+++ b/src/plugins/Webcam/RecordStartIcon.js
@@ -1,0 +1,7 @@
+const html = require('yo-yo')
+
+module.exports = (props) => {
+  return html`<svg class="UppyIcon" width="100" height="100" viewBox="0 0 100 100">
+    <circle cx="50" cy="50" r="40" />
+  </svg>`
+}

--- a/src/plugins/Webcam/RecordStopIcon.js
+++ b/src/plugins/Webcam/RecordStopIcon.js
@@ -1,0 +1,7 @@
+const html = require('yo-yo')
+
+module.exports = (props) => {
+  return html`<svg class="UppyIcon" width="100" height="100" viewBox="0 0 100 100">
+    <rect x="15" y="15" width="70" height="70" />
+  </svg>`
+}

--- a/src/plugins/Webcam/SnapshotButton.js
+++ b/src/plugins/Webcam/SnapshotButton.js
@@ -1,0 +1,14 @@
+const html = require('yo-yo')
+const CameraIcon = require('./CameraIcon')
+
+module.exports = function SnapshotButton ({ onSnapshot }) {
+  return html`
+    <button class="UppyButton--circular UppyButton--red UppyButton--sizeM UppyWebcam-recordButton"
+      type="button"
+      title="Take a snapshot"
+      aria-label="Take a snapshot"
+      onclick=${onSnapshot}>
+      ${CameraIcon()}
+    </button>
+  `
+}

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -23,8 +23,12 @@ module.exports = class Webcam extends Plugin {
     // set default options
     const defaultOptions = {
       enableFlash: true,
-      audio: true,
-      video: true
+      modes: [
+        'video-audio',
+        'video-only',
+        'audio-only',
+        'picture'
+      ]
     }
 
     this.params = {
@@ -185,6 +189,7 @@ module.exports = class Webcam extends Plugin {
       onStopRecording: this.stopRecording,
       onFocus: this.focus,
       onStop: this.stop,
+      modes: this.opts.modes,
       supportsRecording: supportsMediaRecorder(),
       recording: state.webcam.isRecording,
       getSWFHTML: this.webcam.getSWFHTML,

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -20,7 +20,9 @@ module.exports = class Webcam extends Plugin {
 
     // set default options
     const defaultOptions = {
-      enableFlash: true
+      enableFlash: true,
+      audio: true,
+      video: true
     }
 
     this.params = {
@@ -78,7 +80,12 @@ module.exports = class Webcam extends Plugin {
   }
 
   stop () {
-    this.stream.getVideoTracks()[0].stop()
+    this.stream.getAudioTracks().forEach((track) => {
+      track.stop()
+    })
+    this.stream.getVideoTracks().forEach((track) => {
+      track.stop()
+    })
     this.webcamActive = false
     this.stream = null
     this.streamSrc = null

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -1,6 +1,8 @@
 const Plugin = require('../Plugin')
 const WebcamProvider = require('../../uppy-base/src/plugins/Webcam')
-const { extend, getFileTypeExtension } = require('../../core/Utils')
+const { extend,
+        getFileTypeExtension,
+        supportsMediaRecorder } = require('../../core/Utils')
 const WebcamIcon = require('./WebcamIcon')
 const CameraScreen = require('./CameraScreen')
 const PermissionsScreen = require('./PermissionsScreen')
@@ -183,6 +185,7 @@ module.exports = class Webcam extends Plugin {
       onStopRecording: this.stopRecording,
       onFocus: this.focus,
       onStop: this.stop,
+      supportsRecording: supportsMediaRecorder(),
       recording: state.webcam.isRecording,
       getSWFHTML: this.webcam.getSWFHTML,
       src: this.streamSrc

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -140,7 +140,7 @@ module.exports = class Webcam extends Plugin {
       mimeType: 'image/jpeg'
     }
 
-    const video = document.querySelector('.UppyWebcam-video')
+    const video = this.target.querySelector('.UppyWebcam-video')
 
     const image = this.webcam.getImage(video, opts)
 

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -56,6 +56,8 @@ module.exports = class Webcam extends Plugin {
     this.start = this.start.bind(this)
     this.stop = this.stop.bind(this)
     this.takeSnapshot = this.takeSnapshot.bind(this)
+    this.startRecording = this.startRecording.bind(this)
+    this.stopRecording = this.stopRecording.bind(this)
 
     this.webcam = new WebcamProvider(this.opts, this.params)
     this.webcamActive = false
@@ -122,6 +124,13 @@ module.exports = class Webcam extends Plugin {
     })
   }
 
+  isRecording () {
+    if (!this.recorder) {
+      return false
+    }
+    return this.recorder.state === 'recording'
+  }
+
   stop () {
     this.stream.getAudioTracks().forEach((track) => {
       track.stop()
@@ -169,8 +178,11 @@ module.exports = class Webcam extends Plugin {
 
     return CameraScreen(extend(state.webcam, {
       onSnapshot: this.takeSnapshot,
+      onStartRecording: this.startRecording,
+      onStopRecording: this.stopRecording,
       onFocus: this.focus,
       onStop: this.stop,
+      recording: this.isRecording(),
       getSWFHTML: this.webcam.getSWFHTML,
       src: this.streamSrc
     }))

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -92,11 +92,19 @@ module.exports = class Webcam extends Plugin {
       this.recordingChunks.push(event.data)
     })
     this.recorder.start()
+
+    this.updateState({
+      isRecording: true
+    })
   }
 
   stopRecording () {
     return new Promise((resolve, reject) => {
       this.recorder.addEventListener('stop', () => {
+        this.updateState({
+          isRecording: false
+        })
+
         const mimeType = this.recordingChunks[0].type
         const fileExtension = getFileTypeExtension(mimeType)
 
@@ -122,13 +130,6 @@ module.exports = class Webcam extends Plugin {
 
       this.recorder.stop()
     })
-  }
-
-  isRecording () {
-    if (!this.recorder) {
-      return false
-    }
-    return this.recorder.state === 'recording'
   }
 
   stop () {
@@ -182,7 +183,7 @@ module.exports = class Webcam extends Plugin {
       onStopRecording: this.stopRecording,
       onFocus: this.focus,
       onStop: this.stop,
-      recording: this.isRecording(),
+      recording: state.webcam.isRecording,
       getSWFHTML: this.webcam.getSWFHTML,
       src: this.streamSrc
     }))

--- a/src/scss/_webcam.scss
+++ b/src/scss/_webcam.scss
@@ -37,7 +37,7 @@
   right: 30px;
 }
 
-.UppyWebcam-stopRecordBtn .UppyIcon {
+.UppyWebcam-recordButton .UppyIcon {
   width: 50%;
   height: 50%;
   position: relative;

--- a/src/uppy-base/src/plugins/Webcam.js
+++ b/src/uppy-base/src/plugins/Webcam.js
@@ -14,8 +14,7 @@ module.exports = class Webcam {
     // set default options
     const defaultOptions = {
       enableFlash: true,
-      audio: true,
-      video: true
+      modes: []
     }
 
     const defaultParams = {
@@ -109,10 +108,16 @@ module.exports = class Webcam {
     this.userMedia = this._userMedia === undefined ? this.userMedia : this._userMedia
     return new Promise((resolve, reject) => {
       if (this.userMedia) {
+        const acceptsAudio = this.opts.modes.indexOf('video-audio') !== -1 ||
+          this.opts.modes.indexOf('audio-only') !== -1
+        const acceptsVideo = this.opts.modes.indexOf('video-audio') !== -1 ||
+          this.opts.modes.indexOf('video-only') !== -1 ||
+          this.opts.modes.indexOf('picture') !== -1
+
         // ask user for access to their camera
         this.mediaDevices.getUserMedia({
-          audio: this.opts.audio,
-          video: this.opts.video
+          audio: acceptsAudio,
+          video: acceptsVideo
         })
         .then((stream) => {
           return resolve(stream)

--- a/src/uppy-base/src/plugins/Webcam.js
+++ b/src/uppy-base/src/plugins/Webcam.js
@@ -13,7 +13,9 @@ module.exports = class Webcam {
 
     // set default options
     const defaultOptions = {
-      enableFlash: true
+      enableFlash: true,
+      audio: true,
+      video: true
     }
 
     const defaultParams = {
@@ -109,8 +111,8 @@ module.exports = class Webcam {
       if (this.userMedia) {
         // ask user for access to their camera
         this.mediaDevices.getUserMedia({
-          audio: false,
-          video: true
+          audio: this.opts.audio,
+          video: this.opts.video
         })
         .then((stream) => {
           return resolve(stream)


### PR DESCRIPTION
In browsers that support it, this patch shows a "Record" button on the webcam screen that will start or stop a video recording. By default, video and audio is recorded—both can be toggled using the new `video` and `audio` boolean options to the `Webcam` plugin.

```js
uppy.use(Webcam, {
  audio: false,
  video: true
})
```

Polishing to do:

 - What to do when `audio: true`, but `video: false`? Or should these options not even be available to the developer, but let the user decide instead through browser permissions?
 - Option for preferred format? FF and Chrome both support WebM, I'm not 100% sure on others (would be :100: to test in some more places)
 - Actually show the error somewhere that can theoretically occur if `MediaRecorder` is available, but we don't know the format it used.