### PR TITLE
Checks for plugin type and plugin id rather than name

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -609,21 +609,21 @@ class Uppy {
 
     // Instantiate
     const plugin = new Plugin(this, opts)
-    const pluginName = plugin.id
+    const pluginId = plugin.id
     this.plugins[plugin.type] = this.plugins[plugin.type] || []
 
-    if (!pluginName) {
-      throw new Error('Your plugin must have a name')
+    if (!pluginId) {
+      throw new Error('Your plugin must have an id')
     }
 
-    if (!plugin.type) {
+    if (!plugin.type || plugin.type === 'none') {
       throw new Error('Your plugin must have a type')
     }
 
-    let existsPluginAlready = this.getPlugin(pluginName)
+    let existsPluginAlready = this.getPlugin(pluginId)
     if (existsPluginAlready) {
-      let msg = `Already found a plugin named '${existsPluginAlready.name}'.
-        Tried to use: '${pluginName}'.
+      let msg = `Already found a plugin named '${existsPluginAlready.id}'.
+        Tried to use: '${pluginId}'.
         Uppy is currently limited to running one of every plugin.
         Share your use case with us over at
         https://github.com/transloadit/uppy/issues/

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -616,7 +616,7 @@ class Uppy {
       throw new Error('Your plugin must have an id')
     }
 
-    if (!plugin.type || plugin.type === 'none') {
+    if (!plugin.type) {
       throw new Error('Your plugin must have a type')
     }
 

--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -17,7 +17,6 @@ module.exports = class Plugin {
   constructor (core, opts) {
     this.core = core
     this.opts = opts || {}
-    this.type = 'none'
 
     // clear everything inside the target selector
     this.opts.replaceTargetContent === this.opts.replaceTargetContent || true


### PR DESCRIPTION
Even when a plugin didn't have a 'type' property it would still get set to type='none' by the parent plugin class. This PR checks that type==='none' and throws an error if it does.

The pluginName check actually uses plugin.id, so I've updated it the errors and variable names to be pluginId instead to avoid confusion (the plugins actually expose id and name).