### PR TITLE
transloadit: Emit event when assembly is created; add assembly data to existing events.

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -109,6 +109,8 @@ module.exports = class Transloadit extends Plugin {
 
       this.core.setState({ files })
 
+      this.core.emit('transloadit:assembly', assembly, Object.keys(filesToUpload))
+
       return this.connectSocket(assembly)
     }).then(() => {
       this.core.log('Transloadit: Created assembly')


### PR DESCRIPTION
The `transloadit:assembly` event is emitted when an assembly is created.
It receives the assembly data in the first parameter, and the file IDs
of the files that it belongs to in the second parameter.

```js
uppy.on('transloadit:assembly', (assembly, fileIDs) => {
  const files = fileIDs.map((id) => uppy.getState().files[id])
  console.log({ assembly, files })
})
```

This also adds a new parameter to the `transloadit:upload` and
`transloadit:result` events, containing the assembly data.

```js
uppy.on('transloadit:upload', (file, assembly) => {
  console.log('an upload was completed with template id', assembly.template_id)
})
```

```js
uppy.on('transloadit:result', (stepName, result, assembly) => {
  console.log(`${stepName}:`, result, 'from', assembly)
})
```