### PR TITLE
transloadit: support uploading to a different service, then importing into assembly

### DIFF
--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -30,7 +30,7 @@ module.exports = class Client {
     Object.keys(fields).forEach((key) => {
       data.append(key, fields[key])
     })
-    data.append('tus_num_expected_upload_files', expectedFiles)
+    data.append('num_expected_upload_files', expectedFiles)
 
     return fetch(`${this.apiUrl}/assemblies`, {
       method: 'post',
@@ -49,7 +49,7 @@ module.exports = class Client {
 
   reserveFile (assembly, file) {
     const size = encodeURIComponent(file.size)
-    return fetch(`${assembly.assembly_ssl_url}/reserve_file?size=${size}`)
+    return fetch(`${assembly.assembly_ssl_url}/reserve_file?size=${size}`, { method: 'post' })
       .then((response) => response.json())
   }
 
@@ -61,7 +61,9 @@ module.exports = class Client {
     const url = encodeURIComponent(file.uploadURL)
     const filename = encodeURIComponent(file.name)
     const fieldname = 'file'
-    return fetch(`${assembly.assembly_ssl_url}/add_file?size=${size}&filename=${filename}&fieldname=${fieldname}&s3Url=${url}`)
+
+    const qs = `size=${size}&filename=${filename}&fieldname=${fieldname}&s3Url=${url}`
+    return fetch(`${assembly.assembly_ssl_url}/add_file?${qs}`, { method: 'post' })
       .then((response) => response.json())
   }
 

--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -47,6 +47,24 @@ module.exports = class Client {
     })
   }
 
+  reserveFile (assembly, file) {
+    const size = encodeURIComponent(file.size)
+    return fetch(`${assembly.assembly_ssl_url}/reserve_file?size=${size}`)
+      .then((response) => response.json())
+  }
+
+  addFile (assembly, file) {
+    if (!file.uploadURL) {
+      return Promise.reject(new Error('File does not have an `uploadURL`.'))
+    }
+    const size = encodeURIComponent(file.size)
+    const url = encodeURIComponent(file.uploadURL)
+    const filename = encodeURIComponent(file.name)
+    const fieldname = 'file'
+    return fetch(`${assembly.assembly_ssl_url}/add_file?size=${size}&filename=${filename}&fieldname=${fieldname}&s3Url=${url}`)
+      .then((response) => response.json())
+  }
+
   /**
    * Get the current status for an assembly.
    *

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -167,8 +167,10 @@ module.exports = class Transloadit extends Plugin {
       this.core.emit('transloadit:assembly-created', assembly, fileIDs)
 
       return this.connectSocket(assembly)
-    }).then(() => {
+        .then(() => assembly)
+    }).then((assembly) => {
       this.core.log('Transloadit: Created assembly')
+      return assembly
     }).catch((err) => {
       this.core.info(this.opts.locale.strings.creatingAssemblyFailed, 'error', 0)
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -140,17 +140,17 @@ module.exports = class Transloadit extends Plugin {
         // Attach meta parameters for the Tus plugin. See:
         // https://github.com/tus/tusd/wiki/Uploading-to-Transloadit-using-tus#uploading-using-tus
         // TODO Should this `meta` be moved to a `tus.meta` property instead?
-        // If the MetaData plugin can add eg. resize parameters, it doesn't
-        // make much sense to set those as upload-metadata for tus.
-        const meta = Object.assign({}, file.meta, {
+        const tlMeta = {
           assembly_url: assembly.assembly_url,
           filename: file.name,
           fieldname: 'file'
-        })
+        }
+        const meta = Object.assign({}, file.meta, tlMeta)
         // Add assembly-specific Tus endpoint.
         const tus = Object.assign({}, file.tus, {
           endpoint: assembly.tus_url,
-          metaFields: ['assembly_url', 'filename', 'fieldname']
+          // Only send assembly metadata to the tus endpoint.
+          metaFields: Object.keys(tlMeta)
         })
         const transloadit = {
           assembly: assembly.assembly_id

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -477,6 +477,10 @@ module.exports = class Transloadit extends Plugin {
   uninstall () {
     this.core.removePreProcessor(this.prepareUpload)
     this.core.removePostProcessor(this.afterUpload)
+
+    if (this.opts.importFromUploadURLs) {
+      this.core.off('core:upload-success', this.onFileUploadURLAvailable)
+    }
   }
 
   getAssembly (id) {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -113,6 +113,8 @@ module.exports = class Transloadit extends Plugin {
   }
 
   createAssembly (fileIDs, uploadID, options) {
+    const pluginOptions = this.opts
+
     this.core.log('Transloadit: create assembly')
 
     return this.client.createAssembly({
@@ -156,7 +158,7 @@ module.exports = class Transloadit extends Plugin {
 
         const newFile = Object.assign({}, file, { transloadit })
         // Only configure the Tus plugin if we are uploading straight to Transloadit (the default).
-        if (!opts.importFromUploadURLs) {
+        if (!pluginOptions.importFromUploadURLs) {
           Object.assign(newFile, { meta, tus })
         }
         return newFile
@@ -177,7 +179,7 @@ module.exports = class Transloadit extends Plugin {
       this.core.log('Transloadit: Created assembly')
       return assembly
     }).catch((err) => {
-      this.core.info(this.opts.locale.strings.creatingAssemblyFailed, 'error', 0)
+      this.core.info(pluginOptions.locale.strings.creatingAssemblyFailed, 'error', 0)
 
       // Reject the promise.
       throw err

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -199,7 +199,8 @@ module.exports = class Transloadit extends Plugin {
     const assembly = this.state.assemblies[file.transloadit.assembly]
 
     this.client.addFile(assembly, file).catch((err) => {
-      console.error('ignoring', err)
+      this.core.log(err)
+      this.core.emit('core:upload-error', file.id, err)
     })
   }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -153,11 +153,13 @@ module.exports = class Transloadit extends Plugin {
         const transloadit = {
           assembly: assembly.assembly_id
         }
-        return Object.assign(
-          {},
-          file,
-          { meta, tus, transloadit }
-        )
+
+        const newFile = Object.assign({}, file, { transloadit })
+        // Only configure the Tus plugin if we are uploading straight to Transloadit (the default).
+        if (!opts.importFromUploadURLs) {
+          Object.assign(newFile, { meta, tus })
+        }
+        return newFile
       }
 
       const files = Object.assign({}, this.core.state.files)
@@ -427,7 +429,7 @@ module.exports = class Transloadit extends Plugin {
     this.core.addPostProcessor(this.afterUpload)
 
     if (this.opts.importFromUploadURLs) {
-      this.core.on('file:upload-success', this.onFileUploaded)
+      this.core.on('core:upload-success', this.onFileUploaded)
     }
 
     this.updateState({

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -20,6 +20,8 @@ uppy.use(Transloadit, {
 })
 ```
 
+NB: It is not required to use the `Tus10` plugin if [importFromUploadURLs](#importFromUploadURLs) is enabled.
+
 ## Options
 
 ### `waitForEncoding`
@@ -30,6 +32,35 @@ Whether to wait for all assemblies to complete before completing the upload.
 
 Whether to wait for metadata to be extracted from uploaded files before completing the upload.
 If `waitForEncoding` is enabled, this has no effect.
+
+### `importFromUploadURLs`
+
+Instead of uploading to Transloadit's servers directly, allow another plugin to upload files, and then import those files into the Transloadit assembly.
+Default `false`.
+
+When enabling this option, Transloadit will *not* configure the Tus plugin to upload to Transloadit.
+Instead, a separate upload plugin must be used.
+Once the upload completes, the Transloadit plugin adds the uploaded file to the assembly.
+
+For example, to upload files to an S3 bucket and then transcode them:
+
+```js
+uppy.use(AwsS3, {
+  getUploadParameters (file) {
+    return { /* upload parameters */ }
+  }
+})
+uppy.use(Transloadit, {
+  importFromUploadURLs: true,
+  params: {
+    auth: { key: /* secret */ },
+    template_id: /* secret */
+  }
+})
+```
+
+In order for this to work, the upload plugin must assign a publically accessible `uploadURL` property to the uploaded file object.
+The Tus and S3 plugins both do this—for the XHRUpload plugin, you may have to specify a custom `getUploadResponse` function.
 
 ### `params`
 


### PR DESCRIPTION
Just opening this up to show current progress.
When `importFromUploadURLs` option is true, the Transloadit plugin will not try to upload files directly to assemblies using the Tus plugin, but will instead wait for another user-registered upload plugin to complete, and import the URL reported by the uploader plugin into the assembly.

- [x] When `/add_file` fails, fail the postprocessing step and not the upload step.