### PR TITLE
Fix references to incorrect width/height attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ To be released: 2018-01-26.
 - [ ] dashboard: cancel button for any kind of uploads? currently resume/pause only for tus, and cancel for XHR (@arturi, @goto-bus-stop)
 - [ ] docs: quick start guide: https://community.transloadit.com/t/quick-start-guide-would-be-really-helpful/14605 (@arturi)
 - [ ] docs: on writing plugins (@goto-bus-stop)
+- [ ] docs: fix reference to incorrect width/height options (#475 / @xhocquet)
 - [ ] goldenretriever: add “ghost” files (@arturi)
 - [ ] webcam: URL.createObjectURL(MediaStream) is deprecated and will be removed soon: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
 - [ ] xhrupload: add bundle option to send multiple files in one request (#442 / @goto-bus-stop)
@@ -117,9 +118,9 @@ Released: 2017-12-21.
 Theme: 🎄 Christmas edition
 
 - **⚠️ Breaking** core: rendering engine switched from `Yo-Yo` to `Preact`, and all views from `html` hyperx template strings to `JSX` (#451 / @arturi)
-- **⚠️ Breaking** core: large refactor of Core and Plugins: `setFileState`, merge `MetaData` plugin into `Dashboard`, prefix "private" core methods with underscores (@arturi / #438) 
-- **⚠️ Breaking** core: renamed `core` to `uppy` in plugins and what not. So instead of `this.core.state` we now use `this.uppy.state` (#438 / @arturi) 
-- **⚠️ Breaking** core: renamed events to remove `core:` prefix, as been suggested already. So: `success`, `error`, `upload-started` and so on, and prefixed event names for plugins sometimes, like `dashboard:file-card` (#438 / @arturi) 
+- **⚠️ Breaking** core: large refactor of Core and Plugins: `setFileState`, merge `MetaData` plugin into `Dashboard`, prefix "private" core methods with underscores (@arturi / #438)
+- **⚠️ Breaking** core: renamed `core` to `uppy` in plugins and what not. So instead of `this.core.state` we now use `this.uppy.state` (#438 / @arturi)
+- **⚠️ Breaking** core: renamed events to remove `core:` prefix, as been suggested already. So: `success`, `error`, `upload-started` and so on, and prefixed event names for plugins sometimes, like `dashboard:file-card` (#438 / @arturi)
 - **⚠️ Breaking** core: CSS class names have been altered to use `uppy-` namespace, so `.UppyDashboard-files` --> `.uppy-Dashboard-files` and so on
 - **⚠️ Breaking** dashboard: added `metaFields` option, pass an array of settings for UI field objects `{ id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }` (#438 / @arturi, @goto-bus-stop)
 - **⚠️ Breaking** core: deprecate `getMetaFromForm` in favor of new `Form` plugin (#407 / @arturi)

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -22,8 +22,8 @@ uppy.use(Dashboard, {
   target: 'body',
   trigger: '#uppy-select-files',
   inline: false,
-  width: 750,
-  height: 550,
+  maxWidth: 750,
+  maxHeight: 550,
   semiTransparent: false,
   showProgressDetails: false,
   hideUploadButton: false,
@@ -74,11 +74,11 @@ By default Dashboard will be rendered as a modal, which is opened via clicking o
 
 String with a CSS selector for a button that will trigger opening Dashboard modal. Multiple buttons or links can be used, if it’s a class selector (`.uppy-choose`, for example).
 
-### `width: 750`
+### `maxWidth: 750`
 
 Maximum width of the Dashboard in pixels. Used when `inline: true`.
 
-### `height: 550`
+### `maxHeight: 550`
 
 Maximum height of the Dashboard in pixels. Used when `inline: true`.
 


### PR DESCRIPTION
Fixes #475 

Just remove old references to `width` and `height` options for Dashboard, which are in fact `maxWidth` and `maxHeight`