### PR TITLE
transloadit: Fix sending fields to an assembly

### DIFF
--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -27,7 +27,9 @@ module.exports = class Client {
       data.append('signature', signature)
     }
 
-    data.append('fields', JSON.stringify(fields))
+    Object.keys(fields).forEach((key) => {
+      data.append(key, fields[key])
+    })
     data.append('tus_num_expected_upload_files', expectedFiles)
 
     return fetch(`${this.apiUrl}/assemblies`, {


### PR DESCRIPTION
Previously this was sending a `fields` field with a JSON string, but
that's not how it works. Instead we should send separate form
fields for each field.

(Thanks @Acconut!)