### PR TITLE
Transloadit: Fix starting uploads after a previous upload has finished

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -52,10 +52,18 @@ module.exports = class Transloadit extends Plugin {
   createAssembly () {
     this.core.log('Transloadit: create assembly')
 
+    const files = this.core.state.files
+    const expectedFiles = Object.keys(files).reduce((count, fileID) => {
+      if (!files[fileID].progress.uploadStarted || files[fileID].isRemote) {
+        return count + 1
+      }
+      return count
+    }, 0)
+
     return this.client.createAssembly({
       params: this.opts.params,
       fields: this.opts.fields,
-      expectedFiles: Object.keys(this.core.state.files).length,
+      expectedFiles,
       signature: this.opts.signature
     }).then((assembly) => {
       this.updateState({ assembly })


### PR DESCRIPTION
Previously the transloadit plugin would just tell the server that it was going to upload however many files are selected, but that may include files that have been uploaded before. The tus plugin would then not upload files that had been uploaded before, so the number of expected files was different than the number of uploaded files, so the assembly would never finish.

This patch only counts files that haven't started uploading yet. This way the transloadit plugin will tell the server to expect the correct number of files.