### PR TITLE
[WIP] Improve the look of FileItem component and file type icons

### DIFF
--- a/src/plugins/Dashboard/FileCard.js
+++ b/src/plugins/Dashboard/FileCard.js
@@ -45,12 +45,13 @@ module.exports = function fileCard (props) {
     </div>
     ${props.fileCardFor
       ? html`<div class="UppyDashboardFileCard-inner">
-          <div class="UppyDashboardFileCard-preview">
+          <div class="UppyDashboardFileCard-preview" style="background-color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
             ${file.preview
               ? html`<img alt="${file.name}" src="${file.preview}">`
-              : html`<div class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
-                  ${getFileTypeIcon(file.type.general, file.type.specific).icon}
-                </div>`
+              : html`<div class="UppyDashboardItem-previewIconWrap">
+                <span class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">${getFileTypeIcon(file.type.general, file.type.specific).icon}</span>
+                <svg class="UppyDashboardItem-previewIconBg" width="72" height="93" viewBox="0 0 72 93"><g><path d="M24.08 5h38.922A2.997 2.997 0 0 1 66 8.003v74.994A2.997 2.997 0 0 1 63.004 86H8.996A2.998 2.998 0 0 1 6 83.01V22.234L24.08 5z" fill="#FFF"/><path d="M24 5L6 22.248h15.007A2.995 2.995 0 0 0 24 19.244V5z" fill="#E4E4E4"/></g></svg>
+              </div>`
             }
           </div>
           <div class="UppyDashboardFileCard-info">

--- a/src/plugins/Dashboard/FileItem.js
+++ b/src/plugins/Dashboard/FileItem.js
@@ -29,7 +29,7 @@ module.exports = function fileItem (props) {
                         ${props.resumableUploads ? 'is-resumable' : ''}"
                   id="uppy_${file.id}"
                   title="${file.meta.name}">
-      <div class="UppyDashboardItem-preview">
+      <div class="UppyDashboardItem-preview" style="background-color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
         ${file.source
           ? html`<div class="UppyDashboardItem-sourceIcon">
             ${acquirers.map(acquirer => {
@@ -40,8 +40,9 @@ module.exports = function fileItem (props) {
         }
         ${file.preview
           ? html`<img alt="${file.name}" src="${file.preview}">`
-          : html`<div class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
-              ${getFileTypeIcon(file.type.general, file.type.specific).icon}
+          : html`<div class="UppyDashboardItem-previewIconWrap">
+              <span class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">${getFileTypeIcon(file.type.general, file.type.specific).icon}</span>
+              <svg class="UppyDashboardItem-previewIconBg" width="72" height="93" viewBox="0 0 72 93"><g><path d="M24.08 5h38.922A2.997 2.997 0 0 1 66 8.003v74.994A2.997 2.997 0 0 1 63.004 86H8.996A2.998 2.998 0 0 1 6 83.01V22.234L24.08 5z" fill="#FFF"/><path d="M24 5L6 22.248h15.007A2.995 2.995 0 0 0 24 19.244V5z" fill="#E4E4E4"/></g></svg>
             </div>`
         }
         <div class="UppyDashboardItem-progress">

--- a/src/plugins/Dashboard/FileItem.js
+++ b/src/plugins/Dashboard/FileItem.js
@@ -29,7 +29,7 @@ module.exports = function fileItem (props) {
                         ${props.resumableUploads ? 'is-resumable' : ''}"
                   id="uppy_${file.id}"
                   title="${file.meta.name}">
-      <div class="UppyDashboardItem-preview" style="background-color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
+      <div class="UppyDashboardItem-preview">
         ${file.source
           ? html`<div class="UppyDashboardItem-sourceIcon">
             ${acquirers.map(acquirer => {
@@ -38,13 +38,15 @@ module.exports = function fileItem (props) {
           </div>`
           : ''
         }
-        ${file.preview
-          ? html`<img alt="${file.name}" src="${file.preview}">`
-          : html`<div class="UppyDashboardItem-previewIconWrap">
-              <span class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">${getFileTypeIcon(file.type.general, file.type.specific).icon}</span>
-              <svg class="UppyDashboardItem-previewIconBg" width="72" height="93" viewBox="0 0 72 93"><g><path d="M24.08 5h38.922A2.997 2.997 0 0 1 66 8.003v74.994A2.997 2.997 0 0 1 63.004 86H8.996A2.998 2.998 0 0 1 6 83.01V22.234L24.08 5z" fill="#FFF"/><path d="M24 5L6 22.248h15.007A2.995 2.995 0 0 0 24 19.244V5z" fill="#E4E4E4"/></g></svg>
-            </div>`
-        }
+        <div class="UppyDashboardItem-previewInnerWrap" style="background-color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">
+          ${file.preview
+            ? html`<img alt="${file.name}" src="${file.preview}">`
+            : html`<div class="UppyDashboardItem-previewIconWrap">
+                <span class="UppyDashboardItem-previewIcon" style="color: ${getFileTypeIcon(file.type.general, file.type.specific).color}">${getFileTypeIcon(file.type.general, file.type.specific).icon}</span>
+                <svg class="UppyDashboardItem-previewIconBg" width="72" height="93" viewBox="0 0 72 93"><g><path d="M24.08 5h38.922A2.997 2.997 0 0 1 66 8.003v74.994A2.997 2.997 0 0 1 63.004 86H8.996A2.998 2.998 0 0 1 6 83.01V22.234L24.08 5z" fill="#FFF"/><path d="M24 5L6 22.248h15.007A2.995 2.995 0 0 0 24 19.244V5z" fill="#E4E4E4"/></g></svg>
+              </div>`
+          }
+        </div>
         <div class="UppyDashboardItem-progress">
           <button class="UppyDashboardItem-progressBtn"
                   title="${isUploaded

--- a/src/plugins/Dashboard/getFileTypeIcon.js
+++ b/src/plugins/Dashboard/getFileTypeIcon.js
@@ -29,8 +29,15 @@ module.exports = function getIconByMime (fileTypeGeneral, fileTypeSpecific) {
     }
   }
 
+  if (fileTypeGeneral === 'image') {
+    return {
+      color: '#f2f2f2',
+      icon: ''
+    }
+  }
+
   return {
-    color: '#ccc',
+    color: '#cbcbcb',
     icon: ''
   }
 }

--- a/src/plugins/Dashboard/getFileTypeIcon.js
+++ b/src/plugins/Dashboard/getFileTypeIcon.js
@@ -1,4 +1,4 @@
-const { iconText, iconFile, iconAudio, iconVideo, iconPDF } = require('./icons')
+const { iconText, iconAudio, iconVideo, iconPDF } = require('./icons')
 
 module.exports = function getIconByMime (fileTypeGeneral, fileTypeSpecific) {
   if (fileTypeGeneral === 'text') {
@@ -30,7 +30,7 @@ module.exports = function getIconByMime (fileTypeGeneral, fileTypeSpecific) {
   }
 
   return {
-    color: '#000',
-    icon: iconFile()
+    color: '#ccc',
+    icon: ''
   }
 }

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -285,7 +285,7 @@
   left: 0;
   right: 0;
   transform: translateY(-105%);
-  transition: transform 0.25s ease-in-out;
+  transition: transform 0.2s ease-in-out;
   will-change: transform;
   background-color: darken($color-white, 4%);
   box-shadow: 0 0 10px 5px rgba($color-black, 0.15);
@@ -438,7 +438,7 @@
 }
 
 .UppyDashboardItem-preview {
-  overflow: hidden;
+  // overflow: hidden;
   width: 60px;
   height: 60px;
   border-bottom: 0;
@@ -451,23 +451,20 @@
   .UppyDashboard--wide & {
     width: 100%;
     height: 100px;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    // border-bottom: 1px solid rgba($color-gray, 0.2);
     border: 0;
   }
 }
 
-  .UppyDashboardItem-preview:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba($color-black, 0.65);
-    display: none;
-  }
+  // .UppyDashboardItem-preview:after {
+  //   content: '';
+  //   position: absolute;
+  //   top: 0;
+  //   bottom: 0;
+  //   left: 0;
+  //   right: 0;
+  //   background-color: rgba($color-black, 0.65);
+  //   display: none;
+  // }
 
 .UppyDashboardItem-sourceIcon {
   color: rgba($color-white, 0.95);
@@ -476,11 +473,38 @@
   left: 8px;
   width: 15px;
   height: 15px;
+  z-index: $zIndex-3;
 }
+
+.UppyDashboardItem-previewInnerWrap {
+  width: 100%;
+  height: 100%;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+  .UppyDashboardItem-previewInnerWrap:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba($color-black, 0.65);
+    display: none;
+    z-index: $zIndex-2;
+  }
 
 .UppyDashboardItem-sourceIcon .UppyIcon {
   filter: drop-shadow(0 0 1px rgba(0,0,0,.4));
 }
+
 
 .UppyDashboardItem-preview img {
   width: 100%;
@@ -488,24 +512,29 @@
   object-fit: cover;
 }
 
+
 .UppyDashboardItem-previewIconWrap {
-  height: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  height: 85%;
+  position: relative;
 }
 
 .UppyDashboardItem-previewIconBg {
-  position: absolute;
-  height: 75%;
-  z-index: $zIndex-1;
+  height: 100%;
   filter: drop-shadow(rgba(0, 0, 0, 0.1) 0px 0px 1px);
+  // position: absolute;
+  // z-index: $zIndex-1;
 }
 
 .UppyDashboardItem-previewIcon {
-  width: 34px;
-  height: 26px;
-  z-index: $zIndex-2;
+  // width: 34px;
+  // height: 26px;
+  width: 40%;
+  max-height: 80%;
+  z-index: $zIndex-1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .UppyDashboardItem-info {
@@ -602,6 +631,7 @@
   position: absolute;
   top: 8px;
   right: 5px;
+  z-index: $zIndex-3;
 
   .UppyDashboard--wide & {
     top: -8px;
@@ -636,12 +666,20 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: $zIndex-2;
+  z-index: $zIndex-3;
   color: $color-white;
   text-align: center;
   width: 120px;
   display: none;
 }
+
+  .UppyDashboardItem.is-complete .UppyDashboardItem-progress {
+    transform: initial;
+    top: -10px;
+    right: -10px;
+    left: initial;
+    width: auto;
+  }
 
   .UppyDashboardItem.is-inprogress .UppyDashboardItem-progress,
   .UppyDashboardItem.is-complete .UppyDashboardItem-progress {
@@ -660,6 +698,17 @@
     height: 55px;
   }
 }
+
+  .UppyDashboardItem.is-complete .UppyDashboardItem-progressBtn {
+    width: 15px;
+    height: 15px;
+    opacity: 1;
+
+    .UppyDashboard--wide & {
+      width: 25px;
+      height: 25px;
+    }
+  }
 
 .UppyDashboardItem-progressInfo {
   font-size: 9px;
@@ -734,7 +783,7 @@
     opacity: 1;
   }
 
-  .UppyDashboardItem-preview:after {
+  .UppyDashboardItem-previewInnerWrap:after {
     display: block;
   }
 }
@@ -753,9 +802,9 @@
     cursor: default;
   }
 
-  .UppyDashboardItem-preview:after {
-    display: block;
-  }
+  // .UppyDashboardItem-previewInnerWrap:after {
+  //   display: block;
+  // }
 
   .progress {
     stroke: $color-green;
@@ -965,6 +1014,7 @@
   justify-content: center;
   border-bottom: 1px solid rgba($color-gray, 0.3);
   background-color: lighten($color-gray, 40%);
+  position: relative;
 }
 
 .UppyDashboardFileCard-preview img {

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -456,11 +456,18 @@
 .UppyDashboardItem-sourceIcon {
   color: rgba($color-white, 0.95);
   position: absolute;
-  top: 8px;
+  top: 4px;
+  left: 4px;
+  width: 10px;
+  height: 10px;
+  z-index: $zIndex-3;
+
+  .UppyDashboard--wide & {
+    top: 8px;
   left: 8px;
   width: 15px;
   height: 15px;
-  z-index: $zIndex-3;
+  }
 }
 
 .UppyDashboardItem-previewInnerWrap {

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -155,7 +155,7 @@
 
   .UppyDashboard--wide & {
     margin: 0 5px;
-    width: 70px;
+    width: 75px;
   }
 }
 
@@ -422,23 +422,22 @@
   margin: 10px 0;
   position: relative;
   background-color: $color-white;
-  // border: 1px solid rgba($color-gray, 0.2);
   display: flex;
   align-items: center;
+  border: 1px solid rgba($color-gray, 0.2);
 
   .UppyDashboard--wide & {
-    // display: block;
     flex-direction: column;
     float: left;
     width: 140px;
     height: 170px;
     margin: 15px 21px;
     border-radius: 6px;
+    border: 0;
   }
 }
 
 .UppyDashboardItem-preview {
-  // overflow: hidden;
   width: 60px;
   height: 60px;
   border-bottom: 0;
@@ -446,7 +445,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border-right: 1px solid rgba($color-gray, 0.2);
 
   .UppyDashboard--wide & {
     width: 100%;
@@ -454,17 +452,6 @@
     border: 0;
   }
 }
-
-  // .UppyDashboardItem-preview:after {
-  //   content: '';
-  //   position: absolute;
-  //   top: 0;
-  //   bottom: 0;
-  //   left: 0;
-  //   right: 0;
-  //   background-color: rgba($color-black, 0.65);
-  //   display: none;
-  // }
 
 .UppyDashboardItem-sourceIcon {
   color: rgba($color-white, 0.95);
@@ -479,14 +466,17 @@
 .UppyDashboardItem-previewInnerWrap {
   width: 100%;
   height: 100%;
-  border-top-left-radius: 6px;
-  border-top-right-radius: 6px;
   overflow: hidden;
   position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
+
+  .UppyDashboard--wide & {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+  }
 }
 
   .UppyDashboardItem-previewInnerWrap:after {
@@ -521,20 +511,23 @@
 .UppyDashboardItem-previewIconBg {
   height: 100%;
   filter: drop-shadow(rgba(0, 0, 0, 0.1) 0px 0px 1px);
-  // position: absolute;
-  // z-index: $zIndex-1;
 }
 
 .UppyDashboardItem-previewIcon {
   // width: 34px;
   // height: 26px;
-  width: 40%;
-  max-height: 80%;
+  width: 25%;
+  max-height: 55%;
   z-index: $zIndex-1;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+
+  .UppyDashboard--wide & {
+    width: 40%;
+    max-height: 80%;
+  }
 }
 
 .UppyDashboardItem-info {
@@ -671,6 +664,7 @@
   text-align: center;
   width: 120px;
   display: none;
+  transition: all .35 ease;
 }
 
   .UppyDashboardItem.is-complete .UppyDashboardItem-progress {
@@ -692,6 +686,7 @@
   height: 38px;
   opacity: 0.9;
   cursor: pointer;
+  transition: all .35s ease;
 
   .UppyDashboard--wide & {
     width: 55px;
@@ -922,6 +917,7 @@
   position: absolute;
   bottom: 16px;
   right: 16px;
+  z-index: $zIndex-3;
 
   .UppyDashboard--wide & {
     bottom: 20px;

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -464,10 +464,14 @@
 
   .UppyDashboard--wide & {
     top: 8px;
-  left: 8px;
-  width: 15px;
-  height: 15px;
+    left: 8px;
+    width: 15px;
+    height: 15px;
   }
+}
+
+.UppyDashboardItem-sourceIcon .UppyIcon {
+  filter: drop-shadow(0 0 1px rgba(0,0,0,.15));
 }
 
 .UppyDashboardItem-previewInnerWrap {
@@ -497,10 +501,6 @@
     display: none;
     z-index: $zIndex-2;
   }
-
-.UppyDashboardItem-sourceIcon .UppyIcon {
-  filter: drop-shadow(0 0 1px rgba(0,0,0,.4));
-}
 
 
 .UppyDashboardItem-preview img {

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -422,12 +422,13 @@
   margin: 10px 0;
   position: relative;
   background-color: $color-white;
-  border: 1px solid rgba($color-gray, 0.2);
+  // border: 1px solid rgba($color-gray, 0.2);
   display: flex;
   align-items: center;
 
   .UppyDashboard--wide & {
-    display: block;
+    // display: block;
+    flex-direction: column;
     float: left;
     width: 140px;
     height: 170px;
@@ -452,8 +453,8 @@
     height: 100px;
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
-    border-bottom: 1px solid rgba($color-gray, 0.2);
-    border-right: 0;
+    // border-bottom: 1px solid rgba($color-gray, 0.2);
+    border: 0;
   }
 }
 
@@ -487,16 +488,24 @@
   object-fit: cover;
 }
 
-.UppyDashboardItem-previewIcon {
+.UppyDashboardItem-previewIconWrap {
   height: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.UppyDashboardItem-previewIcon .UppyIcon {
-  width: 100%;
-  height: 100%;
+.UppyDashboardItem-previewIconBg {
+  position: absolute;
+  height: 75%;
+  z-index: $zIndex-1;
+  filter: drop-shadow(rgba(0, 0, 0, 0.1) 0px 0px 1px);
+}
+
+.UppyDashboardItem-previewIcon {
+  width: 34px;
+  height: 26px;
+  z-index: $zIndex-2;
 }
 
 .UppyDashboardItem-info {
@@ -505,8 +514,14 @@
   max-width: 70%;
 
   .UppyDashboard--wide & {
+    width: 100%;
     max-width: 100%;
-    height: 60px;
+    flex: 1;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border: 1px solid rgba($color-gray, 0.2);
+    border-top: 0;
+    // height: 60px;
   }
 }
 


### PR DESCRIPTION
Originally suggested by @nqst and needed to make sure source icon (the one that’s showing where the file is coming from, Dropbox or Google Drive) is visible. As well as possibly just make the UI nicer.

Design:

![service-logos](https://cloud.githubusercontent.com/assets/1199054/26790686/93f4f10c-49e2-11e7-8f94-56039054f688.png)

Current reality (notice excess borders have also been removed):

<img width="748" alt="screen shot 2017-06-05 at 11 29 18 am" src="https://cloud.githubusercontent.com/assets/1199054/26790611/55812b8e-49e2-11e7-9445-4beb6451fa02.png">
