### PR TITLE
chore(package): update `main` file listed in package definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uppy",
   "version": "0.17.0",
   "description": "Almost as cute as a Puppy :dog:",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "jsnext:main": "src/index.js",
   "files": [
     "src/",


### PR DESCRIPTION
I get an error `require`-ing modules when using Webpack. The `lib/index.js` file _appears_ be be a remnant from an older/outdated directory structure. Changing this line resolved the Webpack errors for me.