### PR TITLE
Add `unpkg` to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you like, you can also use a pre-built bundle, for example from [unpkg CDN](h
 1\. Add a script to the bottom of `<body>`:
 
 ``` html
-<script src="https://unpkg.com/uppy/dist/uppy.min.js"></script>
+<script src="https://unpkg.com/uppy"></script>
 ```
 
 2\. Add CSS to `<head>`:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Almost as cute as a Puppy :dog:",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
+  "unpkg": "dist/uppy.min.js",
   "files": [
     "src/",
     "lib/",

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -17,7 +17,7 @@ const Tus10 = require('uppy/lib/plugins/Tus10')
  
 const uppy = Uppy({ autoProceed: false })
   .use(Dashboard, {
-    trigger: '#select-files', 
+    trigger: '#select-files',
     replaceTargetContent: true
   })
   .use(Tus10, {endpoint: '//master.tus.io/files/'})
@@ -30,7 +30,7 @@ uppy.on('core:success', (files) => {
 
 [Try it live](/examples/dashboard/)
 
-Drag and Drop, Webcam, basic file manipulation (adding metadata), uploading via tus resumable uploads or XHR/Multipart is all possible using just the uppy client module. 
+Drag and Drop, Webcam, basic file manipulation (adding metadata), uploading via tus resumable uploads or XHR/Multipart is all possible using just the uppy client module.
 
 Adding [Uppy Server](/docs/server/) to the mix enables remote sources, such as Instagram, Google Drive and Dropbox. Uploads from remote sources are handled server-to-serber,(so a 5 GB video won’t be eating into your mobile data plan. Files are removed from Uppy Server after an upload is complete, or after a reasonable timeout. Access tokens also don’t stick around for long, for security reasons.
 
@@ -40,16 +40,16 @@ Adding [Uppy Server](/docs/server/) to the mix enables remote sources, such as I
 $ npm install uppy
 ```
 
-We recommend installing from NPM and then using a module bundler such as [Webpack](http://webpack.github.io/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/). 
+We recommend installing from NPM and then using a module bundler such as [Webpack](http://webpack.github.io/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
 
-If you like, you can also use a pre-built bundle, for example from [unpkg CDN](https://unpkg.com/uppy/). In that case `Uppy` will attach itself to the global `window.Uppy` object. 
+If you like, you can also use a pre-built bundle, for example from [unpkg CDN](https://unpkg.com/uppy/). In that case `Uppy` will attach itself to the global `window.Uppy` object.
 
 > ⚠️ The bundle currently consists of most Uppy plugins, so this method is not  recommended for production, as your users will have to download all plugins, even if you are using just a few.
 
 1\. Add a script to the bottom of `<body>`:
 
 ``` html
-<script src="https://unpkg.com/uppy/dist/uppy.min.js"></script>
+<script src="https://unpkg.com/uppy"></script>
 ```
 
 2\. Add CSS to `<head>`:

--- a/website/src/examples/i18n/app.html
+++ b/website/src/examples/i18n/app.html
@@ -3,7 +3,7 @@
 
 <div class="UppyDragDrop"></div>
 
-<!-- Load Uppy pre-built bundled version. You can use a CDN: https://unpkg.com/uppy/dist/uppy.min.js -->
+<!-- Load Uppy pre-built bundled version. You can use a CDN: https://unpkg.com/uppy -->
 <script src="/uppy/uppy.min.js"></script>
 <script>
   var uppy = Uppy.Core({debug: true});
@@ -12,7 +12,7 @@
     locale: {
       strings: {
         chooseFile: 'Выберите файл',
-        orDragDrop: 'или перенесите его сюда'      
+        orDragDrop: 'или перенесите его сюда'
       }
     }
   });


### PR DESCRIPTION
This points https://unpkg.com/uppy to the minified bundle instead of to
the commonjs source files.

Use the short endpoint in the readme and website examples.