### PR TITLE
transloadit: Emit file upload error if assembly fails.

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -423,6 +423,9 @@ module.exports = class Transloadit extends Plugin {
         // Clear postprocessing state for all our files.
         const files = this.getAssemblyFiles(assembly.assembly_id)
         files.forEach((file) => {
+          // TODO Maybe make a postprocess-error event here?
+          this.core.emit('core:upload-error', file.id, error)
+
           this.core.emit('core:postprocess-complete', file.id)
         })
 


### PR DESCRIPTION
I'm reusing the `upload-error` event for this, maybe we should add a
`postprocess-error` event too. Anyway, this sets the `.error` state on
files if the assembly they were uploaded to fails for some reason.

This was pulled out of #366 to maybe land it faster.