### PR TITLE
Fixes setTimeout to correctly debounce auto upload

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -316,9 +316,9 @@ class Uppy {
         this.emit('core:file-added', newFile)
         this.log(`Added file: ${fileName}, ${fileID}, mime type: ${fileType}`)
 
-        if (this.opts.autoProceed && !this.scheduledAutoProceed) {
+        if (this.opts.autoProceed) {
+          clearTimeout(this.scheduledAutoProceed)
           this.scheduledAutoProceed = setTimeout(() => {
-            this.scheduledAutoProceed = null
             this.upload().catch((err) => {
               console.error(err.stack || err.message || err)
             })


### PR DESCRIPTION
The auto upload after adding a file wasn't working correctly.. it wasn't debouncing (setting the instance of a timer to null does not clear the timer).

To simplify the code it was pretty much doing this:
```
var foo;
for(var i=0;i<10;i++) {
  foo = setTimeout(function() {
    foo = null;
    console.log('hello')
  }, 100);  
}
```
This outputs 'hello' x10

With the PR, it uses clearTimeout to debounce correctly..
```
var foo;
for(var i=0;i<10;i++) {
  clearTimeout(foo)
  foo = setTimeout(function() {
    console.log('hello')
  }, 100);  
}
```
This outputs 'hello' x1 (100ms after the last iteration)

So with the currently logic if you called addFile multiple times it would create a new upload ID for each file. With this PR it will batch all the files together and add them to one upload ID.
