### PR TITLE
core: Resize thumbnails using <canvas>

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -330,6 +330,19 @@ class Uppy {
   }
 
   /**
+   * Generate a preview image for the given file, if possible.
+   */
+  generatePreview (file) {
+    if (Utils.isPreviewSupported(file.type.specific) && !file.isRemote) {
+      Utils.createThumbnail(file, 200).then((thumbnail) => {
+        this.setPreviewURL(file.id, thumbnail)
+      }).catch((err) => {
+        console.warn(err.stack || err.message)
+      })
+    }
+  }
+
+  /**
    * Set the preview URL for a file.
    */
   setPreviewURL (fileID, preview) {
@@ -438,17 +451,7 @@ class Uppy {
     })
 
     this.on('core:file-added', (file) => {
-      this.emit('core:generate-preview', file)
-    })
-
-    this.on('core:generate-preview', (file) => {
-      if (Utils.isPreviewSupported(file.type.specific) && !file.isRemote) {
-        Utils.createThumbnail(file, 200).then((thumbnail) => {
-          this.setPreviewURL(file.id, thumbnail)
-        }).catch((err) => {
-          console.warn(err.stack || err.message)
-        })
-      }
+      this.generatePreview(file)
     })
 
     // `remove-file` removes a file from `state.files`, for example when

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -438,6 +438,10 @@ class Uppy {
     })
 
     this.on('core:file-added', (file) => {
+      this.emit('core:generate-preview', file)
+    })
+
+    this.on('core:generate-preview', (file) => {
       if (Utils.isPreviewSupported(file.type.specific) && !file.isRemote) {
         Utils.createThumbnail(file, 200).then((thumbnail) => {
           this.setPreviewURL(file.id, thumbnail)

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -299,14 +299,6 @@ class Uppy {
           preview: file.preview
         }
 
-        if (Utils.isPreviewSupported(fileTypeSpecific) && !isRemote) {
-          Utils.createThumbnail(file, 200).then((thumbnail) => {
-            this.setPreviewURL(fileID, thumbnail)
-          }).catch((err) => {
-            console.warn(err.stack || err.message)
-          })
-        }
-
         const isFileAllowed = this.checkRestrictions(false, newFile, fileType)
         if (!isFileAllowed) return Promise.reject('File not allowed')
 
@@ -443,6 +435,16 @@ class Uppy {
 
     this.on('core:file-add', (data) => {
       this.addFile(data)
+    })
+
+    this.on('core:file-added', (file) => {
+      if (Utils.isPreviewSupported(file.type.specific) && !file.isRemote) {
+        Utils.createThumbnail(file, 200).then((thumbnail) => {
+          this.setPreviewURL(file.id, thumbnail)
+        }).catch((err) => {
+          console.warn(err.stack || err.message)
+        })
+      }
     })
 
     // `remove-file` removes a file from `state.files`, for example when

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -294,31 +294,40 @@ function createThumbnail (file, targetWidth) {
 
   return onload.then((image) => {
     const targetHeight = getProportionalHeight(image, targetWidth)
-    let sourceWidth = image.width
-    let sourceHeight = image.height
-
-    if (targetHeight < image.height / 2) {
-      const steps = Math.floor(Math.log(image.width / targetWidth) / Math.log(2))
-      ;({
-        image,
-        sourceWidth,
-        sourceHeight
-      } = downScaleInSteps(image, steps))
-    }
-
-    const canvas = document.createElement('canvas')
-    canvas.width = targetWidth
-    canvas.height = targetHeight
-
-    const context = canvas.getContext('2d')
-    context.drawImage(image,
-      0, 0, sourceWidth, sourceHeight,
-      0, 0, targetWidth, targetHeight)
-
+    const canvas = resizeImage(image, targetWidth, targetHeight)
     return canvasToBlob(canvas)
   }).then((blob) => {
     return URL.createObjectURL(blob)
   })
+}
+
+/**
+ * Resize an image to the target `width` and `height`.
+ *
+ * Returns a Canvas with the resized image on it.
+ */
+function resizeImage (image, targetWidth, targetHeight) {
+  let sourceWidth = image.width
+  let sourceHeight = image.height
+
+  if (targetHeight < image.height / 2) {
+    const steps = Math.floor(Math.log(image.width / targetWidth) / Math.log(2))
+    const stepScaled = downScaleInSteps(image, steps)
+    image = stepScaled.image
+    sourceWidth = stepScaled.sourceWidth
+    sourceHeight = stepScaled.sourceHeight
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = targetWidth
+  canvas.height = targetHeight
+
+  const context = canvas.getContext('2d')
+  context.drawImage(image,
+    0, 0, sourceWidth, sourceHeight,
+    0, 0, targetWidth, targetHeight)
+
+  return canvas
 }
 
 /**

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -3,7 +3,6 @@ const throttle = require('lodash.throttle')
 // because of this https://github.com/sindresorhus/file-type/issues/78
 // and https://github.com/sindresorhus/copy-text-to-clipboard/issues/5
 const fileType = require('../vendor/file-type')
-const html = require('yo-yo')
 
 /**
  * A collection of small utility functions that help with dom manipulation, adding listeners,
@@ -297,7 +296,7 @@ function createThumbnail (file, width) {
   return onload.then((image) => {
     const height = getProportionalHeight(image, width)
 
-    const canvas = html`<canvas></canvas>`
+    const canvas = document.createElement('canvas')
     canvas.width = width
     canvas.height = height
 

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -295,7 +295,7 @@ function createThumbnail (file, targetWidth) {
   return onload.then((image) => {
     const targetHeight = getProportionalHeight(image, targetWidth)
     const canvas = resizeImage(image, targetWidth, targetHeight)
-    return canvasToBlob(canvas)
+    return canvasToBlob(canvas, 'image/jpeg')
   }).then((blob) => {
     return URL.createObjectURL(blob)
   })
@@ -369,14 +369,14 @@ function downScaleInSteps (image, steps) {
  * @param {HTMLCanvasElement} canvas
  * @return {Promise}
  */
-function canvasToBlob (canvas) {
+function canvasToBlob (canvas, type, quality) {
   if (canvas.toBlob) {
     return new Promise((resolve) => {
-      canvas.toBlob(resolve)
+      canvas.toBlob(resolve, type, quality)
     })
   }
   return Promise.resolve().then(() => {
-    return dataURItoBlob(canvas.toDataURL(), {})
+    return dataURItoBlob(canvas.toDataURL(type, quality), {})
   })
 }
 

--- a/src/plugins/RestoreFiles/index.js
+++ b/src/plugins/RestoreFiles/index.js
@@ -95,7 +95,7 @@ module.exports = class RestoreFiles extends Plugin {
       )
       updatedFiles[fileID] = updatedFile
 
-      this.core.emit('core:generate-preview', updatedFile)
+      this.core.generatePreview(updatedFile)
     })
     this.core.setState({
       files: updatedFiles

--- a/src/plugins/RestoreFiles/index.js
+++ b/src/plugins/RestoreFiles/index.js
@@ -1,5 +1,4 @@
 const Plugin = require('../Plugin')
-const Utils = require('../../core/Utils')
 const ServiceWorkerStore = require('./ServiceWorkerStore')
 const IndexedDBStore = require('./IndexedDBStore')
 
@@ -91,13 +90,12 @@ module.exports = class RestoreFiles extends Plugin {
         data: cachedData,
         isRestored: true
       }
-      if (this.core.state.files[fileID] && Utils.isPreviewSupported(this.core.state.files[fileID].type.specific)) {
-        updatedFileData.preview = Utils.getThumbnail(cachedData)
-      }
       const updatedFile = Object.assign({}, updatedFiles[fileID],
         Object.assign({}, updatedFileData)
       )
       updatedFiles[fileID] = updatedFile
+
+      this.core.emit('core:generate-preview', updatedFile)
     })
     this.core.setState({
       files: updatedFiles


### PR DESCRIPTION
(I thought this was already merged for some reason 🙈)

> Low prio!

PR #199 changed thumbnails to be `blob:` Object URLs instead of base64
data URLs, which significantly speeds up rerenders. However, there are
some unintended side effects: GIFs play in previews and really large
images (say, 5+ MB) load in slowly from top to bottom.

This PR uses `blob:` Object URLs to read the image and to display the
previews, but uses a `<canvas>` in between to resize the image, like how
it worked before #199. This has the rerender benefits of Object
URLs, while also making GIFs preview as static images.

Todo:

 - [x] Scale down nicer, right now previews are grainy. Ref https://stackoverflow.com/questions/17861447/html5-canvas-drawimage-how-to-apply-antialiasing
 - [ ] Maybe WebWorkerify it so we don't hang for a while on 25MB+ files … would have to pass image data to the worker by drawing on canvas and then doing `getImageData`, so would need to check that that isn't also very slow. If we do this we can use an algorithm that scales well immediately