### PR TITLE
core: Throw clearer error when `.use`ing undefined

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -601,6 +601,12 @@ class Uppy {
  * @return {Object} self for chaining
  */
   use (Plugin, opts) {
+    if (typeof Plugin !== 'function') {
+      let msg = `Expected a plugin class, but got ${Plugin === null ? 'null' : typeof Plugin}.` +
+        ' Please verify that the plugin was imported and spelled correctly.'
+      throw new TypeError(msg)
+    }
+
     // Instantiate
     const plugin = new Plugin(this, opts)
     const pluginName = plugin.id


### PR DESCRIPTION
Previously this would throw "Plugin is not a constructor" when trying to
instantiate the plugin. Now it checks that the Plugin is actually a
function (and hopefully a constructor…) and throws a more helpful error
if it is not.