### PR TITLE
Remove the last few potentially buggy uses of `document.querySelector`

### DIFF
--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -123,7 +123,7 @@ module.exports = class DragDrop extends Plugin {
     // }
 
     // onload=${(ev) => {
-    //   const firstInput = document.querySelector(`${this.target} .UppyDragDrop-focus`)
+    //   const firstInput = this.target.querySelector('.UppyDragDrop-focus')
     //   firstInput.focus()
     // }}
 

--- a/src/plugins/Webcam/CameraScreen.js
+++ b/src/plugins/Webcam/CameraScreen.js
@@ -27,7 +27,8 @@ module.exports = (props) => {
   return html`
     <div class="UppyWebcam-container" onload=${(el) => {
       props.onFocus()
-      document.querySelector('.UppyWebcam-recordButton').focus()
+      const recordButton = el.querySelector('.UppyWebcam-recordButton')
+      if (recordButton) recordButton.focus()
     }} onunload=${(el) => {
       props.onStop()
     }}>

--- a/src/uppy-base/src/plugins/Webcam.js
+++ b/src/uppy-base/src/plugins/Webcam.js
@@ -177,7 +177,6 @@ module.exports = class Webcam {
         }
       }
       delete this.stream
-      delete this.video
     }
 
     if (this.userMedia !== true) {
@@ -246,7 +245,7 @@ module.exports = class Webcam {
    * Stops the webcam capture and video playback.
    */
   stop () {
-    let { video, videoStream } = this
+    let { videoStream } = this
 
     this.updateState({
       cameraReady: false
@@ -262,20 +261,6 @@ module.exports = class Webcam {
       videoStream.onended = null
       videoStream = null
     }
-
-    if (video) {
-      video.onerror = null
-      video.pause()
-
-      if (video.mozSrcObject) {
-        video.mozSrcObject = null
-      }
-
-      video.src = ''
-    }
-
-    this.video = document.querySelector('.UppyWebcam-video')
-    this.canvas = document.querySelector('.UppyWebcam-canvas')
   }
 
   flashNotify (type, msg) {


### PR DESCRIPTION
This patch removes the last few uses of `document.querySelector` that may end up selecting the wrong elements. The only one that actually matters is the one doing autofocus for the `recordButton` in the Webcam plugin. There probably aren't a lot of use cases that require having multiple webcam plugins open at the same time, but now at least the button autofocus will work there lol.

I don't think the `stop` method in the uppy-base Webcam plugin is used at all so I removed all the stuff from there that depended on the result of the `querySelector` call there as well.