### PR TITLE
Do not check isPreviewSupported for unknown filetypes

### DIFF
--- a/src/generic-provider-views/index.js
+++ b/src/generic-provider-views/index.js
@@ -166,7 +166,7 @@ module.exports = class View {
     }
 
     Utils.getFileType(tagFile).then(fileType => {
-      if (Utils.isPreviewSupported(fileType[1])) {
+      if (fileType && Utils.isPreviewSupported(fileType[1])) {
         tagFile.preview = this.plugin.getItemThumbnailUrl(file)
       }
       this.plugin.core.log('Adding remote file')


### PR DESCRIPTION
getFileType returns undefined for non-whitelisted files and currently fails while uploading files from e.g. dropbox when trying to upload non-whitelisted file. Stack trace from https://uppy.io/examples/dashboard/ while trying to upload a zip file:

```
index.js:169 Uncaught (in promise) TypeError: Cannot read property '1' of undefined
    at index.js:169
    at <anonymous>
```

Note that checkRestrictions will still fail for such files, but at least it's possible to override this method to look on filenames instead. 