### PR TITLE
Allow configurable FileInput input name

### DIFF
--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -22,7 +22,8 @@ module.exports = class FileInput extends Plugin {
       replaceTargetContent: true,
       multipleFiles: true,
       pretty: true,
-      locale: defaultLocale
+      locale: defaultLocale,
+      inputName: 'files[]'
     }
 
     // Merge default options with the ones set by user
@@ -59,7 +60,7 @@ module.exports = class FileInput extends Plugin {
     const input = html`<input class="uppy-FileInput-input"
            style="${this.opts.pretty ? hiddenInputStyle : ''}"
            type="file"
-           name="files[]"
+           name=${this.opts.inputName}
            onchange=${this.handleInputChange.bind(this)}
            multiple="${this.opts.multipleFiles ? 'true' : 'false'}"
            value="">`

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -3,5 +3,6 @@ require('isomorphic-fetch')
 require('./core.spec.js')
 require('./translator.spec.js')
 require('./Transloadit.spec.js')
+require('./plugins/FileInput.spec.js')
 // TODO: enable once getFile error is fixed
 // require('./GoogleDrive.spec.js')

--- a/test/unit/plugins/FileInput.spec.js
+++ b/test/unit/plugins/FileInput.spec.js
@@ -1,0 +1,12 @@
+import test from 'tape'
+import FileInput from '../../../src/plugins/FileInput'
+
+test('FileInput plugin: options', function (t) {
+  let fi = new FileInput()
+  t.equal(fi.opts.inputName, 'files[]', 'inputName defaults to files[]')
+
+  fi = new FileInput(null, { inputName: 'upload' })
+  t.equal(fi.opts.inputName, 'upload', 'inputName can be overridden')
+
+  t.end()
+})


### PR DESCRIPTION
Allow a configurable input name in the FileInput plugin with a default of `files[]`. This functionality matches the Multipart plugin.

Add basic unit tests for `inputName` FileInput constructor option.