### PR TITLE
multipart: Add `headers` option, fixes #159.

### DIFF
--- a/src/plugins/Multipart.js
+++ b/src/plugins/Multipart.js
@@ -13,7 +13,8 @@ module.exports = class Multipart extends Plugin {
     const defaultOptions = {
       fieldName: 'files[]',
       responseUrlFieldName: 'url',
-      bundle: true
+      bundle: true,
+      headers: {}
     }
 
     // Merge default options with the ones set by user
@@ -87,6 +88,11 @@ module.exports = class Multipart extends Plugin {
       })
 
       xhr.open('POST', this.opts.endpoint, true)
+
+      Object.keys(this.opts.headers).forEach((header) => {
+        xhr.setRequestHeader(header, this.opts.headers[header])
+      })
+
       xhr.send(formPost)
 
       this.core.emitter.on('core:upload-cancel', (fileID) => {


### PR DESCRIPTION
This adds a `headers` option that takes an Object. Key/value pairs
are added as HTTP headers on each upload request.