### PR TITLE
set the newState before emiting "core:state-update" .

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -128,9 +128,9 @@ class Uppy {
    */
   setState (stateUpdate) {
     const newState = Object.assign({}, this.state, stateUpdate)
-    this.emit('core:state-update', this.state, newState, stateUpdate)
 
     this.state = newState
+    this.emit('core:state-update', this.state, newState, stateUpdate)
     this.updateAll(this.state)
   }
 


### PR DESCRIPTION
Seems that the newState was set after emiting "core:state-update" which caused the newState being not set properly

This addresses the issue mentioned in https://github.com/transloadit/uppy/issues/340