### PR TITLE
https://preact.js.org/ is not reachable

### DIFF
--- a/website/src/docs/react.md
+++ b/website/src/docs/react.md
@@ -63,7 +63,7 @@ The plugins that are available as React component wrappers are:
  - [StatusBar][]
 
 [React]: https://facebook.github.io/react
-[Preact]: https://preact.js.org/
+[Preact]: https://preactjs.com/
 [Dashboard]: /docs/dashboard
 [DragDrop]: /docs/dragdrop
 [ProgressBar]: /docs/progressbar


### PR DESCRIPTION
Hi,
Preactjs link ` https://preact.js.org/` is not reachable. I change it by https://preactjs.com/