### PR TITLE
core: Remove `core:upload-complete` event.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,16 @@
       "integrity": "sha1-9vGlzl05caSt6RoR0i1MRZrNN18=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -1445,9 +1455,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1734,6 +1744,7 @@
       "integrity": "sha1-BQjMHnv0wVIxLC+lI+Z2wLC5IxE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1755,7 +1766,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -4907,14 +4917,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4923,6 +4925,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6186,10 +6196,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -6678,16 +6688,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -7697,6 +7697,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -7704,7 +7705,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.2.11",
         "resolve": "1.3.3",
@@ -9319,6 +9319,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
+    },
+    "promise-settle": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-settle/-/promise-settle-0.3.0.tgz",
+      "integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY="
     },
     "propagate": {
       "version": "0.4.0",
@@ -10973,14 +10978,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -11033,6 +11030,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "requires": {
+        "safe-buffer": "5.0.1"
       }
     },
     "stringstream": {
@@ -11831,6 +11836,7 @@
           "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
           "dev": true,
           "requires": {
+            "JSONStream": "1.3.1",
             "assert": "1.4.1",
             "browser-pack": "6.0.2",
             "browser-resolve": "1.11.2",
@@ -11852,7 +11858,6 @@
             "https-browserify": "0.0.1",
             "inherits": "2.0.3",
             "insert-module-globals": "7.0.1",
-            "JSONStream": "1.3.1",
             "labeled-stream-splicer": "2.0.0",
             "module-deps": "4.1.1",
             "os-browserify": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "nanoraf": "3.0.1",
     "on-load": "3.2.0",
     "prettier-bytes": "1.0.4",
+    "promise-settle": "^0.3.0",
     "socket.io-client": "2.0.1",
     "tus-js-client": "1.4.3",
     "url-parse": "1.1.9",

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -525,13 +525,6 @@ class Uppy {
       })
 
       this.calculateTotalProgress()
-
-      if (this.getState().totalProgress === 100) {
-        const completeFiles = Object.keys(updatedFiles).filter((file) => {
-          return updatedFiles[file].progress.uploadComplete
-        })
-        this.emit('core:upload-complete', completeFiles.length)
-      }
     })
 
     this.on('core:update-meta', (data, fileID) => {

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -324,16 +324,16 @@ module.exports = class Tus10 extends Plugin {
   }
 
   uploadFiles (files) {
-    files.forEach((file, index) => {
+    return Promise.all(files.map((file, index) => {
       const current = parseInt(index, 10) + 1
       const total = files.length
 
       if (!file.isRemote) {
-        this.upload(file, current, total)
+        return this.upload(file, current, total)
       } else {
-        this.uploadRemote(file, current, total)
+        return this.uploadRemote(file, current, total)
       }
-    })
+    }))
   }
 
   handleUpload (fileIDs) {
@@ -345,11 +345,7 @@ module.exports = class Tus10 extends Plugin {
     this.core.log('Tus is uploading...')
     const filesToUpload = fileIDs.map((fileID) => this.core.getFile(fileID))
 
-    this.uploadFiles(filesToUpload)
-
-    return new Promise((resolve) => {
-      this.core.once('core:upload-complete', resolve)
-    })
+    return this.uploadFiles(filesToUpload)
   }
 
   actions () {

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -1,5 +1,6 @@
 const Plugin = require('./Plugin')
 const tus = require('tus-js-client')
+const settle = require('promise-settle')
 const UppySocket = require('../core/UppySocket')
 const Utils = require('../core/Utils')
 require('whatwg-fetch')
@@ -324,7 +325,7 @@ module.exports = class Tus10 extends Plugin {
   }
 
   uploadFiles (files) {
-    return Promise.all(files.map((file, index) => {
+    return settle(files.map((file, index) => {
       const current = parseInt(index, 10) + 1
       const total = files.length
 

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -176,16 +176,16 @@ module.exports = class XHRUpload extends Plugin {
   }
 
   selectForUpload (files) {
-    files.forEach((file, i) => {
+    return Promise.all(files.map((file, i) => {
       const current = parseInt(i, 10) + 1
       const total = files.length
 
       if (file.isRemote) {
-        this.uploadRemote(file, current, total)
+        return this.uploadRemote(file, current, total)
       } else {
-        this.upload(file, current, total)
+        return this.upload(file, current, total)
       }
-    })
+    }))
 
     //   if (this.opts.bundle) {
     //     uploaders.push(this.upload(files, 0, files.length))
@@ -208,11 +208,7 @@ module.exports = class XHRUpload extends Plugin {
       return this.core.state.files[fileID]
     }
 
-    this.selectForUpload(files)
-
-    return new Promise((resolve) => {
-      this.core.once('core:upload-complete', resolve)
-    })
+    return this.selectForUpload(files).then(() => null)
   }
 
   install () {

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -1,4 +1,5 @@
 const Plugin = require('./Plugin')
+const settle = require('promise-settle')
 const UppySocket = require('../core/UppySocket')
 const Utils = require('../core/Utils')
 
@@ -176,7 +177,7 @@ module.exports = class XHRUpload extends Plugin {
   }
 
   selectForUpload (files) {
-    return Promise.all(files.map((file, i) => {
+    return settle(files.map((file, i) => {
       const current = parseInt(i, 10) + 1
       const total = files.length
 


### PR DESCRIPTION
XHRUpload and Tus were relying on `core:upload-complete` to determine
when their uploads had all finished, but `core:upload-complete` could
fire before all XHR `onload` handlers were called. Then, because
XHRUpload and Tus would resolve their `handleUpload` promises at that
point, the `core:success` event could fire *before* all
`core:upload-success` events had fired, and before the plugins properly
handled responses. In particular, some files may not have `.uploadURL`
properties when `core:success` is fired:

https://community.transloadit.com/t/unable-to-get-to-work-the-awss3-plugin/14477/16

I think, that the XHR `onprogress` event would fire first at 100%, and
then the `onload` handler fired at some point later (after the response
was parsed or whatever the browser does to it). This could cause the
`core:upload-complete` event to fire before responses were handled by
Uppy.

The XHRUpload and Tus plugins now use the Promises that they were
already creating to wait for uploads to complete. This way they will
always have handled responses before handing over control to
postprocessors and before the `core:success` event is fired.

Since `core:upload-complete` is now unused, I just removed it for now.

TODO:

 - [x] This means the entire upload fails when a single file errored. Instead of `Promise.all`, perhaps use https://www.npmjs.com/package/promise-settle