### PR TITLE
Add `Uppy#close` for tearing down an Uppy instance.

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -452,6 +452,24 @@ class Uppy {
     })
   }
 
+  /**
+   * Uninstall and remove a plugin.
+   *
+   * @param {Plugin} instance The plugin instance to remove.
+   */
+  removePlugin (instance) {
+    const list = this.plugins[instance.type]
+
+    if (instance.uninstall) {
+      instance.uninstall()
+    }
+
+    const index = list.indexOf(instance)
+    if (index !== -1) {
+      list.splice(index, 1)
+    }
+  }
+
 /**
  * Logs stuff to console, only if `debug` is set to true. Silent in production.
  *

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -470,6 +470,19 @@ class Uppy {
     }
   }
 
+  /**
+   * Uninstall all plugins and close down this Uppy instance.
+   */
+  close () {
+    this.iteratePlugins((plugin) => {
+      plugin.uninstall()
+    })
+
+    if (this.socket) {
+      this.socket.close()
+    }
+  }
+
 /**
  * Logs stuff to console, only if `debug` is set to true. Silent in production.
  *

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -166,9 +166,15 @@ module.exports = class DragDrop extends Plugin {
     const plugin = this
     this.target = this.mount(target, plugin)
 
-    dragDrop(this.target.querySelector('.UppyDragDrop-container'), (files) => {
+    const dndContainer = this.target.querySelector('.UppyDragDrop-container')
+    this.removeDragDropListener = dragDrop(dndContainer, (files) => {
       this.handleDrop(files)
       this.core.log(files)
     })
+  }
+
+  uninstall () {
+    this.removeDragDropListener()
+    this.unmount()
   }
 }

--- a/src/plugins/Dropbox/index.js
+++ b/src/plugins/Dropbox/index.js
@@ -66,6 +66,10 @@ module.exports = class Dropbox extends Plugin {
     return
   }
 
+  uninstall () {
+    this.unmount()
+  }
+
   onAuth (authenticated) {
     this.view.updateState({authenticated})
     if (authenticated) {

--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -80,4 +80,8 @@ module.exports = class FileInput extends Plugin {
     const plugin = this
     this.target = this.mount(target, plugin)
   }
+
+  uninstall () {
+    this.unmount()
+  }
 }

--- a/src/plugins/GoogleDrive/index.js
+++ b/src/plugins/GoogleDrive/index.js
@@ -64,6 +64,10 @@ module.exports = class Google extends Plugin {
     return
   }
 
+  uninstall () {
+    this.unmount()
+  }
+
   onAuth (authenticated) {
     this.view.updateState({authenticated})
     if (authenticated) {

--- a/src/plugins/Informer.js
+++ b/src/plugins/Informer.js
@@ -113,4 +113,8 @@ module.exports = class Informer extends Plugin {
     const plugin = this
     this.target = this.mount(target, plugin)
   }
+
+  uninstall () {
+    this.unmount()
+  }
 }

--- a/src/plugins/MagicLog.js
+++ b/src/plugins/MagicLog.js
@@ -19,16 +19,24 @@ module.exports = class MagicLog extends Plugin {
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
+
+    this.handleStateUpdate = this.handleStateUpdate.bind(this)
+  }
+
+  handleStateUpdate (prev, state, patch) {
+    console.group('State')
+    console.log('Prev', prev)
+    console.log('Next', state)
+    console.log('Patch', patch)
+    console.groupEnd()
   }
 
   install () {
     const uppy = this.core.emitter
-    uppy.on('state-update', (prev, state, patch) => {
-      console.group('State')
-      console.log('Prev', prev)
-      console.log('Next', state)
-      console.log('Patch', patch)
-      console.groupEnd()
-    })
+    uppy.on('state-update', this.handleStateUpdate)
+  }
+
+  uninstall () {
+    this.core.emitter.off('state-update', this.handleStateUpdate)
   }
 }

--- a/src/plugins/MetaData.js
+++ b/src/plugins/MetaData.js
@@ -17,6 +17,18 @@ module.exports = class MetaData extends Plugin {
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
+
+    this.handleFileAdded = this.handleFileAdded.bind(this)
+  }
+
+  handleFileAdded (fileID) {
+    const metaFields = this.opts.fields
+
+    metaFields.forEach((item) => {
+      const obj = {}
+      obj[item.id] = item.value
+      this.core.updateMeta(obj, fileID)
+    })
   }
 
   addInitialMeta () {
@@ -26,16 +38,14 @@ module.exports = class MetaData extends Plugin {
       metaFields: metaFields
     })
 
-    this.core.emitter.on('file-added', (fileID) => {
-      metaFields.forEach((item) => {
-        const obj = {}
-        obj[item.id] = item.value
-        this.core.updateMeta(obj, fileID)
-      })
-    })
+    this.core.emitter.on('file-added', this.handleFileAdded)
   }
 
   install () {
     this.addInitialMeta()
+  }
+
+  uninstall () {
+    this.core.emitter.off('file-added', this.handleFileAdded)
   }
 }

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -25,6 +25,7 @@ module.exports = class Plugin {
     this.mount = this.mount.bind(this)
     this.focus = this.focus.bind(this)
     this.install = this.install.bind(this)
+    this.uninstall = this.uninstall.bind(this)
 
     // this.frame = null
   }
@@ -109,6 +110,10 @@ module.exports = class Plugin {
   }
 
   install () {
+    return
+  }
+
+  uninstall () {
     return
   }
 }

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -98,6 +98,12 @@ module.exports = class Plugin {
     }
   }
 
+  unmount () {
+    if (this.el && this.el.parentNode) {
+      this.el.parentNode.removeChild(this.el)
+    }
+  }
+
   focus () {
     return
   }

--- a/src/plugins/ProgressBar.js
+++ b/src/plugins/ProgressBar.js
@@ -38,4 +38,8 @@ module.exports = class ProgressBar extends Plugin {
     const plugin = this
     this.target = this.mount(target, plugin)
   }
+
+  uninstall () {
+    this.unmount()
+  }
 }

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -216,6 +216,11 @@ module.exports = class Webcam extends Plugin {
     this.target = this.mount(target, plugin)
   }
 
+  uninstall () {
+    this.webcam.reset()
+    this.unmount()
+  }
+
   /**
    * Little shorthand to update the state with my new state
    */


### PR DESCRIPTION
This patch adds a method `uppy.close()` that "uninstalls" all plugins and removes any handlers Uppy may have attached. This is useful if you've got an SPA and don't want to keep your Uppy instances around forever while switching between client-side views.

The Tus and Multipart plugins already had an `uninstall` method, so they aren't changed here.