### PR TITLE
core: set bytesUploaded/bytesTotal as soon as the file is added

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -169,6 +169,8 @@ class Uppy {
         data: file.data,
         progress: {
           percentage: 0,
+          bytesUploaded: 0,
+          bytesTotal: file.data.size || 0,
           uploadComplete: false,
           uploadStarted: false
         },


### PR DESCRIPTION
This fixes an issue with the upload ETA sometimes being `NaN`. These
properties would be undefined when some files did not yet emit progress
events, blowing up the ETA calculation.