### PR TITLE
updateAll method uses iteratePlugins method

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -115,10 +115,8 @@ class Uppy {
    *
    */
   updateAll (state) {
-    Object.keys(this.plugins).forEach((pluginType) => {
-      this.plugins[pluginType].forEach((plugin) => {
-        plugin.update(state)
-      })
+    this.iteratePlugins(plugin => {
+      plugin.update(state)
     })
   }
 


### PR DESCRIPTION
updateAll was performing it's own series of loops to update all the plugins. This PR makes use of the existing iterate method.