### PR TITLE
GoldenRetriever: Fix IndexedDB store initialisation when not cleaning up

### DIFF
--- a/src/plugins/GoldenRetriever/IndexedDBStore.js
+++ b/src/plugins/GoldenRetriever/IndexedDBStore.js
@@ -86,7 +86,7 @@ class IndexedDBStore {
       this.ready = IndexedDBStore.cleanup()
         .then(createConnection, createConnection)
     } else {
-      this.ready = createConnection
+      this.ready = createConnection()
     }
   }
 


### PR DESCRIPTION
We should be actually creating the connection right there.

This happened when using multiple instances, the first instance would
auto-cleanup and take the first path, while the second instance would
take this second path.

Fixes part 2 of #429