### PR TITLE
Dynamic Transloadit assembly options

### DIFF
--- a/test/unit/Transloadit.spec.js
+++ b/test/unit/Transloadit.spec.js
@@ -59,3 +59,93 @@ test('Transloadit: Validates response from getAssemblyOptions()', (t) => {
     })
   }, t.fail)
 })
+
+test('Transloadit: Uses different assemblies for different params', (t) => {
+  t.plan(5)
+
+  const uppy = new Core({ autoProceed: false })
+
+  uppy.use(Transloadit, {
+    getAssemblyOptions: (file) => ({
+      params: {
+        auth: { key: 'fake key' },
+        steps: {
+          fake_step: { data: file.name }
+        }
+      }
+    })
+  })
+
+  const tl = uppy.getPlugin('Transloadit')
+  const files = ['a.png', 'b.png', 'c.png', 'd.png']
+  let i = 0
+  tl.client.createAssembly = (opts) => {
+    t.equal(opts.params.steps.fake_step.data, files[i], `assembly for file ${files[i]}`)
+    i++
+    // Short-circuit upload
+    return Promise.reject('short-circuit')
+  }
+
+  const data = Buffer.alloc(10)
+  data.size = data.byteLength
+
+  Promise.all([
+    uppy.addFile({ name: 'a.png', data }),
+    uppy.addFile({ name: 'b.png', data }),
+    uppy.addFile({ name: 'c.png', data }),
+    uppy.addFile({ name: 'd.png', data })
+  ]).then(() => {
+    uppy.upload().then(t.fail, () => {
+      t.equal(i, 4, 'created 4 assemblies')
+      t.end()
+    })
+  }, t.fail)
+})
+
+test('Transloadit: Should merge files with same parameters into one assembly', (t) => {
+  t.plan(3)
+
+  const uppy = new Core({ autoProceed: false })
+
+  uppy.use(Transloadit, {
+    getAssemblyOptions: (file) => ({
+      params: {
+        auth: { key: 'fake key' },
+        steps: {
+          fake_step: { data: file.size }
+        }
+      }
+    })
+  })
+
+  const tl = uppy.getPlugin('Transloadit')
+  const assemblies = [
+    { data: 10, files: ['a.png', 'b.png', 'c.png'] },
+    { data: 20, files: ['d.png'] }
+  ]
+  let i = 0
+  tl.client.createAssembly = (opts) => {
+    const assembly = assemblies[i]
+    t.equal(opts.params.steps.fake_step.data, assembly.data, `assembly for files ${assembly.files.join(',')}`)
+    i++
+    // Short-circuit upload
+    return Promise.reject('short-circuit')
+  }
+
+  const data = Buffer.alloc(10)
+  data.size = data.byteLength
+  const data2 = Buffer.alloc(20)
+  data2.size = data2.byteLength
+
+  Promise.all([
+    uppy.addFile({ name: 'a.png', data }),
+    uppy.addFile({ name: 'b.png', data }),
+    uppy.addFile({ name: 'c.png', data }),
+    uppy.addFile({ name: 'd.png', data: data2 })
+  ]).then(() => {
+    uppy.upload().then(t.fail, () => {
+      t.equal(i, 2, 'created two assemblies')
+      t.end()
+    })
+  }, t.fail)
+})


### PR DESCRIPTION
This patch adds a `getAssemblyOptions` function option to the
Transloadit plugin. This option can return an object or a Promise for an
object to configure the Transloadit assembly. The returned object can
contain `params`, a `signature`, and `fields`.

`getAssemblyOptions` is called on each file, so each file can return a
different set of options. Files that returned the same options are
bundled together and run through a single assembly. Files that return
different options will be run through different assemblies.

This means that it is now possible to make assembly parameters depend on
user input from eg. the MetaData plugin, and have different parameters
for different files. It's now also possible to generate very short-lived
signatures on the server when an upload starts, by calling `fetch` inside the
`getAssemblyOptions` hook.