### PR TITLE
Updates state with error messages rather than error objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/transloadit/uppy/issues"
   },
   "homepage": "https://github.com/transloadit/uppy#readme",
+  "jest": {
+    "testPathIgnorePatterns": ["lib"]
+  },
   "devDependencies": {
     "autoprefixer": "6.3.7",
     "babel-cli": "6.11.4",

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -477,7 +477,7 @@ class Uppy {
   retryAll () {
     const updatedFiles = Object.assign({}, this.getState().files)
     const filesToRetry = Object.keys(updatedFiles).filter(file => {
-      return updatedFiles[file].error
+      return updatedFiles[file].error.message
     })
 
     filesToRetry.forEach((file) => {
@@ -595,16 +595,16 @@ class Uppy {
     // })
 
     this.on('core:error', (error) => {
-      this.setState({ error })
+      this.setState({ error: error.message })
     })
 
     this.on('core:upload-error', (fileID, error) => {
       const updatedFiles = Object.assign({}, this.state.files)
       const updatedFile = Object.assign({}, updatedFiles[fileID],
-        { error: error }
+        { error: error.message }
       )
       updatedFiles[fileID] = updatedFile
-      this.setState({ files: updatedFiles, error: error })
+      this.setState({ files: updatedFiles, error: error.message })
 
       const fileName = this.state.files[fileID].name
       let message = `Failed to upload ${fileName}`

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -924,8 +924,8 @@ describe('src/Core', () => {
     it('should update the state when receiving the core:error event', () => {
       const core = new Core()
       core.run()
-      core.emit('core:error', { foo: 'bar' })
-      expect(core.state.error).toEqual({foo: 'bar'})
+      core.emit('core:error', new Error('foooooo'))
+      expect(core.state.error).toEqual('foooooo')
     })
 
     it('should update the state when receiving the core:upload-error event', () => {


### PR DESCRIPTION
Fixes the issue specified in https://github.com/transloadit/uppy/issues/402

Rather than storing error objects in the state this PR makes it so that it only stores the error message. Full errors get outputted to the console anyway, which is a more useful environment for debugging and logging (and easier for other systems to tap into etc).