### PR TITLE
feature: add support for remote multipart uploads #160

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -363,12 +363,12 @@ function getSocketHost (url) {
   return `${socketProtocol}://${host}`
 }
 
-function _emitSocketProgress (uppyInstance, progressData, file) {
+function _emitSocketProgress (uploader, progressData, file) {
   const {progress, bytesUploaded, bytesTotal} = progressData
   if (progress) {
-    uppyInstance.core.log(`Upload progress: ${progress}`)
-    uppyInstance.core.emitter.emit('core:upload-progress', {
-      uploader: uppyInstance,
+    uploader.core.log(`Upload progress: ${progress}`)
+    uploader.core.emitter.emit('core:upload-progress', {
+      uploader,
       id: file.id,
       bytesUploaded: bytesUploaded,
       bytesTotal: bytesTotal

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -1,3 +1,4 @@
+const throttle = require('lodash.throttle')
 // import mime from 'mime-types'
 // import pica from 'pica'
 
@@ -353,6 +354,30 @@ function findDOMElement (element) {
   }
 }
 
+function getSocketHost (url) {
+  // get the host domain
+  var regex = /^(?:https?:\/\/|\/\/)?(?:[^@\n]+@)?(?:www\.)?([^\n]+)/
+  var host = regex.exec(url)[1]
+  var socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
+
+  return `${socketProtocol}://${host}`
+}
+
+function _emitSocketProgress (uppyInstance, progressData, file) {
+  const {progress, bytesUploaded, bytesTotal} = progressData
+  if (progress) {
+    uppyInstance.core.log(`Upload progress: ${progress}`)
+    uppyInstance.core.emitter.emit('core:upload-progress', {
+      uploader: uppyInstance,
+      id: file.id,
+      bytesUploaded: bytesUploaded,
+      bytesTotal: bytesTotal
+    })
+  }
+}
+
+const emitSocketProgress = throttle(_emitSocketProgress, 300, {leading: true, trailing: true})
+
 module.exports = {
   generateFileID,
   toArray,
@@ -377,5 +402,7 @@ module.exports = {
   // makeCachingFunction,
   copyToClipboard,
   prettyETA,
-  findDOMElement
+  findDOMElement,
+  getSocketHost,
+  emitSocketProgress
 }

--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -160,7 +160,12 @@ module.exports = class Multipart extends Plugin {
     filesForUpload.forEach((file, i) => {
       const current = parseInt(i, 10) + 1
       const total = filesForUpload.length
-      file.isRemote ? this.uploadRemote(file, current, total) : this.upload(file, current, total)
+
+      if (file.isRemote) {
+        this.uploadRemote(file, current, total)
+      } else {
+        this.upload(file, current, total)
+      }
     })
 
     //   if (this.opts.bundle) {


### PR DESCRIPTION
This is a fix for [#160](https://github.com/transloadit/uppy/issues/160). It enables Multipart uploads for remote files (e.g Google drive files, etc). @goto-bus-stop do you mind reviewing this?