### PR TITLE
Add progress API & display for pre- and postprocessors

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -394,12 +394,11 @@ class Uppy {
     })
     this.on('core:postprocess-complete', (fileID) => {
       const files = Object.assign({}, this.getState().files)
-      files[fileID] = Object.assign({}, files[fileID], {
-        progress: Object.assign({}, files[fileID].progress, {
-          complete: true
-        })
-      })
+      files[fileID] = Object.assign({}, files[fileID])
       delete files[fileID].progress.postprocess
+      // TODO should we set some kind of `fullyComplete` property on the file object
+      // so it's easier to see that the file is upload…fully complete…rather than
+      // what we have to do now (`uploadComplete && !postprocess`)
 
       this.setState({ files: files })
     })

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -577,23 +577,17 @@ class Uppy {
   upload () {
     this.emit('core:upload')
 
-    const waitingFileIDs = Object.keys(this.state.files)
-      .map(getFile, this)
-      .filter(isFileWaiting)
-      .map(toFileID)
-    function getFile (fileID) {
-      return this.state.files[fileID]
-    }
-    function isFileWaiting (file) {
+    const waitingFileIDs = []
+    Object.keys(this.state.files).forEach((fileID) => {
+      const file = this.state.files[fileID]
       // TODO: replace files[file].isRemote with some logic
       //
       // filter files that are now yet being uploaded / haven’t been uploaded
       // and remote too
-      return !file.progress.uploadStarted || file.isRemote
-    }
-    function toFileID (file) {
-      return file.id
-    }
+      if (!file.progress.uploadStarted || file.isRemote) {
+        waitingFileIDs.push(file.id)
+      }
+    })
 
     const promise = Utils.runPromiseSequence(
       [...this.preProcessors, ...this.uploaders, ...this.postProcessors],

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -308,11 +308,6 @@ class Uppy {
       ))
       updatedFiles[fileID] = updatedFile
 
-      // Preprocessing should be complete by now.
-      if (updatedFile.progress.preprocess) {
-        delete updatedFile.progress.preprocess
-      }
-
       this.setState({files: updatedFiles})
     })
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -575,8 +575,6 @@ class Uppy {
   }
 
   upload () {
-    let promise = Promise.resolve()
-
     this.emit('core:upload')
 
     const waitingFileIDs = Object.keys(this.state.files)
@@ -597,13 +595,10 @@ class Uppy {
       return file.id
     }
 
-    ;[].concat(
-      this.preProcessors,
-      this.uploaders,
-      this.postProcessors
-    ).forEach((fn) => {
-      promise = promise.then(() => fn(waitingFileIDs))
-    })
+    const promise = Utils.runPromiseSequence(
+      [...this.preProcessors, ...this.uploaders, ...this.postProcessors],
+      waitingFileIDs
+    )
 
     // Not returning the `catch`ed promise, because we still want to return a rejected
     // promise from this method if the upload failed.

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -371,9 +371,16 @@ class Uppy {
         })
       })
 
-      this.setState({
-        files: files
+      this.setState({ files: files })
+    })
+    this.on('core:preprocess-complete', (fileID) => {
+      const files = Object.assign({}, this.getState().files)
+      files[fileID] = Object.assign({}, files[fileID], {
+        progress: Object.assign({}, files[fileID].progress)
       })
+      delete files[fileID].progress.preprocess
+
+      this.setState({ files: files })
     })
     this.on('core:postprocess-progress', (fileID, progress) => {
       const files = Object.assign({}, this.getState().files)
@@ -383,9 +390,18 @@ class Uppy {
         })
       })
 
-      this.setState({
-        files: files
+      this.setState({ files: files })
+    })
+    this.on('core:postprocess-complete', (fileID) => {
+      const files = Object.assign({}, this.getState().files)
+      files[fileID] = Object.assign({}, files[fileID], {
+        progress: Object.assign({}, files[fileID].progress, {
+          complete: true
+        })
       })
+      delete files[fileID].progress.postprocess
+
+      this.setState({ files: files })
     })
 
     // show informer if offline
@@ -591,11 +607,8 @@ class Uppy {
     }
 
     ;[].concat(
-      () => this.emit('core:preprocessing'),
       this.preProcessors,
-      () => this.emit('core:uploading'),
       this.uploaders,
-      () => this.emit('core:postprocessing'),
       this.postProcessors
     ).forEach((fn) => {
       promise = promise.then(() => fn(waitingFileIDs))

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -389,7 +389,9 @@ class Uppy {
     })
     this.on('core:postprocess-complete', (fileID) => {
       const files = Object.assign({}, this.getState().files)
-      files[fileID] = Object.assign({}, files[fileID])
+      files[fileID] = Object.assign({}, files[fileID], {
+        progress: Object.assign({}, files[fileID].progress)
+      })
       delete files[fileID].progress.postprocess
       // TODO should we set some kind of `fullyComplete` property on the file object
       // so it's easier to see that the file is upload…fully complete…rather than

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -53,9 +53,6 @@ class Uppy {
       capabilities: {
         resumableUploads: false
       },
-      progress: {
-        state: 'waiting'
-      },
       totalProgress: 0
     }
 
@@ -195,11 +192,9 @@ class Uppy {
     if (this.opts.autoProceed && !this.scheduledAutoProceed) {
       this.scheduledAutoProceed = setTimeout(() => {
         this.scheduledAutoProceed = null
-        this.upload()
-          .catch((err) => {
-            console.error(err.stack || err.message)
-          })
-        // this.bus.emit('core:upload')
+        this.upload().catch((err) => {
+          console.error(err.stack || err.message)
+        })
       }, 4)
     }
   }

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -391,7 +391,7 @@ class Uppy {
     this.on('core:success', () => {
       console.log('core:success')
       this.setState({
-        progress: { state: 'completed' }
+        progress: { state: 'complete' }
       })
     })
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -536,12 +536,30 @@ class Uppy {
 
     this.emit('core:upload')
 
+    const waitingFileIDs = Object.keys(this.state.files)
+      .map(getFile, this)
+      .filter(isFileWaiting)
+      .map(toFileID)
+    function getFile (fileID) {
+      return this.state.files[fileID]
+    }
+    function isFileWaiting (file) {
+      // TODO: replace files[file].isRemote with some logic
+      //
+      // filter files that are now yet being uploaded / haven’t been uploaded
+      // and remote too
+      return !file.progress.uploadStarted || file.isRemote
+    }
+    function toFileID (file) {
+      return file.id
+    }
+
     ;[].concat(
       this.preProcessors,
       this.uploaders,
       this.postProcessors
     ).forEach((fn) => {
-      promise = promise.then(() => fn())
+      promise = promise.then(() => fn(waitingFileIDs))
     })
 
     // Not returning the `catch`ed promise, because we still want to return a rejected

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -313,6 +313,11 @@ class Uppy {
       ))
       updatedFiles[fileID] = updatedFile
 
+      // Preprocessing should be complete by now.
+      if (updatedFile.progress.preprocess) {
+        delete updatedFile.progress.preprocess
+      }
+
       this.setState({files: updatedFiles})
     })
 
@@ -358,43 +363,28 @@ class Uppy {
       this.updateMeta(data, fileID)
     })
 
-    this.on('core:preprocessing', () => {
-      this.setState({
-        progress: { state: 'preprocessing' }
+    this.on('core:preprocess-progress', (fileID, progress) => {
+      const files = Object.assign({}, this.getState().files)
+      files[fileID] = Object.assign({}, files[fileID], {
+        progress: Object.assign({}, files[fileID].progress, {
+          preprocess: progress
+        })
       })
-    })
-    this.on('preprocessor:progress', (progress) => {
-      if (this.state.progress.state !== 'preprocessing') {
-        return
-      }
 
       this.setState({
-        progress: Object.assign({}, this.state.progress, progress)
+        files: files
       })
     })
-    this.on('core:uploading', () => {
-      this.setState({
-        progress: { state: 'uploading' }
+    this.on('core:postprocess-progress', (fileID, progress) => {
+      const files = Object.assign({}, this.getState().files)
+      files[fileID] = Object.assign({}, files[fileID], {
+        progress: Object.assign({}, files[fileID].progress, {
+          postprocess: progress
+        })
       })
-    })
-    this.on('core:postprocessing', () => {
-      this.setState({
-        progress: { state: 'postprocessing' }
-      })
-    })
-    this.on('postprocessor:progress', (progress) => {
-      if (this.state.progress.state !== 'postprocessing') {
-        return
-      }
 
       this.setState({
-        progress: Object.assign({}, this.state.progress, progress)
-      })
-    })
-    this.on('core:success', () => {
-      console.log('core:success')
-      this.setState({
-        progress: { state: 'complete' }
+        files: files
       })
     })
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -192,12 +192,15 @@ class Uppy {
     this.bus.emit('file-added', fileID)
     this.log(`Added file: ${fileName}, ${fileID}, mime type: ${fileType}`)
 
-    if (this.opts.autoProceed) {
-      this.upload()
-        .catch((err) => {
-          console.error(err.stack || err.message)
-        })
-      // this.bus.emit('core:upload')
+    if (this.opts.autoProceed && !this.scheduledAutoProceed) {
+      this.scheduledAutoProceed = setTimeout(() => {
+        this.scheduledAutoProceed = null
+        this.upload()
+          .catch((err) => {
+            console.error(err.stack || err.message)
+          })
+        // this.bus.emit('core:upload')
+      }, 4)
     }
   }
 

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -123,6 +123,17 @@ function extend (...objs) {
 }
 
 /**
+ * Runs an array of promise-returning functions in sequence.
+ */
+function runPromiseSequence (functions, ...args) {
+  let promise = Promise.resolve()
+  functions.forEach((func) => {
+    promise = promise.then(() => func(...args))
+  })
+  return promise
+}
+
+/**
  * Takes function or class, returns its name.
  * Because IE doesn’t support `constructor.name`.
  * https://gist.github.com/dfkaye/6384439, http://stackoverflow.com/a/15714445
@@ -395,6 +406,7 @@ module.exports = {
   // $,
   // $$,
   extend,
+  runPromiseSequence,
   supportsMediaRecorder,
   isTouchDevice,
   getFileNameAndExtension,

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -142,6 +142,7 @@ module.exports = function Dashboard (props) {
 
         <div class="UppyDashboard-progressindicators">
           ${StatusBar({
+            progress: props.progress,
             totalProgress: props.totalProgress,
             totalFileCount: props.totalFileCount,
             totalSize: props.totalSize,

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -142,7 +142,6 @@ module.exports = function Dashboard (props) {
 
         <div class="UppyDashboard-progressindicators">
           ${StatusBar({
-            progress: props.progress,
             totalProgress: props.totalProgress,
             totalFileCount: props.totalFileCount,
             totalSize: props.totalSize,

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -160,6 +160,7 @@ module.exports = function Dashboard (props) {
             totalETA: props.totalETA,
             startUpload: props.startUpload,
             newFileCount: props.newFiles.length,
+            files: props.files,
             i18n: props.i18n,
             resumableUploads: props.resumableUploads
           })}

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -25,7 +25,7 @@ module.exports = (props) => {
         ${message}
       </div>
     `
-  } else if (props.progress.state === 'completed') {
+  } else if (props.progress.state === 'complete') {
     progressValue = 100
     progressBarContent = html`
       <div class="UppyDashboard-statusBarContent">
@@ -54,8 +54,7 @@ module.exports = (props) => {
   const width = typeof progressValue === 'number' ? progressValue : 100
 
   return html`
-    <div class="UppyDashboard-statusBar
-                ${props.progress.state === 'completed' ? 'is-complete' : ''}"
+    <div class="UppyDashboard-statusBar is-${props.progress.state}"
                 aria-hidden="${isHidden}"
                 title="">
       <progress style="display: none;" min="0" max="100" value=${progressValue}></progress>

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -1,34 +1,23 @@
 const html = require('yo-yo')
 const throttle = require('lodash.throttle')
 
-function getProgressBarWidth (props) {
-  return props.totalProgress
-}
-
 function progressDetails (props) {
-  // console.log(Date.now())
   return html`<span>${props.totalProgress || 0}%・${props.complete} / ${props.inProgress}・${props.totalUploadedSize} / ${props.totalSize}・↑ ${props.totalSpeed}/s・${props.totalETA}</span>`
 }
 
 const throttledProgressDetails = throttle(progressDetails, 1000, {leading: true, trailing: true})
-// const throttledProgressBarWidth = throttle(progressBarWidth, 300, {leading: true, trailing: true})
 
 module.exports = (props) => {
   props = props || {}
 
   const isHidden = props.progress.state === 'waiting' // props.totalFileCount === 0 || !props.isUploadStarted
 
-  let progressValue
-  let progressBarWidth
   let progressBarContent
+  let progressValue
   if (props.progress.state === 'preprocessing' || props.progress.state === 'postprocessing') {
     const { mode, value, message } = props.progress
-    if (mode === 'indeterminate') {
-      progressValue = undefined
-      progressBarWidth = 100
-    } else {
+    if (mode === 'determinate') {
       progressValue = value * 100
-      progressBarWidth = value * 100
     }
     progressBarContent = html`
       <div class="UppyDashboard-statusBarContent">
@@ -38,7 +27,6 @@ module.exports = (props) => {
     `
   } else if (props.progress.state === 'completed') {
     progressValue = 100
-    progressBarWidth = 100
     progressBarContent = html`
       <div class="UppyDashboard-statusBarContent">
         <span title="Complete">
@@ -51,7 +39,6 @@ module.exports = (props) => {
     `
   } else {
     progressValue = props.totalProgress
-    progressBarWidth = getProgressBarWidth(props)
     progressBarContent = html`
       <div class="UppyDashboard-statusBarContent">
         ${props.isUploadStarted && !props.isAllComplete
@@ -64,14 +51,16 @@ module.exports = (props) => {
     `
   }
 
+  const width = typeof progressValue === 'number' ? progressValue : 100
+
   return html`
     <div class="UppyDashboard-statusBar
                 ${props.progress.state === 'completed' ? 'is-complete' : ''}"
                 aria-hidden="${isHidden}"
                 title="">
-      <progress style="display: none;" min="0" max="100" value="${progressValue}"></progress>
+      <progress style="display: none;" min="0" max="100" value=${progressValue}></progress>
       <div class="UppyDashboard-statusBarProgress ${props.progress.mode ? `is-${props.progress.mode}` : ''}"
-           style="width: ${progressBarWidth}%"></div>
+           style="width: ${width}%"></div>
       ${progressBarContent}
     </div>
   `

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -7,11 +7,11 @@ function progressDetails (props) {
 
 const throttledProgressDetails = throttle(progressDetails, 1000, {leading: true, trailing: true})
 
-const STATE_WAITING = 0
-const STATE_PREPROCESSING = 1
-const STATE_UPLOADING = 2
-const STATE_POSTPROCESSING = 3
-const STATE_COMPLETE = 4
+const STATE_WAITING = 'waiting'
+const STATE_PREPROCESSING = 'preprocessing'
+const STATE_UPLOADING = 'uploading'
+const STATE_POSTPROCESSING = 'postprocessing'
+const STATE_COMPLETE = 'complete'
 
 function getUploadingState (props, files) {
   // If ALL files have been completed, show the completed state.
@@ -41,16 +41,6 @@ function getUploadingState (props, files) {
   return state
 }
 
-function getUploadStateName (state) {
-  return [
-    'waiting',
-    'preprocessing',
-    'uploading',
-    'postprocessing',
-    'complete'
-  ][state]
-}
-
 module.exports = (props) => {
   props = props || {}
 
@@ -75,7 +65,7 @@ module.exports = (props) => {
   const width = typeof progressValue === 'number' ? progressValue : 100
 
   return html`
-    <div class="UppyDashboard-statusBar is-${getUploadStateName(uploadState)}"
+    <div class="UppyDashboard-statusBar is-${uploadState}"
                 aria-hidden="${uploadState === STATE_WAITING}"
                 title="">
       <progress style="display: none;" min="0" max="100" value=${progressValue}></progress>

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -77,14 +77,17 @@ module.exports = (props) => {
 }
 
 const ProgressBarProcessing = (props) => {
-  const progresses = Object.keys(props.files)
-    .map(getProgress)
-    .filter(Boolean)
-  function getProgress (fileID) {
-    const progress = props.files[fileID].progress
-    // Return preprocessing or postprocessing progress.
-    return progress.preprocess || progress.postprocess
-  }
+  // Collect pre or postprocessing progress states.
+  const progresses = []
+  Object.keys(props.files).forEach((fileID) => {
+    const { progress } = props.files[fileID]
+    if (progress.preprocess) {
+      progresses.push(progress.preprocess)
+    }
+    if (progress.postprocess) {
+      progresses.push(progress.postprocess)
+    }
+  })
 
   // In the future we should probably do this differently. For now we'll take the
   // mode and message from the first file…

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -10,7 +10,7 @@ const throttledProgressDetails = throttle(progressDetails, 1000, {leading: true,
 module.exports = (props) => {
   props = props || {}
 
-  const isHidden = props.progress.state === 'waiting' // props.totalFileCount === 0 || !props.isUploadStarted
+  const isHidden = props.progress.state === 'waiting'
 
   let progressBarContent
   let progressValue
@@ -37,7 +37,7 @@ module.exports = (props) => {
         </span>
       </div>
     `
-  } else {
+  } else if (props.progress.state === 'uploading') {
     progressValue = props.totalProgress
     progressBarContent = html`
       <div class="UppyDashboard-statusBarContent">

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -15,40 +15,16 @@ module.exports = (props) => {
   let progressBarContent
   let progressValue
   if (props.progress.state === 'preprocessing' || props.progress.state === 'postprocessing') {
-    const { mode, value, message } = props.progress
-    if (mode === 'determinate') {
-      progressValue = value * 100
+    if (props.progress.mode === 'determinate') {
+      progressValue = props.progress.value * 100
     }
-    progressBarContent = html`
-      <div class="UppyDashboard-statusBarContent">
-        ${mode === 'determinate' ? `${progressValue}%・` : ''}
-        ${message}
-      </div>
-    `
+    progressBarContent = ProgressBarProcessing(props.progress)
   } else if (props.progress.state === 'complete') {
     progressValue = 100
-    progressBarContent = html`
-      <div class="UppyDashboard-statusBarContent">
-        <span title="Complete">
-          <svg class="UppyDashboard-statusBarAction UppyIcon" width="18" height="17" viewBox="0 0 23 17">
-            <path d="M8.944 17L0 7.865l2.555-2.61 6.39 6.525L20.41 0 23 2.645z" />
-          </svg>
-          Upload complete・${props.totalProgress}%
-        </span>
-      </div>
-    `
+    progressBarContent = ProgressBarComplete(props)
   } else if (props.progress.state === 'uploading') {
     progressValue = props.totalProgress
-    progressBarContent = html`
-      <div class="UppyDashboard-statusBarContent">
-        ${props.isUploadStarted && !props.isAllComplete
-          ? !props.isAllPaused
-            ? html`<span title="Uploading">${pauseResumeButtons(props)} Uploading... ${throttledProgressDetails(props)}</span>`
-            : html`<span title="Paused">${pauseResumeButtons(props)} Paused・${props.totalProgress}%</span>`
-          : null
-          }
-      </div>
-    `
+    progressBarContent = ProgressBarUploading(props)
   }
 
   const width = typeof progressValue === 'number' ? progressValue : 100
@@ -61,6 +37,41 @@ module.exports = (props) => {
       <div class="UppyDashboard-statusBarProgress ${props.progress.mode ? `is-${props.progress.mode}` : ''}"
            style="width: ${width}%"></div>
       ${progressBarContent}
+    </div>
+  `
+}
+
+const ProgressBarProcessing = ({ mode, message, value }) => {
+  return html`
+    <div class="UppyDashboard-statusBarContent">
+      ${mode === 'determinate' ? `${value * 100}%・` : ''}
+      ${message}
+    </div>
+  `
+}
+
+const ProgressBarUploading = (props) => {
+  return html`
+    <div class="UppyDashboard-statusBarContent">
+      ${props.isUploadStarted && !props.isAllComplete
+        ? !props.isAllPaused
+          ? html`<span title="Uploading">${pauseResumeButtons(props)} Uploading... ${throttledProgressDetails(props)}</span>`
+          : html`<span title="Paused">${pauseResumeButtons(props)} Paused・${props.totalProgress}%</span>`
+        : null
+        }
+    </div>
+  `
+}
+
+const ProgressBarComplete = ({ totalProgress }) => {
+  return html`
+    <div class="UppyDashboard-statusBarContent">
+      <span title="Complete">
+        <svg class="UppyDashboard-statusBarAction UppyIcon" width="18" height="17" viewBox="0 0 23 17">
+          <path d="M8.944 17L0 7.865l2.555-2.61 6.39 6.525L20.41 0 23 2.645z" />
+        </svg>
+        Upload complete・${totalProgress}%
+      </span>
     </div>
   `
 }

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -389,6 +389,7 @@ module.exports = class DashboardUI extends Plugin {
 
     return Dashboard({
       state: state,
+      progress: state.progress,
       modal: state.modal,
       newFiles: newFiles,
       files: files,

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -317,6 +317,9 @@ module.exports = class DashboardUI extends Plugin {
              files[file].progress.uploadStarted &&
              !files[file].isPaused
     })
+    const processingFiles = Object.keys(files).filter((file) => {
+      return files[file].progress.preprocess || files[file].progress.postprocess
+    })
 
     let inProgressFilesArray = []
     inProgressFiles.forEach((file) => {
@@ -336,7 +339,9 @@ module.exports = class DashboardUI extends Plugin {
     totalSize = prettyBytes(totalSize)
     totalUploadedSize = prettyBytes(totalUploadedSize)
 
-    const isAllComplete = state.totalProgress === 100 && completeFiles.length === Object.keys(files).length
+    const isAllComplete = state.totalProgress === 100 &&
+      completeFiles.length === Object.keys(files).length &&
+      processingFiles.length === 0
     const isAllPaused = inProgressFiles.length === 0 && !isAllComplete && uploadStartedFiles.length > 0
     const isUploadStarted = uploadStartedFiles.length > 0
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -310,7 +310,7 @@ module.exports = class DashboardUI extends Plugin {
       return files[file].progress.uploadStarted
     })
     const completeFiles = Object.keys(files).filter((file) => {
-      return files[file].progress.complete
+      return files[file].progress.uploadComplete
     })
     const inProgressFiles = Object.keys(files).filter((file) => {
       return !files[file].progress.uploadComplete &&

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -310,7 +310,7 @@ module.exports = class DashboardUI extends Plugin {
       return files[file].progress.uploadStarted
     })
     const completeFiles = Object.keys(files).filter((file) => {
-      return files[file].progress.uploadComplete
+      return files[file].progress.complete
     })
     const inProgressFiles = Object.keys(files).filter((file) => {
       return !files[file].progress.uploadComplete &&
@@ -336,7 +336,7 @@ module.exports = class DashboardUI extends Plugin {
     totalSize = prettyBytes(totalSize)
     totalUploadedSize = prettyBytes(totalUploadedSize)
 
-    const isAllComplete = state.totalProgress === 100
+    const isAllComplete = state.totalProgress === 100 && completeFiles.length === Object.keys(files).length
     const isAllPaused = inProgressFiles.length === 0 && !isAllComplete && uploadStartedFiles.length > 0
     const isUploadStarted = uploadStartedFiles.length > 0
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -394,7 +394,6 @@ module.exports = class DashboardUI extends Plugin {
 
     return Dashboard({
       state: state,
-      progress: state.progress,
       modal: state.modal,
       newFiles: newFiles,
       files: files,

--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -150,16 +150,9 @@ module.exports = class Multipart extends Plugin {
       return
     }
 
-    const filesForUpload = []
-    Object.keys(files).forEach((file) => {
-      if (!files[file].progress.uploadStarted || files[file].isRemote) {
-        filesForUpload.push(files[file])
-      }
-    })
-
-    filesForUpload.forEach((file, i) => {
+    files.forEach((file, i) => {
       const current = parseInt(i, 10) + 1
-      const total = filesForUpload.length
+      const total = files.length
 
       if (file.isRemote) {
         this.uploadRemote(file, current, total)
@@ -177,9 +170,12 @@ module.exports = class Multipart extends Plugin {
     //   }
   }
 
-  handleUpload () {
+  handleUpload (fileIDs) {
     this.core.log('Multipart is uploading...')
-    const files = this.core.getState().files
+    const files = fileIDs.map(getFile, this)
+    function getFile (fileID) {
+      return this.core.state.files[fileID]
+    }
 
     this.selectForUpload(files)
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -171,14 +171,15 @@ module.exports = class Transloadit extends Plugin {
       this.socket.on('result', this.onResult.bind(this))
     }
 
-    this.assemblyReady = new Promise((resolve, reject) => {
-      if (this.opts.waitForEncoding) {
-        this.socket.on('finished', resolve)
-      } else if (this.opts.waitForMetadata) {
-        this.socket.on('metadata', resolve)
-      }
-      this.socket.on('error', reject)
-    })
+    if (this.opts.waitForEncoding) {
+      this.socket.on('finished', () => {
+        this.core.emit('transloadit:complete', assembly)
+      })
+    } else if (this.opts.waitForMetadata) {
+      this.socket.on('metadata', () => {
+        this.core.emit('transloadit:complete', assembly)
+      })
+    }
 
     return new Promise((resolve, reject) => {
       this.socket.on('connect', resolve)
@@ -212,31 +213,40 @@ module.exports = class Transloadit extends Plugin {
       return
     }
 
+    // Pick a file that is part of this assembly...
     const fileID = fileIDs[0]
     const file = this.core.state.files[fileID]
-    const assembly = this.state.assemblies[file.assembly]
 
     this.core.emit('informer', this.opts.locale.strings.encoding, 'info', 0)
-    return this.assemblyReady.then(() => {
-      return this.client.getAssemblyStatus(assembly.assembly_ssl_url)
-    }).then((assembly) => {
-      this.updateState({
-        assemblies: Object.assign({}, this.state.assemblies, {
-          [assembly.assembly_id]: assembly
+    const onAssemblyFinished = (assembly) => {
+      // An assembly for a different upload just finished. We can ignore it.
+      if (assembly.assembly_id !== file.transloadit.assembly) {
+        return
+      }
+      // Remove this handler once we find the assembly we needed.
+      this.core.emitter.off('transloadit:complete', onAssemblyFinished)
+
+      return this.client.getAssemblyStatus(assembly.assembly_ssl_url).then((assembly) => {
+        this.updateState({
+          assemblies: Object.assign({}, this.state.assemblies, {
+            [assembly.assembly_id]: assembly
+          })
         })
+
+        // TODO set the `file.uploadURL` to a result?
+        // We will probably need an option here so the plugin user can tell us
+        // which result to pick…?
+
+        this.core.emit('informer:hide')
+      }).catch((err) => {
+        // Always hide the Informer
+        this.core.emit('informer:hide')
+
+        throw err
       })
+    }
 
-      // TODO set the `file.uploadURL` to a result?
-      // We will probably need an option here so the plugin user can tell us
-      // which result to pick…?
-
-      this.core.emit('informer:hide')
-    }).catch((err) => {
-      // Always hide the Informer
-      this.core.emit('informer:hide')
-
-      throw err
-    })
+    this.core.on('transloadit:complete', onAssemblyFinished)
   }
 
   install () {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -64,6 +64,11 @@ module.exports = class Transloadit extends Plugin {
   createAssembly (filesToUpload) {
     this.core.log('Transloadit: create assembly')
 
+    this.core.emit('preprocess:progress', {
+      mode: 'indefinite',
+      message: ''
+    })
+
     return this.client.createAssembly({
       params: this.opts.params,
       fields: this.opts.fields,
@@ -200,8 +205,15 @@ module.exports = class Transloadit extends Plugin {
       return map
     }
 
+    this.core.emit('preprocessor:progress', {
+      mode: 'indeterminate',
+      message: this.opts.locale.strings.creatingAssembly
+    })
     return this.createAssembly(filesToUpload).then(() => {
-      this.core.emit('informer:hide')
+      this.core.emit('preprocessor:progress', {
+        mode: 'determinate',
+        value: 1
+      })
     })
   }
 
@@ -217,7 +229,11 @@ module.exports = class Transloadit extends Plugin {
     const fileID = fileIDs[0]
     const file = this.core.state.files[fileID]
 
-    this.core.emit('informer', this.opts.locale.strings.encoding, 'info', 0)
+    this.core.emit('postprocessor:progress', {
+      mode: 'indeterminate',
+      message: this.opts.locale.strings.encoding
+    })
+
     const onAssemblyFinished = (assembly) => {
       // An assembly for a different upload just finished. We can ignore it.
       if (assembly.assembly_id !== file.transloadit.assembly) {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -205,7 +205,11 @@ module.exports = class Transloadit extends Plugin {
         message: this.opts.locale.strings.creatingAssembly
       })
     })
-    return this.createAssembly(filesToUpload)
+    return this.createAssembly(filesToUpload).then(() => {
+      fileIDs.forEach((fileID) => {
+        this.core.emit('core:preprocess-complete', fileID)
+      })
+    })
   }
 
   afterUpload (fileIDs) {
@@ -245,6 +249,10 @@ module.exports = class Transloadit extends Plugin {
         // TODO set the `file.uploadURL` to a result?
         // We will probably need an option here so the plugin user can tell us
         // which result to pick…?
+
+        fileIDs.forEach((fileID) => {
+          this.core.emit('core:postprocess-complete', fileID)
+        })
       })
     }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -65,7 +65,7 @@ module.exports = class Transloadit extends Plugin {
     this.core.log('Transloadit: create assembly')
 
     this.core.emit('preprocess:progress', {
-      mode: 'indefinite',
+      mode: 'indeterminate',
       message: ''
     })
 

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -298,28 +298,14 @@ module.exports = class Tus10 extends Plugin {
     })
   }
 
-  selectForUpload (files) {
-    // TODO: replace files[file].isRemote with some logic
-    //
-    // filter files that are now yet being uploaded / haven’t been uploaded
-    // and remote too
-    const filesForUpload = Object.keys(files).filter((file) => {
-      if (!files[file].progress.uploadStarted || files[file].isRemote) {
-        return true
-      }
-      return false
-    }).map((file) => {
-      return files[file]
-    })
-
-    this.uploadFiles(filesForUpload)
-  }
-
-  handleUpload () {
+  handleUpload (fileIDs) {
     this.core.log('Tus is uploading...')
-    const files = this.core.getState().files
+    const filesToUpload = fileIDs.map(getFile, this)
+    function getFile (fileID) {
+      return this.core.state.files[fileID]
+    }
 
-    this.selectForUpload(files)
+    this.uploadFiles(filesToUpload)
 
     return new Promise((resolve) => {
       this.core.bus.once('core:upload-complete', resolve)

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -1047,6 +1047,8 @@
   }
 }
 
+
+
 .UppyDashboard-statusBar[aria-hidden=true] {
   height: 0;
 }
@@ -1065,7 +1067,19 @@
   height: 100%;
   position: absolute;
   z-index: $zIndex-2;
-  transition: all .3s ease-out;
+  transition: background-color, width .3s ease-out;
+
+  &.is-indeterminate {
+    $stripe-color: darken($color-cornflower-blue, 10%);
+    background-size: 64px 64px;
+    background-image: linear-gradient(45deg, $stripe-color 25%, transparent 25%, transparent 50%, $stripe-color 50%, $stripe-color 75%, transparent 75%, transparent);
+    animation: statusBarProgressStripes 1s linear infinite;
+  }
+}
+
+@keyframes statusBarProgressStripes {
+  from { background-position: 64px 0; }
+  to { background-position: 0 0; }
 }
 
 .UppyDashboard-statusBarContent {

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -1047,8 +1047,6 @@
   }
 }
 
-
-
 .UppyDashboard-statusBar[aria-hidden=true] {
   height: 0;
 }


### PR DESCRIPTION
This PR now does a few different things in order to make the progress bar show stuff from pre and postprocessors fairly accurately:

---
While working on the Transloadit plugin I changed the way uploads are
started. Now, uploads go through a kind of "pipeline", where plugins get a
chance to pre- and postprocess uploaded files. However, this pipeline
didn't take into account that multiple upload "jobs" may be started at
different times--it assumed that you'd only call `upload()` once. Each
plugin (pre, upload, and post) found the relevant files for the job on
its own, which could get out of sync. The Transloadit plugin didn't
support uploading to different assemblies simultaneously at all.

This patch fixes that by moving the files-to-upload finding into the
`upload()` method, and passing the IDs of the files that should be
handled in this upload "job" to each pre/upload/post handler. Also, the
Transloadit plugin can now handle multiple assemblies at once.

---

This patch allows pre- and postprocessors to hook into the dashboard statusbar. For example, the Transloadit plugin can now display "Preparing upload" in the statusbar while it's creating an assembly, and "Encoding..." while it's waiting for the assembly to complete.

This is implemented by adding `core:preprocess-progress` and `core:postprocess-progress` events. These events set progress data on the file state objects. These events have two parameters, 1) the file ID and 2) an object parameter that can have the following properties:

 - `mode` - the type of progress indicator to show, either 'determinate' or 'indeterminate'. In determinate mode, the statusbar will fill up depending on the given `value`. In indeterminate mode the statusbar will be filled up entirely but animate with stripes to show that work is being done.
 - `message` - plaintext message to show in the status bar. No HTML!
 - `value` - in 'determinate' mode, a number between 0-1 indicating the current progress.

---

TODO:

 - [x] maybe the `progress` state object has to be scaled back to only be used for the pre and postprocessor progress. so check if anything else in the state tree already serves the same purpose for uploading/waiting/completed states (i think there is)
 - [ ] think about what happens if a pre/postprocessor does not fire progress events. should the progressbar just show the `uploading` version at 0% and 100% respectively, or should we default to indeterminate "Preparing upload" and "Finishing upload" messages?
 - [x] Actually implement `value` for determinate mode and check that it works.