### PR TITLE
Make the webcam video fill the available space as much as possible

### DIFF
--- a/src/scss/_webcam.scss
+++ b/src/scss/_webcam.scss
@@ -12,19 +12,15 @@
 }
 
 .UppyWebcam-videoContainer {
-  width: 70%;
-  height: 80%;
-  position: relative;
-  overflow: hidden;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .UppyWebcam-video {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  min-width: 100%;
-  min-height: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 // .UppyWebcam-canvas {


### PR DESCRIPTION
Takes up the maximum available space while retaining aspect ratio by using css `max-width: 100%; max-height: 100%` on the video element. /cc @nqst 

Before:

![Before](http://i.imgur.com/5iKLCsV.png)

After: 

![After](http://i.imgur.com/Q8HHEwt.png)

(This example is a bit exaggerated because the image is very high resolution, but who knows, someone might use a 4K webcam someday!)

And on mobile:

![Mobile](http://i.imgur.com/FSRM9be.jpg)
