### PR TITLE
fix: folder deselection did not remove all files

### DIFF
--- a/src/generic-provider-views/index.js
+++ b/src/generic-provider-views/index.js
@@ -378,7 +378,12 @@ module.exports = class View {
     if (folder.loading) {
       return
     }
-    for (let fileId of folder.files) {
+    // deepcopy the files before iteration because the
+    // original array constantly gets mutated during
+    // the iteration by updateFolderState as each file
+    // is removed and 'core:file-removed' is emitted.
+    const files = folder.files.concat([])
+    for (const fileId of files) {
       if (fileId in this.plugin.core.getState().files) {
         this.plugin.core.removeFile(fileId)
       }


### PR DESCRIPTION
I noticed a bug in the new folder selection feature. Deselecting a folder did not remove all the files of the folder because [this](https://github.com/transloadit/uppy/blob/6fcab8e9cbd56a6c34c40cb70502bdcb94c883eb/src/generic-provider-views/index.js#L75) constantly mutates [this array](https://github.com/transloadit/uppy/blob/6fcab8e9cbd56a6c34c40cb70502bdcb94c883eb/src/generic-provider-views/index.js#L381) during its own iteration, so the indexing gets messed up, and it misses out some items during iteration.