### PR TITLE
transloadit: remove `this.state` getter

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -124,13 +124,14 @@ module.exports = class Transloadit extends Plugin {
       signature: options.signature
     }).then((assembly) => {
       // Store the list of assemblies related to this upload.
-      const assemblyList = this.state.uploadsAssemblies[uploadID]
-      const uploadsAssemblies = Object.assign({}, this.state.uploadsAssemblies, {
+      const state = this.core.state.transloadit
+      const assemblyList = state.uploadsAssemblies[uploadID]
+      const uploadsAssemblies = Object.assign({}, state.uploadsAssemblies, {
         [uploadID]: assemblyList.concat([ assembly.assembly_id ])
       })
 
       this.updateState({
-        assemblies: Object.assign(this.state.assemblies, {
+        assemblies: Object.assign(state.assemblies, {
           [assembly.assembly_id]: assembly
         }),
         uploadsAssemblies
@@ -211,7 +212,8 @@ module.exports = class Transloadit extends Plugin {
       return
     }
 
-    const assembly = this.state.assemblies[file.transloadit.assembly]
+    const state = this.core.state.transloadit
+    const assembly = state.assemblies[file.transloadit.assembly]
 
     this.client.addFile(assembly, file).catch((err) => {
       this.core.log(err)
@@ -232,9 +234,10 @@ module.exports = class Transloadit extends Plugin {
   }
 
   onFileUploadComplete (assemblyId, uploadedFile) {
+    const state = this.core.state.transloadit
     const file = this.findFile(uploadedFile)
     this.updateState({
-      files: Object.assign({}, this.state.files, {
+      files: Object.assign({}, state.files, {
         [uploadedFile.id]: {
           id: file.id,
           uploadedFile
@@ -245,20 +248,22 @@ module.exports = class Transloadit extends Plugin {
   }
 
   onResult (assemblyId, stepName, result) {
-    const file = this.state.files[result.original_id]
+    const state = this.core.state.transloadit
+    const file = state.files[result.original_id]
     // The `file` may not exist if an import robot was used instead of a file upload.
     result.localId = file ? file.id : null
 
     this.updateState({
-      results: this.state.results.concat(result)
+      results: state.results.concat(result)
     })
     this.core.emit('transloadit:result', stepName, result, this.getAssembly(assemblyId))
   }
 
   onAssemblyFinished (url) {
     this.client.getAssemblyStatus(url).then((assembly) => {
+      const state = this.core.state.transloadit
       this.updateState({
-        assemblies: Object.assign({}, this.state.assemblies, {
+        assemblies: Object.assign({}, state.assemblies, {
           [assembly.assembly_id]: assembly
         })
       })
@@ -321,8 +326,9 @@ module.exports = class Transloadit extends Plugin {
       })
     }
 
+    const state = this.core.state.transloadit
     const uploadsAssemblies = Object.assign({},
-      this.state.uploadsAssemblies,
+      state.uploadsAssemblies,
       { [uploadID]: [] })
     this.updateState({ uploadsAssemblies })
 
@@ -351,7 +357,8 @@ module.exports = class Transloadit extends Plugin {
   }
 
   afterUpload (fileIDs, uploadID) {
-    const assemblyIDs = this.state.uploadsAssemblies[uploadID]
+    const state = this.core.state.transloadit
+    const assemblyIDs = state.uploadsAssemblies[uploadID]
 
     // If we don't have to wait for encoding metadata or results, we can close
     // the socket immediately and finish the upload.
@@ -448,7 +455,8 @@ module.exports = class Transloadit extends Plugin {
       this.core.on('transloadit:import-error', onImportError)
     }).then(() => {
       // Clean up uploadID → assemblyIDs, they're no longer going to be used anywhere.
-      const uploadsAssemblies = Object.assign({}, this.state.uploadsAssemblies)
+      const state = this.core.state.transloadit
+      const uploadsAssemblies = Object.assign({}, state.uploadsAssemblies)
       delete uploadsAssemblies[uploadID]
       this.updateState({ uploadsAssemblies })
     })
@@ -484,7 +492,8 @@ module.exports = class Transloadit extends Plugin {
   }
 
   getAssembly (id) {
-    return this.state.assemblies[id]
+    const state = this.core.state.transloadit
+    return state.assemblies[id]
   }
 
   getAssemblyFiles (assemblyID) {
@@ -496,12 +505,8 @@ module.exports = class Transloadit extends Plugin {
     })
   }
 
-  get state () {
-    return this.core.state.transloadit || {}
-  }
-
   updateState (newState) {
-    const transloadit = Object.assign({}, this.state, newState)
+    const transloadit = Object.assign({}, this.core.state.transloadit, newState)
 
     this.core.setState({ transloadit })
   }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -130,7 +130,7 @@ module.exports = class Transloadit extends Plugin {
         [uploadID]: assemblyList.concat([ assembly.assembly_id ])
       })
 
-      this.updateState({
+      this.setPluginState({
         assemblies: Object.assign(state.assemblies, {
           [assembly.assembly_id]: assembly
         }),
@@ -236,7 +236,7 @@ module.exports = class Transloadit extends Plugin {
   onFileUploadComplete (assemblyId, uploadedFile) {
     const state = this.core.state.transloadit
     const file = this.findFile(uploadedFile)
-    this.updateState({
+    this.setPluginState({
       files: Object.assign({}, state.files, {
         [uploadedFile.id]: {
           id: file.id,
@@ -253,7 +253,7 @@ module.exports = class Transloadit extends Plugin {
     // The `file` may not exist if an import robot was used instead of a file upload.
     result.localId = file ? file.id : null
 
-    this.updateState({
+    this.setPluginState({
       results: state.results.concat(result)
     })
     this.core.emit('transloadit:result', stepName, result, this.getAssembly(assemblyId))
@@ -262,7 +262,7 @@ module.exports = class Transloadit extends Plugin {
   onAssemblyFinished (url) {
     this.client.getAssemblyStatus(url).then((assembly) => {
       const state = this.core.state.transloadit
-      this.updateState({
+      this.setPluginState({
         assemblies: Object.assign({}, state.assemblies, {
           [assembly.assembly_id]: assembly
         })
@@ -330,7 +330,7 @@ module.exports = class Transloadit extends Plugin {
     const uploadsAssemblies = Object.assign({},
       state.uploadsAssemblies,
       { [uploadID]: [] })
-    this.updateState({ uploadsAssemblies })
+    this.setPluginState({ uploadsAssemblies })
 
     let optionsPromise
     if (fileIDs.length > 0) {
@@ -458,7 +458,7 @@ module.exports = class Transloadit extends Plugin {
       const state = this.core.state.transloadit
       const uploadsAssemblies = Object.assign({}, state.uploadsAssemblies)
       delete uploadsAssemblies[uploadID]
-      this.updateState({ uploadsAssemblies })
+      this.setPluginState({ uploadsAssemblies })
     })
   }
 
@@ -470,7 +470,7 @@ module.exports = class Transloadit extends Plugin {
       this.core.on('core:upload-success', this.onFileUploadURLAvailable)
     }
 
-    this.updateState({
+    this.setPluginState({
       // Contains assembly status objects, indexed by their ID.
       assemblies: {},
       // Contains arrays of assembly IDs, indexed by the upload ID that they belong to.
@@ -505,7 +505,7 @@ module.exports = class Transloadit extends Plugin {
     })
   }
 
-  updateState (newState) {
+  setPluginState (newState) {
     const transloadit = Object.assign({}, this.core.state.transloadit, newState)
 
     this.core.setState({ transloadit })

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -72,7 +72,7 @@ module.exports = class Webcam extends Plugin {
     this.i18n = this.translator.translate.bind(this.translator)
 
     this.install = this.install.bind(this)
-    this.updateState = this.updateState.bind(this)
+    this.setPluginState = this.setPluginState.bind(this)
 
     this.render = this.render.bind(this)
 
@@ -104,7 +104,7 @@ module.exports = class Webcam extends Plugin {
   /**
    * Little shorthand to update the state with my new state
    */
-  updateState (newState) {
+  setPluginState (newState) {
     const {state} = this.core
     const webcam = Object.assign({}, state.webcam, newState)
 
@@ -117,13 +117,13 @@ module.exports = class Webcam extends Plugin {
     this.webcam.start()
       .then((stream) => {
         this.stream = stream
-        this.updateState({
+        this.setPluginState({
           // videoStream: stream,
           cameraReady: true
         })
       })
       .catch((err) => {
-        this.updateState({
+        this.setPluginState({
           cameraError: err
         })
       })
@@ -141,7 +141,7 @@ module.exports = class Webcam extends Plugin {
     })
     this.recorder.start()
 
-    this.updateState({
+    this.setPluginState({
       isRecording: true
     })
   }
@@ -149,7 +149,7 @@ module.exports = class Webcam extends Plugin {
   stopRecording () {
     return new Promise((resolve, reject) => {
       this.recorder.addEventListener('stop', () => {
-        this.updateState({
+        this.setPluginState({
           isRecording: false
         })
 


### PR DESCRIPTION
`this.state` was a bit confusing, wasn't clear where the state was coming from. now these functions first assign `state = this.core.state.transloadit` explicitly and use that.

From comments here https://github.com/transloadit/uppy/pull/291#discussion_r135058115