### PR TITLE
Remove functions from state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ What we need to do to release Uppy 1.0
 - [ ] refactoring: clean up code everywhere
 - [ ] docs: on using plugins, all options, list of plugins, i18n
 - [ ] uppy-server: better error handling, general cleanup (remove unused code. etc)
-- [ ] uppy-server: security audit 
+- [ ] uppy-server: security audit
 - [x] uppy-server: storing tokens in user’s browser only (d040281cc9a63060e2f2685c16de0091aee5c7b4)
 - [ ] consider iframe / more security for Transloadit/Uppy integration widget and Uppy itself. Page can’t get files from Google Drive if its an iframe; possibility for folder restriction for provider plugins
 - [ ] automatically host releases on edgly and use that as our main CDN
@@ -95,6 +95,7 @@ What we need to do to release Uppy 1.0
 
 To be released: 2017-11-10
 
+- [x] s3: Automatically wrap XHRUpload. **Users should remove `.use(XHRUpload)` when using S3.** (@goto-bus-stop)
 - [x] webcam: look into simplifying / improving webcam plugin (probably good to do modern browsers only) (#382 / @goto-bus-stop)
 - [ ] webcam: only show the webcam tab when browser support is available (@arturi, @goto-bus-stop)
 - [ ] core: Redux PR (#216, #338 / @arturi, @goto-bus-stop, @richardwillars)

--- a/examples/aws-presigned-url/main.js
+++ b/examples/aws-presigned-url/main.js
@@ -1,6 +1,5 @@
 const Uppy = require('uppy/lib/core/Core.js')
 const Dashboard = require('uppy/lib/plugins/Dashboard')
-const XHRUpload = require('uppy/lib/plugins/XHRUpload')
 const AwsS3 = require('uppy/lib/plugins/AwsS3')
 
 const uppy = Uppy({
@@ -12,7 +11,6 @@ uppy.use(Dashboard, {
   inline: true,
   target: 'body'
 })
-uppy.use(XHRUpload)
 uppy.use(AwsS3, {
   getUploadParameters (file) {
     // Send a request to our PHP signing endpoint.

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -6,16 +6,11 @@ permalink: docs/aws-s3/
 ---
 
 The `AwsS3` plugin can be used to upload files directly to an S3 bucket.
-
-As of now, the `AwsS3` plugin "decorates" the XHRUpload plugin.
-To upload files directly to S3, both the XHRUpload and AwsS3 plugins must be used:
+Uploads can be signed using [uppy-server][uppy-server docs] or a custom signing function.
 
 ```js
-// No options have to be provided to the XHRUpload plugin,
-// the S3 plugin will configure it.
-uppy.use(XHRUpload)
 uppy.use(AwsS3, {
-  // Options for S3
+  // Options
 })
 ```
 
@@ -26,7 +21,6 @@ uppy.use(AwsS3, {
 When using [uppy-server][uppy-server docs] to sign S3 uploads, set this option to the root URL of the uppy-server.
 
 ```js
-uppy.use(XHRUpload)
 uppy.use(AwsS3, {
   host: 'https://uppy-server.my-app.com/'
 })
@@ -134,35 +128,33 @@ That way, no private keys to the S3 bucket need to be shared on the client.
 For example, there could be a PHP server endpoint that prepares a presigned URL for a file:
 
 ```js
-uppy
-  .use(XHRUpload)
-  .use(AwsS3, {
-    getUploadParameters (file) {
-      // Send a request to our PHP signing endpoint.
-      return fetch('/s3-sign.php', {
-        method: 'post',
-        // Send and receive JSON.
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({
-          filename: file.name,
-          contentType: file.type
-        })
-      }).then((response) => {
-        // Parse the JSON response.
-        return response.json()
-      }).then((data) => {
-        // Return an object in the correct shape.
-        return {
-          method: data.method,
-          url: data.url,
-          fields: {}
-        }
+uppy.use(AwsS3, {
+  getUploadParameters (file) {
+    // Send a request to our PHP signing endpoint.
+    return fetch('/s3-sign.php', {
+      method: 'post',
+      // Send and receive JSON.
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        filename: file.name,
+        contentType: file.type
       })
-    }
-  })
+    }).then((response) => {
+      // Parse the JSON response.
+      return response.json()
+    }).then((data) => {
+      // Return an object in the correct shape.
+      return {
+        method: data.method,
+        url: data.url,
+        fields: {}
+      }
+    })
+  }
+})
 ```
 
 See the [aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/master/examples/aws-presigned-url) for a small example that implements both the server-side and the client-side.


### PR DESCRIPTION
Aiming to remove all functions from state so that it's easier to serialize, which is good both for Redux-like things and for GoldenRetriever.

So far this PR changes the AwsS3 plugin to pass the options to the XHRUpload plugin directly. Previously users would do `.use(XHRUpload).use(AwsS3)`, but now they should only do `.use(AwsS3)`. The AwsS3 plugin calls `.use(XHRUpload)` with the correct options. I liked how the separation worked earlier internally, but it doesn't really make much sense for users to have to add two plugins for AwsS3. Now the internal separation is still intact (AwsS3 plugin signs the upload, XHRUpload uploads it), but users only have to add one plugin and there are no function options being passed through `core.state.xhrUpload`.

Maybe we can do a similar thing with the Transloadit plugin which does not currently support uploading with XHR. There, the idea was that uploaders could be swapped out, so you could use tus or XHR with transloadit. But the Transloadit plugin doesn't configure XHR so only Tus can be used anyway. And you have to manually pass `{ resume: false }` to tus which is error prone…

Todo: 

 - [ ] Check if we're storing functions anywhere else
 - [ ] Probably do the same with the Transloadit plugin?

Side note, should we have some convention for breaking changes in the changelog?