### PR TITLE
Fix fields in XHR remote uploader

### DIFF
--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -207,7 +207,7 @@ module.exports = class XHRUpload extends Plugin {
         : Object.keys(file.meta)
 
       metaFields.forEach((name) => {
-        fields[name] = file.meta.name
+        fields[name] = file.meta[name]
       })
 
       fetch(file.remote.url, {


### PR DESCRIPTION
Before this all field data values were the same so remote uploads didn't work with S3.