### PR TITLE
restore: Fix server-side require()

### DIFF
--- a/src/plugins/RestoreFiles/IndexedDBStore.js
+++ b/src/plugins/RestoreFiles/IndexedDBStore.js
@@ -1,5 +1,6 @@
 const prettyBytes = require('prettier-bytes')
-const indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.OIndexedDB || window.msIndexedDB
+const indexedDB = typeof window !== 'undefined' &&
+  (window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.OIndexedDB || window.msIndexedDB)
 
 const isSupported = !!indexedDB
 

--- a/src/plugins/RestoreFiles/ServiceWorkerStore.js
+++ b/src/plugins/RestoreFiles/ServiceWorkerStore.js
@@ -1,8 +1,8 @@
-const isSupported = 'serviceWorker' in navigator
+const isSupported = typeof navigator !== 'undefined' && 'serviceWorker' in navigator
 
 function waitForServiceWorker () {
   return new Promise((resolve, reject) => {
-    if (!('serviceWorker' in navigator)) {
+    if (!isSupported) {
       reject(new Error('Unsupported'))
     } else if (navigator.serviceWorker.controller) {
       // A serviceWorker is already registered and active.


### PR DESCRIPTION
This prevents errors when checking for IndexedDB or service worker
support. While the Golden Retriever can't be used on the server, at
least now it won't crash. That's nice for server rendering, you can still
`require()` your entire client application server side this way.