### PR TITLE
Show fatal upload errors in the dashboard StatusBar

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -280,6 +280,13 @@ class Uppy {
     //   this.setState({bla: 'bla'})
     // }, 20)
 
+    this.on('core:error', (error) => {
+      this.setState({ error })
+    })
+    this.on('core:upload', () => {
+      this.setState({ error: null })
+    })
+
     this.on('core:file-add', (data) => {
       this.addFile(data)
     })

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -142,6 +142,7 @@ module.exports = function Dashboard (props) {
 
         <div class="UppyDashboard-progressindicators">
           ${StatusBar({
+            error: props.state.error,
             totalProgress: props.totalProgress,
             totalFileCount: props.totalFileCount,
             totalSize: props.totalSize,

--- a/src/plugins/Dashboard/StatusBar.js
+++ b/src/plugins/Dashboard/StatusBar.js
@@ -7,6 +7,7 @@ function progressDetails (props) {
 
 const throttledProgressDetails = throttle(progressDetails, 1000, {leading: true, trailing: true})
 
+const STATE_ERROR = 'error'
 const STATE_WAITING = 'waiting'
 const STATE_PREPROCESSING = 'preprocessing'
 const STATE_UPLOADING = 'uploading'
@@ -14,6 +15,10 @@ const STATE_POSTPROCESSING = 'postprocessing'
 const STATE_COMPLETE = 'complete'
 
 function getUploadingState (props, files) {
+  if (props.error) {
+    return STATE_ERROR
+  }
+
   // If ALL files have been completed, show the completed state.
   if (props.isAllComplete) {
     return STATE_COMPLETE
@@ -60,6 +65,8 @@ module.exports = (props) => {
     progressBarContent = ProgressBarComplete(props)
   } else if (uploadState === STATE_UPLOADING) {
     progressBarContent = ProgressBarUploading(props)
+  } else if (uploadState === STATE_ERROR) {
+    progressBarContent = ProgressBarError(props)
   }
 
   const width = typeof progressValue === 'number' ? progressValue : 100
@@ -128,6 +135,16 @@ const ProgressBarComplete = ({ totalProgress }) => {
           <path d="M8.944 17L0 7.865l2.555-2.61 6.39 6.525L20.41 0 23 2.645z" />
         </svg>
         Upload complete・${totalProgress}%
+      </span>
+    </div>
+  `
+}
+
+const ProgressBarError = ({ error }) => {
+  return html`
+    <div class="UppyDashboard-statusBarContent">
+      <span>
+        ${error.message}
       </span>
     </div>
   `

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -273,6 +273,11 @@ module.exports = class Transloadit extends Plugin {
         // Remove this handler once we find the assembly we needed.
         this.core.emitter.off('transloadit:assembly-error', onAssemblyError)
 
+        // Clear postprocessing state for all our files.
+        fileIDs.forEach((fileID) => {
+          this.core.emit('core:postprocess-complete', fileID)
+        })
+
         // Reject the `afterUpload()` promise.
         reject(error)
       }

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -1123,6 +1123,10 @@
   background-color: $color-green;
 }
 
+.UppyDashboard-statusBar.is-error .UppyDashboard-statusBarProgress {
+  background-color: $color-red;
+}
+
 .UppyDashboard-statusBar.is-complete .UppyDashboard-statusBarContent {
   text-align: center;
   padding-left: 0;


### PR DESCRIPTION
When an upload fails in a way that causes `upload()` to reject, the error is stored in the state and displayed in the StatusBar w/ a red background. When a new upload is started, the error state is cleared.

![error](https://user-images.githubusercontent.com/1006268/26927115-c95d1b9c-4c50-11e7-9866-dc8949563ea1.gif)