### PR TITLE
transloadit: Add `alwaysRunAssembly` option 

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -870,7 +870,9 @@ class Uppy {
             [uploadID]: currentUpload
           })
         })
-        return fn(fileIDs)
+        // TODO give this the `currentUpload` object as its only parameter maybe?
+        // Otherwise when more metadata may be added to the upload this would keep getting more parameters
+        return fn(fileIDs, uploadID)
       })
     })
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -282,6 +282,10 @@ module.exports = class Transloadit extends Plugin {
     // A file ID that is part of this assembly...
     const fileID = fileIDs[0]
 
+    if (!fileID) {
+      return Promise.resolve()
+    }
+
     // If we don't have to wait for encoding metadata or results, we can close
     // the socket immediately and finish the upload.
     if (!this.shouldWait()) {

--- a/test/unit/Transloadit.spec.js
+++ b/test/unit/Transloadit.spec.js
@@ -149,3 +149,19 @@ test('Transloadit: Should merge files with same parameters into one assembly', (
     })
   }, t.fail)
 })
+
+test('Does not create an assembly if no files are being uploaded', (t) => {
+  t.plan(0)
+
+  const uppy = new Core()
+  uppy.use(Transloadit, {
+    getAssemblyOptions () {
+      t.fail('should not create assembly')
+    }
+  })
+  uppy.run()
+
+  uppy.upload().then(() => {
+    t.end()
+  }).catch(t.fail)
+})


### PR DESCRIPTION
This adds back the ability to run assemblies without uploading any
files, which is useful in case the assembly uses an import robot.

To do this, this patch adds a new state key to the Transloadit plugin's
state, named `uploadsAssemblies` (open to bikeshedding lol)
This key associates assembly IDs with the upload ID that triggered them.
This allows figuring out which assemblies need to finish before
resolving the upload promise.

The upload ID is now passed to preprocessors and postprocessors so
they can use it to store metadata that is related to an upload instead
of to a single file.

When `alwaysRunAssembly` is set to true, and zero files are available
for upload, an assembly is created anyway for the options returned by
`getAssemblyOptions(null)`.

It turns out that `afterUpload` actually didn't work correctly if
multiple assemblies were used for a single upload. I changed it so that
it does, and incidentally that also made it work again with zero-file
assemblies.

I'll be adding some tests so we don't regress on this again, there are
a lot of ways to use the :tl: plugin so it's clearly a bit much to remember
to test it manually…