### PR TITLE
Fix of the .uppy-DragDrop-inner spacing on small screens

### DIFF
--- a/src/scss/_dragdrop.scss
+++ b/src/scss/_dragdrop.scss
@@ -11,14 +11,15 @@
   .uppy-DragDrop-inner {
     margin: 0;
     text-align: center;
-    padding: 80px 0;
+    padding: 80px 15px;
+    line-height: 1.4;
   }
   
   .uppy-DragDrop-arrow {
     width: 60px;
     height: 60px;
     fill: lighten($color-gray, 30%);
-    margin-bottom: 20px;
+    margin-bottom: 17px;
   }
   
     .uppy-DragDrop-container.is-dragdrop-supported {
@@ -53,7 +54,7 @@
     display: block;
     cursor: pointer;
     font-size: 1.15em;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
   }
 
   .uppy-DragDrop-note {

--- a/src/scss/_dragdrop.scss
+++ b/src/scss/_dragdrop.scss
@@ -11,7 +11,7 @@
   .uppy-DragDrop-inner {
     margin: 0;
     text-align: center;
-    padding: 80px 15px;
+    padding: 80px 20px;
     line-height: 1.4;
   }
   


### PR DESCRIPTION
On small screens, the content of the `.uppy-DragDrop-inner` was sticking to the side edges, and when there are two lines of the note, its lines were too close to each other:

![image](https://user-images.githubusercontent.com/375537/32186690-730b9f80-bdab-11e7-8c6e-60815b5edb31.png)

Now it's fixed: the note's `line-height` increased, and side paddings added:

![image](https://user-images.githubusercontent.com/375537/32186724-90ce7ca4-bdab-11e7-80f1-dec341264e32.png)
