### PR TITLE
react: Fix `uppy` PropType, closes #411

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -1103,3 +1103,5 @@ class Uppy {
 module.exports = function (opts) {
   return new Uppy(opts)
 }
+// Expose class constructor.
+module.exports.Uppy = Uppy

--- a/src/react/Dashboard.js
+++ b/src/react/Dashboard.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core/Core')
+const UppyCore = require('../core/Core').Uppy
 const DashboardPlugin = require('../plugins/Dashboard')
 
 const h = React.createElement

--- a/src/react/DashboardModal.js
+++ b/src/react/DashboardModal.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core/Core')
+const UppyCore = require('../core/Core').Uppy
 const DashboardPlugin = require('../plugins/Dashboard')
 
 const h = React.createElement

--- a/src/react/DragDrop.js
+++ b/src/react/DragDrop.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core')
+const UppyCore = require('../core').Uppy
 const DragDropPlugin = require('../plugins/DragDrop')
 
 const h = React.createElement

--- a/src/react/ProgressBar.js
+++ b/src/react/ProgressBar.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core')
+const UppyCore = require('../core').Uppy
 const ProgressBarPlugin = require('../plugins/ProgressBar')
 
 const h = React.createElement

--- a/src/react/StatusBar.js
+++ b/src/react/StatusBar.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core')
+const UppyCore = require('../core').Uppy
 const StatusBarPlugin = require('../plugins/StatusBar')
 
 const h = React.createElement

--- a/src/react/Wrapper.js
+++ b/src/react/Wrapper.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const PropTypes = require('prop-types')
-const UppyCore = require('../core')
+const UppyCore = require('../core').Uppy
 
 const h = React.createElement
 


### PR DESCRIPTION
The React components were expecting an `instanceOf` the uppy core factory function, not of the uppy core class itself. This patch exposes the uppy core class constructor on the `./core` module for the react components to use.

Tested this by opening up the `examples/react-example` and verifying that there were no proptype warnings in the console. Previously it would log the warning described in #411.