### PR TITLE
dashboard: Prevent submitting outer form while editing metadata

### DIFF
--- a/src/plugins/Dashboard/FileCard.js
+++ b/src/plugins/Dashboard/FileCard.js
@@ -8,7 +8,7 @@ module.exports = function fileCard (props) {
 
   function tempStoreMeta (ev) {
     const value = ev.target.value
-    const name = ev.target.attributes.name.value
+    const name = ev.target.dataset.name
     meta[name] = value
   }
 
@@ -18,8 +18,8 @@ module.exports = function fileCard (props) {
       return html`<fieldset class="UppyDashboardFileCard-fieldset">
         <label class="UppyDashboardFileCard-label">${field.name}</label>
         <input class="UppyDashboardFileCard-input"
-               name="${field.id}"
                type="text"
+               data-name="${field.id}"
                value="${file.meta[field.id]}"
                placeholder="${field.placeholder || ''}"
                onkeyup=${tempStoreMeta} /></fieldset>`


### PR DESCRIPTION
Fixes #286

Using a `data-` attribute instead of the `name` attribute. Inputs with
`name` attributes submit the form they belong to when `enter` is
pressed, but inputs without do not:
https://stackoverflow.com/questions/3008035/stop-an-input-field-in-a-form-from-being-submitted

A cool followup would be to listen for enter keypresses and close the metadata editor when they happen.