### PR TITLE
transloadit: implement assembly status restore

### DIFF
--- a/examples/bundled-example/main.js
+++ b/examples/bundled-example/main.js
@@ -3,25 +3,18 @@ const Dashboard = require('../../src/plugins/Dashboard')
 const GoogleDrive = require('../../src/plugins/GoogleDrive')
 const Dropbox = require('../../src/plugins/Dropbox')
 const Instagram = require('../../src/plugins/Instagram')
-// const Webcam = require('../../src/plugins/Webcam')
+const Webcam = require('../../src/plugins/Webcam')
 const Tus = require('../../src/plugins/Tus')
-const Transloadit = require('../../src/plugins/Transloadit')
-// const Multipart = require('../../src/plugins/Multipart')
+// const XHRUpload = require('../../src/plugins/XHRUpload')
 // const FileInput = require('../../src/plugins/FileInput')
 // const MetaData = require('../../src/plugins/MetaData')
 // const Informer = require('../../src/plugins/Informer')
 // const StatusBar = require('../../src/plugins/StatusBar')
 // const DragDrop = require('../../src/plugins/DragDrop')
-const GoldenRetriever = require('../../src/plugins/GoldenRetriever')
+// const GoldenRetriever = require('../../src/plugins/GoldenRetriever')
 
 const PROTOCOL = location.protocol === 'https:' ? 'https' : 'http'
 const TUS_ENDPOINT = PROTOCOL + '://master.tus.io/files/'
-
-console.warn(`
-
-  STARTING EXAMPLE!
-
-`)
 
 const uppy = Uppy({
   debug: true,
@@ -30,9 +23,30 @@ const uppy = Uppy({
     username: 'John',
     license: 'Creative Commons'
   }
+  // restrictions: {
+  //   maxFileSize: 300000,
+  //   maxNumberOfFiles: 10,
+  //   minNumberOfFiles: 2,
+  //   allowedFileTypes: ['image/*', 'video/*']
+  // }
+  // onBeforeFileAdded: (currentFile, files) => {
+  //   if (currentFile.name === 'pitercss-IMG_0616.jpg') {
+  //     return Promise.resolve()
+  //   }
+  //   return Promise.reject('this is not the file I was looking for')
+  // },
+  // onBeforeUpload: (files) => {
+  //   if (Object.keys(files).length < 2) {
+  //     return Promise.reject('too few files')
+  //   }
+  //   return Promise.resolve()
+  // }
 })
   .use(Dashboard, {
     trigger: '#uppyModalOpener',
+    target: '.MyForm',
+    // maxWidth: 350,
+    // maxHeight: 400,
     inline: false,
     disableStatusBar: false,
     disableInformer: false,
@@ -40,33 +54,22 @@ const uppy = Uppy({
     replaceTargetContent: false,
     hideUploadButton: false,
     closeModalOnClickOutside: false,
-    metaFields: [
-      { id: 'license', name: 'License', value: 'Creative Commons', placeholder: 'specify license' },
-      { id: 'caption', name: 'Caption', value: 'none', placeholder: 'describe what the image is about' }
-    ],
     locale: {
-      strings: {browse: 'browse'}
-    }
+      strings: { browse: 'browse' }
+    },
+    metaFields: [
+      { id: 'license', name: 'License', placeholder: 'specify license' },
+      { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }
+    ]
+    // note: 'Images and video only, 300kb or less'
   })
   .use(GoogleDrive, {target: Dashboard, host: 'http://localhost:3020'})
   .use(Dropbox, {target: Dashboard, host: 'http://localhost:3020'})
   .use(Instagram, {target: Dashboard, host: 'http://localhost:3020'})
-  // .use(Tus, { resume: false })
-  .use(require('../../src/plugins/XHRUpload'))
-  .use(require('../../src/plugins/AwsS3'), {
-    host: 'http://localhost:3020'
-  })
+  .use(Webcam, {target: Dashboard})
+  .use(Tus, {endpoint: TUS_ENDPOINT, resume: true})
+  // .use(GoldenRetriever, {serviceWorker: true})
   .run()
-  .use(Transloadit, {
-    importFromUploadURLs: true,
-    // alwaysRunAssembly: true,
-    waitForEncoding: true,
-    params: {
-      auth: { key: '05a61ed019fe11e783fdbd1f56c73eb0' },
-      template_id: 'ff1fb8201b7211e7bbafa9a78f1dc173'
-    }
-  })
-  .use(GoldenRetriever, {})
 
 uppy.on('complete', ({ successful, failed }) => {
   if (failed.length === 0) {
@@ -76,47 +79,6 @@ uppy.on('complete', ({ successful, failed }) => {
   }
   console.log('successful files:', successful)
   console.log('failed files:', failed)
-  localStorage.savedResults = '[]'
-})
-
-const wrapper = document.createElement('div')
-const yo = require('yo-yo')
-function render () {
-  yo.update(wrapper, yo`
-    <div style="margin-top: 20px;">
-      <h1>Results (${results.length})</h1>
-      <div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
-        ${results.map(ResultPreview)}
-      </div>
-    </div>
-  `)
-}
-
-function ResultPreview (result) {
-  if (result.type === 'image') {
-    return yo`<img class="UppyDemo-resultImg" src="${result.ssl_url}" />`
-  }
-  if (result.type === 'video') {
-    return yo`<video width="320" height="240" src="${result.ssl_url}" />`
-  }
-  if (result.type === 'audio') {
-    return yo`<audio width="320" height="52" src="${result.ssl_url}" />`
-  }
-
-  return ''
-}
-
-let results = []
-try {
-  results = JSON.parse(localStorage.savedResults)
-  render()
-} catch (err) {}
-
-uppy.on('transloadit:result', (stepName, result) => {
-  results.push({ ssl_url: result.ssl_url, type: result.type })
-  render()
-  localStorage.savedResults = JSON.stringify(results)
->>>>>>> Stashed changes
 })
 
 if ('serviceWorker' in navigator) {
@@ -132,5 +94,3 @@ if ('serviceWorker' in navigator) {
 
 var modalTrigger = document.querySelector('#uppyModalOpener')
 if (modalTrigger) modalTrigger.click()
-
-document.body.appendChild(wrapper)

--- a/examples/bundled-example/main.js
+++ b/examples/bundled-example/main.js
@@ -3,18 +3,25 @@ const Dashboard = require('../../src/plugins/Dashboard')
 const GoogleDrive = require('../../src/plugins/GoogleDrive')
 const Dropbox = require('../../src/plugins/Dropbox')
 const Instagram = require('../../src/plugins/Instagram')
-const Webcam = require('../../src/plugins/Webcam')
+// const Webcam = require('../../src/plugins/Webcam')
 const Tus = require('../../src/plugins/Tus')
-// const XHRUpload = require('../../src/plugins/XHRUpload')
+const Transloadit = require('../../src/plugins/Transloadit')
+// const Multipart = require('../../src/plugins/Multipart')
 // const FileInput = require('../../src/plugins/FileInput')
 // const MetaData = require('../../src/plugins/MetaData')
 // const Informer = require('../../src/plugins/Informer')
 // const StatusBar = require('../../src/plugins/StatusBar')
 // const DragDrop = require('../../src/plugins/DragDrop')
-// const GoldenRetriever = require('../../src/plugins/GoldenRetriever')
+const GoldenRetriever = require('../../src/plugins/GoldenRetriever')
 
 const PROTOCOL = location.protocol === 'https:' ? 'https' : 'http'
 const TUS_ENDPOINT = PROTOCOL + '://master.tus.io/files/'
+
+console.warn(`
+
+  STARTING EXAMPLE!
+
+`)
 
 const uppy = Uppy({
   debug: true,
@@ -23,30 +30,9 @@ const uppy = Uppy({
     username: 'John',
     license: 'Creative Commons'
   }
-  // restrictions: {
-  //   maxFileSize: 300000,
-  //   maxNumberOfFiles: 10,
-  //   minNumberOfFiles: 2,
-  //   allowedFileTypes: ['image/*', 'video/*']
-  // }
-  // onBeforeFileAdded: (currentFile, files) => {
-  //   if (currentFile.name === 'pitercss-IMG_0616.jpg') {
-  //     return Promise.resolve()
-  //   }
-  //   return Promise.reject('this is not the file I was looking for')
-  // },
-  // onBeforeUpload: (files) => {
-  //   if (Object.keys(files).length < 2) {
-  //     return Promise.reject('too few files')
-  //   }
-  //   return Promise.resolve()
-  // }
 })
   .use(Dashboard, {
     trigger: '#uppyModalOpener',
-    target: '.MyForm',
-    // maxWidth: 350,
-    // maxHeight: 400,
     inline: false,
     disableStatusBar: false,
     disableInformer: false,
@@ -54,22 +40,33 @@ const uppy = Uppy({
     replaceTargetContent: false,
     hideUploadButton: false,
     closeModalOnClickOutside: false,
-    locale: {
-      strings: { browse: 'browse' }
-    },
     metaFields: [
-      { id: 'license', name: 'License', placeholder: 'specify license' },
-      { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }
-    ]
-    // note: 'Images and video only, 300kb or less'
+      { id: 'license', name: 'License', value: 'Creative Commons', placeholder: 'specify license' },
+      { id: 'caption', name: 'Caption', value: 'none', placeholder: 'describe what the image is about' }
+    ],
+    locale: {
+      strings: {browse: 'browse'}
+    }
   })
   .use(GoogleDrive, {target: Dashboard, host: 'http://localhost:3020'})
   .use(Dropbox, {target: Dashboard, host: 'http://localhost:3020'})
   .use(Instagram, {target: Dashboard, host: 'http://localhost:3020'})
-  .use(Webcam, {target: Dashboard})
-  .use(Tus, {endpoint: TUS_ENDPOINT, resume: true})
-  // .use(GoldenRetriever, {serviceWorker: true})
+  // .use(Tus, { resume: false })
+  .use(require('../../src/plugins/XHRUpload'))
+  .use(require('../../src/plugins/AwsS3'), {
+    host: 'http://localhost:3020'
+  })
   .run()
+  .use(Transloadit, {
+    importFromUploadURLs: true,
+    // alwaysRunAssembly: true,
+    waitForEncoding: true,
+    params: {
+      auth: { key: '05a61ed019fe11e783fdbd1f56c73eb0' },
+      template_id: 'ff1fb8201b7211e7bbafa9a78f1dc173'
+    }
+  })
+  .use(GoldenRetriever, {})
 
 uppy.on('complete', ({ successful, failed }) => {
   if (failed.length === 0) {
@@ -79,6 +76,47 @@ uppy.on('complete', ({ successful, failed }) => {
   }
   console.log('successful files:', successful)
   console.log('failed files:', failed)
+  localStorage.savedResults = '[]'
+})
+
+const wrapper = document.createElement('div')
+const yo = require('yo-yo')
+function render () {
+  yo.update(wrapper, yo`
+    <div style="margin-top: 20px;">
+      <h1>Results (${results.length})</h1>
+      <div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+        ${results.map(ResultPreview)}
+      </div>
+    </div>
+  `)
+}
+
+function ResultPreview (result) {
+  if (result.type === 'image') {
+    return yo`<img class="UppyDemo-resultImg" src="${result.ssl_url}" />`
+  }
+  if (result.type === 'video') {
+    return yo`<video width="320" height="240" src="${result.ssl_url}" />`
+  }
+  if (result.type === 'audio') {
+    return yo`<audio width="320" height="52" src="${result.ssl_url}" />`
+  }
+
+  return ''
+}
+
+let results = []
+try {
+  results = JSON.parse(localStorage.savedResults)
+  render()
+} catch (err) {}
+
+uppy.on('transloadit:result', (stepName, result) => {
+  results.push({ ssl_url: result.ssl_url, type: result.type })
+  render()
+  localStorage.savedResults = JSON.stringify(results)
+>>>>>>> Stashed changes
 })
 
 if ('serviceWorker' in navigator) {
@@ -94,3 +132,5 @@ if ('serviceWorker' in navigator) {
 
 var modalTrigger = document.querySelector('#uppyModalOpener')
 if (modalTrigger) modalTrigger.click()
+
+document.body.appendChild(wrapper)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7327,7 +7327,7 @@
       "requires": {
         "attempt-x": "1.1.1",
         "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.5.1",
+        "is-object-like-x": "1.6.0",
         "object-get-own-property-descriptor-x": "3.2.0",
         "to-string-tag-x": "1.4.2"
       }
@@ -7457,15 +7457,15 @@
       "dev": true
     },
     "is-function-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.2.0.tgz",
-      "integrity": "sha512-ANQAythCIUKu0UprLZubZsYwAhYcNoM/FlrQSyFIXDoBzeGcHo6SHNPHCAl/T7UQyNiGzBirfUq0znic8P/Bew==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
+      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "requires": {
         "attempt-x": "1.1.1",
         "has-to-string-tag-x": "1.4.1",
         "is-falsey-x": "1.0.1",
         "is-primitive": "2.0.0",
-        "normalize-space-x": "2.0.0",
+        "normalize-space-x": "3.0.0",
         "replace-comments-x": "2.0.0",
         "to-boolean-x": "1.0.1",
         "to-string-tag-x": "1.4.2"
@@ -7481,15 +7481,15 @@
       }
     },
     "is-index-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz",
-      "integrity": "sha512-BJ7vtw0jvcjBX4UsT7KkpZUliAMX3vJugZimDKy4W6ilGDtvUZ8nYsYnROVrrsjNjg5LJ3MN9NvyRVALfDW/wQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
+      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
       "requires": {
-        "math-clamp-x": "1.1.0",
+        "math-clamp-x": "1.2.0",
         "max-safe-integer": "1.0.1",
-        "safe-to-string-x": "2.0.3",
-        "to-integer-x": "2.1.0",
-        "to-number-x": "1.1.0"
+        "to-integer-x": "3.0.0",
+        "to-number-x": "2.0.0",
+        "to-string-symbols-supported-x": "1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -7544,11 +7544,11 @@
       }
     },
     "is-object-like-x": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz",
-      "integrity": "sha512-AtUeYE4Xs8EbuHuG6yBHiLdIlWRPPFidcIs3JE6PJZ/mzUQFOK8X5J1OA+3cVi0rlrdUCjiX52obtCV2hxs+HA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz",
+      "integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
       "requires": {
-        "is-function-x": "3.2.0",
+        "is-function-x": "3.3.0",
         "is-primitive": "2.0.0"
       }
     },
@@ -9208,11 +9208,11 @@
       }
     },
     "math-clamp-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz",
-      "integrity": "sha512-c7Hxz6Ji4HtwUSMI1HU3Y7pcWQyuINlnCeE1675ZfNbEELFHeqHnEQXrWB7kLiiNTMi6QM38txFAfKq2IYqZpQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
       "requires": {
-        "to-number-x": "1.1.0"
+        "to-number-x": "2.0.0"
       }
     },
     "math-expression-evaluator": {
@@ -9222,12 +9222,12 @@
       "dev": true
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz",
-      "integrity": "sha512-3shFG0Ea5vOMCgQCrylyzu3POQRTvvaclb4VArnICToTgshMfA4Dlb9q9lZO1SD/rUD9mOTJZ7dTtlfCq7I91A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
+      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
       "requires": {
         "is-nan-x": "1.0.1",
-        "to-number-x": "1.1.0"
+        "to-number-x": "2.0.0"
       }
     },
     "max-safe-integer": {
@@ -9709,6 +9709,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true
+    },
+    "nan-x": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.0.tgz",
+      "integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg=="
     },
     "nanoraf": {
       "version": "3.0.1",
@@ -10210,13 +10215,13 @@
       "dev": true
     },
     "normalize-space-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-2.0.0.tgz",
-      "integrity": "sha512-R3nAbBlbEtn649TVgKzhgALTjilK5bgsbIsbk7+dtiDcEpuVVr7cUezwO7Tnm5e3IgaULi2s+FfVGj9WzVq1WA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
+      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "requires": {
         "cached-constructors-x": "1.0.0",
-        "trim-x": "2.0.2",
-        "white-space-x": "2.0.3"
+        "trim-x": "3.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "normalize-url": {
@@ -10377,10 +10382,10 @@
       "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
       "requires": {
         "attempt-x": "1.1.1",
-        "has-own-property-x": "3.1.1",
+        "has-own-property-x": "3.2.0",
         "has-symbol-support-x": "1.4.1",
         "is-falsey-x": "1.0.1",
-        "is-index-x": "1.0.0",
+        "is-index-x": "1.1.0",
         "is-primitive": "2.0.0",
         "is-string": "1.0.4",
         "property-is-enumerable-x": "1.1.0",
@@ -10729,6 +10734,17 @@
         "is-dotfile": "1.0.3",
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
+      }
+    },
+    "parse-int-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
+      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+      "requires": {
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "to-string-x": "1.4.2",
+        "trim-left-x": "3.0.0"
       }
     },
     "parse-json": {
@@ -12087,6 +12103,15 @@
         "to-string-x": "1.4.2"
       }
     },
+    "require-coercible-to-string-x": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
+      "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
+      "requires": {
+        "require-object-coercible-x": "1.4.1",
+        "to-string-x": "1.4.2"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12257,14 +12282,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz",
-      "integrity": "sha512-hbxWZc0a+3VG7SpSKpZbBiXwQOV/bW/hwNvMFRPCL/60Ze/6Y8atHqv/0dWiWc9sHmkFqVCMR5gjmukMzKnA6A==",
-      "requires": {
-        "to-string-symbols-supported-x": "1.0.0"
-      }
     },
     "sane": {
       "version": "1.6.0",
@@ -13621,54 +13638,26 @@
       "dev": true
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz",
-      "integrity": "sha512-M9iETTi+xMMZtUC70q4VE63XL2mXmNABxwxsIebOfd8K4ZHKCJLD9GyE6RlEPnbOPZj21QinuoVkqWsBsBknRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
+      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
       "requires": {
         "is-finite-x": "3.0.2",
         "is-nan-x": "1.0.1",
-        "math-sign-x": "2.1.0",
-        "to-number-x": "1.1.0"
+        "math-sign-x": "3.0.0",
+        "to-number-x": "2.0.0"
       }
     },
     "to-number-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.1.0.tgz",
-      "integrity": "sha512-m0v+VykgXsJ8JUSDKcvaASl977pSx5U1D6kyApFxP/KarJr7ZzVWrlHYTOxGDDodytsyh+iwZXpxBZpaWOvv4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
+      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
       "requires": {
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "parse-int-x": "2.0.0",
         "to-primitive-x": "1.1.0",
-        "trim-x": "1.0.4"
-      },
-      "dependencies": {
-        "trim-left-x": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.7.tgz",
-          "integrity": "sha512-0UMUaK+dyb1UVs/slcjkikjQ5O1VOHLUB5VPTcIDJ9IRJCau5ENeH71hu+B4yuPpudXnbwQGyq5AS49kbEIpMw==",
-          "requires": {
-            "cached-constructors-x": "1.0.0",
-            "to-string-x": "1.4.2",
-            "white-space-x": "2.0.3"
-          }
-        },
-        "trim-right-x": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.4.tgz",
-          "integrity": "sha512-W/NQvE5MS+rZhTMnsscwnQpto+VszsUWPWGaxcHrUut/QhkRvabz2HOZIAg+u5jUt9rIZwfEpMB3UUIJLtmtxA==",
-          "requires": {
-            "cached-constructors-x": "1.0.0",
-            "to-string-x": "1.4.2",
-            "white-space-x": "2.0.3"
-          }
-        },
-        "trim-x": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.4.tgz",
-          "integrity": "sha512-+9P1RH7/k6S6OYQjk2pnvYsYx/CUiD6bVKmJwkPmSYhQkOYeXFahwDWxMMxEWw+5Sxj1rMkohZh93x0OoE6KZA==",
-          "requires": {
-            "trim-left-x": "1.3.7",
-            "trim-right-x": "1.3.4"
-          }
-        }
+        "trim-x": "3.0.0"
       }
     },
     "to-object-x": {
@@ -13687,7 +13676,7 @@
       "requires": {
         "has-symbol-support-x": "1.4.1",
         "is-date-object": "1.0.1",
-        "is-function-x": "3.2.0",
+        "is-function-x": "3.3.0",
         "is-nil-x": "1.4.1",
         "is-primitive": "2.0.0",
         "is-symbol": "1.0.1",
@@ -13804,13 +13793,13 @@
       "dev": true
     },
     "trim-left-x": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz",
-      "integrity": "sha512-7JTQAjTmsUB07eDuVoBxAtRbvrC141gYhEnKoP5FHZGc7phaqjbqII7+nFT15gc73F0D7qPb7W+Ny8Im0Kip/Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
+      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "requires": {
         "cached-constructors-x": "1.0.0",
         "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "2.0.3"
+        "white-space-x": "3.0.0"
       }
     },
     "trim-newlines": {
@@ -13826,22 +13815,22 @@
       "dev": true
     },
     "trim-right-x": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz",
-      "integrity": "sha512-hdz1fDE/roIkWWNtA43matOTi3dHgLhDkKTo+hFgLwlYSqjNt7Qr0QKZyik8ZDTpjUmrgHtU5/lb+gL/pngWvQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
+      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "requires": {
         "cached-constructors-x": "1.0.0",
         "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "2.0.3"
+        "white-space-x": "3.0.0"
       }
     },
     "trim-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz",
-      "integrity": "sha512-FnvMjV360hsj/OQpAaXqAKspNqyawkVe5zkWH/aOVOGcSnbeJYpeOYiaKIZYpu0ZQes3pq7IRm4whHJqAoev7w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
+      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "requires": {
-        "trim-left-x": "2.0.1",
-        "trim-right-x": "2.0.1"
+        "trim-left-x": "3.0.0",
+        "trim-right-x": "3.0.0"
       }
     },
     "tryit": {
@@ -13866,9 +13855,9 @@
       }
     },
     "tus-js-client": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.4.4.tgz",
-      "integrity": "sha1-l5Ry9K4oq81o790iRfzuuMW2Hmc=",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.4.5.tgz",
+      "integrity": "sha1-7lJd+KLE3EETvPkz3dfUCj20O5U=",
       "requires": {
         "buffer-from": "0.1.1",
         "extend": "3.0.1",
@@ -15391,9 +15380,9 @@
       "dev": true
     },
     "white-space-x": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz",
-      "integrity": "sha512-An6uHDfZizY0t7x8iyY8nLej1lnqyaFSyTKjwwqS0VIhvV4tof6a+Et4uJVFlZh7HUAOgKoZfm5hFzl/D4xDgw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.0.tgz",
+      "integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg=="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "prettier-bytes": "1.0.4",
     "prop-types": "^15.5.10",
     "socket.io-client": "2.0.2",
-    "tus-js-client": "^1.4.4",
+    "tus-js-client": "^1.4.5",
     "url-parse": "1.1.9",
     "whatwg-fetch": "2.0.3",
     "yo-yo": "1.4.0",

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -416,7 +416,6 @@ class Uppy {
       this.removeUpload(uploadID)
     })
 
-    this.calculateTotalProgress()
     this._calculateTotalProgress()
     this.emit('file-removed', fileID)
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -719,6 +719,11 @@ class Uppy {
       this.setState({ files: files })
     })
 
+    this.on('restored', () => {
+      // Files may have changed--ensure progress is still accurate.
+      this._calculateTotalProgress()
+    })
+
     // show informer if offline
     if (typeof window !== 'undefined') {
       window.addEventListener('online', () => this.updateOnlineStatus())

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -101,6 +101,7 @@ class Uppy {
     this.setState({
       plugins: {},
       files: {},
+      currentUploads: {},
       capabilities: {
         resumableUploads: false
       },
@@ -393,7 +394,7 @@ class Uppy {
     // Remove this file from its `currentUpload`.
     const updatedUploads = Object.assign({}, currentUploads)
     const removeUploads = []
-    Object.keys(currentUploads).forEach((uploadID) => {
+    Object.keys(updatedUploads).forEach((uploadID) => {
       const newFileIDs = currentUploads[uploadID].fileIDs.filter((uploadFileID) => uploadFileID !== fileID)
       // Remove the upload if no files are associated with it anymore.
       if (newFileIDs.length === 0) {

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -152,6 +152,7 @@ describe('src/Core', () => {
         bee: 'boo',
         capabilities: { resumableUploads: false },
         files: {},
+        currentUploads: {},
         foo: 'baar',
         info: { isHidden: true, message: '', type: 'info' },
         meta: {},
@@ -174,6 +175,7 @@ describe('src/Core', () => {
         bee: 'boo',
         capabilities: { resumableUploads: false },
         files: {},
+        currentUploads: {},
         foo: 'bar',
         info: { isHidden: true, message: '', type: 'info' },
         meta: {},
@@ -185,6 +187,7 @@ describe('src/Core', () => {
         bee: 'boo',
         capabilities: { resumableUploads: false },
         files: {},
+        currentUploads: {},
         foo: 'baar',
         info: { isHidden: true, message: '', type: 'info' },
         meta: {},
@@ -201,6 +204,7 @@ describe('src/Core', () => {
       expect(core.getState()).toEqual({
         capabilities: { resumableUploads: false },
         files: {},
+        currentUploads: {},
         foo: 'bar',
         info: { isHidden: true, message: '', type: 'info' },
         meta: {},
@@ -227,6 +231,7 @@ describe('src/Core', () => {
     expect(coreStateUpdateEventMock.mock.calls[1][1]).toEqual({
       capabilities: { resumableUploads: false },
       files: {},
+      currentUploads: {},
       foo: 'bar',
       info: { isHidden: true, message: '', type: 'info' },
       meta: {},
@@ -254,6 +259,7 @@ describe('src/Core', () => {
     expect(coreStateUpdateEventMock.mock.calls[0][1]).toEqual({
       capabilities: { resumableUploads: false },
       files: {},
+      currentUploads: {},
       info: { isHidden: true, message: '', type: 'info' },
       meta: {},
       plugins: {},

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -168,6 +168,10 @@ module.exports = class GoldenRetriever extends Plugin {
     this.uppy.setState({
       files: updatedFiles
     })
+
+    // Files have changed--make sure the progress is accurate.
+    this.uppy.calculateTotalProgress()
+
     this.uppy.emit('restored', this.savedPluginData)
 
     if (obsoleteBlobs.length) {

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -48,7 +48,7 @@ module.exports = class GoldenRetriever extends Plugin {
     const savedState = this.MetaDataStore.load()
 
     if (savedState) {
-      this.uppy.log('Recovered some state from Local Storage')
+      this.uppy.log('[GoldenRetriever] Recovered some state from Local Storage')
       this.uppy.setState({
         currentUploads: savedState.currentUploads || {},
         files: savedState.files || {}
@@ -121,11 +121,11 @@ module.exports = class GoldenRetriever extends Plugin {
       const numberOfFilesRecovered = Object.keys(blobs).length
       const numberOfFilesTryingToRecover = Object.keys(this.uppy.state.files).length
       if (numberOfFilesRecovered === numberOfFilesTryingToRecover) {
-        this.uppy.log(`Successfully recovered ${numberOfFilesRecovered} blobs from Service Worker!`)
+        this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from Service Worker!`)
         this.uppy.info(`Successfully recovered ${numberOfFilesRecovered} files`, 'success', 3000)
         this.onBlobsLoaded(blobs)
       } else {
-        this.uppy.log('Failed to recover blobs from Service Worker, trying IndexedDB now...')
+        this.uppy.log('[GoldenRetriever] Failed to recover blobs from Service Worker, trying IndexedDB now...')
         this.loadFileBlobsFromIndexedDB()
       }
     })
@@ -136,11 +136,11 @@ module.exports = class GoldenRetriever extends Plugin {
       const numberOfFilesRecovered = Object.keys(blobs).length
 
       if (numberOfFilesRecovered > 0) {
-        this.uppy.log(`Successfully recovered ${numberOfFilesRecovered} blobs from Indexed DB!`)
+        this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from Indexed DB!`)
         this.uppy.info(`Successfully recovered ${numberOfFilesRecovered} files`, 'success', 3000)
         return this.onBlobsLoaded(blobs)
       }
-      this.uppy.log('Couldn’t recover anything from IndexedDB :(')
+      this.uppy.log('[GoldenRetriever] Couldn’t recover anything from IndexedDB :(')
     })
   }
 
@@ -165,10 +165,10 @@ module.exports = class GoldenRetriever extends Plugin {
 
       this.uppy.generatePreview(updatedFile)
     })
+
     this.uppy.setState({
       files: updatedFiles
     })
-
     // Files have changed--make sure the progress is accurate.
     this.uppy.calculateTotalProgress()
 
@@ -176,7 +176,7 @@ module.exports = class GoldenRetriever extends Plugin {
 
     if (obsoleteBlobs.length) {
       this.deleteBlobs(obsoleteBlobs).then(() => {
-        this.uppy.log(`[GoldenRetriever] cleaned up ${obsoleteBlobs.length} old files`)
+        this.uppy.log(`[GoldenRetriever] Cleaned up ${obsoleteBlobs.length} old files`)
       })
     }
   }
@@ -199,14 +199,14 @@ module.exports = class GoldenRetriever extends Plugin {
 
     if (Object.keys(this.uppy.state.files).length > 0) {
       if (this.ServiceWorkerStore) {
-        this.uppy.log('Attempting to load files from Service Worker...')
+        this.uppy.log('[GoldenRetriever] Attempting to load files from Service Worker...')
         this.loadFileBlobsFromServiceWorker()
       } else {
-        this.uppy.log('Attempting to load files from Indexed DB...')
+        this.uppy.log('[GoldenRetriever] Attempting to load files from Indexed DB...')
         this.loadFileBlobsFromIndexedDB()
       }
     } else {
-      this.core.log('No files need to be loaded, only restoring processing state...')
+      this.uppy.log('[GoldenRetriever] No files need to be loaded, only restoring processing state...')
       this.onBlobsLoaded([])
     }
 
@@ -215,13 +215,13 @@ module.exports = class GoldenRetriever extends Plugin {
 
       if (this.ServiceWorkerStore) {
         this.ServiceWorkerStore.put(file).catch((err) => {
-          this.uppy.log('Could not store file', 'error')
+          this.uppy.log('[GoldenRetriever] Could not store file', 'error')
           this.uppy.log(err)
         })
       }
 
       this.IndexedDBStore.put(file).catch((err) => {
-        this.uppy.log('Could not store file', 'error')
+        this.uppy.log('[GoldenRetriever] Could not store file', 'error')
         this.uppy.log(err)
       })
     })
@@ -234,7 +234,7 @@ module.exports = class GoldenRetriever extends Plugin {
     this.uppy.on('complete', ({ successful }) => {
       const fileIDs = successful.map((file) => file.id)
       this.deleteBlobs(fileIDs).then(() => {
-        this.uppy.log(`[GoldenRetriever] removed ${successful.length} files that finished uploading`)
+        this.uppy.log(`[GoldenRetriever] Removed ${successful.length} files that finished uploading`)
       })
     })
 

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -49,7 +49,12 @@ module.exports = class GoldenRetriever extends Plugin {
 
     if (savedState) {
       this.uppy.log('Recovered some state from Local Storage')
-      this.uppy.setState(savedState)
+      this.uppy.setState({
+        currentUploads: savedState.currentUploads || {},
+        files: savedState.files || {}
+      })
+
+      this.savedPluginData = savedState.pluginData
     }
   }
 
@@ -99,9 +104,15 @@ module.exports = class GoldenRetriever extends Plugin {
       this.getUploadingFiles()
     )
 
+    const pluginData = {}
+    this.uppy.emit('restore:get-data', (data) => {
+      Object.assign(pluginData, data)
+    })
+
     this.MetaDataStore.save({
       currentUploads: this.uppy.state.currentUploads,
-      files: filesToSave
+      files: filesToSave,
+      pluginData: pluginData
     })
   }
 
@@ -157,7 +168,7 @@ module.exports = class GoldenRetriever extends Plugin {
     this.uppy.setState({
       files: updatedFiles
     })
-    this.uppy.emit('restored')
+    this.uppy.emit('restored', this.savedPluginData)
 
     if (obsoleteBlobs.length) {
       this.deleteBlobs(obsoleteBlobs).then(() => {

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -172,9 +172,6 @@ module.exports = class GoldenRetriever extends Plugin {
     this.uppy.setState({
       files: updatedFiles
     })
-    // Files have changed--make sure the progress is accurate.
-    // TODO make uppy detect that this is necessary somehow?
-    this.uppy._calculateTotalProgress()
 
     this.uppy.emit('restored', this.savedPluginData)
 

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -205,6 +205,9 @@ module.exports = class GoldenRetriever extends Plugin {
         this.uppy.log('Attempting to load files from Indexed DB...')
         this.loadFileBlobsFromIndexedDB()
       }
+    } else {
+      this.core.log('No files need to be loaded, only restoring processing state...')
+      this.onBlobsLoaded([])
     }
 
     this.uppy.on('file-added', (file) => {

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -170,7 +170,8 @@ module.exports = class GoldenRetriever extends Plugin {
       files: updatedFiles
     })
     // Files have changed--make sure the progress is accurate.
-    this.uppy.calculateTotalProgress()
+    // TODO make uppy detect that this is necessary somehow?
+    this.uppy._calculateTotalProgress()
 
     this.uppy.emit('restored', this.savedPluginData)
 

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -105,6 +105,9 @@ module.exports = class GoldenRetriever extends Plugin {
     )
 
     const pluginData = {}
+    // TODO Find a better way to do this?
+    // Other plugins can attach a restore:get-data listener that receives this callback.
+    // Plugins can then use this callback (sync) to provide data to be stored.
     this.uppy.emit('restore:get-data', (data) => {
       Object.assign(pluginData, data)
     })

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -15,10 +15,6 @@ const STATE_POSTPROCESSING = 'postprocessing'
 const STATE_COMPLETE = 'complete'
 
 function getUploadingState (props, files) {
-  // if (props.error) {
-  //   return STATE_ERROR
-  // }
-
   if (props.isAllErrored) {
     return STATE_ERROR
   }
@@ -198,9 +194,9 @@ const ProgressBarError = ({ error, retryAll, i18n }) => {
     <div class="UppyStatusBar-content" role="alert">
         <strong>${i18n('uploadFailed')}.</strong>
         <span>${i18n('pleasePressRetry')}</span>
-        <span class="UppyStatusBar-details" 
-              data-balloon="${error}" 
-              data-balloon-pos="up" 
+        <span class="UppyStatusBar-details"
+              data-balloon="${error}"
+              data-balloon-pos="up"
               data-balloon-length="large">?</span>
       </div>
   `

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -568,7 +568,7 @@ module.exports = class Transloadit extends Plugin {
     fileIDs = fileIDs.filter((file) => !file.error)
 
     const state = this.getPluginState()
-    // const state = this.getPluginState()
+
     // If we're still restoring state, wait for that to be done.
     if (this.restored) {
       return this.restored.then(() => {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -295,14 +295,14 @@ module.exports = class Transloadit extends Plugin {
 
   getPersistentData (setData) {
     const state = this.getPluginState()
-    const assemblyStates = state.assemblies
+    const assemblies = state.assemblies
     const uploadsAssemblies = state.uploadsAssemblies
     const uploads = Object.keys(state.files)
     const results = state.results.map((result) => result.id)
 
     setData({
       [this.id]: {
-        assemblyStates,
+        assemblies,
         uploadsAssemblies,
         uploads,
         results
@@ -377,7 +377,7 @@ module.exports = class Transloadit extends Plugin {
     const savedState = pluginData && pluginData[this.id] ? pluginData[this.id] : {}
     const knownUploads = savedState.files || []
     const knownResults = savedState.results || []
-    const previousAssemblies = savedState.assemblyStates || {}
+    const previousAssemblies = savedState.assemblies || {}
     const uploadsAssemblies = savedState.uploadsAssemblies || {}
 
     if (Object.keys(uploadsAssemblies).length === 0) {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -301,9 +301,10 @@ module.exports = class Transloadit extends Plugin {
   onRestored (pluginData) {
     const opts = this.opts
 
-    const knownUploads = pluginData[this.id].files || []
-    const knownResults = pluginData[this.id].results || []
-    const previousAssemblies = pluginData[this.id].assemblies || {}
+    const savedState = pluginData && pluginData[this.id] ? pluginData[this.id] : {}
+    const knownUploads = savedState.files || []
+    const knownResults = savedState.results || []
+    const previousAssemblies = savedState.assemblies || {}
 
     const allUploads = []
     const allResults = []
@@ -342,7 +343,7 @@ module.exports = class Transloadit extends Plugin {
     // on files.
     const recoverUploadAssemblies = () => {
       const uploadsAssemblies = {}
-      const uploads = this.uppy.state.currentUploads
+      const uploads = this.uppy.state.currentUploads || {}
       Object.keys(uploads).forEach((uploadID) => {
         const files = uploads[uploadID].fileIDs
           .map((fileID) => this.uppy.getFile(fileID))

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -241,8 +241,19 @@ module.exports = class Transloadit extends Plugin {
       if (!files.hasOwnProperty(id)) {
         continue
       }
-      if (files[id].uploadURL === uploadedFile.tus_upload_url || (files[id].tus && files[id].tus.uploadUrl === uploadedFile.tus_upload_url)) {
+      // Completed file upload.
+      if (files[id].uploadURL === uploadedFile.tus_upload_url) {
         return files[id]
+      }
+      // In-progress file upload.
+      if (files[id].tus && files[id].tus.uploadUrl === uploadedFile.tus_upload_url) {
+        return files[id]
+      }
+      if (!uploadedFile.is_tus_file) {
+        // Fingers-crossed check for non-tus uploads, eg imported from S3.
+        if (files[id].name === uploadedFile.name && files[id].size === uploadedFile.size) {
+          return files[id]
+        }
       }
     }
   }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -3,6 +3,14 @@ const Plugin = require('../../core/Plugin')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')
 
+function defaultGetAssemblyOptions (file, options) {
+  return {
+    params: options.params,
+    signature: options.signature,
+    fields: options.fields
+  }
+}
+
 /**
  * Upload files to Transloadit using Tus.
  */
@@ -29,13 +37,7 @@ module.exports = class Transloadit extends Plugin {
       signature: null,
       params: null,
       fields: {},
-      getAssemblyOptions (file, options) {
-        return {
-          params: options.params,
-          signature: options.signature,
-          fields: options.fields
-        }
-      },
+      getAssemblyOptions: defaultGetAssemblyOptions,
       locale: defaultLocale
     }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -239,7 +239,7 @@ module.exports = class Transloadit extends Plugin {
       if (!files.hasOwnProperty(id)) {
         continue
       }
-      if (files[id].uploadURL === uploadedFile.tus_upload_url) {
+      if (files[id].uploadURL === uploadedFile.tus_upload_url || (files[id].tus && files[id].tus.uploadUrl === uploadedFile.tus_upload_url)) {
         return files[id]
       }
     }

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -499,7 +499,6 @@ module.exports = class Transloadit extends Plugin {
     } else if (this.opts.waitForMetadata) {
       socket.on('metadata', () => {
         this.onAssemblyFinished(assembly.assembly_ssl_url)
-        this.uppy.emit('transloadit:complete', assembly)
       })
     }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -440,14 +440,6 @@ module.exports = class Transloadit extends Plugin {
         })
       })
 
-      console.info('Transloadit: RESTORED:')
-      console.info({
-        assemblies: assembliesById,
-        files: files,
-        results: results,
-        uploadsAssemblies: uploadsAssemblies
-      })
-
       this.setPluginState({
         assemblies: assembliesById,
         files: files,

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -309,6 +309,11 @@ module.exports = class Transloadit extends Plugin {
     const previousAssemblies = savedState.assemblyStates || {}
     const uploadsAssemblies = savedState.uploadsAssemblies || {}
 
+    if (Object.keys(uploadsAssemblies).length === 0) {
+      // Nothing to restore.
+      return
+    }
+
     const allUploads = []
     const allResults = []
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -342,21 +342,25 @@ module.exports = class Transloadit extends Plugin {
         return !prevState.results.some((prev) => prev.id === result.id)
       })
 
-      this.uppy.log('[Transloadit] New fully uploaded files since restore:', newUploads)
+      this.uppy.log('[Transloadit] New fully uploaded files since restore:')
+      this.uppy.log(newUploads)
       newUploads.forEach(({ assembly, uploadedFile }) => {
-        this.uppy.log('[Transloadit]  emitting transloadit:upload', uploadedFile.id)
+        this.uppy.log(`[Transloadit]  emitting transloadit:upload ${uploadedFile.id}`)
         this.uppy.emit('transloadit:upload', uploadedFile, this.getAssembly(assembly))
       })
-      this.uppy.log('[Transloadit] New results since restore:', newResults)
+      this.uppy.log('[Transloadit] New results since restore:')
+      this.uppy.log(newResults)
       newResults.forEach(({ assembly, stepName, result, id }) => {
-        this.uppy.log('[Transloadit]  emitting transloadit:result', stepName, id)
+        this.uppy.log(`[Transloadit]  emitting transloadit:result ${stepName}, ${id}`)
         this.uppy.emit('transloadit:result', stepName, result, this.getAssembly(assembly))
       })
 
       const newAssemblies = state.assemblies
       const previousAssemblies = prevState.assemblies
-      this.uppy.log('[Transloadit] Current assembly status after restore', newAssemblies)
-      this.uppy.log('[Transloadit] Assembly status before restore', previousAssemblies)
+      this.uppy.log('[Transloadit] Current assembly status after restore')
+      this.uppy.log(newAssemblies)
+      this.uppy.log('[Transloadit] Assembly status before restore')
+      this.uppy.log(previousAssemblies)
       Object.keys(newAssemblies).forEach((assemblyId) => {
         const oldAssembly = previousAssemblies[assemblyId]
         diffAssemblyStatus(oldAssembly, newAssemblies[assemblyId])
@@ -365,18 +369,23 @@ module.exports = class Transloadit extends Plugin {
 
     // Emit events for assemblies that have completed or errored while we were away.
     const diffAssemblyStatus = (prev, next) => {
-      this.uppy.log('[Transloadit] Diff assemblies', prev, next)
+      this.uppy.log('[Transloadit] Diff assemblies')
+      this.uppy.log(prev)
+      this.uppy.log(next)
 
       if (opts.waitForEncoding && next.ok === 'ASSEMBLY_COMPLETED' && prev.ok !== 'ASSEMBLY_COMPLETED') {
-        this.uppy.log('[Transloadit]  Emitting transloadit:complete for', next.assembly_id, next)
+        this.uppy.log(`[Transloadit]  Emitting transloadit:complete for ${next.assembly_id}`)
+        this.uppy.log(next)
         this.uppy.emit('transloadit:complete', next)
       } else if (opts.waitForMetadata && next.upload_meta_data_extracted && !prev.upload_meta_data_extracted) {
-        this.uppy.log('[Transloadit]  Emitting transloadit:complete after metadata extraction for', next.assembly_id, next)
+        this.uppy.log(`[Transloadit]  Emitting transloadit:complete after metadata extraction for ${next.assembly_id}`)
+        this.uppy.log(next)
         this.uppy.emit('transloadit:complete', next)
       }
 
       if (next.error && !prev.error) {
-        this.uppy.log('[Transloadit]  !!! Emitting transloadit:assembly-error for', next.assembly_id, next)
+        this.uppy.log(`[Transloadit]  !!! Emitting transloadit:assembly-error for ${next.assembly_id}`)
+        this.uppy.log(next)
         this.uppy.emit('transloadit:assembly-error', next, new Error(next.message))
       }
     }
@@ -622,10 +631,10 @@ module.exports = class Transloadit extends Plugin {
       const onAssemblyFinished = (assembly) => {
         // An assembly for a different upload just finished. We can ignore it.
         if (assemblyIDs.indexOf(assembly.assembly_id) === -1) {
-          this.uppy.log('[Transloadit] afterUpload(): Ignoring finished assembly', assembly.assembly_id)
+          this.uppy.log(`[Transloadit] afterUpload(): Ignoring finished assembly ${assembly.assembly_id}`)
           return
         }
-        this.uppy.log('[Transloadit] afterUpload(): Got assembly finish', assembly.assembly_id)
+        this.uppy.log(`[Transloadit] afterUpload(): Got assembly finish ${assembly.assembly_id}`)
 
         // TODO set the `file.uploadURL` to a result?
         // We will probably need an option here so the plugin user can tell us
@@ -642,10 +651,11 @@ module.exports = class Transloadit extends Plugin {
       const onAssemblyError = (assembly, error) => {
         // An assembly for a different upload just errored. We can ignore it.
         if (assemblyIDs.indexOf(assembly.assembly_id) === -1) {
-          this.uppy.log('[Transloadit] afterUpload(): Ignoring errored assembly', assembly.assembly_id)
+          this.uppy.log(`[Transloadit] afterUpload(): Ignoring errored assembly ${assembly.assembly_id}`)
           return
         }
-        this.uppy.log('[Transloadit] afterUpload(): Got assembly error', assembly.assembly_id, error)
+        this.uppy.log(`[Transloadit] afterUpload(): Got assembly error ${assembly.assembly_id}`)
+        this.uppy.log(error)
 
         // Clear postprocessing state for all our files.
         const files = this.getAssemblyFiles(assembly.assembly_id)


### PR DESCRIPTION
<strike>Pretty early, mostly just opening this up so I can leave todos here.</strike>

This PR will implement restoring an upload to Transloadit after a browser crash, using GoldenRetriever. It should request new assembly statuses, set up the status WebSocket connections again, and account for any events that were missed.

Currently this happens after Golden Retriever restores an upload. I think we can use this same functionality when the internet connection died and comes `core:back-online` too. We do have information about assemblies, files, and results in state in that case, but we may have missed some events.

If we persist the entire assemblies state to localStorage for Golden Retriever, we could follow the exact same steps both for restoring from localStorage after a page refresh, and for picking things back up after a connection problem. I think.

At the moment, this:

 - [x] Fetches assembly statuses for files that were still uploading
 - [x] Reconnects to their WebSockets
 - [x] Restores assembly, files, results state
 - [x] Emits events that were missed:
    - [x] `transloadit:upload`
    - [x] `transloadit:result`
    - [x] `transloadit:assembly-error`
    - [x] `transloadit:complete`
 - [x] Does the Right Thing™ depending on `waitForEncoding` and `waitForMetadata` options
 - [x] Works when no files are being uploaded with `alwaysRunAssembly: true`
 - [x] Works when files were uploaded elsewhere first with `importFromUploadURLs`