### PR TITLE
Install Webcam only if it is supported by the browser

### DIFF
--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -303,6 +303,11 @@ module.exports = class Webcam extends Plugin {
   }
 
   install () {
+    if (!this.supportsUserMedia) {
+      this.core.log('Camera APIs are not supported in current browser, Webcam not installed', 'warning')
+      return
+    }
+
     this.setPluginState({
       cameraReady: false
     })


### PR DESCRIPTION
Before this PR a Webcam icon tab would appear in a browser that doesn’t support UserMedia and clicking on it would bring up a screen telling you to allow webcam access, when in reality you are never prompted for it.

Now the Webcam just won’t install if it’s unsupported. What else could be done:

- If Webcam APIs are not supported, or even when they are, but system support is better, like on mobile devices, where you can choose between a front and rear camera and so on, show the icon, but make it call as a built-in system file picker