### PR TITLE
Add support for Redux DevTools via a plugin

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -65,10 +65,10 @@ class Uppy {
     // Container for different types of plugins
     this.plugins = {}
 
-    // @TODO maybe bindall
     this.translator = new Translator({locale: this.opts.locale})
     this.i18n = this.translator.translate.bind(this.translator)
     this.getState = this.getState.bind(this)
+    this.getPlugin = this.getPlugin.bind(this)
     this.updateMeta = this.updateMeta.bind(this)
     this.initSocket = this.initSocket.bind(this)
     this.log = this.log.bind(this)
@@ -106,21 +106,33 @@ class Uppy {
     }
 
     // for debugging and testing
-
-    this.withDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
-
-    if (this.withDevTools) {
-      this.devTools = window.devToolsExtension.connect()
-      this.devToolsUnsubscribe = this.devTools.subscribe((message) => {
-        // Implement monitors actions. For example time traveling:
-        if (message.type === 'DISPATCH' && message.payload.type === 'JUMP_TO_STATE') {
-          const state = JSON.parse(message.state)
-          // this.setState(state)
-          this.state = Object.assign({}, this.state, state)
-          this.updateAll(this.state)
-        }
-      })
-    }
+    // // Implement monitors actions.
+    // // See https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f
+    // // and https://github.com/zalmoxisus/mobx-remotedev/blob/master/src/monitorActions.js
+    // this.withDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
+    // if (this.withDevTools) {
+    //   this.devTools = window.devToolsExtension.connect()
+    //   this.devToolsUnsubscribe = this.devTools.subscribe((message) => {
+    //     if (message.type === 'DISPATCH') {
+    //       console.log(message.payload.type)
+    //       switch (message.payload.type) {
+    //         case 'RESET':
+    //           this.reset()
+    //           return
+    //         case 'IMPORT_STATE':
+    //           const computedStates = message.payload.nextLiftedState.computedStates
+    //           this.state = Object.assign({}, this.state, computedStates[computedStates.length - 1].state)
+    //           this.updateAll(this.state)
+    //           return
+    //         case 'JUMP_TO_STATE':
+    //         case 'JUMP_TO_ACTION':
+    //           // this.setState(state)
+    //           this.state = Object.assign({}, this.state, JSON.parse(message.state))
+    //           this.updateAll(this.state)
+    //       }
+    //     }
+    //   })
+    // }
 
     // this.updateNum = 0
     if (this.opts.debug) {
@@ -491,11 +503,11 @@ class Uppy {
     //   this.setState({bla: 'bla'})
     // }, 20)
 
-    this.on('core:state-update', (prevState, nextState, patch) => {
-      if (this.withDevTools) {
-        this.devTools.send('UPPY_STATE_UPDATE', nextState)
-      }
-    })
+    // this.on('core:state-update', (prevState, nextState, patch) => {
+    //   if (this.withDevTools) {
+    //     this.devTools.send('UPPY_STATE_UPDATE', nextState)
+    //   }
+    // })
 
     this.on('core:error', (error) => {
       this.setState({ error })
@@ -555,7 +567,6 @@ class Uppy {
     const throttledCalculateProgress = throttle(this.calculateProgress, 100, {leading: true, trailing: false})
 
     this.on('core:upload-progress', (data) => {
-      // this.calculateProgress(data)
       throttledCalculateProgress(data)
     })
 
@@ -564,8 +575,6 @@ class Uppy {
       const updatedFile = Object.assign({}, updatedFiles[fileID], {
         progress: Object.assign({}, updatedFiles[fileID].progress, {
           uploadComplete: true,
-          // good or bad idea? setting the percentage to 100 if upload is successful,
-          // so that if we lost some progress events on the way, its still marked “compete”?
           percentage: 100
         }),
         uploadURL: uploadURL

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -139,12 +139,12 @@ module.exports = function Dashboard (props) {
                     type="button"
                     onclick=${props.hideAllPanels}>${props.i18n('done')}</button>
           </div>
-          ${props.activePanel ? props.activePanel.render(props.state) : ''}
+          ${props.activePanel ? props.getPlugin(props.activePanel.id).render(props.state) : ''}
         </div>
 
         <div class="UppyDashboard-progressindicators">
           ${props.progressindicators.map((target) => {
-            return target.render(props.state)
+            return props.getPlugin(target.id).render(props.state)
           })}
         </div>
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -313,7 +313,7 @@ module.exports = class DashboardUI extends Plugin {
       return target.type === 'acquirer'
     })
 
-    const progressindicators = pluginState.targets.filter((target) => {
+    const progressindicators = pluginState.targets.filter(target => {
       const plugin = this.core.getPlugin(target.id)
       target.icon = plugin.icon || this.opts.defaultTabIcon
       target.render = plugin.render
@@ -354,6 +354,7 @@ module.exports = class DashboardUI extends Plugin {
       totalProgress: state.totalProgress,
       acquirers: acquirers,
       activePanel: pluginState.activePanel,
+      getPlugin: this.core.getPlugin,
       progressindicators: progressindicators,
       autoProceed: this.core.opts.autoProceed,
       hideUploadButton: this.opts.hideUploadButton,

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -93,7 +93,7 @@ module.exports = class DashboardUI extends Plugin {
   addTarget (plugin) {
     const callerPluginId = plugin.id || plugin.constructor.name
     const callerPluginName = plugin.title || callerPluginId
-    const callerPluginIcon = plugin.icon || this.opts.defaultTabIcon
+    // const callerPluginIcon = plugin.icon || this.opts.defaultTabIcon
     const callerPluginType = plugin.type
 
     if (callerPluginType !== 'acquirer' &&
@@ -107,9 +107,9 @@ module.exports = class DashboardUI extends Plugin {
     const target = {
       id: callerPluginId,
       name: callerPluginName,
-      icon: callerPluginIcon,
+      // icon: callerPluginIcon,
       type: callerPluginType,
-      render: plugin.render,
+      // render: plugin.render,
       isHidden: true
     }
 
@@ -306,11 +306,17 @@ module.exports = class DashboardUI extends Plugin {
     totalSize = prettyBytes(totalSize)
     totalUploadedSize = prettyBytes(totalUploadedSize)
 
-    const acquirers = pluginState.targets.filter((target) => {
+    const acquirers = pluginState.targets.filter(target => {
+      const plugin = this.core.getPlugin(target.id)
+      target.icon = plugin.icon || this.opts.defaultTabIcon
+      target.render = plugin.render
       return target.type === 'acquirer'
     })
 
     const progressindicators = pluginState.targets.filter((target) => {
+      const plugin = this.core.getPlugin(target.id)
+      target.icon = plugin.icon || this.opts.defaultTabIcon
+      target.render = plugin.render
       return target.type === 'progressindicator'
     })
 

--- a/src/plugins/ReduxDevTools.js
+++ b/src/plugins/ReduxDevTools.js
@@ -1,14 +1,17 @@
 const Plugin = require('./Plugin')
 
 /**
+ * Add Redux DevTools support to Uppy
  *
+ * See https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f
+ * and https://github.com/zalmoxisus/mobx-remotedev/blob/master/src/monitorActions.js
  */
 module.exports = class ReduxDevTools extends Plugin {
   constructor (core, opts) {
     super(core, opts)
     this.type = 'debugger'
     this.id = 'ReduxDevTools'
-    this.title = 'Redux Dev Tools'
+    this.title = 'Redux DevTools'
 
     // set default options
     const defaultOptions = {}
@@ -29,6 +32,8 @@ module.exports = class ReduxDevTools extends Plugin {
     this.devToolsUnsubscribe = this.devTools.subscribe((message) => {
       if (message.type === 'DISPATCH') {
         console.log(message.payload.type)
+
+        // Implement monitors actions
         switch (message.payload.type) {
           case 'RESET':
             this.core.reset()
@@ -49,9 +54,6 @@ module.exports = class ReduxDevTools extends Plugin {
   }
 
   install () {
-    // Implement monitors actions.
-    // See https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f
-    // and https://github.com/zalmoxisus/mobx-remotedev/blob/master/src/monitorActions.js
     this.withDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
     if (this.withDevTools) {
       this.initDevTools()

--- a/src/plugins/ReduxDevTools.js
+++ b/src/plugins/ReduxDevTools.js
@@ -1,0 +1,67 @@
+const Plugin = require('./Plugin')
+
+/**
+ *
+ */
+module.exports = class ReduxDevTools extends Plugin {
+  constructor (core, opts) {
+    super(core, opts)
+    this.type = 'debugger'
+    this.id = 'ReduxDevTools'
+    this.title = 'Redux Dev Tools'
+
+    // set default options
+    const defaultOptions = {}
+
+    // merge default options with the ones set by user
+    this.opts = Object.assign({}, defaultOptions, opts)
+
+    this.handleStateChange = this.handleStateChange.bind(this)
+    this.initDevTools = this.initDevTools.bind(this)
+  }
+
+  handleStateChange (prevState, nextState, patch) {
+    this.devTools.send('UPPY_STATE_UPDATE', nextState)
+  }
+
+  initDevTools () {
+    this.devTools = window.devToolsExtension.connect()
+    this.devToolsUnsubscribe = this.devTools.subscribe((message) => {
+      if (message.type === 'DISPATCH') {
+        console.log(message.payload.type)
+        switch (message.payload.type) {
+          case 'RESET':
+            this.core.reset()
+            return
+          case 'IMPORT_STATE':
+            const computedStates = message.payload.nextLiftedState.computedStates
+            this.core.state = Object.assign({}, this.core.state, computedStates[computedStates.length - 1].state)
+            this.core.updateAll(this.core.state)
+            return
+          case 'JUMP_TO_STATE':
+          case 'JUMP_TO_ACTION':
+            // this.setState(state)
+            this.core.state = Object.assign({}, this.core.state, JSON.parse(message.state))
+            this.core.updateAll(this.core.state)
+        }
+      }
+    })
+  }
+
+  install () {
+    // Implement monitors actions.
+    // See https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f
+    // and https://github.com/zalmoxisus/mobx-remotedev/blob/master/src/monitorActions.js
+    this.withDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
+    if (this.withDevTools) {
+      this.initDevTools()
+      this.core.on('core:state-update', this.handleStateChange)
+    }
+  }
+
+  uninstall () {
+    if (this.withDevTools) {
+      this.core.emitter.off('core:state-update', this.handleStateUpdate)
+    }
+  }
+}


### PR DESCRIPTION
- Sends state updates to DevTools; Subscribes to DevTools and sets Uppy state to state provided by DevTools for time traveling; supports replaying all actions, step by step, persisting state, jumping to specific state
- Works without modifying everything else, which is cool. Though I’m not saying adopting Redux would be too hard (see #338), and it might provide better structure, but we are just not sure yet;
- We could add support for custom action type names, and then we’ll get actions like `UPPY_ADD_FILE` and such (see this comment https://news.ycombinator.com/item?id=15342850);
- Implemented as a separate plugin

(Try by installing and activating: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

And the second commit is useful regardless:

> Don’t store function references in state to keep state serializable
> Instead of storing methods in state, find plugin and add methods to the object that we pass to `render`, when it’s needed.

This might be useful for parsing/stringifying JSON, so we don’t forget: https://www.npmjs.com/package/jsan

<img width="1273" alt="screen shot 2017-09-30 at 12 19 13 am" src="https://user-images.githubusercontent.com/1199054/31042448-4db5091c-a576-11e7-9fbe-1ef385a38979.png">

done P.S. ~~This could probably be a plugin 🤔~~