### PR TITLE
Dashboard: show()/hide()/isOpen()

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -71,6 +71,7 @@ class Uppy {
     this.updateMeta = this.updateMeta.bind(this)
     this.initSocket = this.initSocket.bind(this)
     this.log = this.log.bind(this)
+    this.info = this.info.bind(this)
     this.addFile = this.addFile.bind(this)
     this.removeFile = this.removeFile.bind(this)
     this.calculateProgress = this.calculateProgress.bind(this)

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -516,17 +516,23 @@ function isDOMElement (obj) {
  */
 function findDOMElement (element) {
   if (typeof element === 'string') {
-    const elements = [].slice.call(document.querySelectorAll(element))
-    if (elements.length > 1) {
-      return elements
-    }
-    return elements[0]
-    // return document.querySelector(element)
+    return document.querySelector(element)
   }
 
   if (typeof element === 'object' && isDOMElement(element)) {
     return element
   }
+}
+
+/**
+ * Find one or more DOM elements.
+ *
+ * @param {string} selector
+ * @return {Array|null}
+ */
+function findAllDOMElements (selector) {
+  const elements = [].slice.call(document.querySelectorAll(selector))
+  return elements.length > 0 ? elements : null
 }
 
 function getSocketHost (url) {
@@ -580,6 +586,7 @@ module.exports = {
   copyToClipboard,
   prettyETA,
   findDOMElement,
+  findAllDOMElements,
   getSocketHost,
   emitSocketProgress
 }

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -527,12 +527,18 @@ function findDOMElement (element) {
 /**
  * Find one or more DOM elements.
  *
- * @param {string} selector
+ * @param {string} element
  * @return {Array|null}
  */
-function findAllDOMElements (selector) {
-  const elements = [].slice.call(document.querySelectorAll(selector))
-  return elements.length > 0 ? elements : null
+function findAllDOMElements (element) {
+  if (typeof element === 'string') {
+    const elements = [].slice.call(document.querySelectorAll(element))
+    return elements.length > 0 ? elements : null
+  }
+
+  if (typeof element === 'object' && isDOMElement(element)) {
+    return element
+  }
 }
 
 function getSocketHost (url) {

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -516,7 +516,12 @@ function isDOMElement (obj) {
  */
 function findDOMElement (element) {
   if (typeof element === 'string') {
-    return document.querySelector(element)
+    const elements = [].slice.call(document.querySelectorAll(element))
+    if (elements.length > 1) {
+      return elements
+    }
+    return elements[0]
+    // return document.querySelector(element)
   }
 
   if (typeof element === 'object' && isDOMElement(element)) {

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -537,7 +537,7 @@ function findAllDOMElements (element) {
   }
 
   if (typeof element === 'object' && isDOMElement(element)) {
-    return element
+    return [element]
   }
 }
 

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -69,7 +69,7 @@ module.exports = function Dashboard (props) {
               type="button"
               aria-label="${props.i18n('closeModal')}"
               title="${props.i18n('closeModal')}"
-              onclick=${props.hide}>${closeIcon()}</button>
+              onclick=${props.closeModal}>${closeIcon()}</button>
 
       <div class="UppyDashboard-innerWrap">
 

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -69,7 +69,7 @@ module.exports = function Dashboard (props) {
               type="button"
               aria-label="${props.i18n('closeModal')}"
               title="${props.i18n('closeModal')}"
-              onclick=${props.hideModal}>${closeIcon()}</button>
+              onclick=${props.hide}>${closeIcon()}</button>
 
       <div class="UppyDashboard-innerWrap">
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -4,7 +4,7 @@ const dragDrop = require('drag-drop')
 const Dashboard = require('./Dashboard')
 const StatusBar = require('../StatusBar')
 const Informer = require('../Informer')
-const { findDOMElement } = require('../../core/Utils')
+const { findAllDOMElements } = require('../../core/Utils')
 const prettyBytes = require('prettier-bytes')
 const { defaultTabIcon } = require('./icons')
 
@@ -199,7 +199,7 @@ module.exports = class DashboardUI extends Plugin {
 
   initEvents () {
     // Modal open button
-    const showModalTrigger = findDOMElement(this.opts.trigger)
+    const showModalTrigger = findAllDOMElements(this.opts.trigger)
     if (!this.opts.inline && showModalTrigger) {
       if (Array.isArray(showModalTrigger)) {
         showModalTrigger.forEach(trigger => trigger.addEventListener('click', this.show))
@@ -221,7 +221,7 @@ module.exports = class DashboardUI extends Plugin {
   }
 
   removeEvents () {
-    const showModalTrigger = findDOMElement(this.opts.trigger)
+    const showModalTrigger = findAllDOMElements(this.opts.trigger)
     if (!this.opts.inline && showModalTrigger) {
       if (Array.isArray(showModalTrigger)) {
         showModalTrigger.forEach(trigger => trigger.removeEventListener('click', this.show))
@@ -271,7 +271,7 @@ module.exports = class DashboardUI extends Plugin {
   }
 
   handleDrop (files) {
-    this.core.log('[Dashboard] Files were droppeded')
+    this.core.log('[Dashboard] Files were dropped')
 
     files.forEach((file) => {
       this.core.addFile({

--- a/src/plugins/StatusBar/index.js
+++ b/src/plugins/StatusBar/index.js
@@ -11,8 +11,8 @@ const prettyBytes = require('prettier-bytes')
 module.exports = class StatusBarUI extends Plugin {
   constructor (core, opts) {
     super(core, opts)
-    this.id = 'StatusBarUI'
-    this.title = 'StatusBar UI'
+    this.id = 'StatusBar'
+    this.title = 'StatusBar'
     this.type = 'progressindicator'
 
     // set default options

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -21,12 +21,14 @@ Dashboard is a universal UI plugin for Uppy:
 uppy.use(Dashboard, {
   target: 'body',
   getMetaFromForm: true,
+  trigger: '#uppy-select-files',
   inline: false,
   width: 750,
   height: 550,
+  showProgressDetails: false,
+  hideUploadButton: false,
   note: false,
-  disableStatusBar: false,
-  disableInformer: false,
+  closeModalOnClickOutside: false,
   locale: {
     strings: {
       selectToUpload: 'Select files to upload',
@@ -60,7 +62,7 @@ By default Dashboard will be rendered as a modal, which is opened via clicking o
 
 ### `trigger: '#uppy-select-files'`
 
-String with a CSS selector for a button that will trigger opening Dashboard modal.
+String with a CSS selector for a button that will trigger opening Dashboard modal. Multiple buttons or links can be used, if it’s a class selector (`.uppy-choose`, for example).
 
 ### `width: 750`
 
@@ -89,3 +91,28 @@ See [general plugin options](/docs/plugins).
 ### `locale`
 
 See [general plugin options](/docs/plugins).
+
+## Methods
+
+### `openModal()`
+
+Shows the Dashboard modal. Use it like this:
+
+`uppy.getPlugin('Dashboard').openModal()`
+
+### `closeModal()`
+
+Hides the Dashboard modal. Use it like this:
+
+`uppy.getPlugin('Dashboard').closeModal()`
+
+### `isModalOpen()`
+
+Returns `true` if the Dashboard modal is open, `false` otherwise.
+
+```js
+const dashboard = uppy.getPlugin('Dashboard')
+if ( dashboard.isModalOpen() ) {
+  dashboard.closeModal()
+}
+```


### PR DESCRIPTION
Fixes #327 

This refactor simplifies the Dashboard modal API, so you can:

```js
uppy.getPlugin('Dashboard').show()/hide()/isOpen()
```

Not sure if `show()` is better than `showModal()` and if its worth changing, `showModal` is more explicit, while `show` might conflict with other things, like “show filecard” or “show provider panel”. But it is simpler to use and remember. Focusing so much on this minor thing, cause it might dictate how we name things everywhere.

Bonus: in an attempt to fix #326, this PR adds support for multiple `trigger`'s.