### PR TITLE
Transloadit plugin, closes #173

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "namespace-emitter": "1.0.0",
     "on-load": "3.2.0",
     "prettier-bytes": "1.0.3",
+    "socket.io-client": "^1.7.3",
     "tus-js-client": "1.4.3",
+    "url-parse": "^1.1.8",
     "whatwg-fetch": "1.0.0",
     "yo-yo": "1.4.0",
     "yo-yoify": "3.5.0"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const MetaData = require('./plugins/MetaData.js')
 // Uploaders
 const Tus10 = require('./plugins/Tus10')
 const Multipart = require('./plugins/Multipart')
+const Transloadit = require('./plugins/Transloadit')
 
 module.exports = {
   Core,
@@ -37,6 +38,7 @@ module.exports = {
   FileInput,
   Tus10,
   Multipart,
+  Transloadit,
   Dashboard,
   MetaData,
   Webcam

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -332,7 +332,10 @@ module.exports = class DashboardUI extends Plugin {
     }
 
     const startUpload = (ev) => {
-      this.core.upload()
+      this.core.upload().catch((err) => {
+        // Log error.
+        console.error(err.stack || err.message)
+      })
     }
 
     const pauseUpload = (fileID) => {

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -332,7 +332,7 @@ module.exports = class DashboardUI extends Plugin {
     }
 
     const startUpload = (ev) => {
-      this.core.emitter.emit('core:upload')
+      this.core.upload()
     }
 
     const pauseUpload = (fileID) => {

--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -16,6 +16,8 @@ module.exports = class Multipart extends Plugin {
 
     // Merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
+
+    this.handleUpload = this.handleUpload.bind(this)
   }
 
   upload (file, current, total) {
@@ -129,12 +131,22 @@ module.exports = class Multipart extends Plugin {
     //   }
   }
 
-  install () {
-    const bus = this.core.emitter
-    bus.on('core:upload', () => {
-      this.core.log('Multipart is uploading...')
-      const files = this.core.getState().files
-      this.selectForUpload(files)
+  handleUpload () {
+    this.core.log('Multipart is uploading...')
+    const files = this.core.getState().files
+
+    this.selectForUpload(files)
+
+    return new Promise((resolve) => {
+      this.core.bus.once('core:upload-complete', resolve)
     })
+  }
+
+  install () {
+    this.core.addUploader(this.handleUpload)
+  }
+
+  uninstall () {
+    this.core.removeUploader(this.handleUpload)
   }
 }

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -9,7 +9,7 @@ module.exports = class Client {
    *
    * @param {object} options
    */
-  createAssembly ({ templateId, params, expectedFiles }) {
+  createAssembly ({ templateId, params, signature, expectedFiles }) {
     const data = new FormData()
     const finalParams = Object.assign({}, params, {
       // `params.auth` may already be specified, especially if signature
@@ -23,6 +23,10 @@ module.exports = class Client {
       finalParams.template_id = templateId
     }
     data.append('params', JSON.stringify(finalParams))
+    if (signature) {
+      data.append('signature', signature)
+    }
+
     data.append('fields', JSON.stringify({
       // Nothing yet.
     }))

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -12,9 +12,16 @@ module.exports = class Client {
   createAssembly ({ templateId, params, expectedFiles }) {
     const data = new FormData()
     const finalParams = Object.assign({}, params, {
-      template_id: templateId,
-      auth: { key: this.opts.key }
+      // `params.auth` may already be specified, especially if signature
+      // authentication is used. In that case we use it.
+      // TODO this logic is the inverse of what happens in the `new Client` in
+      // index.js. There, `opts.key` is preferred to `params.auth.key`. It
+      // should perhaps `throw` instead if both are given.
+      auth: params.auth || { key: this.opts.key }
     })
+    if (templateId) {
+      finalParams.template_id = templateId
+    }
     data.append('params', JSON.stringify(finalParams))
     data.append('fields', JSON.stringify({
       // Nothing yet.

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -9,7 +9,13 @@ module.exports = class Client {
    *
    * @param {object} options
    */
-  createAssembly ({ templateId, params, signature, expectedFiles }) {
+  createAssembly ({
+    templateId,
+    params,
+    fields,
+    signature,
+    expectedFiles
+  }) {
     const data = new FormData()
     data.append('params', typeof params === 'string'
       ? params
@@ -18,9 +24,7 @@ module.exports = class Client {
       data.append('signature', signature)
     }
 
-    data.append('fields', JSON.stringify({
-      // Nothing yet.
-    }))
+    data.append('fields', JSON.stringify(fields))
     data.append('tus_num_expected_upload_files', expectedFiles)
 
     return fetch(`${this.apiUrl}/assemblies`, {

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -9,12 +9,13 @@ module.exports = class Client {
    *
    * @param {object} options
    */
-  createAssembly ({ templateId, expectedFiles }) {
+  createAssembly ({ templateId, params, expectedFiles }) {
     const data = new FormData()
-    data.append('params', JSON.stringify({
+    const finalParams = Object.assign({}, params, {
       template_id: templateId,
       auth: { key: this.opts.key }
-    }))
+    })
+    data.append('params', JSON.stringify(finalParams))
     data.append('fields', JSON.stringify({
       // Nothing yet.
     }))

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -1,5 +1,5 @@
 module.exports = class Client {
-  constructor (opts) {
+  constructor (opts = {}) {
     this.apiUrl = 'https://api2.transloadit.com'
     this.opts = opts
   }
@@ -11,18 +11,9 @@ module.exports = class Client {
    */
   createAssembly ({ templateId, params, signature, expectedFiles }) {
     const data = new FormData()
-    const finalParams = Object.assign({}, params, {
-      // `params.auth` may already be specified, especially if signature
-      // authentication is used. In that case we use it.
-      // TODO this logic is the inverse of what happens in the `new Client` in
-      // index.js. There, `opts.key` is preferred to `params.auth.key`. It
-      // should perhaps `throw` instead if both are given.
-      auth: params.auth || { key: this.opts.key }
-    })
-    if (templateId) {
-      finalParams.template_id = templateId
-    }
-    data.append('params', JSON.stringify(finalParams))
+    data.append('params', typeof params === 'string'
+      ? params
+      : JSON.stringify(params))
     if (signature) {
       data.append('signature', signature)
     }

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -1,3 +1,6 @@
+/**
+ * A Barebones HTTP API client for Transloadit.
+ */
 module.exports = class Client {
   constructor (opts = {}) {
     this.apiUrl = 'https://api2.transloadit.com'

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -44,8 +44,4 @@ module.exports = class Client {
     return fetch(url)
       .then((response) => response.json())
   }
-
-  getTusEndpoint () {
-    return `${this.apiUrl}/resumable/files/`
-  }
 }

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -34,7 +34,7 @@ module.exports = class Client {
         throw error
       }
 
-      return this.getAssemblyStatus(assembly.status_endpoint)
+      return assembly
     })
   }
 

--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -1,0 +1,41 @@
+const io = require('socket.io-client')
+const Emitter = require('namespace-emitter')
+const parseUrl = require('url-parse')
+
+module.exports = class TransloaditSocket {
+  constructor (url, assembly) {
+    const emitter = Emitter()
+    this.on = emitter.on.bind(emitter)
+    this.off = emitter.off.bind(emitter)
+    this.emit = emitter.emit.bind(emitter)
+
+    const parsed = parseUrl(url)
+
+    this.assembly = assembly
+    this.socket = io.connect(parsed.origin, {
+      path: parsed.pathname
+    })
+
+    this.attachDefaultHandlers()
+  }
+
+  attachDefaultHandlers () {
+    this.socket.on('connect', () => {
+      this.socket.emit('assembly_connect', {
+        id: this.assembly.assembly_id
+      })
+
+      this.emit('connect')
+    })
+
+    this.socket.on('assembly_finished', () => {
+      this.emit('finished')
+
+      this.close()
+    })
+  }
+
+  close () {
+    this.socket.disconnect()
+  }
+}

--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -37,6 +37,10 @@ module.exports = class TransloaditSocket {
     this.socket.on('assembly_upload_meta_data_extracted', () => {
       this.emit('metadata')
     })
+
+    this.socket.on('assembly_result_finished', (stepName, result) => {
+      this.emit('result', stepName, result)
+    })
   }
 
   close () {

--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -33,6 +33,10 @@ module.exports = class TransloaditSocket {
 
       this.close()
     })
+
+    this.socket.on('assembly_upload_meta_data_extracted', () => {
+      this.emit('metadata')
+    })
   }
 
   close () {

--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -2,6 +2,9 @@ const io = require('socket.io-client')
 const Emitter = require('namespace-emitter')
 const parseUrl = require('url-parse')
 
+/**
+ * WebSocket status API client for Transloadit.
+ */
 module.exports = class TransloaditSocket {
   constructor (url, assembly) {
     const emitter = Emitter()

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -2,6 +2,10 @@ const Plugin = require('../Plugin')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')
 
+function paramsHasAuthKey (params) {
+  return Boolean(params && params.auth && params.auth.key)
+}
+
 module.exports = class Transloadit extends Plugin {
   constructor (core, opts) {
     super(core, opts)
@@ -20,17 +24,18 @@ module.exports = class Transloadit extends Plugin {
     this.prepareUpload = this.prepareUpload.bind(this)
     this.afterUpload = this.afterUpload.bind(this)
 
-    if (!this.opts.key) {
+    if (!this.opts.key && !paramsHasAuthKey(this.opts.params)) {
       throw new Error('Transloadit: The `key` option is required. ' +
         'You can find your Transloadit API key at https://transloadit.com/accounts/credentials.')
     }
-    if (!this.opts.templateId) {
-      throw new Error('Transloadit: The `templateId` option is required. ' +
-        'You can find your template\'s ID at https://transloadit.com/templates.')
+    if (!this.opts.templateId && !this.opts.params) {
+      throw new Error('Transloadit: At least one of the `templateId` and `params` ' +
+        'options is required. Please configure `params` or find your template\'s ' +
+        'ID at https://transloadit.com/templates.')
     }
 
     this.client = new Client({
-      key: this.opts.key
+      key: this.opts.key || this.opts.params.auth.key
     })
   }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -45,6 +45,11 @@ module.exports = class Transloadit extends Plugin {
       this.updateState({ assembly })
 
       function attachAssemblyMetadata (file, assembly) {
+        // Attach meta parameters for the Tus plugin. See:
+        // https://github.com/tus/tusd/wiki/Uploading-to-Transloadit-using-tus#uploading-using-tus
+        // TODO Should this `meta` be moved to a `tus.meta` property instead?
+        // If the MetaData plugin can add eg. resize parameters, it doesn't
+        // make much sense to set those as upload-metadata for tus.
         const meta = Object.assign({}, file.meta, {
           assembly_url: assembly.assembly_url,
           filename: file.name,

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -16,7 +16,8 @@ module.exports = class Transloadit extends Plugin {
     const defaultOptions = {
       templateId: null,
       waitForEncoding: false,
-      waitForMetadata: false
+      waitForMetadata: false,
+      signature: null
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -45,7 +46,8 @@ module.exports = class Transloadit extends Plugin {
     return this.client.createAssembly({
       templateId: this.opts.templateId,
       params: this.opts.params,
-      expectedFiles: Object.keys(this.core.state.files).length
+      expectedFiles: Object.keys(this.core.state.files).length,
+      signature: this.opts.signature
     }).then((assembly) => {
       this.updateState({ assembly })
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -70,7 +70,7 @@ module.exports = class Transloadit extends Plugin {
 
   uploadFiles () {
     this.core.log(`Transloadit: upload files for ${this.state.assembly.assembly_ssl_url}`)
-    const endpoint = this.client.getTusEndpoint()
+    const endpoint = this.state.assembly.tus_url
 
     // Eh. I think we'll change this later? This is a bit fragile! 😅
     // We probably want to be able to set some meta properties, maybe on the

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -88,6 +88,8 @@ module.exports = class Transloadit extends Plugin {
       if (this.shouldWait()) {
         return this.beginWaiting()
       }
+    }).then(() => {
+      this.core.log('Transloadit: Created assembly')
     }).catch((err) => {
       this.core.emit('informer', '⚠️ Transloadit: Could not create assembly', 'error', 0)
 
@@ -118,6 +120,8 @@ module.exports = class Transloadit extends Plugin {
     return new Promise((resolve, reject) => {
       this.socket.on('connect', resolve)
       this.socket.on('error', reject)
+    }).then(() => {
+      this.core.log('Transloadit: Socket is ready')
     })
   }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -1,0 +1,40 @@
+const Plugin = require('../Plugin')
+
+module.exports = class Transloadit extends Plugin {
+  constructor (core, opts) {
+    super(core, opts)
+    this.type = 'uploader'
+    this.id = 'Transloadit'
+    this.title = 'Transloadit'
+
+    const defaultOptions = {
+      templateId: null
+    }
+
+    this.opts = Object.assign({}, defaultOptions, opts)
+
+    if (!this.opts.templateId) {
+      throw new Error('Transloadit: The `templateId` option is required.')
+    }
+  }
+
+  createAssembly () {
+    this.core.log('Transloadit: create assembly')
+
+    return Promise.resolve()
+  }
+
+  uploadFiles () {
+    this.core.log('Transloadit: upload files')
+
+    return Promise.resolve()
+  }
+
+  install () {
+    const bus = this.core.emitter
+    bus.on('core:upload', () => {
+      this.createAssembly()
+        .then(() => this.uploadFiles())
+    })
+  }
+}

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -1,4 +1,6 @@
 const Plugin = require('../Plugin')
+const Tus10Plugin = require('../Tus10')
+const Client = require('./Client')
 
 module.exports = class Transloadit extends Plugin {
   constructor (core, opts) {
@@ -8,26 +10,84 @@ module.exports = class Transloadit extends Plugin {
     this.title = 'Transloadit'
 
     const defaultOptions = {
-      templateId: null
+      templateId: null,
+      resume: true,
+      allowPause: true
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
 
+    if (!this.opts.key) {
+      throw new Error('Transloadit: The `key` option is required. ' +
+        'You can find your Transloadit API key at https://transloadit.com/accounts/credentials.')
+    }
     if (!this.opts.templateId) {
       throw new Error('Transloadit: The `templateId` option is required.')
     }
+
+    this.client = new Client({
+      key: this.opts.key
+    })
   }
 
   createAssembly () {
     this.core.log('Transloadit: create assembly')
 
-    return Promise.resolve()
+    return this.client.createAssembly({
+      templateId: this.opts.templateId,
+      expectedFiles: Object.keys(this.core.state.files).length
+    }).then((assembly) => {
+      this.updateState({ assembly })
+
+      function attachAssemblyMetadata (file, assembly) {
+        const meta = Object.assign({}, file.meta, {
+          assembly_url: assembly.assembly_url,
+          filename: file.name,
+          fieldname: 'file'
+        })
+        return Object.assign(
+          {},
+          file,
+          { meta }
+        )
+      }
+
+      const filesObj = this.core.state.files
+      const files = {}
+      Object.keys(filesObj).forEach((id) => {
+        files[id] = attachAssemblyMetadata(filesObj[id], assembly)
+      })
+
+      this.core.setState({ files })
+    }).catch((err) => {
+      this.core.emit('informer', '⚠️ Transloadit: Could not create assembly', 'error', 0)
+
+      // Reject the promise.
+      throw err
+    })
   }
 
   uploadFiles () {
-    this.core.log('Transloadit: upload files')
+    this.core.log(`Transloadit: upload files for ${this.state.assembly.assembly_ssl_url}`)
+    const endpoint = this.client.getTusEndpoint()
 
-    return Promise.resolve()
+    // Eh. I think we'll change this later? This is a bit fragile! 😅
+    // We probably want to be able to set some meta properties, maybe on the
+    // files, or in global state, to tell Tus where (and when) to upload.
+    this.uploader = new Tus10Plugin(this.core, {
+      endpoint,
+      resume: this.opts.resume,
+      allowPause: this.opts.allowPause
+    })
+    this.uploader.install()
+
+    const files = Object.keys(this.core.state.files)
+      .map((id) => this.core.state.files[id])
+    this.uploader.uploadFiles(files)
+
+    this.core.emitter.once('core:success', () => {
+      this.uploader.uninstall()
+    })
   }
 
   install () {
@@ -36,5 +96,15 @@ module.exports = class Transloadit extends Plugin {
       this.createAssembly()
         .then(() => this.uploadFiles())
     })
+  }
+
+  get state () {
+    return this.core.state.transloadit || {}
+  }
+
+  updateState (newState) {
+    const transloadit = Object.assign({}, this.state, newState)
+
+    this.core.setState({ transloadit })
   }
 }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -108,6 +108,12 @@ module.exports = class Transloadit extends Plugin {
       this.state.assembly
     )
 
+    if (this.opts.waitForEncoding) {
+      this.socket.on('result', (stepName, result) => {
+        this.core.bus.emit('transloadit:result', stepName, result)
+      })
+    }
+
     this.assemblyReady = new Promise((resolve, reject) => {
       if (this.opts.waitForEncoding) {
         this.socket.on('finished', resolve)

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -22,7 +22,8 @@ module.exports = class Transloadit extends Plugin {
         'You can find your Transloadit API key at https://transloadit.com/accounts/credentials.')
     }
     if (!this.opts.templateId) {
-      throw new Error('Transloadit: The `templateId` option is required.')
+      throw new Error('Transloadit: The `templateId` option is required. ' +
+        'You can find your template\'s ID at https://transloadit.com/templates.')
     }
 
     this.client = new Client({

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -21,6 +21,10 @@ module.exports = class Transloadit extends Plugin {
     this.prepareUpload = this.prepareUpload.bind(this)
     this.afterUpload = this.afterUpload.bind(this)
 
+    if (!this.opts.params) {
+      throw new Error('Transloadit: The `params` option is required.')
+    }
+
     let params = this.opts.params
     if (typeof params === 'string') {
       try {
@@ -33,9 +37,6 @@ module.exports = class Transloadit extends Plugin {
       }
     }
 
-    if (!params) {
-      throw new Error('Transloadit: The `params` option is required.')
-    }
     if (!params.auth || !params.auth.key) {
       throw new Error('Transloadit: The `params.auth.key` option is required.' +
         'You can find your Transloadit API key at https://transloadit.com/accounts/credentials.')

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -39,6 +39,7 @@ module.exports = class Transloadit extends Plugin {
 
     return this.client.createAssembly({
       templateId: this.opts.templateId,
+      params: this.opts.params,
       expectedFiles: Object.keys(this.core.state.files).length
     }).then((assembly) => {
       this.updateState({ assembly })

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -135,6 +135,14 @@ module.exports = class Transloadit extends Plugin {
   afterUpload () {
     this.core.emit('informer', '🔄 Encoding...', 'info', 0)
     return this.assemblyReady.then(() => {
+      return this.client.getAssemblyStatus(this.state.assembly.status_endpoint)
+    }).then((assembly) => {
+      this.updateState({ assembly })
+
+      // TODO set the `file.uploadURL` to a result?
+      // We will probably need an option here so the plugin user can tell us
+      // which result to pick…?
+
       this.core.emit('informer:hide')
     })
   }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -13,7 +13,8 @@ module.exports = class Transloadit extends Plugin {
       waitForEncoding: false,
       waitForMetadata: false,
       signature: null,
-      params: null
+      params: null,
+      fields: {}
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -50,6 +51,7 @@ module.exports = class Transloadit extends Plugin {
 
     return this.client.createAssembly({
       params: this.opts.params,
+      fields: this.opts.fields,
       expectedFiles: Object.keys(this.core.state.files).length,
       signature: this.opts.signature
     }).then((assembly) => {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -2,6 +2,9 @@ const Plugin = require('../Plugin')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')
 
+/**
+ * Upload files to Transloadit using Tus.
+ */
 module.exports = class Transloadit extends Plugin {
   constructor (core, opts) {
     super(core, opts)

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -23,7 +23,14 @@ module.exports = class Transloadit extends Plugin {
 
     let params = this.opts.params
     if (typeof params === 'string') {
-      params = JSON.parse(params)
+      try {
+        params = JSON.parse(params)
+      } catch (err) {
+        // Tell the user that this is not an Uppy bug!
+        err.message = 'Transloadit: The `params` option is a malformed JSON string: ' +
+          err.message
+        throw err
+      }
     }
 
     if (!params) {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -85,7 +85,7 @@ module.exports = class Transloadit extends Plugin {
 
       this.core.setState({ files })
 
-      if (this.opts.waitForEncoding || this.opts.waitForMetadata) {
+      if (this.shouldWait()) {
         return this.beginWaiting()
       }
     }).catch((err) => {
@@ -94,6 +94,10 @@ module.exports = class Transloadit extends Plugin {
       // Reject the promise.
       throw err
     })
+  }
+
+  shouldWait () {
+    return this.opts.waitForEncoding || this.opts.waitForMetadata
   }
 
   beginWaiting () {
@@ -133,14 +137,14 @@ module.exports = class Transloadit extends Plugin {
 
   install () {
     this.core.addPreProcessor(this.prepareUpload)
-    if (this.opts.wait) {
+    if (this.shouldWait()) {
       this.core.addPostProcessor(this.afterUpload)
     }
   }
 
   uninstall () {
     this.core.removePreProcessor(this.prepareUpload)
-    if (this.opts.wait) {
+    if (this.shouldWait()) {
       this.core.removePostProcessor(this.afterUpload)
     }
   }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -11,7 +11,8 @@ module.exports = class Transloadit extends Plugin {
 
     const defaultOptions = {
       templateId: null,
-      wait: false
+      waitForEncoding: false,
+      waitForMetadata: false
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -67,7 +68,7 @@ module.exports = class Transloadit extends Plugin {
 
       this.core.setState({ files })
 
-      if (this.opts.wait) {
+      if (this.opts.waitForEncoding || this.opts.waitForMetadata) {
         return this.beginWaiting()
       }
     }).catch((err) => {
@@ -85,7 +86,11 @@ module.exports = class Transloadit extends Plugin {
     )
 
     this.assemblyReady = new Promise((resolve, reject) => {
-      this.socket.on('finished', resolve)
+      if (this.opts.waitForEncoding) {
+        this.socket.on('finished', resolve)
+      } else if (this.opts.waitForMetadata) {
+        this.socket.on('metadata', resolve)
+      }
       this.socket.on('error', reject)
     })
 

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -318,13 +318,17 @@ module.exports = class Tus10 extends Plugin {
   handleUpload () {
     this.core.log('Tus is uploading...')
     const files = this.core.getState().files
+
     this.selectForUpload(files)
+
+    return new Promise((resolve) => {
+      this.core.bus.once('core:upload-complete', resolve)
+    })
   }
 
   actions () {
     this.core.emitter.on('core:pause-all', this.handlePauseAll)
     this.core.emitter.on('core:resume-all', this.handleResumeAll)
-    this.core.emitter.on('core:upload', this.handleUpload)
   }
 
   addResumableUploadsCapabilityFlag () {
@@ -337,12 +341,13 @@ module.exports = class Tus10 extends Plugin {
 
   install () {
     this.addResumableUploadsCapabilityFlag()
+    this.core.addUploader(this.handleUpload)
     this.actions()
   }
 
   uninstall () {
+    this.core.removeUploader(this.handleUpload)
     this.core.emitter.off('core:pause-all', this.handlePauseAll)
     this.core.emitter.off('core:resume-all', this.handleResumeAll)
-    this.core.emitter.off('core:upload', this.handleUpload)
   }
 }

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -115,7 +115,13 @@ module.exports = class Tus10 extends Plugin {
 
     // Create a new tus upload
     return new Promise((resolve, reject) => {
-      const optsTus = Object.assign({}, tusDefaultOptions, this.opts)
+      const optsTus = Object.assign(
+        {},
+        tusDefaultOptions,
+        this.opts,
+        // Install file-specific upload overrides.
+        file.tus || {}
+      )
 
       optsTus.onError = (err) => {
         this.core.log(err)

--- a/test/unit/Transloadit.spec.js
+++ b/test/unit/Transloadit.spec.js
@@ -1,0 +1,17 @@
+import test from 'tape'
+import Core from '../../src/core/Core'
+import Transloadit from '../../src/plugins/Transloadit'
+
+test('Throws errors if options are missing', (t) => {
+  const uppy = new Core()
+
+  t.throws(() => {
+    uppy.use(Transloadit, { key: null, templateId: 'abc' })
+  }, 'The `key` option is required.')
+
+  t.throws(() => {
+    uppy.use(Transloadit, { key: 'abc', templateId: null })
+  }, 'The `templateId` option is required.')
+
+  t.end()
+})

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -2,5 +2,6 @@ require('babel-register')
 require('isomorphic-fetch')
 require('./core.spec.js')
 require('./translator.spec.js')
+require('./Transloadit.spec.js')
 // TODO: enable once getFile error is fixed
 // require('./GoogleDrive.spec.js')


### PR DESCRIPTION
This PR contains the very early beginnings of a Transloadit integration.

Currently: When the `core:upload` event is fired, the plugin creates an Assembly with a configurable `templateId`. <strike>Then, it creates a Tus plugin instance (HACK!) and uses it to upload the files to the assembly.

Of course it shouldn't be creating a Tus plugin instance. The Transloadit plugin _could_ extend from Tus, and that should work fairly well. However it's also pretty nice to have them separate and using the Uppy plugin system.</strike> I've implemented it like I described below :point_down: 

One way to make things work as separate plugins that I can think of is adding an `upload` method to Uppy core and allowing plugins to register promise-returning `beforeUpload` and `afterUpload` callbacks that are run in sequence. These callbacks can then manipulate the files before they're actually passed to the uploader. It's a bit of a different paradigm from the events-based setup we use so far, but it's also pretty flexible. The Transloadit plugin could add a `beforeUpload` handler that creates the assembly and adds metadata to `file` objects so the `Tus` plugin can upload them to the right place. It can then also add an `afterUpload` handler that displays an "Encoding :arrows_counterclockwise:" message while waiting for the Assembly to finish. Since these would return Promises, all of this happens in a single call: `uppy.upload().then(() => { /*all done!*/ })`.

This way would require the Tus and Multipart plugins to be updated to have an `upload` handler that returns a Promise that resolves/rejects once all file uploads have "completed" (successfully or not).

Artur suggested adding a conditional `core:beforeUpload` event, something like this in Slack:

```js
if (uppy.hasEncoderPlugin()) {
  uppy.bus.emit('core:beforeUpload')
} else {
  uppy.bus.emit('core:upload')
}

// and for a transloadit `wait` option like in the jQuery sdk:
if (uppy.hasEncoderPlugin() /*or a diff name?*/) {
  uppy.bus.emit('core:afterUpload')
} else {
  uppy.bus.emit('core:success')
}
```

Which may be easier. I don't think it could support _multiple_ "encoder" plugins though (say, one that converts images to jpgs in a web worker, and _then_ one that creates a transloadit assembly)