### PR TITLE
s3: Add ability to configure request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ Theme: React and Retry
 - [x] goldenretriever: Omit completed uploads from saved file state—previously, when an upload was finished and the user refreshed the page, all the finished files would still be there because we saved the entire list of files. Changed this to only store files that are part of an in-progress upload, or that have yet to be uploaded (#358, #324 / @goto-bus-stop)
 - [x] goldenretriever: Remove files from cache when upload finished—this uses the deleteBlobs function when core:success fires (#358, #324 / @goto-bus-stop)
 - [ ] goldenretriever: add a timestamp to cached blobs, and to delete old blobs on boot (#358, #324 / @goto-bus-stop)
-- [ ] s3: have some way to configure content-disposition for uploads, see #243 (@goto-bus-stop)
+- [x] s3: have some way to configure content-disposition for uploads, see #243 (@goto-bus-stop)
 - [x] core: move `setPluginState` and add `getPluginState` to `Plugin` class (#363 / @goto-bus-stop)
 
 ## 0.19.1

--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -99,17 +99,24 @@ module.exports = class AwsS3 extends Plugin {
         const {
           method = 'post',
           url,
-          fields
+          fields,
+          headers
         } = responses[index]
+        const xhrOpts = {
+          method,
+          formData: method.toLowerCase() === 'post',
+          endpoint: url,
+          fieldName: 'file',
+          metaFields: Object.keys(fields)
+        }
+
+        if (headers) {
+          xhrOpts.headers = headers
+        }
+
         const updatedFile = Object.assign({}, file, {
           meta: Object.assign({}, file.meta, fields),
-          xhrUpload: {
-            method,
-            formData: method.toLowerCase() === 'post',
-            endpoint: url,
-            fieldName: 'file',
-            metaFields: Object.keys(fields)
-          }
+          xhrUpload: xhrOpts
         })
 
         updatedFiles[id] = updatedFile

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -36,6 +36,24 @@ module.exports = class XHRUpload extends Plugin {
     this.handleUpload = this.handleUpload.bind(this)
   }
 
+  getOptions (file) {
+    const opts = Object.assign({},
+      this.opts,
+      this.core.state.xhrUpload || {},
+      file.xhrUpload || {}
+    )
+    opts.headers = {}
+    Object.assign(opts.headers, this.opts.headers)
+    if (this.core.state.xhrUpload) {
+      Object.assign(opts.headers, this.core.state.xhrUpload.headers)
+    }
+    if (file.xhrUpload) {
+      Object.assign(opts.headers, file.xhrUpload.headers)
+    }
+
+    return opts
+  }
+
   createFormDataUpload (file, opts) {
     const formPost = new FormData()
 
@@ -57,19 +75,7 @@ module.exports = class XHRUpload extends Plugin {
   }
 
   upload (file, current, total) {
-    const opts = Object.assign({},
-      this.opts,
-      this.core.state.xhrUpload || {},
-      file.xhrUpload || {}
-    )
-    opts.headers = {}
-    Object.assign(opts.headers, this.opts.headers)
-    if (this.core.state.xhrUpload) {
-      Object.assign(opts.headers, this.core.state.xhrUpload.headers)
-    }
-    if (file.xhrUpload) {
-      Object.assign(opts.headers, file.xhrUpload.headers)
-    }
+    const opts = this.getOptions(file)
 
     this.core.log(`uploading ${current} of ${total}`)
     return new Promise((resolve, reject) => {
@@ -140,7 +146,7 @@ module.exports = class XHRUpload extends Plugin {
   }
 
   uploadRemote (file, current, total) {
-    const opts = Object.assign({}, this.opts, file.xhrUpload || {})
+    const opts = this.getOptions(file)
     return new Promise((resolve, reject) => {
       this.core.emit('core:upload-started', file.id)
 

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -62,6 +62,14 @@ module.exports = class XHRUpload extends Plugin {
       this.core.state.xhrUpload || {},
       file.xhrUpload || {}
     )
+    opts.headers = {}
+    Object.assign(opts.headers, this.opts.headers)
+    if (this.core.state.xhrUpload) {
+      Object.assign(opts.headers, this.core.state.xhrUpload.headers)
+    }
+    if (file.xhrUpload) {
+      Object.assign(opts.headers, file.xhrUpload.headers)
+    }
 
     this.core.log(`uploading ${current} of ${total}`)
     return new Promise((resolve, reject) => {
@@ -100,14 +108,6 @@ module.exports = class XHRUpload extends Plugin {
           this.core.emit('core:upload-error', file.id, error)
           return reject(error)
         }
-
-        // var upload = {}
-        //
-        // if (opts.bundle) {
-        //   upload = {files: files}
-        // } else {
-        //   upload = {file: files[current]}
-        // }
       })
 
       xhr.addEventListener('error', (ev) => {

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -150,6 +150,16 @@ module.exports = class XHRUpload extends Plugin {
     return new Promise((resolve, reject) => {
       this.core.emit('core:upload-started', file.id)
 
+      const fields = {}
+      const metaFields = Array.isArray(opts.metaFields)
+        ? opts.metaFields
+        // Send along all fields by default.
+        : Object.keys(file.meta)
+
+      metaFields.forEach((name) => {
+        fields[name] = file.meta.name
+      })
+
       fetch(file.remote.url, {
         method: 'post',
         credentials: 'include',
@@ -160,7 +170,9 @@ module.exports = class XHRUpload extends Plugin {
         body: JSON.stringify(Object.assign({}, file.remote.body, {
           endpoint: opts.endpoint,
           size: file.data.size,
-          fieldname: opts.fieldName
+          fieldname: opts.fieldName,
+          fields,
+          headers: opts.headers
         }))
       })
       .then((res) => {


### PR DESCRIPTION
Closes #243

If `getUploadParameters` returns an object with a `headers` property,
those headers are added to the HTTP request used for the upload.

This way headers like `Content-Disposition` can be added without
requiring support for that on the signing server side.

```js
uppy.use(AwsS3, {
  getUploadParameters (file) {
    return fetch(`/sign?name=${file.name}&type=${file.type.mime}`)
      .then((response) => response.json())
      .then((data) => Object.assign(data, {
        headers: {
          'Content-Disposition': file.meta.contentDisposition
        }
      }))
  }
})

// later
uppy.addFile({
  name: 'xyz.jpg',
  mime: 'image/jpeg',
  data: someArrayBuffer,
  meta: {
    contentDisposition: 'inline'
  }
})
```

To do this the XHRUpload plugin needed to merge header objects
from different configuration locations together, in https://github.com/transloadit/uppy/pull/368/commits/c8133c1250fe31a20c0c66918a20fb37419297ff and https://github.com/transloadit/uppy/pull/368/commits/df6d4f06c10b481ad4cff6bd164da938234eb7da