### PR TITLE
docs: Document StatusBar plugin

### DIFF
--- a/website/src/docs/plugins.md
+++ b/website/src/docs/plugins.md
@@ -7,14 +7,23 @@ order: 3
 
 Plugins are what makes Uppy useful: they help select, manipulate and upload files.
 
-- **Acquirers (neat UIs for picking files):** 
+- **Acquirers (neat UIs for picking files):**
   - [Dashboard](/docs/dashboard) — full featured sleek UI with file previews, metadata editing, upload/pause/resume/cancel buttons and more
   - [DragDrop](/docs/dragdrop) — plain and simple drag and drop area
   - FileInput — even more plain and simple, just a button
   - [Provider Plugins](#Provider-Plugins) (remote sources that work through [Uppy Server](/docs/uppy-server/)): Instagram, GoogleDrive, Dropbox
-- **Uploaders:** Tus10, XHRUpload, S3
-- **Progress:** ProgressBar, StatusBar, Informer
-- **Helpers:** GoldenRetriever
+- **Uploaders:**
+  - Tus10 — uploads using the tus resumable upload protocol
+  - XHRUpload — classic multipart form uploads or binary uploads using XMLHTTPRequest
+  - [AwsS3](/docs/aws-s3) — uploader for AWS S3
+- **Progress:**
+  - ProgressBar — add a small YouTube-style progress bar at the top of the page
+  - [StatusBar](/docs/statusbar) — advanced upload progress status bar
+  - Informer — show notifications
+- **Helpers:**
+  - [GoldenRetriever](/docs/golden-retriever) — restore files and continue uploading after a page refresh or a browser crash
+- **Encoding Services:**
+  - [Transloadit](/docs/transloadit) — manipulate and transcode uploaded files using the [transloadit.com](https://transloadit.com) service
 
 ## Common Options
 

--- a/website/src/docs/statusbar.md
+++ b/website/src/docs/statusbar.md
@@ -1,0 +1,20 @@
+---
+type: docs
+order: 8
+title: "StatusBar"
+permalink: docs/statusbar/
+---
+
+The StatusBar shows upload progress and speed, ETAs, pre- and post-processing information, and allows users to control (pause/resume/cancel) the upload.
+Best used together with a simple file source plugin, such as [FileInput][] or [DragDrop][], or a custom implementation.
+
+[Try it live](/examples/statusbar/)
+
+## Options
+
+### `target: null`
+
+DOM element, CSS selector, or plugin to mount the StatusBar into.
+
+[FileInput]: https://github.com/transloadit/uppy/blob/master/src/plugins/FileInput.js
+[DragDrop]: /docs/dragdrop


### PR DESCRIPTION
Not a whole lot to this plugin atm :)

I think we should add an option to always show the statusbar, that would be useful for standalone usage. Right now the statusbar is hidden by default, and animates in when an upload starts.

Todo:

 - [x] Need to make sure that the page `order` is correct and doesn't conflict with another page, will do after the call