### PR TITLE
core: Only catch errors from `onBeforeUpload`

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -230,7 +230,10 @@ class Uppy {
   }
 
   addFile (file) {
-    return this.opts.onBeforeFileAdded(file, this.getState().files).then(() => {
+    return this.opts.onBeforeFileAdded(file, this.getState().files).catch((err) => {
+      this.emit('informer', err, 'error', 5000)
+      return Promise.reject(`onBeforeFileAdded: ${err}`)
+    }).then(() => {
       return Utils.getFileType(file).then((fileType) => {
         const updatedFiles = Object.assign({}, this.state.files)
         const fileName = file.name || 'noname'
@@ -287,10 +290,6 @@ class Uppy {
           }, 4)
         }
       })
-    })
-    .catch((err) => {
-      this.emit('informer', err, 'error', 5000)
-      return Promise.reject(`onBeforeFileAdded: ${err}`)
     })
   }
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -669,7 +669,10 @@ class Uppy {
       return Promise.reject('Minimum number of files has not been reached')
     }
 
-    return this.opts.onBeforeUpload(this.getState().files).then(() => {
+    return this.opts.onBeforeUpload(this.getState().files).catch((err) => {
+      this.emit('informer', err, 'error', 5000)
+      return Promise.reject(`onBeforeUpload: ${err}`)
+    }).then(() => {
       this.emit('core:upload')
 
       const waitingFileIDs = []
@@ -699,10 +702,6 @@ class Uppy {
         // return number of uploaded files
         this.emit('core:success', waitingFileIDs)
       })
-    })
-    .catch((err) => {
-      this.emit('informer', err, 'error', 5000)
-      return Promise.reject(`onBeforeUpload: ${err}`)
     })
   }
 }


### PR DESCRIPTION
Previously this code would treat any error at all as an `onBeforeUpload`
error, and show the informer. We also lost the stack trace for errors
because `err` is stringified in the handler. This is correct for
`onBeforeUpload` rejections, since they are string reasons, but not for
other errors.

Now only actual `onBeforeUpload` errors are handled that way, and fatal
upload errors end up in the StatusBar like before and in the console,
with a stack trace.