### PR TITLE
Fix ETA when multiple files are being uploaded, closes #188.

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -377,11 +377,15 @@ function getSpeed (fileProgress) {
   return uploadSpeed
 }
 
+function getBytesRemaining (fileProgress) {
+  return fileProgress.bytesTotal - fileProgress.bytesUploaded
+}
+
 function getETA (fileProgress) {
   if (!fileProgress.bytesUploaded) return 0
 
   const uploadSpeed = getSpeed(fileProgress)
-  const bytesRemaining = fileProgress.bytesTotal - fileProgress.bytesUploaded
+  const bytesRemaining = getBytesRemaining(fileProgress)
   const secondsRemaining = Math.round(bytesRemaining / uploadSpeed * 10) / 10
 
   return secondsRemaining
@@ -465,6 +469,7 @@ module.exports = {
   dataURItoBlob,
   dataURItoFile,
   getSpeed,
+  getBytesRemaining,
   getETA,
   // makeWorker,
   // makeCachingFunction,

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -3,7 +3,7 @@ const Translator = require('../../core/Translator')
 const dragDrop = require('drag-drop')
 const Dashboard = require('./Dashboard')
 const { getSpeed } = require('../../core/Utils')
-const { getETA } = require('../../core/Utils')
+const { getBytesRemaining } = require('../../core/Utils')
 const { prettyETA } = require('../../core/Utils')
 const { findDOMElement } = require('../../core/Utils')
 const prettyBytes = require('prettier-bytes')
@@ -288,13 +288,16 @@ module.exports = class DashboardUI extends Plugin {
   }
 
   getTotalETA (files) {
-    let totalSeconds = 0
+    const totalSpeed = this.getTotalSpeed(files)
+    if (totalSpeed === 0) {
+      return 0
+    }
 
-    files.forEach((file) => {
-      totalSeconds = totalSeconds + getETA(file.progress)
-    })
+    const totalBytesRemaining = files.reduce((total, file) => {
+      return total + getBytesRemaining(file.progress)
+    }, 0)
 
-    return totalSeconds
+    return Math.round(totalBytesRemaining / totalSpeed * 10) / 10
   }
 
   render (state) {


### PR DESCRIPTION
The "total" ETA shown in the dashboard was inaccurate when multiple
files were being uploaded, because the ETA for multiple simultaneous
uploads were added together to produce the total ETA.

This patch changes the ETA logic to use the total upload speed and
the total amount of bytes remaining to compute the ETA.