### PR TITLE
 xhrupload: stop trying to upload if it stalled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ What we need to do to release Uppy 1.0
 - [ ] refactoring: clean up code everywhere
 - [ ] docs: on using plugins, all options, list of plugins, i18n
 - [ ] uppy-server: better error handling, general cleanup (remove unused code. etc)
-- [ ] uppy-server: security audit 
+- [ ] uppy-server: security audit
 - [x] uppy-server: storing tokens in user’s browser only (d040281cc9a63060e2f2685c16de0091aee5c7b4)
 - [ ] consider iframe / more security for Transloadit/Uppy integration widget and Uppy itself. Page can’t get files from Google Drive if its an iframe; possibility for folder restriction for provider plugins
 - [ ] automatically host releases on edgly and use that as our main CDN
@@ -112,7 +112,7 @@ To be released: 2017-11-10
 - [ ] uppy-server: look into storing tokens in user’s browser only (@ifedapoolarewaju)
 - [ ] plugins: add tabindex="0" to buttons and tabs (@arturi)
 - [ ] goldenretriever: add “ghost” files (@arturi)
-- [ ] xhrupload: set a timeout in the onprogress event handler to detect stale network (#378 / @goto-bus-stop)
+- [x] xhrupload: set a timeout in the onprogress event handler to detect stale network (#378 / @goto-bus-stop)
 - [ ] tus: Review b3cc48130e292f08c2a09f2f0adf6b6332bf7692
 - [x] tus: Rename Tus10 → Tus
 - [ ] docs: quick start guide: https://community.transloadit.com/t/quick-start-guide-would-be-really-helpful/14605 (@arturi)

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -97,9 +97,15 @@ module.exports = class XHRUpload extends Plugin {
 
       const xhr = new XMLHttpRequest()
 
+      xhr.upload.addEventListener('loadstart', (ev) => {
+        if (opts.timeout > 0) {
+          // Begin checking for timeouts when loading starts.
+          isAlive()
+        }
+      })
+
       xhr.upload.addEventListener('progress', (ev) => {
         if (opts.timeout > 0) {
-          // Do connection timeout checks.
           isAlive()
         }
 

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -84,15 +84,16 @@ module.exports = class XHRUpload extends Plugin {
         ? this.createFormDataUpload(file, opts)
         : this.createBareUpload(file, opts)
 
+      const onTimedOut = () => {
+        xhr.abort()
+        const error = new Error(`No progress for ${Math.ceil(opts.timeout / 1000)} seconds, aborting`)
+        this.core.emit('core:upload-error', file.id, error)
+        reject(error)
+      }
       let aliveTimer
       const isAlive = () => {
         clearTimeout(aliveTimer)
-        aliveTimer = setTimeout(() => {
-          xhr.abort()
-          const error = new Error(`No progress for ${Math.ceil(opts.timeout / 1000)} seconds, aborting`)
-          this.core.emit('core:upload-error', file.id, error)
-          reject(error)
-        }, opts.timeout)
+        aliveTimer = setTimeout(onTimedOut, opts.timeout)
       }
 
       const xhr = new XMLHttpRequest()

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -100,4 +100,13 @@ getResponseError (xhr) {
 
 The field name containing a publically accessible location of the uploaded file in the response data returned by `getResponseData(xhr)`.
 
+### `timeout: 30 * 1000`
+
+When no upload progress events have been received for this amount of milliseconds, assume the connection has an issue and abort the upload.
+Note that unlike the [`XMLHttpRequest.timeout`][XHR.timeout] property, this is a timer between progress events: the total upload can take longer than this value.
+Set to `0` to disable this check.
+
+The default is 30 seconds.
+
 [FormData]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
+[XHR.timeout]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout


### PR DESCRIPTION
If no progress events have been emitted for `opts.timeout` milliseconds, abort the upload.

Currently this defaults to 30 seconds.

Set `opts.timeout` to 0 to disable this feature, and never auto-abort the upload.