### PR TITLE
statusbar: Don't throttle progress bar updates

### DIFF
--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -1,11 +1,8 @@
 const html = require('yo-yo')
-const throttle = require('lodash.throttle')
 
 function progressDetails (props) {
   return html`<span>${props.totalProgress || 0}%・${props.complete} / ${props.inProgress}・${props.totalUploadedSize} / ${props.totalSize}・↑ ${props.totalSpeed}/s・${props.totalETA}</span>`
 }
-
-const throttledProgressDetails = throttle(progressDetails, 1000, {leading: true, trailing: true})
 
 const STATE_ERROR = 'error'
 const STATE_WAITING = 'waiting'
@@ -129,7 +126,7 @@ const ProgressBarUploading = (props) => {
     <div class="UppyStatusBar-content">
       ${props.isUploadStarted && !props.isAllComplete
         ? !props.isAllPaused
-          ? html`<span title="Uploading">${pauseResumeButtons(props)} Uploading... ${throttledProgressDetails(props)}</span>`
+          ? html`<span title="Uploading">${pauseResumeButtons(props)} Uploading... ${progressDetails(props)}</span>`
           : html`<span title="Paused">${pauseResumeButtons(props)} Paused・${props.totalProgress}%</span>`
         : null
         }


### PR DESCRIPTION
This shouldn't be necessary (anymore), we already [throttle
progress updates in core](https://github.com/transloadit/uppy/blob/5de51770c26066b858d6370b6dfa50cb8c934525/src/core/Core.js#L317).

This throttle also applied to only a part of the StatusBar, so the blue
progress bar in the background would still update quickly, while the
text would only update once per second.