### PR TITLE
providers: consistently use sticky hostname

### DIFF
--- a/src/uppy-base/src/plugins/Provider.js
+++ b/src/uppy-base/src/plugins/Provider.js
@@ -58,11 +58,11 @@ module.exports = class Provider {
   }
 
   authUrl () {
-    return `${this.opts.host}/${this.id}/connect`
+    return `${this.hostname}/${this.id}/connect`
   }
 
   fileUrl (id) {
-    return `${this.opts.host}/${this.id}/get/${id}`
+    return `${this.hostname}/${this.id}/get/${id}`
   }
 
   list (directory) {


### PR DESCRIPTION
Some other merge didn't include these changes from #265.

`this.opts.host` is the original hostname given by the user in plugin options.
`this.hostname` is the "sticky" hostname, if uppy-server replies with an `i-am` header that is used instead.