### PR TITLE
Pass through errors

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -527,6 +527,12 @@ class Uppy {
       promise = promise.then(() => fn())
     })
 
+    // Not returning the `catch`ed promise, because we still want to return a rejected
+    // promise from this method if the upload failed.
+    promise.catch((err) => {
+      this.emit('core:error', err)
+    })
+
     return promise.then(() => {
       this.emit('core:success')
     })

--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -44,6 +44,10 @@ module.exports = class TransloaditSocket {
     this.socket.on('assembly_result_finished', (stepName, result) => {
       this.emit('result', stepName, result)
     })
+
+    this.socket.on('assembly_error', (err) => {
+      this.emit('error', Object.assign(new Error(err.message), err))
+    })
   }
 
   close () {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -160,6 +160,11 @@ module.exports = class Transloadit extends Plugin {
       // which result to pick…?
 
       this.core.emit('informer:hide')
+    }).catch((err) => {
+      // Always hide the Informer
+      this.core.emit('informer:hide')
+
+      throw err
     })
   }
 


### PR DESCRIPTION
This PR does two things:

 - Add a `core:error` event for when uploads fail, vs. `core:success`
 - Make assembly errors from the Transloadit websocket reject the Transloadit plugin postprocessor promise, firing a `core:error` event

This way users can handle errors if they haven't manually called `upload()` (i.e., most of the time).