### PR TITLE
Rework the newish upload pipeline for better simultaneous upload support

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -548,12 +548,30 @@ class Uppy {
 
     this.emit('core:upload')
 
+    const waitingFileIDs = Object.keys(this.state.files)
+      .map(getFile, this)
+      .filter(isFileWaiting)
+      .map(toFileID)
+    function getFile (fileID) {
+      return this.state.files[fileID]
+    }
+    function isFileWaiting (file) {
+      // TODO: replace files[file].isRemote with some logic
+      //
+      // filter files that are now yet being uploaded / haven’t been uploaded
+      // and remote too
+      return !file.progress.uploadStarted || file.isRemote
+    }
+    function toFileID (file) {
+      return file.id
+    }
+
     ;[].concat(
       this.preProcessors,
       this.uploaders,
       this.postProcessors
     ).forEach((fn) => {
-      promise = promise.then(() => fn())
+      promise = promise.then(() => fn(waitingFileIDs))
     })
 
     // Not returning the `catch`ed promise, because we still want to return a rejected

--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -109,16 +109,9 @@ module.exports = class Multipart extends Plugin {
       return
     }
 
-    const filesForUpload = []
-    Object.keys(files).forEach((file) => {
-      if (!files[file].progress.uploadStarted || files[file].isRemote) {
-        filesForUpload.push(files[file])
-      }
-    })
-
-    filesForUpload.forEach((file, i) => {
+    files.forEach((file, i) => {
       const current = parseInt(i, 10) + 1
-      const total = filesForUpload.length
+      const total = files.length
       this.upload(file, current, total)
     })
 
@@ -131,9 +124,12 @@ module.exports = class Multipart extends Plugin {
     //   }
   }
 
-  handleUpload () {
+  handleUpload (fileIDs) {
     this.core.log('Multipart is uploading...')
-    const files = this.core.getState().files
+    const files = fileIDs.map(getFile, this)
+    function getFile (fileID) {
+      return this.core.state.files[fileID]
+    }
 
     this.selectForUpload(files)
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -61,24 +61,20 @@ module.exports = class Transloadit extends Plugin {
     this.client = new Client()
   }
 
-  createAssembly () {
+  createAssembly (filesToUpload) {
     this.core.log('Transloadit: create assembly')
-
-    const files = this.core.state.files
-    const expectedFiles = Object.keys(files).reduce((count, fileID) => {
-      if (!files[fileID].progress.uploadStarted || files[fileID].isRemote) {
-        return count + 1
-      }
-      return count
-    }, 0)
 
     return this.client.createAssembly({
       params: this.opts.params,
       fields: this.opts.fields,
-      expectedFiles,
+      expectedFiles: Object.keys(filesToUpload).length,
       signature: this.opts.signature
     }).then((assembly) => {
-      this.updateState({ assembly })
+      this.updateState({
+        assemblies: Object.assign(this.state.assemblies, {
+          [assembly.assembly_id]: assembly
+        })
+      })
 
       function attachAssemblyMetadata (file, assembly) {
         // Attach meta parameters for the Tus plugin. See:
@@ -95,22 +91,24 @@ module.exports = class Transloadit extends Plugin {
         const tus = Object.assign({}, file.tus, {
           endpoint: assembly.tus_url
         })
+        const transloadit = {
+          assembly: assembly.assembly_id
+        }
         return Object.assign(
           {},
           file,
-          { meta, tus }
+          { meta, tus, transloadit }
         )
       }
 
-      const filesObj = this.core.state.files
-      const files = {}
-      Object.keys(filesObj).forEach((id) => {
-        files[id] = attachAssemblyMetadata(filesObj[id], assembly)
+      const files = Object.assign({}, this.core.state.files)
+      Object.keys(filesToUpload).forEach((id) => {
+        files[id] = attachAssemblyMetadata(files[id], assembly)
       })
 
       this.core.setState({ files })
 
-      return this.connectSocket()
+      return this.connectSocket(assembly)
     }).then(() => {
       this.core.log('Transloadit: Created assembly')
     }).catch((err) => {
@@ -162,10 +160,10 @@ module.exports = class Transloadit extends Plugin {
     this.core.bus.emit('transloadit:result', stepName, result)
   }
 
-  connectSocket () {
+  connectSocket (assembly) {
     this.socket = new StatusSocket(
-      this.state.assembly.websocket_url,
-      this.state.assembly
+      assembly.websocket_url,
+      assembly
     )
 
     this.socket.on('upload', this.onFileUploadComplete.bind(this))
@@ -191,14 +189,23 @@ module.exports = class Transloadit extends Plugin {
     })
   }
 
-  prepareUpload () {
+  prepareUpload (fileIDs) {
     this.core.emit('informer', this.opts.locale.strings.creatingAssembly, 'info', 0)
-    return this.createAssembly().then(() => {
+    const filesToUpload = fileIDs.map(getFile, this).reduce(intoFileMap, {})
+    function getFile (fileID) {
+      return this.core.state.files[fileID]
+    }
+    function intoFileMap (map, file) {
+      map[file.id] = file
+      return map
+    }
+
+    return this.createAssembly(filesToUpload).then(() => {
       this.core.emit('informer:hide')
     })
   }
 
-  afterUpload () {
+  afterUpload (fileIDs) {
     // If we don't have to wait for encoding metadata or results, we can close
     // the socket immediately and finish the upload.
     if (!this.shouldWait()) {
@@ -206,11 +213,19 @@ module.exports = class Transloadit extends Plugin {
       return
     }
 
+    const fileID = fileIDs[0]
+    const file = this.core.state.files[fileID]
+    const assembly = this.state.assemblies[file.assembly]
+
     this.core.emit('informer', this.opts.locale.strings.encoding, 'info', 0)
     return this.assemblyReady.then(() => {
-      return this.client.getAssemblyStatus(this.state.assembly.status_endpoint)
+      return this.client.getAssemblyStatus(assembly.status_endpoint)
     }).then((assembly) => {
-      this.updateState({ assembly })
+      this.updateState({
+        assemblies: Object.assign({}, this.state.assemblies, {
+          [assembly.assembly_id]: assembly
+        })
+      })
 
       // TODO set the `file.uploadURL` to a result?
       // We will probably need an option here so the plugin user can tell us
@@ -230,7 +245,7 @@ module.exports = class Transloadit extends Plugin {
     this.core.addPostProcessor(this.afterUpload)
 
     this.updateState({
-      assembly: null,
+      assemblies: {},
       files: {},
       results: []
     })

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -322,28 +322,14 @@ module.exports = class Tus10 extends Plugin {
     })
   }
 
-  selectForUpload (files) {
-    // TODO: replace files[file].isRemote with some logic
-    //
-    // filter files that are now yet being uploaded / haven’t been uploaded
-    // and remote too
-    const filesForUpload = Object.keys(files).filter((file) => {
-      if (!files[file].progress.uploadStarted || files[file].isRemote) {
-        return true
-      }
-      return false
-    }).map((file) => {
-      return files[file]
-    })
-
-    this.uploadFiles(filesForUpload)
-  }
-
-  handleUpload () {
+  handleUpload (fileIDs) {
     this.core.log('Tus is uploading...')
-    const files = this.core.getState().files
+    const filesToUpload = fileIDs.map(getFile, this)
+    function getFile (fileID) {
+      return this.core.state.files[fileID]
+    }
 
-    this.selectForUpload(files)
+    this.uploadFiles(filesToUpload)
 
     return new Promise((resolve) => {
       this.core.bus.once('core:upload-complete', resolve)


### PR DESCRIPTION
While working on the Transloadit plugin I changed the way uploads are
started. Now, uploads go through a kind of "pipeline", where plugins get a
chance to pre- and postprocess uploaded files. However, this pipeline
didn't take into account that multiple upload "jobs" may be started at
different times--it assumed that you'd only call `upload()` once. Each
plugin (pre, upload, and post) found the relevant files for the job on
its own, which could get out of sync. The Transloadit plugin didn't
support uploading to different assemblies simultaneously at all.

This patch fixes that by moving the files-to-upload finding into the
`upload()` method, and passing the IDs of the files that should be
handled in this upload "job" to each pre/upload/post handler. Also, the
Transloadit plugin can now handle multiple assemblies at once.

This is (going to be) a prerequisite for #202.