### PR TITLE
ci: Remove duplicate build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ cache:
   - website/node_modules
 script:
 - npm run web:install
-- npm run build
 - npm run test
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:acceptance; fi
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
   - website/node_modules
 script:
 - npm run web:install
+- npm run build
 - npm run test
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:acceptance; fi
 env:

--- a/package.json
+++ b/package.json
@@ -165,6 +165,6 @@
     "web:preview": "npm-run-all --parallel web:examples:watch web:bundle:update:watch web:serve",
     "web:update:frontpage:code:sample": "cd website && ./node_modules/.bin/hexo generate && cp -f public/frontpage-code-sample.html ./themes/uppy/layout/partials/frontpage-code-sample.html",
     "web": "npm-run-all web:clean web:build",
-    "prepublish": "npm-run-all clean build"
+    "prepublishOnly": "npm-run-all clean build"
   }
 }


### PR DESCRIPTION
This is also already being done using the `prepublish` hook called by `npm install`. saves some work during CI runs.