### PR TITLE
[WIP] Experiment with yo-yo --> preact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,16 @@
       "integrity": "sha1-9vGlzl05caSt6RoR0i1MRZrNN18=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -1445,9 +1455,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1734,6 +1744,7 @@
       "integrity": "sha1-BQjMHnv0wVIxLC+lI+Z2wLC5IxE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1755,7 +1766,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -4907,14 +4917,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4923,6 +4925,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6186,10 +6196,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -6678,16 +6688,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -7697,6 +7697,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -7704,7 +7705,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.2.11",
         "resolve": "1.3.3",
@@ -9265,9 +9265,9 @@
       }
     },
     "preact": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.4.tgz",
-      "integrity": "sha1-FE6lDLV7dlmsX2MRkblBi97H7Qo="
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.6.tgz",
+      "integrity": "sha1-ACi0Ju+Y/Mp0Gjxhf/W4E7mpR8c="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -10978,14 +10978,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -11038,6 +11030,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "requires": {
+        "safe-buffer": "5.0.1"
       }
     },
     "stringstream": {
@@ -11836,6 +11836,7 @@
           "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
           "dev": true,
           "requires": {
+            "JSONStream": "1.3.1",
             "assert": "1.4.1",
             "browser-pack": "6.0.2",
             "browser-resolve": "1.11.2",
@@ -11857,7 +11858,6 @@
             "https-browserify": "0.0.1",
             "inherits": "2.0.3",
             "insert-module-globals": "7.0.1",
-            "JSONStream": "1.3.1",
             "labeled-stream-splicer": "2.0.0",
             "module-deps": "4.1.1",
             "os-browserify": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,7 +972,7 @@
         "@f/is-svg": "1.0.0",
         "@f/svg-namespace": "1.0.1",
         "camel-case": "3.0.0",
-        "hyperx": "2.3.0",
+        "hyperx": "2.3.1",
         "is-boolean-attribute": "0.0.1",
         "normalize-html-whitespace": "0.2.0",
         "on-load": "3.2.0",
@@ -1277,7 +1277,7 @@
       "integrity": "sha1-Ot4W4jarIgTY0cZurEvVc3k6yZk=",
       "requires": {
         "global": "4.3.2",
-        "hyperx": "2.3.0",
+        "hyperx": "2.3.1",
         "on-load": "3.2.0"
       }
     },
@@ -6070,9 +6070,9 @@
       "integrity": "sha1-glMI1Ju44pV5I/cxmBvMgRytev8="
     },
     "hyperx": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hyperx/-/hyperx-2.3.0.tgz",
-      "integrity": "sha1-cPRz1m1K1VDd0cg+S+JlEna78eI=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hyperx/-/hyperx-2.3.1.tgz",
+      "integrity": "sha512-wBbSBfbWEqMsr5bJ6h7rV9a1y2hDCsV/0Lqz2zqa/nEfbZ4WR/1FDi/gkNsHK7894zf8ilbgv8RHY7DkgM9wJw==",
       "requires": {
         "hyperscript-attribute-to-property": "1.0.0"
       }
@@ -12177,7 +12177,7 @@
       "requires": {
         "acorn": "5.0.3",
         "falafel": "2.1.0",
-        "hyperx": "2.3.0",
+        "hyperx": "2.3.1",
         "on-load": "3.2.0",
         "through2": "2.0.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9264,6 +9264,11 @@
         }
       }
     },
+    "preact": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.4.tgz",
+      "integrity": "sha1-FE6lDLV7dlmsX2MRkblBi97H7Qo="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "namespace-emitter": "^2.0.0",
     "nanoraf": "3.0.1",
     "on-load": "3.2.0",
-    "preact": "^8.2.4",
+    "preact": "^8.2.6",
     "prettier-bytes": "1.0.4",
     "socket.io-client": "2.0.1",
     "tus-js-client": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "namespace-emitter": "^2.0.0",
     "nanoraf": "3.0.1",
     "on-load": "3.2.0",
+    "preact": "^8.2.4",
     "prettier-bytes": "1.0.4",
     "socket.io-client": "2.0.1",
     "tus-js-client": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "drag-drop": "2.13.2",
     "es6-promise": "3.2.1",
     "get-form-data": "^1.2.5",
+    "hyperx": "^2.3.1",
     "lodash.throttle": "4.1.1",
     "mime-match": "^1.0.2",
     "namespace-emitter": "^2.0.0",

--- a/src/generic-provider-views/AuthView.js
+++ b/src/generic-provider-views/AuthView.js
@@ -1,21 +1,35 @@
-const html = require('yo-yo')
-const onload = require('on-load')
+// const html = require('yo-yo')
+// const onload = require('on-load')
 const LoaderView = require('./Loader')
 
-module.exports = (props) => {
-  const demoLink = props.demo ? html`<button class="UppyProvider-authBtnDemo" onclick=${props.handleDemoAuth}>Proceed with Demo Account</button>` : null
-  const AuthBlock = () => html`
-    <div class="UppyProvider-auth">
-      <h1 class="UppyProvider-authTitle">Please authenticate with <span class="UppyProvider-authTitleName">${props.pluginName}</span><br> to select files</h1>
-      <button type="button" class="UppyProvider-authBtn" onclick=${props.handleAuth}>Authenticate</button>
-      ${demoLink}
-    </div>
-  `
-  return onload(html`
-    <div style="height: 100%;">
-      ${props.checkAuthInProgress
-        ? LoaderView()
-        : AuthBlock()
-      }
-    </div>`, props.checkAuth, null, `auth${props.pluginName}`)
+const { h, Component } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
+class AuthView extends Component {
+  componentDidMount () {
+    this.props.checkAuth()
+  }
+
+  render () {
+    const demoLink = this.props.demo ? html`<button class="UppyProvider-authBtnDemo" onclick=${this.props.handleDemoAuth}>Proceed with Demo Account</button>` : null
+    const AuthBlock = () => html`
+      <div class="UppyProvider-auth">
+        <h1 class="UppyProvider-authTitle">Please authenticate with <span class="UppyProvider-authTitleName">${this.props.pluginName}</span><br> to select files</h1>
+        <button type="button" class="UppyProvider-authBtn" onclick=${this.props.handleAuth}>Authenticate</button>
+        ${demoLink}
+      </div>
+    `
+
+    return html`
+      <div style="height: 100%;">
+        ${this.props.checkAuthInProgress
+          ? LoaderView()
+          : AuthBlock()
+        }
+      </div>
+    `
+  }
 }
+
+module.exports = AuthView

--- a/src/generic-provider-views/Breadcrumb.js
+++ b/src/generic-provider-views/Breadcrumb.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`

--- a/src/generic-provider-views/Breadcrumbs.js
+++ b/src/generic-provider-views/Breadcrumbs.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Breadcrumb = require('./Breadcrumb')
 
 module.exports = (props) => {

--- a/src/generic-provider-views/Browser.js
+++ b/src/generic-provider-views/Browser.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Breadcrumbs = require('./Breadcrumbs')
 const Table = require('./Table')
 

--- a/src/generic-provider-views/Loader.js
+++ b/src/generic-provider-views/Loader.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`

--- a/src/generic-provider-views/Table.js
+++ b/src/generic-provider-views/Table.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Row = require('./TableRow')
 
 module.exports = (props) => {

--- a/src/generic-provider-views/TableColumn.js
+++ b/src/generic-provider-views/TableColumn.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`

--- a/src/generic-provider-views/TableRow.js
+++ b/src/generic-provider-views/TableRow.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Column = require('./TableColumn')
 
 module.exports = (props) => {

--- a/src/generic-provider-views/index.js
+++ b/src/generic-provider-views/index.js
@@ -3,6 +3,10 @@ const Browser = require('./Browser')
 const LoaderView = require('./Loader')
 const Utils = require('../core/Utils')
 
+const { h } = require('preact')
+// const hyperx = require('hyperx')
+// const html = hyperx(h, {attrToProp: false})
+
 /**
  * Class to easily generate generic views for plugins
  *
@@ -385,7 +389,7 @@ module.exports = class View {
     }
 
     if (!authenticated) {
-      return AuthView({
+      return h(AuthView, {
         pluginName: this.plugin.title,
         demo: this.plugin.opts.demo,
         checkAuth: this.checkAuth,
@@ -393,6 +397,14 @@ module.exports = class View {
         handleDemoAuth: this.handleDemoAuth,
         checkAuthInProgress: checkAuthInProgress
       })
+      // return AuthView({
+      //   pluginName: this.plugin.title,
+      //   demo: this.plugin.opts.demo,
+      //   checkAuth: this.checkAuth,
+      //   handleAuth: this.handleAuth,
+      //   handleDemoAuth: this.handleDemoAuth,
+      //   checkAuthInProgress: checkAuthInProgress
+      // })
     }
 
     const browserProps = Object.assign({}, state[this.plugin.stateId], {

--- a/src/plugins/Dashboard/ActionBrowseTagline.js
+++ b/src/plugins/Dashboard/ActionBrowseTagline.js
@@ -1,4 +1,8 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   const input = html`

--- a/src/plugins/Dashboard/ActionBrowseTagline.js
+++ b/src/plugins/Dashboard/ActionBrowseTagline.js
@@ -1,15 +1,10 @@
-// const html = require('yo-yo')
-
 const { h } = require('preact')
 const hyperx = require('hyperx')
 const html = hyperx(h, {attrToProp: false})
 
-module.exports = (props) => {
-  const input = html`
-    <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
-           onchange=${props.handleInputChange} />
-  `
+let inputEl
 
+module.exports = (props) => {
   return html`
     <span>
       ${props.acquirers.length === 0
@@ -19,9 +14,11 @@ module.exports = (props) => {
       <button type="button"
               class="UppyDashboard-browse"
               onclick=${(ev) => {
-                input.click()
+                inputEl.click()
               }}>${props.i18n('browse')}</button>
-      ${input}
+      <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
+             ref=${(el) => { inputEl = el }}
+             onchange=${props.handleInputChange} />
     </span>
   `
 }

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const FileList = require('./FileList')
 const Tabs = require('./Tabs')
 const FileCard = require('./FileCard')

--- a/src/plugins/Dashboard/FileCard.js
+++ b/src/plugins/Dashboard/FileCard.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const getFileTypeIcon = require('./getFileTypeIcon')
 const { checkIcon } = require('./icons')
 

--- a/src/plugins/Dashboard/FileItem.js
+++ b/src/plugins/Dashboard/FileItem.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const { getETA,
          getSpeed,
          prettyETA,

--- a/src/plugins/Dashboard/FileItemProgress.js
+++ b/src/plugins/Dashboard/FileItemProgress.js
@@ -1,4 +1,8 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 // http://codepen.io/Harkko/pen/rVxvNM
 // https://css-tricks.com/svg-line-animation-works/

--- a/src/plugins/Dashboard/FileList.js
+++ b/src/plugins/Dashboard/FileList.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const FileItem = require('./FileItem')
 const ActionBrowseTagline = require('./ActionBrowseTagline')
 const { dashboardBgIcon } = require('./icons')

--- a/src/plugins/Dashboard/Tabs.js
+++ b/src/plugins/Dashboard/Tabs.js
@@ -7,6 +7,8 @@ const html = hyperx(h, {attrToProp: false})
 const ActionBrowseTagline = require('./ActionBrowseTagline')
 const { localIcon } = require('./icons')
 
+let inputEl
+
 module.exports = (props) => {
   const isHidden = Object.keys(props.files).length === 0
 
@@ -24,11 +26,6 @@ module.exports = (props) => {
     `
   }
 
-  const input = html`
-    <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
-           onchange=${props.handleInputChange} />
-  `
-
   return html`<div class="UppyDashboardTabs">
     <nav>
       <ul class="UppyDashboardTabs-list" role="tablist">
@@ -37,12 +34,14 @@ module.exports = (props) => {
                   role="tab"
                   tabindex="0"
                   onclick=${(ev) => {
-                    input.click()
+                    inputEl.click()
                   }}>
             ${localIcon()}
             <h5 class="UppyDashboardTab-name">${props.i18n('myDevice')}</h5>
           </button>
-          ${input}
+          <input class="UppyDashboard-input" type="file" name="files[]" multiple="true"
+                 ref=${(el) => { inputEl = el }}
+                 onchange=${props.handleInputChange} />
         </li>
         ${props.acquirers.map((target) => {
           return html`<li class="UppyDashboardTab">

--- a/src/plugins/Dashboard/Tabs.js
+++ b/src/plugins/Dashboard/Tabs.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const ActionBrowseTagline = require('./ActionBrowseTagline')
 const { localIcon } = require('./icons')
 

--- a/src/plugins/Dashboard/UploadBtn.js
+++ b/src/plugins/Dashboard/UploadBtn.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const { uploadIcon } = require('./icons')
 
 module.exports = (props) => {

--- a/src/plugins/Dashboard/icons.js
+++ b/src/plugins/Dashboard/icons.js
@@ -1,4 +1,8 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 // https://css-tricks.com/creating-svg-icon-system-react/
 

--- a/src/plugins/Dashboard/icons.js
+++ b/src/plugins/Dashboard/icons.js
@@ -2,7 +2,8 @@
 
 const { h } = require('preact')
 const hyperx = require('hyperx')
-const html = hyperx(h, {attrToProp: false})
+// const html = hyperx(h, {attrToProp: false})
+const html = hyperx((tag, props, kids) => h(tag, props, ...kids))
 
 // https://css-tricks.com/creating-svg-icon-system-react/
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -7,6 +7,7 @@ const Informer = require('../Informer')
 const { findDOMElement } = require('../../core/Utils')
 const prettyBytes = require('prettier-bytes')
 const { defaultTabIcon } = require('./icons')
+const preact = require('preact')
 
 /**
  * Modal Dialog & Dashboard
@@ -203,7 +204,7 @@ module.exports = class DashboardUI extends Plugin {
     document.body.addEventListener('keyup', this.handleEscapeKeyPress)
 
     // Drag Drop
-    this.removeDragDropListener = dragDrop(this.el, (files) => {
+    this.removeDragDropListener = dragDrop(this.root, (files) => {
       this.handleDrop(files)
     })
   }
@@ -277,6 +278,11 @@ module.exports = class DashboardUI extends Plugin {
 
   resumeAll () {
     this.core.emit('core:resume-all')
+  }
+
+  update (state) {
+    if (typeof this.root === 'undefined') return
+    preact.render(this.render(state), this.target, this.root)
   }
 
   render (state) {
@@ -407,7 +413,11 @@ module.exports = class DashboardUI extends Plugin {
 
     const target = this.opts.target
     const plugin = this
-    this.target = this.mount(target, plugin)
+
+    if (target) {
+      this.target = this.mount(target, plugin)
+      this.root = preact.render(this.render(this.core.state), this.target)
+    }
 
     if (!this.opts.disableStatusBar) {
       this.core.use(StatusBar, {

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -130,6 +130,8 @@ module.exports = class DashboardUI extends Plugin {
   }
 
   showPanel (id) {
+    console.log('show panel')
+
     const modal = this.core.getState().modal
 
     const activePanel = modal.targets.filter((target) => {

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -2,7 +2,11 @@ const Plugin = require('./../Plugin')
 const Translator = require('../../core/Translator')
 const { toArray } = require('../../core/Utils')
 const dragDrop = require('drag-drop')
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 /**
  * Drag & Drop plugin

--- a/src/plugins/Dropbox/index.js
+++ b/src/plugins/Dropbox/index.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Plugin = require('../Plugin')
 
 const Provider = require('../../uppy-base/src/plugins/Provider')

--- a/src/plugins/Informer.js
+++ b/src/plugins/Informer.js
@@ -1,5 +1,9 @@
 const Plugin = require('./Plugin')
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 /**
  * Informer

--- a/src/plugins/Instagram/index.js
+++ b/src/plugins/Instagram/index.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const Plugin = require('../Plugin')
 
 const Provider = require('../../uppy-base/src/plugins/Provider')

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -1,7 +1,8 @@
-const yo = require('yo-yo')
-const nanoraf = require('nanoraf')
+// const yo = require('yo-yo')
+// const nanoraf = require('nanoraf')
 const { findDOMElement } = require('../core/Utils')
 const getFormData = require('get-form-data')
+const { render } = require('preact')
 
 /**
  * Boilerplate that all Plugins share - and should not be used
@@ -52,9 +53,13 @@ module.exports = class Plugin {
     const targetElement = findDOMElement(target)
 
     // Set up nanoraf.
-    this.updateUI = nanoraf((state) => {
-      this.el = yo.update(this.el, this.render(state))
-    })
+    // this.updateUI = nanoraf((state) => {
+    //   // this.el = yo.update(this.el, this.render(state))
+    //   render(this.render(state), targetElement, this.el)
+    // })
+    this.updateUI = (state) => {
+      render(this.render(state), targetElement, this.el)
+    }
 
     if (targetElement) {
       this.core.log(`Installing ${callerPluginName} to a DOM element`)
@@ -70,7 +75,9 @@ module.exports = class Plugin {
         targetElement.innerHTML = ''
       }
 
-      this.el = plugin.render(this.core.state)
+      // this.el = plugin.render(this.core.state)
+      this.el = render(this.render(this.core.state), targetElement, this.el)
+
       targetElement.appendChild(this.el)
 
       return targetElement

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -78,7 +78,7 @@ module.exports = class Plugin {
       // this.el = plugin.render(this.core.state)
       this.el = render(this.render(this.core.state), targetElement, this.el)
 
-      targetElement.appendChild(this.el)
+      // targetElement.appendChild(this.el)
 
       return targetElement
     } else {

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -2,7 +2,7 @@
 // const nanoraf = require('nanoraf')
 const { findDOMElement } = require('../core/Utils')
 const getFormData = require('get-form-data')
-const { render } = require('preact')
+// const preact = require('preact')
 
 /**
  * Boilerplate that all Plugins share - and should not be used
@@ -29,15 +29,17 @@ module.exports = class Plugin {
     this.uninstall = this.uninstall.bind(this)
   }
 
-  update (state) {
-    if (typeof this.el === 'undefined') {
-      return
-    }
+  // update (state) {
+  //   if (typeof this.el === 'undefined') {
+  //     return
+  //   }
 
-    if (this.updateUI) {
-      this.updateUI(state)
-    }
-  }
+  //   if (this.updateUI) {
+  //     this.updateUI(state)
+  //   }
+  // }
+
+  update () {}
 
   /**
    * Check if supplied `target` is a DOM element or an `object`.
@@ -57,9 +59,9 @@ module.exports = class Plugin {
     //   // this.el = yo.update(this.el, this.render(state))
     //   render(this.render(state), targetElement, this.el)
     // })
-    this.updateUI = (state) => {
-      render(this.render(state), targetElement, this.el)
-    }
+    // this.updateUI = (state) => {
+    //   render(this.render(state), targetElement, this.el)
+    // }
 
     if (targetElement) {
       this.core.log(`Installing ${callerPluginName} to a DOM element`)
@@ -76,7 +78,7 @@ module.exports = class Plugin {
       }
 
       // this.el = plugin.render(this.core.state)
-      this.el = render(this.render(this.core.state), targetElement, this.el)
+      // this.el = render(this.render(this.core.state), targetElement, this.el)
 
       // targetElement.appendChild(this.el)
 
@@ -97,14 +99,12 @@ module.exports = class Plugin {
   }
 
   unmount () {
-    if (this.el && this.el.parentNode) {
-      this.el.parentNode.removeChild(this.el)
+    if (this.root && this.root.parentNode) {
+      this.root.parentNode.removeChild(this.root)
     }
   }
 
-  install () {
-    return
-  }
+  install () {}
 
   uninstall () {
     this.unmount()

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -1,4 +1,9 @@
-const html = require('yo-yo')
+// const html = require('yo-yo')
+
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const throttle = require('lodash.throttle')
 
 function progressDetails (props) {

--- a/src/plugins/Webcam/CameraIcon.js
+++ b/src/plugins/Webcam/CameraIcon.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`<svg class="UppyIcon" width="100" height="77" viewBox="0 0 100 77">

--- a/src/plugins/Webcam/CameraScreen.js
+++ b/src/plugins/Webcam/CameraScreen.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h, Component } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const SnapshotButton = require('./SnapshotButton')
 const RecordButton = require('./RecordButton')
 
@@ -6,40 +9,51 @@ function isModeAvailable (modes, mode) {
   return modes.indexOf(mode) !== -1
 }
 
-module.exports = (props) => {
-  const src = props.src || ''
-  let video
-
-  if (props.useTheFlash) {
-    video = props.getSWFHTML()
-  } else {
-    video = html`<video class="UppyWebcam-video" autoplay muted src="${src}"></video>`
+class CameraScreen extends Component {
+  componentDidMount () {
+    this.props.onFocus()
+    const recordButton = this.webcamContainer.querySelector('.UppyWebcam-recordButton')
+    if (recordButton) recordButton.focus()
   }
 
-  const shouldShowRecordButton = props.supportsRecording && (
-    isModeAvailable(props.modes, 'video-only') ||
-    isModeAvailable(props.modes, 'audio-only') ||
-    isModeAvailable(props.modes, 'video-audio')
-  )
+  componentWillUnmount () {
+    this.props.onStop()
+  }
 
-  const shouldShowSnapshotButton = isModeAvailable(props.modes, 'picture')
+  render () {
+    const src = this.props.src || ''
+    let video
 
-  return html`
-    <div class="UppyWebcam-container" onload=${(el) => {
-      props.onFocus()
-      const recordButton = el.querySelector('.UppyWebcam-recordButton')
-      if (recordButton) recordButton.focus()
-    }} onunload=${(el) => {
-      props.onStop()
-    }}>
-      <div class='UppyWebcam-videoContainer'>
-        ${video}
+    if (this.props.useTheFlash) {
+      video = this.props.getSWFHTML()
+    } else {
+      video = html`<video class="UppyWebcam-video" autoplay muted src="${src}"></video>`
+    }
+
+    const shouldShowRecordButton = this.props.supportsRecording && (
+      isModeAvailable(this.props.modes, 'video-only') ||
+      isModeAvailable(this.props.modes, 'audio-only') ||
+      isModeAvailable(this.props.modes, 'video-audio')
+    )
+
+    const shouldShowSnapshotButton = isModeAvailable(this.props.modes, 'picture')
+
+    return html`
+      <div class="UppyWebcam-container" ref=${(el) => {
+        console.log(el)
+        this.webcamContainer = el
+      }}>
+        <div class='UppyWebcam-videoContainer'>
+          ${video}
+        </div>
+        <div class='UppyWebcam-buttonContainer'>
+          ${shouldShowRecordButton ? RecordButton(this.props) : null}
+          ${shouldShowSnapshotButton ? SnapshotButton(this.props) : null}
+        </div>
+        <canvas class="UppyWebcam-canvas" style="display: none;"></canvas>
       </div>
-      <div class='UppyWebcam-buttonContainer'>
-        ${shouldShowRecordButton ? RecordButton(props) : null}
-        ${shouldShowSnapshotButton ? SnapshotButton(props) : null}
-      </div>
-      <canvas class="UppyWebcam-canvas" style="display: none;"></canvas>
-    </div>
-  `
+    `
+  }
 }
+
+module.exports = CameraScreen

--- a/src/plugins/Webcam/PermissionsScreen.js
+++ b/src/plugins/Webcam/PermissionsScreen.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`

--- a/src/plugins/Webcam/RecordButton.js
+++ b/src/plugins/Webcam/RecordButton.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const RecordStartIcon = require('./RecordStartIcon')
 const RecordStopIcon = require('./RecordStopIcon')
 

--- a/src/plugins/Webcam/RecordStartIcon.js
+++ b/src/plugins/Webcam/RecordStartIcon.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`<svg class="UppyIcon" width="100" height="100" viewBox="0 0 100 100">

--- a/src/plugins/Webcam/RecordStopIcon.js
+++ b/src/plugins/Webcam/RecordStopIcon.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`<svg class="UppyIcon" width="100" height="100" viewBox="0 0 100 100">

--- a/src/plugins/Webcam/SnapshotButton.js
+++ b/src/plugins/Webcam/SnapshotButton.js
@@ -1,4 +1,7 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
+
 const CameraIcon = require('./CameraIcon')
 
 module.exports = function SnapshotButton ({ onSnapshot }) {

--- a/src/plugins/Webcam/WebcamIcon.js
+++ b/src/plugins/Webcam/WebcamIcon.js
@@ -1,4 +1,6 @@
-const html = require('yo-yo')
+const { h } = require('preact')
+const hyperx = require('hyperx')
+const html = hyperx(h, {attrToProp: false})
 
 module.exports = (props) => {
   return html`

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -8,6 +8,8 @@ const WebcamIcon = require('./WebcamIcon')
 const CameraScreen = require('./CameraScreen')
 const PermissionsScreen = require('./PermissionsScreen')
 
+const { h } = require('preact')
+
 /**
  * Webcam
  */
@@ -277,7 +279,7 @@ module.exports = class Webcam extends Plugin {
       this.streamSrc = this.stream ? URL.createObjectURL(this.stream) : null
     }
 
-    return CameraScreen(extend(state.webcam, {
+    return h(CameraScreen, extend(state.webcam, {
       onSnapshot: this.takeSnapshot,
       onStartRecording: this.startRecording,
       onStopRecording: this.stopRecording,


### PR DESCRIPTION
Continuing experiments from #296.

This one uses Preact and works right out of the box, including inline-styles as
strings, and has rendering optimizations built-in. Has mostly same benefits compared to yo-yo.

Lifecycle events are different though, because they mirror React: https://github.com/developit/preact#components. If my understanding is correct, instead of inlining them: `<div oncreate=${doRequest}>bla</div>` we’ll have to refactor that `<div>` into a separate component and use `componentDidMount`. It does have more events too.

My vote is for Preact, because already works, mature and getting a lot of popularity recently. And maybe JSX in the future, but starting with Preact.