### PR TITLE
Add option to hide progress bar after upload finish #464

### DIFF
--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -75,6 +75,7 @@ module.exports = class Dashboard extends Plugin {
       defaultTabIcon: defaultTabIcon,
       showProgressDetails: false,
       hideUploadButton: false,
+      hideProgressAfterFinish: false,
       note: null,
       closeModalOnClickOutside: false,
       locale: defaultLocale,
@@ -497,7 +498,8 @@ module.exports = class Dashboard extends Plugin {
     if (!this.opts.disableStatusBar) {
       this.uppy.use(StatusBar, {
         target: this,
-        hideUploadButton: this.opts.hideUploadButton
+        hideUploadButton: this.opts.hideUploadButton,
+        hideAfterFinish: this.opts.hideProgressAfterFinish
       })
     }
 

--- a/src/plugins/ProgressBar.js
+++ b/src/plugins/ProgressBar.js
@@ -16,7 +16,8 @@ module.exports = class ProgressBar extends Plugin {
     const defaultOptions = {
       target: 'body',
       replaceTargetContent: false,
-      fixed: false
+      fixed: false,
+      hideAfterFinish: true
     }
 
     // merge default options with the ones set by user
@@ -27,8 +28,8 @@ module.exports = class ProgressBar extends Plugin {
 
   render (state) {
     const progress = state.totalProgress || 0
-
-    return <div class="uppy uppy-ProgressBar" style={{ position: this.opts.fixed ? 'fixed' : 'initial' }}>
+    const isHidden = progress === 100 && this.opts.hideAfterFinish
+    return <div class="uppy uppy-ProgressBar" style={{ position: this.opts.fixed ? 'fixed' : 'initial' }} aria-hidden={isHidden}>
       <div class="uppy-ProgressBar-inner" style={{ width: progress + '%' }} />
       <div class="uppy-ProgressBar-percentage">{progress}</div>
     </div>

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -98,6 +98,7 @@ module.exports = (props) => {
   let progressValue = props.totalProgress
   let progressMode
   let progressBarContent
+  let hiddenClass = ''
   if (uploadState === STATE_PREPROCESSING || uploadState === STATE_POSTPROCESSING) {
     const progress = calculateProcessingProgress(props.files)
     progressMode = progress.mode
@@ -108,6 +109,9 @@ module.exports = (props) => {
     progressBarContent = ProgressBarProcessing(progress)
   } else if (uploadState === STATE_COMPLETE) {
     progressBarContent = ProgressBarComplete(props)
+    if (props.hideAfterFinish) {
+      hiddenClass = 'is-hidden'
+    }
   } else if (uploadState === STATE_UPLOADING) {
     progressBarContent = ProgressBarUploading(props)
   } else if (uploadState === STATE_ERROR) {
@@ -119,11 +123,11 @@ module.exports = (props) => {
   const isHidden = (uploadState === STATE_WAITING && props.hideUploadButton) ||
     (uploadState === STATE_WAITING && !props.newFiles > 0)
 
-  const progressClasses = `uppy-StatusBar-progress 
+  const progressClasses = `uppy-StatusBar-progress
                            ${progressMode ? 'is-' + progressMode : ''}`
 
   return (
-    <div class={`uppy uppy-StatusBar is-${uploadState}`} aria-hidden={isHidden}>
+    <div class={`uppy uppy-StatusBar is-${uploadState} ${hiddenClass}`} aria-hidden={isHidden}>
       <div class={progressClasses}
         style={{ width: width + '%' }}
         role="progressbar"

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -110,7 +110,7 @@ module.exports = (props) => {
   } else if (uploadState === STATE_COMPLETE) {
     progressBarContent = ProgressBarComplete(props)
     if (props.hideAfterFinish) {
-      hiddenClass = 'is-hidden'
+      hiddenClass = 'uppy--hidden'
     }
   } else if (uploadState === STATE_UPLOADING) {
     progressBarContent = ProgressBarUploading(props)

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -98,7 +98,6 @@ module.exports = (props) => {
   let progressValue = props.totalProgress
   let progressMode
   let progressBarContent
-  let hiddenClass = ''
   if (uploadState === STATE_PREPROCESSING || uploadState === STATE_POSTPROCESSING) {
     const progress = calculateProcessingProgress(props.files)
     progressMode = progress.mode
@@ -109,9 +108,6 @@ module.exports = (props) => {
     progressBarContent = ProgressBarProcessing(progress)
   } else if (uploadState === STATE_COMPLETE) {
     progressBarContent = ProgressBarComplete(props)
-    if (props.hideAfterFinish) {
-      hiddenClass = 'uppy--hidden'
-    }
   } else if (uploadState === STATE_UPLOADING) {
     progressBarContent = ProgressBarUploading(props)
   } else if (uploadState === STATE_ERROR) {
@@ -121,13 +117,14 @@ module.exports = (props) => {
 
   const width = typeof progressValue === 'number' ? progressValue : 100
   const isHidden = (uploadState === STATE_WAITING && props.hideUploadButton) ||
-    (uploadState === STATE_WAITING && !props.newFiles > 0)
+    (uploadState === STATE_WAITING && !props.newFiles > 0) ||
+    (uploadState === STATE_COMPLETE && props.hideAfterFinish)
 
   const progressClasses = `uppy-StatusBar-progress
                            ${progressMode ? 'is-' + progressMode : ''}`
 
   return (
-    <div class={`uppy uppy-StatusBar is-${uploadState} ${hiddenClass}`} aria-hidden={isHidden}>
+    <div class={`uppy uppy-StatusBar is-${uploadState}`} aria-hidden={isHidden}>
       <div class={progressClasses}
         style={{ width: width + '%' }}
         role="progressbar"

--- a/src/plugins/StatusBar/index.js
+++ b/src/plugins/StatusBar/index.js
@@ -47,7 +47,7 @@ module.exports = class StatusBar extends Plugin {
       hideUploadButton: false,
       showProgressDetails: false,
       locale: defaultLocale,
-      hideAfterFinish: false
+      hideAfterFinish: true
     }
 
     // merge default options with the ones set by user

--- a/src/plugins/StatusBar/index.js
+++ b/src/plugins/StatusBar/index.js
@@ -46,7 +46,8 @@ module.exports = class StatusBar extends Plugin {
       target: 'body',
       hideUploadButton: false,
       showProgressDetails: false,
-      locale: defaultLocale
+      locale: defaultLocale,
+      hideAfterFinish: false
     }
 
     // merge default options with the ones set by user
@@ -164,7 +165,8 @@ module.exports = class StatusBar extends Plugin {
       totalETA: totalETA,
       files: state.files,
       resumableUploads: resumableUploads,
-      hideUploadButton: this.opts.hideUploadButton
+      hideUploadButton: this.opts.hideUploadButton,
+      hideAfterFinish: this.opts.hideAfterFinish
     })
   }
 

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -18,10 +18,6 @@
   box-sizing: inherit;
 }
 
-.uppy--hidden {
-  display: none
-}
-
 // https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4
 
 .UppyIcon {

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -18,6 +18,10 @@
   box-sizing: inherit;
 }
 
+.uppy--hidden {
+  display: none
+}
+
 // https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4
 
 .UppyIcon {

--- a/src/scss/_progressbar.scss
+++ b/src/scss/_progressbar.scss
@@ -10,6 +10,11 @@
   width: 100%;
   height: 3px;
   z-index: 10000;
+  transition: height .2s;
+}
+
+.uppy-ProgressBar[aria-hidden=true] {
+  height: 0;
 }
 
 .uppy-ProgressBar-inner {

--- a/src/scss/_statusbar.scss
+++ b/src/scss/_statusbar.scss
@@ -16,6 +16,10 @@
   height: 0;
 }
 
+.uppy-StatusBar.is-hidden {
+  display: none;
+}
+
 .uppy-StatusBar.is-complete .uppy-StatusBar-progress {
   background-color: $color-green;
 }
@@ -134,8 +138,8 @@
         background-color: $color-cornflower-blue;
         color: $color-white;
 
-        &:hover { 
-          background-color: darken($color-cornflower-blue, 20%); 
+        &:hover {
+          background-color: darken($color-cornflower-blue, 20%);
         }
       }
 

--- a/src/scss/_statusbar.scss
+++ b/src/scss/_statusbar.scss
@@ -16,10 +16,6 @@
   height: 0;
 }
 
-.uppy-StatusBar.is-hidden {
-  display: none;
-}
-
 .uppy-StatusBar.is-complete .uppy-StatusBar-progress {
   background-color: $color-green;
 }

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -27,6 +27,7 @@ uppy.use(Dashboard, {
   semiTransparent: false,
   showProgressDetails: false,
   hideUploadButton: false,
+  hideProgressAfterFinish: false,
   note: null,
   metaFields: [],
   closeModalOnClickOutside: false,
@@ -93,6 +94,10 @@ Show progress bars for the uploads.
 ### `hideUploadButton: false`
 
 Hide the upload button. Use this if you are providing a custom upload button somewhere on the page using the `uppy.upload()` API.
+
+### `hideProgressAfterFinish: false`
+
+Hide StatusBar after upload finish
 
 ### `note: null`
 

--- a/website/src/docs/progressbar.md
+++ b/website/src/docs/progressbar.md
@@ -14,7 +14,8 @@ ProgressBar is a minimalist plugin that shows the current upload progress in a t
 ```js
 uppy.use(ProgressBar, {
   target: '.UploadForm',
-  fixed: false
+  fixed: false,
+  hideAfterFinish: true
 })
 ```
 
@@ -32,3 +33,7 @@ uppy.use(ProgressBar, {
   fixed: true
 })
 ```
+
+### `hideAfterFinish: true`
+
+When true, progress bar hides after the uplaod has finished. If true, it remains visible

--- a/website/src/docs/statusbar.md
+++ b/website/src/docs/statusbar.md
@@ -16,5 +16,9 @@ Best used together with a simple file source plugin, such as [FileInput][] or [D
 
 DOM element, CSS selector, or plugin to mount the StatusBar into.
 
+### `hideAfterFinish: true`
+
+Hide StatusBar after upload finish
+
 [FileInput]: https://github.com/transloadit/uppy/blob/master/src/plugins/FileInput.js
 [DragDrop]: /docs/dragdrop


### PR DESCRIPTION
Hello
This pull request is connected to issue #464.
The first commit adds an option to hide progress bar after upload is finished.

Please don't hurt me if I did something not the way I was supposed to, I'm new here :smiley: