### PR TITLE
Merge tus client options with uppy. Hence, enable custom headers support

### DIFF
--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -103,7 +103,7 @@ module.exports = class Tus10 extends Plugin {
 
     // Create a new tus upload
     return new Promise((resolve, reject) => {
-      var optsTus = Object.assign({}, tusDefaultOptions, this.opts)
+      const optsTus = Object.assign({}, tusDefaultOptions, this.opts)
 
       optsTus.onError = (err) => {
         this.core.log(err)


### PR DESCRIPTION
I needed to set custom headers and although `tus-js-client`, the dependency to make upload can have custom headers, Uppy was not able to.

This PR is one way to solve it for `Tus10` (because plugins does not always use the same way to send http request, hence to custom the headers)
Waiting for your feedback
