### PR TITLE
Transloadit: emit an upload event w/ tl data when a file upload is complete

### DIFF
--- a/src/plugins/Transloadit/Socket.js
+++ b/src/plugins/Transloadit/Socket.js
@@ -37,6 +37,10 @@ module.exports = class TransloaditSocket {
       this.close()
     })
 
+    this.socket.on('assembly_upload_finished', (file) => {
+      this.emit('upload', file)
+    })
+
     this.socket.on('assembly_upload_meta_data_extracted', () => {
       this.emit('metadata')
     })

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -119,6 +119,11 @@ module.exports = class Transloadit extends Plugin {
       this.state.assembly
     )
 
+    this.socket.on('upload', (file) => {
+      // TODO associate uploaded files with the files in our `state`
+      this.core.bus.emit('transloadit:upload', file)
+    })
+
     if (this.opts.waitForEncoding) {
       this.socket.on('result', (stepName, result) => {
         this.core.bus.emit('transloadit:result', stepName, result)

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -113,6 +113,9 @@ module.exports = class Transloadit extends Plugin {
     return this.opts.waitForEncoding || this.opts.waitForMetadata
   }
 
+  // TODO if/when the transloadit API returns tus upload metadata in the
+  // file objects in the assembly status, change this to use a unique ID
+  // instead of checking the file name and size.
   findFile ({ name, size }) {
     const files = this.core.state.files
     for (const id in files) {


### PR DESCRIPTION
Provides a "low-level" way to access the uploaded file metadata from transloadit. This way you can do:

```js
const filesById = {}
uppy.on('transloadit:upload', (file) => {
  filesById[file.id] = file
})
uppy.on('transloadit:result', (step, result) => {
  const original = filesById[result.original_id]
  const savings = original.size - result.size
  const percent = Math.round((savings / original.size) * 1000) / 10
  console.log('saved', percent, 'on the size of', original.name)
})
```

I couldn't think of a way yet to associate the uploaded files with the file objects in Uppy's own state, except for comparing some of their properties (name and size, but it wouldn't be 100% reliable), so I've left that as a TODO 🙈 