### PR TITLE
webcam,dashboard: Add `isSupported()` API for providers

### DIFF
--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -311,8 +311,17 @@ module.exports = class DashboardUI extends Plugin {
       })
     }
 
+    const isSupported = (target) => {
+      const plugin = this.core.getPlugin(target.id)
+      // If the plugin does not provide a `supported` check, assume the plugin works everywhere.
+      if (typeof plugin.isSupported !== 'function') {
+        return true
+      }
+      return plugin.isSupported()
+    }
+
     const acquirers = pluginState.targets
-      .filter(target => target.type === 'acquirer')
+      .filter(target => target.type === 'acquirer' && isSupported(target))
       .map(attachRenderFunctionToTarget)
 
     const progressindicators = pluginState.targets


### PR DESCRIPTION
Providers can signal whether they support the current environment using
an optional `isSupported()` method. Providers that always work (eg.
Google Drive) do not need to specify this method.

The check for the Webcam currently only checks if the `getUserMedia`
method exists at all. We could maybe do some more checks, like, if the
mode is `video-only` or `video-audio` but MediaRecorder is not
supported.
e; Oh! Maybe this is helpful: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getSupportedConstraints
e2; nnope that's something different

There might be a better way to do this than an optional method but I
couldn't think of one. I don't think this is terrible but we already have quite
a large API surface for plugins (install, mount, uninstall, render, addTarget;
for providers, icon, isSupported, get*) so I'm not super happy about
adding another method. Suggestions welcome! :D