### PR TITLE
Clear stored tus `uploadUrl` when `resetProgress` is called

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -166,11 +166,14 @@ class Uppy {
       updatedFile.progress = Object.assign({}, updatedFile.progress, defaultProgress)
       updatedFiles[fileID] = updatedFile
     })
-    console.log(updatedFiles)
+
     this.setState({
       files: updatedFiles,
       totalProgress: 0
     })
+
+    // TODO Document on the website
+    this.emit('core:reset-progress')
   }
 
   addPreProcessor (fn) {

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -46,6 +46,7 @@ module.exports = class Tus10 extends Plugin {
 
     this.handlePauseAll = this.handlePauseAll.bind(this)
     this.handleResumeAll = this.handleResumeAll.bind(this)
+    this.handleResetProgress = this.handleResetProgress.bind(this)
     this.handleUpload = this.handleUpload.bind(this)
   }
 
@@ -102,6 +103,20 @@ module.exports = class Tus10 extends Plugin {
 
   handleResumeAll () {
     this.pauseResume('resumeAll')
+  }
+
+  handleResetProgress () {
+    const files = Object.assign({}, this.core.state.files)
+    Object.keys(files).forEach((fileID) => {
+      // Only clone the file object if it has a Tus `uploadUrl` attached.
+      if (files[fileID].tus && files[fileID].tus.uploadUrl) {
+        const tusState = Object.assign({}, files[fileID].tus)
+        delete tusState.uploadUrl
+        files[fileID] = Object.assign({}, files[fileID], { tus: tusState })
+      }
+    })
+
+    this.core.setState({ files })
   }
 
   /**
@@ -341,6 +356,7 @@ module.exports = class Tus10 extends Plugin {
   actions () {
     this.core.on('core:pause-all', this.handlePauseAll)
     this.core.on('core:resume-all', this.handleResumeAll)
+    this.core.on('core:reset-progress', this.handleResetProgress)
 
     if (this.opts.autoRetry) {
       this.core.on('back-online', () => {


### PR DESCRIPTION
As discussed briefly in slack. This fixes an issue where

```js
uppy.resetProgress()
uppy.upload()
```
would attempt to "reupload" tus files to the same endpoint, thus actually resuming those uploads instead of creating new ones.

Going to merge this quickly today to publish a beta release to npm, if you have review comments @arturi or would prefer something else we can revert after and address that then :)