### PR TITLE
transloadit: Fix crash when no files are being uploaded

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -289,8 +289,9 @@ module.exports = class Transloadit extends Plugin {
       optionsPromise = this.getAssemblyOptions(fileIDs)
         .then((allOptions) => this.dedupeAssemblyOptions(allOptions))
     } else if (this.opts.alwaysRunAssembly) {
-      optionsPromise = Promise.resolve().then(() => {
-        const options = this.opts.getAssemblyOptions(null, this.opts)
+      optionsPromise = Promise.resolve(
+        this.opts.getAssemblyOptions(null, this.opts)
+      ).then((options) => {
         this.validateParams(options.params)
         return [
           { fileIDs, options }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -321,6 +321,12 @@ module.exports = class Transloadit extends Plugin {
       return Promise.resolve()
     }
 
+    // If no assemblies were created for this upload, we also do not have to wait.
+    // There's also no sockets or anything to close, so just return immediately.
+    if (assemblyIDs.length === 0) {
+      return Promise.resolve()
+    }
+
     let finishedAssemblies = 0
 
     return new Promise((resolve, reject) => {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -120,8 +120,10 @@ module.exports = class Transloadit extends Plugin {
       signature: options.signature
     }).then((assembly) => {
       // Store the list of assemblies related to this upload.
-      const uploadsAssemblies = Object.assign({}, this.state.uploadsAssemblies)
-      uploadsAssemblies[uploadID] = (uploadsAssemblies[uploadID] || []).concat([ assembly.assembly_id ])
+      const assemblyList = this.state.uploadsAssemblies[uploadID]
+      const uploadsAssemblies = Object.assign({}, this.state.uploadsAssemblies, {
+        [uploadID]: assemblyList.concat([ assembly.assembly_id ])
+      })
 
       this.updateState({
         assemblies: Object.assign(this.state.assemblies, {
@@ -276,6 +278,11 @@ module.exports = class Transloadit extends Plugin {
         })
       })
     }
+
+    const uploadsAssemblies = Object.assign({},
+      this.state.uploadsAssemblies,
+      { [uploadID]: [] })
+    this.updateState({ uploadsAssemblies })
 
     let optionsPromise
     if (fileIDs.length > 0) {

--- a/test/unit/Transloadit.spec.js
+++ b/test/unit/Transloadit.spec.js
@@ -165,3 +165,22 @@ test('Does not create an assembly if no files are being uploaded', (t) => {
     t.end()
   }).catch(t.fail)
 })
+
+test('Creates an assembly if no files are being uploaded but `alwaysRunAssembly` is enabled', (t) => {
+  t.plan(1)
+
+  const uppy = new Core()
+  uppy.use(Transloadit, {
+    alwaysRunAssembly: true,
+    getAssemblyOptions (file) {
+      t.equal(file, null, 'should call getAssemblyOptions with `null`')
+      return Promise.reject()
+    }
+  })
+
+  uppy.upload().then(() => {
+    t.fail('should be rejected by `getAssemblyOptions`')
+  }, () => {
+    t.end()
+  })
+})


### PR DESCRIPTION
Follow-up to #290.

In #290 the `afterUpload` handler would attempt to go through the `uploadsAssemblies` list for the upload, but that didn't exist if `alwaysRunAssembly` was not set and no files were uploaded. This patch initialises the `uploadsAssemblies` list to an empty array as early as necessary.

It also fixes an issue with `getAssemblyOptions` not being able to return a Promise when `alwaysRunAssembly` was set to true.

From manual tests I think this covers all our cases.

There's just one problem now: When no files are being uploaded, we have no place to store progress. That means the statusbar doesn't update when an assembly that imports its input from somewhere is run. Maybe we should attach progress status to the upload itself now, instead of to each file…