### PR TITLE
Check for `uploader` type plugins, issue warnings; better log

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -947,10 +947,6 @@ class Uppy {
       this.log('No uploader type plugins are used', 'warning')
     }
 
-    if (Object.keys(this.state.files).length === 0) {
-      this.log('No files have been added', 'warning')
-    }
-
     const isMinNumberOfFilesReached = this.checkMinNumberOfFiles()
     if (!isMinNumberOfFilesReached) {
       return Promise.reject(new Error('Minimum number of files has not been reached'))

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -787,13 +787,13 @@ class Uppy {
    * @param {String} type optional `error` or `warning`
    */
   log (msg, type) {
-    let message = `[Uppy] [${Utils.getTimeStamp()}] ${msg}`
-
-    global.uppyLog = global.uppyLog + '\n' + 'DEBUG LOG: ' + msg
-
     if (!this.opts.debug) {
       return
     }
+
+    let message = `[Uppy] [${Utils.getTimeStamp()}] ${msg}`
+
+    global.uppyLog = global.uppyLog + '\n' + 'DEBUG LOG: ' + msg
 
     if (type === 'error') {
       console.error(message)

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -42,6 +42,24 @@ function toArray (list) {
 }
 
 /**
+ * Returns a timestamp in the format of `hours:minutes:seconds`
+*/
+function getTimeStamp () {
+  var date = new Date()
+  var hours = pad(date.getHours().toString())
+  var minutes = pad(date.getMinutes().toString())
+  var seconds = pad(date.getSeconds().toString())
+  return hours + ':' + minutes + ':' + seconds
+}
+
+/**
+ * Adds zero to strings shorter than two characters
+*/
+function pad (str) {
+  return str.length !== 2 ? 0 + str : str
+}
+
+/**
  * Takes a file object and turns it into fileID, by converting file.name to lowercase,
  * removing extra characters and adding type, size and lastModified
  *
@@ -519,6 +537,7 @@ function settle (promises) {
 module.exports = {
   generateFileID,
   toArray,
+  getTimeStamp,
   runPromiseSequence,
   supportsMediaRecorder,
   isTouchDevice,


### PR DESCRIPTION
Also adds:
- `warning` support to log
- timestamps (not saying we 100% need those)

<img width="1275" alt="screen shot 2017-09-29 at 4 59 52 pm" src="https://user-images.githubusercontent.com/1199054/31036121-ec7a0eb4-a538-11e7-9033-bdc5445e8062.png">
