### PR TITLE
Transloadit: fix receiving results not associated with an uploaded file, closes #200

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -211,7 +211,7 @@ module.exports = class Transloadit extends Plugin {
 
     this.core.emit('informer', this.opts.locale.strings.encoding, 'info', 0)
     return this.assemblyReady.then(() => {
-      return this.client.getAssemblyStatus(this.state.assembly.status_endpoint)
+      return this.client.getAssemblyStatus(this.state.assembly.assembly_ssl_url)
     }).then((assembly) => {
       this.updateState({ assembly })
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -156,9 +156,8 @@ module.exports = class Transloadit extends Plugin {
   onResult (stepName, result) {
     const file = this.state.files[result.original_id]
     // The `file` may not exist if an import robot was used instead of a file upload.
-    if (!file) return
+    result.localId = file ? file.id : null
 
-    result.localId = file.id
     this.updateState({
       results: this.state.results.concat(result)
     })

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -155,6 +155,9 @@ module.exports = class Transloadit extends Plugin {
 
   onResult (stepName, result) {
     const file = this.state.files[result.original_id]
+    // The `file` may not exist if an import robot was used instead of a file upload.
+    if (!file) return
+
     result.localId = file.id
     this.updateState({
       results: this.state.results.concat(result)


### PR DESCRIPTION
Results that aren't related to an uploaded file will just get a `localId == null`.