### PR TITLE
Restart the entire upload on retry, fixes #387.

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -512,7 +512,6 @@ class Uppy {
 
   reset () {
     this.cancelAll()
-    // this.pauseAll()
   }
 
   cancelAll () {

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -327,10 +327,6 @@ module.exports = class DashboardUI extends Plugin {
       })
     }
 
-    const retryUpload = (fileID) => {
-      this.core.emit('core:upload-retry', fileID)
-    }
-
     const cancelUpload = (fileID) => {
       this.core.emit('core:upload-cancel', fileID)
       this.core.emit('core:file-remove', fileID)
@@ -378,7 +374,7 @@ module.exports = class DashboardUI extends Plugin {
       resumableUploads: this.core.state.capabilities.resumableUploads || false,
       startUpload: startUpload,
       pauseUpload: this.core.pauseResume,
-      retryUpload: retryUpload,
+      retryUpload: this.core.retryUpload,
       cancelUpload: cancelUpload,
       fileCardFor: pluginState.fileCardFor,
       showFileCard: showFileCard,

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -156,7 +156,9 @@ module.exports = class Transloadit extends Plugin {
         const tus = Object.assign({}, file.tus, {
           endpoint: assembly.tus_url,
           // Only send assembly metadata to the tus endpoint.
-          metaFields: Object.keys(tlMeta)
+          metaFields: Object.keys(tlMeta),
+          // Make sure tus doesn't resume a previous upload.
+          uploadUrl: null
         })
         const transloadit = {
           assembly: assembly.assembly_id

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -27,6 +27,25 @@ const tusDefaultOptions = {
 }
 
 /**
+ * Create a wrapper around an event emitter with a `remove` method to remove
+ * all events that were added using the wrapped emitter.
+ */
+function createEventTracker (emitter) {
+  const events = []
+  return {
+    on (event, fn) {
+      events.push([ event, fn ])
+      return emitter.on(event, fn)
+    },
+    remove () {
+      events.forEach(([ event, fn ]) => {
+        emitter.off(event, fn)
+      })
+    }
+  }
+}
+
+/**
  * Tus resumable file uploader
  *
  */
@@ -47,6 +66,10 @@ module.exports = class Tus10 extends Plugin {
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
 
+    this.uploaders = Object.create(null)
+    this.uploaderEvents = Object.create(null)
+    this.uploaderSockets = Object.create(null)
+
     this.handleResetProgress = this.handleResetProgress.bind(this)
     this.handleUpload = this.handleUpload.bind(this)
   }
@@ -66,6 +89,25 @@ module.exports = class Tus10 extends Plugin {
   }
 
   /**
+   * Clean up all references for a file's upload: the tus.Upload instance,
+   * any events related to the file, and the uppy-server WebSocket connection.
+   */
+  resetUploaderReferences (fileID) {
+    if (this.uploaders[fileID]) {
+      this.uploaders[fileID].abort()
+      this.uploaders[fileID] = null
+    }
+    if (this.uploaderEvents[fileID]) {
+      this.uploaderEvents[fileID].remove()
+      this.uploaderEvents[fileID] = null
+    }
+    if (this.uploaderSockets[fileID]) {
+      this.uploaderSockets[fileID].close()
+      this.uploaderSockets[fileID] = null
+    }
+  }
+
+  /**
    * Create a new Tus upload
    *
    * @param {object} file for use with upload
@@ -75,6 +117,8 @@ module.exports = class Tus10 extends Plugin {
    */
   upload (file, current, total) {
     this.core.log(`uploading ${current} of ${total}`)
+
+    this.resetUploaderReferences(file.id)
 
     // Create a new tus upload
     return new Promise((resolve, reject) => {
@@ -90,6 +134,8 @@ module.exports = class Tus10 extends Plugin {
         this.core.log(err)
         this.core.emit('core:upload-error', file.id, err)
         err.message = `Failed because: ${err.message}`
+
+        this.resetUploaderReferences(file.id)
         reject(err)
       }
 
@@ -110,14 +156,17 @@ module.exports = class Tus10 extends Plugin {
           this.core.log('Download ' + upload.file.name + ' from ' + upload.url)
         }
 
+        this.resetUploaderReferences(file.id)
         resolve(upload)
       }
       optsTus.metadata = file.meta
 
       const upload = new tus.Upload(file.data, optsTus)
+      this.uploaders[file.id] = upload
+      this.uploaderEvents[file.id] = createEventTracker(this.core)
 
       this.onFileRemove(file.id, (targetFileID) => {
-        upload.abort()
+        this.resetUploaderReferences(file.id)
         resolve(`upload ${targetFileID} was removed`)
       })
 
@@ -130,8 +179,7 @@ module.exports = class Tus10 extends Plugin {
       })
 
       this.onCancelAll(file.id, () => {
-        upload.abort()
-        this.removeUploadURL(file.id)
+        this.resetUploaderReferences(file.id)
       })
 
       this.onResumeAll(file.id, () => {
@@ -147,6 +195,8 @@ module.exports = class Tus10 extends Plugin {
   }
 
   uploadRemote (file, current, total) {
+    this.resetUploaderReferences(file.id)
+
     return new Promise((resolve, reject) => {
       this.core.log(file.remote.url)
       if (file.serverToken) {
@@ -195,6 +245,8 @@ module.exports = class Tus10 extends Plugin {
     const token = file.serverToken
     const host = getSocketHost(file.remote.host)
     const socket = new UppySocket({ target: `${host}/api/${token}` })
+    this.uploaderSockets[file.id] = socket
+    this.uploaderEvents[file.id] = createEventTracker(this.core)
 
     this.onFileRemove(file.id, () => socket.send('pause', {}))
 
@@ -227,7 +279,7 @@ module.exports = class Tus10 extends Plugin {
 
     socket.on('success', (data) => {
       this.core.emitter.emit('core:upload-success', file.id, data, data.url)
-      socket.close()
+      this.resetUploaderReferences(file.id)
     })
   }
 
@@ -256,27 +308,14 @@ module.exports = class Tus10 extends Plugin {
     }
   }
 
-  removeUploadURL (fileID) {
-    const file = this.core.getFile(fileID)
-
-    // No need to change state if we didn't have an `uploadUrl`.
-    if (!file || !file.tus || !file.tus.uploadUrl) return
-
-    this.updateFile(Object.assign({}, file, {
-      tus: Object.assign({}, file.tus, {
-        uploadUrl: null
-      })
-    }))
-  }
-
   onFileRemove (fileID, cb) {
-    this.core.on('core:file-removed', (targetFileID) => {
+    this.uploaderEvents[fileID].on('core:file-removed', (targetFileID) => {
       if (fileID === targetFileID) cb(targetFileID)
     })
   }
 
   onPause (fileID, cb) {
-    this.core.on('core:upload-pause', (targetFileID, isPaused) => {
+    this.uploaderEvents[fileID].on('core:upload-pause', (targetFileID, isPaused) => {
       if (fileID === targetFileID) {
         // const isPaused = this.core.pauseResume(fileID)
         cb(isPaused)
@@ -285,7 +324,7 @@ module.exports = class Tus10 extends Plugin {
   }
 
   onRetry (fileID, cb) {
-    this.core.on('core:upload-retry', (targetFileID) => {
+    this.uploaderEvents[fileID].on('core:upload-retry', (targetFileID) => {
       if (fileID === targetFileID) {
         cb()
       }
@@ -293,28 +332,28 @@ module.exports = class Tus10 extends Plugin {
   }
 
   onRetryAll (fileID, cb) {
-    this.core.on('core:retry-all', (filesToRetry) => {
+    this.uploaderEvents[fileID].on('core:retry-all', (filesToRetry) => {
       if (!this.core.getFile(fileID)) return
       cb()
     })
   }
 
   onPauseAll (fileID, cb) {
-    this.core.on('core:pause-all', () => {
+    this.uploaderEvents[fileID].on('core:pause-all', () => {
       if (!this.core.getFile(fileID)) return
       cb()
     })
   }
 
   onCancelAll (fileID, cb) {
-    this.core.on('core:cancel-all', () => {
+    this.uploaderEvents[fileID].on('core:cancel-all', () => {
       if (!this.core.getFile(fileID)) return
       cb()
     })
   }
 
   onResumeAll (fileID, cb) {
-    this.core.on('core:resume-all', () => {
+    this.uploaderEvents[fileID].on('core:resume-all', () => {
       if (!this.core.getFile(fileID)) return
       cb()
     })

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -125,14 +125,6 @@ module.exports = class Tus10 extends Plugin {
         isPaused ? upload.abort() : upload.start()
       })
 
-      this.onRetry(file.id, () => {
-        this.removeUploadURL(file.id)
-      })
-
-      this.onRetryAll(file.id, () => {
-        this.removeUploadURL(file.id)
-      })
-
       this.onPauseAll(file.id, () => {
         upload.abort()
       })

--- a/src/plugins/Tus10.js
+++ b/src/plugins/Tus10.js
@@ -126,13 +126,11 @@ module.exports = class Tus10 extends Plugin {
       })
 
       this.onRetry(file.id, () => {
-        upload.abort()
-        upload.start()
+        this.removeUploadURL(file.id)
       })
 
       this.onRetryAll(file.id, () => {
-        upload.abort()
-        upload.start()
+        this.removeUploadURL(file.id)
       })
 
       this.onPauseAll(file.id, () => {
@@ -141,6 +139,7 @@ module.exports = class Tus10 extends Plugin {
 
       this.onCancelAll(file.id, () => {
         upload.abort()
+        this.removeUploadURL(file.id)
       })
 
       this.onResumeAll(file.id, () => {
@@ -263,6 +262,19 @@ module.exports = class Tus10 extends Plugin {
       })
       this.updateFile(newFile)
     }
+  }
+
+  removeUploadURL (fileID) {
+    const file = this.core.getFile(fileID)
+
+    // No need to change state if we didn't have an `uploadUrl`.
+    if (!file || !file.tus || !file.tus.uploadUrl) return
+
+    this.updateFile(Object.assign({}, file, {
+      tus: Object.assign({}, file.tus, {
+        uploadUrl: null
+      })
+    }))
   }
 
   onFileRemove (fileID, cb) {

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -34,8 +34,6 @@ module.exports = class XHRUpload extends Plugin {
     this.opts = Object.assign({}, defaultOptions, opts)
 
     this.handleUpload = this.handleUpload.bind(this)
-    this.handleRetry = this.handleRetry.bind(this)
-    this.handleRetryAll = this.handleRetryAll.bind(this)
   }
 
   getOptions (file) {
@@ -230,25 +228,11 @@ module.exports = class XHRUpload extends Plugin {
     return this.uploadFiles(files).then(() => null)
   }
 
-  handleRetry (targetFileID) {
-    this.handleUpload([targetFileID])
-  }
-
-  handleRetryAll (filesToRetry) {
-    this.handleUpload(filesToRetry)
-  }
-
   install () {
     this.core.addUploader(this.handleUpload)
-
-    this.core.on('core:upload-retry', this.handleRetry)
-    this.core.on('core:retry-all', this.handleRetryAll)
   }
 
   uninstall () {
     this.core.removeUploader(this.handleUpload)
-
-    this.core.off('core:upload-retry', this.handleRetry)
-    this.core.off('core:retry-all', this.handleRetryAll)
   }
 }


### PR DESCRIPTION
Instead of restarting only the file upload itself in the Tus or
XHRUpload plugin, start an entirely new upload for retries. This fixes
retrying uploads with processing plugins, like Transloadit. Previously,
only the Tus upload would be retried--with this patch, a new assembly
will be created and the retry will go to that assembly.