### PR TITLE
xhrupload: Support error messages from the endpoint

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -444,7 +444,11 @@ class Uppy {
 
     this.on('core:upload-error', (fileID, error) => {
       const fileName = this.state.files[fileID].name
-      this.info(`Failed to upload: ${fileName}`, 'error', 5000)
+      let message = `Failed to upload ${fileName}`
+      if (typeof error === 'object' && error.message) {
+        message = `${message}: ${error.message}`
+      }
+      this.info(message, 'error', 5000)
     })
 
     this.on('core:upload', () => {

--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -66,6 +66,14 @@ module.exports = class AwsS3 extends Plugin {
             key: getValue('Key'),
             etag: getValue('ETag')
           }
+        },
+        getResponseError (xhr) {
+          // If no response, we don't have a specific error message, use the default.
+          if (!xhr.responseXML) {
+            return
+          }
+          const error = xhr.responseXML.querySelector('Error > Message')
+          return new Error(error.textContent)
         }
       })
     })

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -20,6 +20,9 @@ module.exports = class XHRUpload extends Plugin {
       headers: {},
       getResponseData (xhr) {
         return JSON.parse(xhr.response)
+      },
+      getResponseError (xhr) {
+        return new Error('Upload error')
       }
     }
 
@@ -88,8 +91,10 @@ module.exports = class XHRUpload extends Plugin {
 
           return resolve(file)
         } else {
-          this.core.emit('core:upload-error', file.id, xhr)
-          return reject('Upload error')
+          const error = opts.getResponseError(xhr) || new Error('Upload error')
+          error.request = xhr
+          this.core.emit('core:upload-error', file.id, error)
+          return reject(error)
         }
 
         // var upload = {}
@@ -103,7 +108,7 @@ module.exports = class XHRUpload extends Plugin {
 
       xhr.addEventListener('error', (ev) => {
         this.core.emit('core:upload-error', file.id)
-        return reject('Upload error')
+        return reject(new Error('Upload error'))
       })
 
       xhr.open(opts.method.toUpperCase(), opts.endpoint, true)


### PR DESCRIPTION
This implements a `getResponseError` option as described in #303. If available, the error message is appended to the generic "Failed to upload" message:

![image](https://user-images.githubusercontent.com/1006268/29916415-fe4efe44-8e3e-11e7-941f-c2ed18f24fdd.png)

This PR also implements the `getResponseError` function for the S3 plugin. The screenshot above is using the S3 plugin with a presigned URL that expired in the past.