### PR TITLE
Show errors that occurred during processing.

### DIFF
--- a/src/plugins/Dashboard/FileItem.js
+++ b/src/plugins/Dashboard/FileItem.js
@@ -14,9 +14,10 @@ module.exports = function fileItem (props) {
   const file = props.file
   const acquirers = props.acquirers
 
-  const isUploaded = file.progress.uploadComplete
-  const uploadInProgressOrComplete = file.progress.uploadStarted
-  const uploadInProgress = file.progress.uploadStarted && !file.progress.uploadComplete
+  const isProcessing = file.progress.preprocess || file.progress.postprocess
+  const isUploaded = file.progress.uploadComplete && !isProcessing && !file.error
+  const uploadInProgressOrComplete = file.progress.uploadStarted || isProcessing
+  const uploadInProgress = (file.progress.uploadStarted && !file.progress.uploadComplete) || isProcessing
   const isPaused = file.isPaused || false
   const error = file.error || false
 
@@ -38,6 +39,7 @@ module.exports = function fileItem (props) {
 
   return html`<li class="UppyDashboardItem
                         ${uploadInProgress ? 'is-inprogress' : ''}
+                        ${isProcessing ? 'is-processing' : ''}
                         ${isUploaded ? 'is-complete' : ''}
                         ${isPaused ? 'is-paused' : ''}
                         ${error ? 'is-error' : ''}

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -713,7 +713,8 @@
   }
 
   .UppyDashboardItem.is-inprogress .UppyDashboardItem-progress,
-  .UppyDashboardItem.is-complete .UppyDashboardItem-progress {
+  .UppyDashboardItem.is-complete .UppyDashboardItem-progress,
+  .UppyDashboardItem.is-error .UppyDashboardItem-progress {
     display: block;
   }
 
@@ -835,6 +836,12 @@
   }
 }
 
+.UppyDashboardItem.is-error {
+  .UppyDashboardItem-previewInnerWrap:after {
+    display: block;
+  }
+}
+
 .UppyDashboardItem.is-paused {
   .pause {
     opacity: 0;
@@ -859,9 +866,6 @@
     opacity: 1;
   }
 }
-
-
-
 
 .UppyTotalProgress {
   @include reset-button;


### PR DESCRIPTION
Previously, file cards in the Dashboard would not show errors that
occurred during processing, such as a failed Transloadit assembly.

This patch also shows the error overlay on files that errored at some
other point than the upload itself.