### PR TITLE
Modify file.name to return just the filename in IE

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -341,7 +341,7 @@ class Uppy {
         const updatedFiles = Object.assign({}, this.getState().files)
         let fileName
         if (file.name) {
-          fileName = file.name
+          fileName = file.name.match(/[^\/\\]+$/)[0]
         } else if (fileType.split('/')[0] === 'image') {
           fileName = fileType.split('/')[0] + '.' + fileType.split('/')[1]
         } else {


### PR DESCRIPTION
In IE `file.name` returns the full path to the user's file on the disk. We will never need the path to the file; even if we for some reason wanted to, that couldn't be cross-browser because only IE gives us that information.

So we update `file.name` to remove the directories and leave only the filename.