### PR TITLE
website/docs/uppy: Fix typo on sample snippet for "uppy.updateMeta(data, fileID)"

### DIFF
--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -217,7 +217,7 @@ uppy.setMeta({resize: 1500})
 Updated metadata for a specific file.
 
 ```js
-uppy.updateMeta('myfileID', {resize: 1500})
+uppy.updateMeta({resize: 1500}, 'myfileID')
 ```
 
 ### `uppy.reset()`


### PR DESCRIPTION
Fix minor typo on sample snippet for uppy.updateMeta(data, fileID).
