### PR TITLE
Use self-identified uppy-server address

### DIFF
--- a/src/generic-provider-views/AuthView.js
+++ b/src/generic-provider-views/AuthView.js
@@ -1,8 +1,9 @@
 const html = require('yo-yo')
+const onload = require('on-load')
 
 module.exports = (props) => {
   const demoLink = props.demo ? html`<button class="UppyProvider-authBtnDemo" onclick=${props.handleDemoAuth}>Proceed with Demo Account</button>` : null
-  return html`
+  return onload(html`
     <div class="UppyProvider-auth">
       <h1 class="UppyProvider-authTitle">
         Please authenticate with <span class="UppyProvider-authTitleName">${props.pluginName}</span><br> to select files
@@ -10,5 +11,5 @@ module.exports = (props) => {
       <button type="button" class="UppyProvider-authBtn" onclick=${props.handleAuth}>Authenticate</button>
       ${demoLink}
     </div>
-  `
+  `, props.checkAuth, null, `auth${props.pluginName}`)
 }

--- a/src/generic-provider-views/index.js
+++ b/src/generic-provider-views/index.js
@@ -61,6 +61,7 @@ module.exports = class View {
     this.getFolder = this.getFolder.bind(this)
     this.getNextFolder = this.getNextFolder.bind(this)
     this.logout = this.logout.bind(this)
+    this.checkAuth = this.checkAuth.bind(this)
     this.handleAuth = this.handleAuth.bind(this)
     this.handleDemoAuth = this.handleDemoAuth.bind(this)
     this.sortByTitle = this.sortByTitle.bind(this)
@@ -93,6 +94,12 @@ module.exports = class View {
     })
 
     this.updateState({ folders, files })
+  }
+
+  checkAuth () {
+    this.Provider.auth()
+      .then(this.plugin.onAuth)
+      .catch(this.handleError)
   }
 
   /**
@@ -358,6 +365,7 @@ module.exports = class View {
       return AuthView({
         pluginName: this.plugin.title,
         demo: this.plugin.opts.demo,
+        checkAuth: this.checkAuth,
         handleAuth: this.handleAuth,
         handleDemoAuth: this.handleDemoAuth
       })

--- a/src/plugins/Dropbox/index.js
+++ b/src/plugins/Dropbox/index.js
@@ -61,10 +61,6 @@ module.exports = class Dropbox extends Plugin {
     const target = this.opts.target
     const plugin = this
     this.target = this.mount(target, plugin)
-
-    this[this.id].auth().then(this.onAuth).catch(this.view.handleError)
-
-    return
   }
 
   uninstall () {

--- a/src/plugins/Dropbox/index.js
+++ b/src/plugins/Dropbox/index.js
@@ -23,7 +23,7 @@ module.exports = class Dropbox extends Plugin {
 
     // writing out the key explicitly for readability the key used to store
     // the provider instance must be equal to this.id.
-    this.Dropbox = new Provider({
+    this.Dropbox = new Provider(core, {
       host: this.opts.host,
       provider: 'dropbox'
     })

--- a/src/plugins/GoogleDrive/index.js
+++ b/src/plugins/GoogleDrive/index.js
@@ -59,10 +59,6 @@ module.exports = class Google extends Plugin {
     const target = this.opts.target
     const plugin = this
     this.target = this.mount(target, plugin)
-
-    // catch error here.
-    this[this.id].auth().then(this.onAuth).catch(this.view.handleError)
-    return
   }
 
   uninstall () {

--- a/src/plugins/GoogleDrive/index.js
+++ b/src/plugins/GoogleDrive/index.js
@@ -20,7 +20,7 @@ module.exports = class Google extends Plugin {
 
     // writing out the key explicitly for readability the key used to store
     // the provider instance must be equal to this.id.
-    this.GoogleDrive = new Provider({
+    this.GoogleDrive = new Provider(core, {
       host: this.opts.host,
       provider: 'drive',
       authProvider: 'google'

--- a/src/plugins/Instagram/index.js
+++ b/src/plugins/Instagram/index.js
@@ -65,10 +65,6 @@ module.exports = class Instagram extends Plugin {
     const target = this.opts.target
     const plugin = this
     this.target = this.mount(target, plugin)
-
-    // catch error here.
-    this[this.id].auth().then(this.onAuth).catch(this.view.handleError)
-    return
   }
 
   uninstall () {

--- a/src/plugins/Instagram/index.js
+++ b/src/plugins/Instagram/index.js
@@ -24,7 +24,7 @@ module.exports = class Instagram extends Plugin {
 
     // writing out the key explicitly for readability the key used to store
     // the provider instance must be equal to this.id.
-    this.Instagram = new Provider({
+    this.Instagram = new Provider(core, {
       host: this.opts.host,
       provider: 'instagram',
       authProvider: 'instagram'

--- a/src/uppy-base/src/plugins/Provider.js
+++ b/src/uppy-base/src/plugins/Provider.js
@@ -7,16 +7,40 @@ const _getName = (id) => {
 }
 
 module.exports = class Provider {
-  constructor (opts) {
+  constructor (core, opts) {
+    this.core = core
     this.opts = opts
     this.provider = opts.provider
     this.id = this.provider
     this.authProvider = opts.authProvider || this.provider
     this.name = this.opts.name || _getName(this.id)
+
+    this.onReceiveResponse = this.onReceiveResponse.bind(this)
+  }
+
+  get hostname () {
+    const uppyServer = this.core.state.uppyServer || {}
+    const host = this.opts.host
+    return uppyServer[host] || host
+  }
+
+  onReceiveResponse (response) {
+    const uppyServer = this.core.state.uppyServer || {}
+    const host = this.opts.host
+    const headers = response.headers
+    // Store the self-identified domain name for the uppy-server we just hit.
+    if (headers.has('i-am') && headers.get('i-am') !== uppyServer[host]) {
+      this.core.setState({
+        uppyServer: Object.assign({}, uppyServer, {
+          [host]: headers.get('i-am')
+        })
+      })
+    }
+    return response
   }
 
   auth () {
-    return fetch(`${this.opts.host}/${this.id}/auth`, {
+    return fetch(`${this.hostname}/${this.id}/auth`, {
       method: 'get',
       credentials: 'include',
       headers: {
@@ -24,6 +48,7 @@ module.exports = class Provider {
         'Content-Type': 'application/json'
       }
     })
+    .then(this.onReceiveResponse)
     .then((res) => {
       return res.json()
       .then((payload) => {
@@ -33,7 +58,7 @@ module.exports = class Provider {
   }
 
   list (directory) {
-    return fetch(`${this.opts.host}/${this.id}/list/${directory || ''}`, {
+    return fetch(`${this.hostname}/${this.id}/list/${directory || ''}`, {
       method: 'get',
       credentials: 'include',
       headers: {
@@ -41,11 +66,12 @@ module.exports = class Provider {
         'Content-Type': 'application/json'
       }
     })
+    .then(this.onReceiveResponse)
     .then((res) => res.json())
   }
 
   logout (redirect = location.href) {
-    return fetch(`${this.opts.host}/${this.id}/logout?redirect=${redirect}`, {
+    return fetch(`${this.hostname}/${this.id}/logout?redirect=${redirect}`, {
       method: 'get',
       credentials: 'include',
       headers: {


### PR DESCRIPTION
When uppy-server responds with an `i-am` header, this patch uses the address in that header for subsequent requests to uppy-server.

The `/:provider/auth` request is delayed to the first time the provider view is mounted.