### PR TITLE
restore: Remove files from cache when their upload finished

### DIFF
--- a/src/plugins/RestoreFiles/index.js
+++ b/src/plugins/RestoreFiles/index.js
@@ -207,6 +207,12 @@ module.exports = class RestoreFiles extends Plugin {
       this.IndexedDBStore.delete(fileID)
     })
 
+    this.core.on('core:success', (fileIDs) => {
+      this.deleteBlobs(fileIDs).then(() => {
+        this.core.log(`RestoreFiles: removed ${fileIDs.length} files that finished uploading`)
+      })
+    })
+
     this.core.on('core:state-update', this.saveFilesStateToLocalStorage)
 
     this.core.on('core:restored', () => {


### PR DESCRIPTION
Another part of #324. This does two things:

- Omit completed uploads from saved file state—previously, when an upload was finished and the user refreshed the page, all the finished files would still be there because we saved the entire list of files. The first commit changes it to only store files that are part of an in-progress upload, or that have yet to be uploaded.
- Remove files from cache when upload finished—this uses the `deleteBlobs` function when `core:success` fires.

The first is necessary for the second, because otherwise we'd be deleting blobs but keep the data about those files in localStorage still.

The final part of #324 would be to add a timestamp to cached blobs, and to delete old blobs on boot. That code would *not* have to check the uppy instance ID, but could instead delete old blobs from all instance IDs.