### PR TITLE
Add XHRUpload option to limit simultaneous uploads

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ website/public/**
 website/themes/uppy/source/js/smooth-scroll.min.js
 website/themes/uppy/source/js/uppy.js
 website/themes/uppy/source/uppy/**
+bundle.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Theme: 🎄 Christmas edition
 - [ ] core: Redux PR (#216 / @arturi, @goto-bus-stop, @richardwillars)
 - [ ] core: css-in-js, while keeping non-random classnames (ideally prefixed) and useful preprocessor features. also see simple https://github.com/codemirror/CodeMirror/blob/master/lib/codemirror.css (@arturi, @goto-bus-stop)
 - [ ] core: improve on Redux PR #216 to allow using Redux (or any other solution) for all Uppy state management, instead of proxy-only (@goto-bus-stop, @arturi)
-- [ ] core: limit amount of simultaneous uploads, queuing? #360 (@goto-bus-stop)
+- [x] core: limit amount of simultaneous uploads, queuing? #360 (#427 / @goto-bus-stop)
 - [ ] core: research !important styles to be immune to any environment/page. Maybe use smth like `postcss-safe-important`, http://cleanslatecss.com/ Or increase specificity (with .uppy prefix) (@arturi)
 - [ ] dashboard: allow minimizing the Dashboard during upload (Uppy then becomes just a tiny progress indicator) (@arturi)
 - [ ] dashboard: cancel button for any kind of uploads? currently resume/pause only for tus, and cancel for XHR (@arturi, @goto-bus-stop)

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -526,6 +526,43 @@ function settle (promises) {
   })
 }
 
+/**
+ * Limit the amount of simultaneously pending Promises.
+ * Returns a function that, when passed a function `fn`,
+ * will make sure that at most `limit` calls to `fn` are pending.
+ *
+ * @param {number} limit
+ * @return {function()}
+ */
+function limitPromises (limit) {
+  let pending = 0
+  const queue = []
+  return (fn) => {
+    return (...args) => {
+      const call = () => {
+        pending++
+        const promise = fn(...args)
+        promise.then(onfinish, onfinish)
+        return promise
+      }
+
+      if (pending >= limit) {
+        return new Promise((resolve, reject) => {
+          queue.push(() => {
+            call().then(resolve, reject)
+          })
+        })
+      }
+      return call()
+    }
+  }
+  function onfinish () {
+    pending--
+    const next = queue.shift()
+    if (next) next()
+  }
+}
+
 module.exports = {
   generateFileID,
   toArray,
@@ -553,5 +590,6 @@ module.exports = {
   findAllDOMElements,
   getSocketHost,
   emitSocketProgress,
-  settle
+  settle,
+  limitPromises
 }

--- a/src/core/Utils.test.js
+++ b/src/core/Utils.test.js
@@ -372,14 +372,14 @@ describe('core/utils', () => {
   })
 
   describe('limitPromises', () => {
-    it('should run at most N promises at the same time', () => {
-      let pending = 0
-      function fn () {
-        pending++
-        return new Promise((resolve) => setTimeout(resolve, 10))
-          .then(() => pending--)
-      }
+    let pending = 0
+    function fn () {
+      pending++
+      return new Promise((resolve) => setTimeout(resolve, 10))
+        .then(() => pending--)
+    }
 
+    it('should run at most N promises at the same time', () => {
       const limit = utils.limitPromises(4)
       const fn2 = limit(fn)
 
@@ -393,6 +393,23 @@ describe('core/utils', () => {
       setTimeout(() => {
         expect(pending).toBe(4)
       }, 10)
+
+      return result.then(() => {
+        expect(pending).toBe(0)
+      })
+    })
+
+    it('should accept Infinity as limit', () => {
+      const limit = utils.limitPromises(Infinity)
+      const fn2 = limit(fn)
+
+      const result = Promise.all([
+        fn2(), fn2(), fn2(), fn2(),
+        fn2(), fn2(), fn2(), fn2(),
+        fn2(), fn2()
+      ])
+
+      expect(pending).toBe(10)
 
       return result.then(() => {
         expect(pending).toBe(0)

--- a/src/core/Utils.test.js
+++ b/src/core/Utils.test.js
@@ -370,4 +370,33 @@ describe('core/utils', () => {
       })
     })
   })
+
+  describe('limitPromises', () => {
+    it('should run at most N promises at the same time', () => {
+      let pending = 0
+      function fn () {
+        pending++
+        return new Promise((resolve) => setTimeout(resolve, 10))
+          .then(() => pending--)
+      }
+
+      const limit = utils.limitPromises(4)
+      const fn2 = limit(fn)
+
+      const result = Promise.all([
+        fn2(), fn2(), fn2(), fn2(),
+        fn2(), fn2(), fn2(), fn2(),
+        fn2(), fn2()
+      ])
+
+      expect(pending).toBe(4)
+      setTimeout(() => {
+        expect(pending).toBe(4)
+      }, 10)
+
+      return result.then(() => {
+        expect(pending).toBe(0)
+      })
+    })
+  })
 })

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -270,9 +270,10 @@ module.exports = class XHRUpload extends Plugin {
       }
     })
 
-    const promises = actions
-      .map(this.limitUploads)
-      .map((action) => action())
+    const promises = actions.map((action) => {
+      const limitedAction = this.limitUploads(action)
+      return limitedAction()
+    })
 
     return settle(promises)
   }

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -108,5 +108,9 @@ Set to `0` to disable this check.
 
 The default is 30 seconds.
 
+### `limit: 0`
+
+Limit the amount of uploads going on at the same time. Passing `0` means no limit.
+
 [FormData]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
 [XHR.timeout]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout


### PR DESCRIPTION
By default, all files are uploaded simultaneously. You can pass `limit: N` to upload up to `N` files simultaneously.

```js
uppy.use(XHRUpload, {
  limit: 10
})
```

Passing `limit: 0` or `limit: Infinity` means unlimited simultaneous uploads.

The limit counts across `upload()` calls, so if there is a `limit: 10` and `upload()` is called with 5 files and then with another 7, it won't start uploading 12 files at the same time.

This uses a helper function inspired by [p-limit](https://www.npmjs.com/package/p-limit). p-limit is ES2015+ so we can't depend on it directly.