### PR TITLE
core: Clear upload progress when upload starts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ideas that will be planned and find their way into a release at one point
 - [ ] consider iframe / more security for Transloadit/Uppy integration widget
 - [ ] statusbar: add option to always show
 - [ ] tus: Rename Tus10 → Tus
+- [ ] have a `resetProgress` method for resetting a single file, and call it before starting an upload. see comment in #393
 
 ## 1.0 Goals
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -628,7 +628,10 @@ class Uppy {
       const updatedFile = Object.assign({}, updatedFiles[fileID],
         Object.assign({}, {
           progress: Object.assign({}, updatedFiles[fileID].progress, {
-            uploadStarted: Date.now()
+            uploadStarted: Date.now(),
+            uploadComplete: false,
+            percentage: 0,
+            bytesUploaded: 0
           })
         }
       ))


### PR DESCRIPTION
This fixes an issue when retrying Tus uploads with the Transloadit
plugin. `uploadComplete` would be true, so the Dashboard would show the
file as complete while it was uploading again.