### PR TITLE
Add default methods to Plugin base class

### DIFF
--- a/src/plugins/Plugin.js
+++ b/src/plugins/Plugin.js
@@ -88,6 +88,14 @@ module.exports = class Plugin {
     }
   }
 
+  render (state) {
+    throw (new Error('Extend the render method to add your plugin to a DOM element'))
+  }
+
+  addTarget (plugin) {
+    throw (new Error('Extend the addTarget method to add your plugin to another plugin\'s target'))
+  }
+
   unmount () {
     if (this.el && this.el.parentNode) {
       this.el.parentNode.removeChild(this.el)

--- a/src/plugins/Plugin.test.js
+++ b/src/plugins/Plugin.test.js
@@ -246,6 +246,42 @@ describe('Plugin', () => {
     })
   })
 
+  describe('.render', () => {
+    beforeEach(() => {
+      plugin = new Plugin()
+    })
+
+    it('is a function', () => {
+      expect(typeof Plugin.prototype.render).toBe('function')
+    })
+
+    it('accepts one parameter', () => {
+      expect(Plugin.prototype.render.length).toBe(1)
+    })
+
+    it('throws by default', () => {
+      expect(() => plugin.render()).toThrow()
+    })
+  })
+
+  describe('.addTarget', () => {
+    beforeEach(() => {
+      plugin = new Plugin()
+    })
+
+    it('is a function', () => {
+      expect(typeof Plugin.prototype.addTarget).toBe('function')
+    })
+
+    it('accepts one parameter', () => {
+      expect(Plugin.prototype.addTarget.length).toBe(1)
+    })
+
+    it('throws by default', () => {
+      expect(() => plugin.addTarget()).toThrow()
+    })
+  })
+
   describe('.unmount', () => {
     beforeEach(() => {
       plugin = new Plugin()


### PR DESCRIPTION
Add `render` and `addTarget` methods that throw by default. These methods should have a sub-class implementation when a plugin wants to mounts on a DOM element or on another plugin's target.