### PR TITLE
tus: Restore correctly from paused state

### DIFF
--- a/src/plugins/Tus.js
+++ b/src/plugins/Tus.js
@@ -171,7 +171,11 @@ module.exports = class Tus extends Plugin {
       })
 
       this.onPause(file.id, (isPaused) => {
-        isPaused ? upload.abort() : upload.start()
+        if (isPaused) {
+          upload.abort()
+        } else {
+          upload.start()
+        }
       })
 
       this.onPauseAll(file.id, () => {
@@ -189,7 +193,10 @@ module.exports = class Tus extends Plugin {
         upload.start()
       })
 
-      upload.start()
+      if (!file.isPaused) {
+        upload.start()
+      }
+
       this.core.emit('core:upload-started', file.id, upload)
     })
   }
@@ -274,6 +281,10 @@ module.exports = class Tus extends Plugin {
       socket.send('pause', {})
       socket.send('resume', {})
     })
+
+    if (file.isPaused) {
+      socket.send('pause', {})
+    }
 
     socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
 

--- a/src/plugins/Tus.js
+++ b/src/plugins/Tus.js
@@ -196,8 +196,9 @@ module.exports = class Tus extends Plugin {
       if (!file.isPaused) {
         upload.start()
       }
-
-      this.core.emit('core:upload-started', file.id, upload)
+      if (!file.isRestored) {
+        this.core.emit('core:upload-started', file.id, upload)
+      }
     })
   }
 


### PR DESCRIPTION
This addresses #433. If the restored upload was paused, the Tus plugin does not immediately continue uploading.

I was thinking of waiting to call `uppy.restore()` for paused files until the user unpaused, but I think that would not be the best way to go about this, so I took this route for the Tus plugin. The Tus plugin already handles pausing internally so I think this makes sense.

IMO, when restoring, we should start in a 'confirmation' state, so that we only really restore all the uploads (and start them, if they were not paused previously) once the user confirms that this is a good idea. It might not be a good idea, for example, if the crash happened on WiFi while uploading a 1GB video, but now the user is commuting and on cellular data. They could also cancel it and then we'd remove all our restore information and show an empty Uppy instance. We could also show the 'ghost' files in this confirmation state.