### PR TITLE
Fix remote uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ideas that will be planned and find their way into a release at one point
 - [ ] test: add tests for `npm pack`
 - [ ] test: add deepFreeze to test that state in not mutated anywhere by accident #320
 - [ ] audio: audio recording similar to Webcam #143
+- [ ] add  typescript definitions and JSDoc everywhere? https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files
 
 ## 1.0 Goals
 
@@ -94,6 +95,7 @@ To be released: 2018-01-26.
 - [ ] s3: rename `AWS S3` to something more general if it works with Google Cloud Storage too? See #460
 - [ ] dashboard: try adding optional whitelabel “powered by uppy.io” (@arturi, @nqst)
 - [ ] dashboard: option for Boolean metadata #454 (@arturi)
+- [ ] dashboard: use more accessible tip lib: https://github.com/ghosh/microtip
 - [ ] transloadit: add error reporting
 - [ ] importurl: new plugin that imports files from urls (@arturi, @ifedapoolarewaju)
 - [ ] core: queue preview generation #431

--- a/examples/cdn-example/index.html
+++ b/examples/cdn-example/index.html
@@ -10,27 +10,18 @@
     <button id="uppyModalOpener">Open Modal</button>
     <script src="https://unpkg.com/uppy/dist/uppy.min.js"></script>
     <script>
-      const Dashboard = Uppy.Dashboard
-      const Webcam = Uppy.Webcam
-      const Tus = Uppy.Tus
-      const Informer = Uppy.Informer
-
       const uppy = Uppy.Core({debug: true, autoProceed: false})
-      .use(Uppy.Dashboard, {
-        trigger: '#uppyModalOpener',
-        target: 'body'
-      })
-      .use(Webcam, {target: Dashboard})
-      .use(Tus, {endpoint: 'https://master.tus.io/files/', resume: true})
-      .use(Informer, {target: Dashboard})
-
-      uppy.run()
+        .use(Uppy.Dashboard, {
+          trigger: '#uppyModalOpener',
+          target: 'body'
+        })
+        .use(Uppy.Webcam, {target: Dashboard})
+        .use(Uppy.Tus, { endpoint: 'https://master.tus.io/files/', resume: true })
+        .run()
 
       uppy.on('success', (fileCount) => {
         console.log(`${fileCount} files uploaded`)
       })
-
-      document.querySelector('#uppyModalOpener').click()
     </script>
   </body>
 </html>

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -9,9 +9,11 @@ const DefaultStore = require('../store/DefaultStore')
 // const deepFreeze = require('deep-freeze-strict')
 
 /**
- * Main Uppy core
+ * Uppy Core module.
+ * Manages plugins, state updates, acts as an event bus,
+ * adds/removes files and metadata.
  *
- * @param {object} opts general options, like locales, to show modal or not to show
+ * @param {object} opts — Uppy options
  */
 class Uppy {
   constructor (opts) {
@@ -69,7 +71,6 @@ class Uppy {
     this.getPlugin = this.getPlugin.bind(this)
     this.setFileMeta = this.setFileMeta.bind(this)
     this.setFileState = this.setFileState.bind(this)
-    // this._initSocket = this._initSocket.bind(this)
     this.log = this.log.bind(this)
     this.info = this.info.bind(this)
     this.hideInfo = this.hideInfo.bind(this)
@@ -77,6 +78,7 @@ class Uppy {
     this.removeFile = this.removeFile.bind(this)
     this.pauseResume = this.pauseResume.bind(this)
     this._calculateProgress = this._calculateProgress.bind(this)
+    this.updateOnlineStatus = this.updateOnlineStatus.bind(this)
     this.resetProgress = this.resetProgress.bind(this)
 
     this.pauseAll = this.pauseAll.bind(this)
@@ -86,7 +88,6 @@ class Uppy {
     this.retryUpload = this.retryUpload.bind(this)
     this.upload = this.upload.bind(this)
 
-    // this.bus = this.emitter = ee()
     this.emitter = ee()
     this.on = this.emitter.on.bind(this.emitter)
     this.off = this.emitter.off.bind(this.emitter)
@@ -128,7 +129,8 @@ class Uppy {
   }
 
   /**
-   * Iterate on all plugins and run `update` on them. Called each time state changes
+   * Iterate on all plugins and run `update` on them.
+   * Called each time state changes.
    *
    */
   updateAll (state) {
@@ -147,19 +149,21 @@ class Uppy {
   }
 
   /**
-   * Returns current state
+   * Returns current state.
    */
   getState () {
     return this.store.getState()
   }
 
-  // Back compat.
+  /**
+  * Back compat for when this.state is used instead of this.getState().
+  */
   get state () {
     return this.getState()
   }
 
   /**
-  * Shorthand to set state for a specific file
+  * Shorthand to set state for a specific file.
   */
   setFileState (fileID, state) {
     this.setState({
@@ -268,7 +272,7 @@ class Uppy {
   }
 
   /**
-  * Check if minNumberOfFiles restriction is reached before uploading
+  * Check if minNumberOfFiles restriction is reached before uploading.
   *
   * @return {boolean}
   * @private
@@ -284,7 +288,7 @@ class Uppy {
 
   /**
   * Check if file passes a set of restrictions set in options: maxFileSize,
-  * maxNumberOfFiles and allowedFileTypes
+  * maxNumberOfFiles and allowedFileTypes.
   *
   * @param {object} file object to check
   * @return {boolean}
@@ -773,7 +777,7 @@ class Uppy {
   }
 
   /**
-   * Registers a plugin with Core
+   * Registers a plugin with Core.
    *
    * @param {Class} Plugin object
    * @param {Object} options object that will be passed to Plugin later
@@ -817,7 +821,7 @@ class Uppy {
   }
 
   /**
-   * Find one Plugin by name
+   * Find one Plugin by name.
    *
    * @param string name description
    */
@@ -834,7 +838,7 @@ class Uppy {
   }
 
   /**
-   * Iterate through all `use`d plugins
+   * Iterate through all `use`d plugins.
    *
    * @param function method description
    */
@@ -877,7 +881,7 @@ class Uppy {
 
   /**
   * Set info message in `state.info`, so that UI plugins like `Informer`
-  * can display the message
+  * can display the message.
   *
   * @param {string} msg Message to be displayed by the informer
   */
@@ -950,16 +954,8 @@ class Uppy {
     }
   }
 
-  // _initSocket (opts) {
-  //   if (!this.socket) {
-  //     this.socket = new UppySocket(opts)
-  //   }
-
-  //   return this.socket
-  // }
-
   /**
-   * Initializes actions, installs all plugins (by iterating on them and calling `install`), sets options
+   * Initializes actions.
    *
    */
   run () {

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -429,7 +429,7 @@ class Uppy {
     })
 
     removeUploads.forEach((uploadID) => {
-      this.removeUpload(uploadID)
+      this._removeUpload(uploadID)
     })
 
     this._calculateTotalProgress()
@@ -1111,7 +1111,7 @@ class Uppy {
       Object.keys(this.getState().files).forEach((fileID) => {
         const file = this.getFile(fileID)
 
-        if (!file.progress.uploadStarted || file.isRemote) {
+        if (!file.progress.uploadStarted) {
           waitingFileIDs.push(file.id)
         }
       })

--- a/src/plugins/Provider/view/index.js
+++ b/src/plugins/Provider/view/index.js
@@ -426,7 +426,6 @@ module.exports = class View {
    * for all of them, depending on current file state.
    */
   toggleCheckbox (e, file) {
-    console.log(e, e.shiftKey)
     e.stopPropagation()
     e.preventDefault()
     let { folders, files, filterInput } = this.plugin.getPluginState()

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -251,6 +251,11 @@ module.exports = class XHRUpload extends Plugin {
             socket.close()
             return resolve()
           })
+
+          socket.on('error', (errData) => {
+            this.uppy.emit('upload-error', file.id, new Error(errData.error))
+            reject(new Error(errData.error))
+          })
         })
       })
     })

--- a/website/src/docs/tus.md
+++ b/website/src/docs/tus.md
@@ -9,6 +9,7 @@ The Tus plugin brings [tus.io](http://tus.io) resumable file uploading to Uppy b
 
 ```js
 uppy.use(Tus, {
+  endpoint: 'https://master.tus.io/files/', // use your tus endpoint here
   resume: true,
   autoRetry: true,
   retryDelays: [0, 1000, 3000, 5000]
@@ -17,8 +18,11 @@ uppy.use(Tus, {
 
 ## Options
 
-The Tus plugin supports all of [tus-js-client][]'s options.
-Additionally:
+The Tus plugin supports all of [tus-js-client][]’s options. Additionally:
+
+### `endpoint: ''`
+
+URL to upload to, where your tus.io server is running.
 
 ### `autoRetry: true`
 


### PR DESCRIPTION
Fixes #445

- Omits files that are `uploadStarted` when selecting which files to upload, even if they are remote. Not sure why did we have a condition to always include remote files?
- Correctly resolve/reject upload promise from remote success/error events for Tus and XHRUpload. Before this PR remote uploads were marked as complete, but `complete` event never fired, because promises were not resolved.

This probably needs a good review and discussion, likely missing something. But in my tests this fixed unnecessary re-uploading from #445 and not emitting `complete` for remote files. Tus/XHR implementations in this area should be more consistent, I think, sharing same methods/conventions.