### PR TITLE
Update namespace-emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7793,9 +7793,9 @@
       "dev": true
     },
     "namespace-emitter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/namespace-emitter/-/namespace-emitter-1.0.0.tgz",
-      "integrity": "sha1-G/OnuKQMd1BwJfMwmgQ6vr9cPY8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/namespace-emitter/-/namespace-emitter-2.0.0.tgz",
+      "integrity": "sha512-U2o/9Lo1T7mlXt21a8A8HRCF4ZkmmjORBMbEGjfEwuuFo06wFFOZp3DR7zxEUWIgaertJ9XKzyU0C1OxECdQAg=="
     },
     "nan": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "get-form-data": "^1.2.5",
     "lodash.throttle": "4.1.1",
     "mime-match": "^1.0.2",
-    "namespace-emitter": "1.0.0",
+    "namespace-emitter": "^2.0.0",
     "nanoraf": "3.0.1",
     "on-load": "3.2.0",
     "prettier-bytes": "1.0.4",


### PR DESCRIPTION
Includes performance improvements and a [fix](https://github.com/sethvincent/namespace-emitter/commit/07385bf019fa40e3787bb4df8f7171bf98637014) for the `off()` method that we need for `transloadit:complete` to fire correctly.