### PR TITLE
deps: Update node-notifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -231,12 +231,6 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
-      "dev": true
-    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2485,16 +2479,6 @@
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
-    "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
-      }
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2741,33 +2725,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
       "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
       "dev": true
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
-      }
-    },
-    "cli-usage": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
-      "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
-      "dev": true,
-      "requires": {
-        "marked": "0.3.6",
-        "marked-terminal": "1.7.0"
-      }
     },
     "cli-width": {
       "version": "2.2.0",
@@ -10279,18 +10236,6 @@
       "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
       "dev": true
     },
-    "lodash._arraycopy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-      "dev": true
-    },
-    "lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
-      "dev": true
-    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -10298,20 +10243,6 @@
       "dev": true,
       "requires": {
         "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._baseclone": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true,
-      "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseassign": "3.2.0",
-        "lodash._basefor": "3.0.3",
-        "lodash.isarray": "3.0.4",
         "lodash.keys": "3.1.2"
       }
     },
@@ -10325,12 +10256,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
       "dev": true
     },
     "lodash._bindcallback": {
@@ -10367,16 +10292,6 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-      "dev": true,
-      "requires": {
-        "lodash._baseclone": "3.3.0",
-        "lodash._bindcallback": "3.0.1"
-      }
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -10581,25 +10496,6 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
-    },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
-    "marked-terminal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
-      "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
-      "dev": true,
-      "requires": {
-        "cardinal": "1.0.0",
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "lodash.assign": "4.2.0",
-        "node-emoji": "1.5.1"
-      }
     },
     "math-clamp-x": {
       "version": "1.2.0",
@@ -11384,15 +11280,6 @@
         "qs": "6.4.0"
       }
     },
-    "node-emoji": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
-      "integrity": "sha1-/ZGOQSdpv4xEgFEjgjOECyr/FqE=",
-      "dev": true,
-      "requires": {
-        "string.prototype.codepointat": "0.2.0"
-      }
-    },
     "node-fetch": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
@@ -11447,35 +11334,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
-    },
-    "node-notifier": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.0.tgz",
-      "integrity": "sha1-1hJdQXcpeCsi035ZKtX3HoPAgWs=",
-      "dev": true,
-      "requires": {
-        "cli-usage": "0.1.4",
-        "growly": "1.3.0",
-        "lodash.clonedeep": "3.0.2",
-        "minimist": "1.2.0",
-        "semver": "5.3.0",
-        "shellwords": "0.1.0",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
     },
     "node-sass": {
       "version": "4.5.0",
@@ -13306,23 +13164,6 @@
         "strip-indent": "1.0.1"
       }
     },
-    "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "dev": true,
-      "requires": {
-        "esprima": "3.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
-          "dev": true
-        }
-      }
-    },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
@@ -14657,12 +14498,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string.prototype.codepointat": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
-      "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg=",
-      "dev": true
     },
     "string.prototype.padend": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "multi-glob": "1.0.1",
     "next-update": "1.2.2",
     "nock": "8.0.0",
-    "node-notifier": "4.6.0",
     "node-sass": "4.5.0",
     "nodemon": "1.8.1",
     "npm-run-all": "2.3.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
+      "integrity": "sha1-vhGklZOOiC0nd3PRGYbzl0qLo3o=",
+      "requires": {
+        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -84,11 +92,6 @@
       "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "ansicolors": {
-      "version": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
-      "dev": true
-    },
     "anymatch": {
       "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
@@ -97,22 +100,10 @@
         "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
       }
     },
-    "aproba": {
-      "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-      "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
-    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-    },
-    "are-we-there-yet": {
-      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-      "requires": {
-        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-      }
     },
     "argparse": {
       "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
@@ -136,18 +127,6 @@
       "version": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
-    },
-    "array-find-index": {
-      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-      "integrity": "sha1-C8Jd2slB7IpJauJY/UrBiAA+868="
-    },
-    "array-index": {
-      "version": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-      "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
     },
     "array-map": {
       "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -190,7 +169,8 @@
     },
     "asn1": {
       "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "optional": true
     },
     "asn1.js": {
       "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz",
@@ -212,7 +192,8 @@
     },
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "optional": true
     },
     "astw": {
       "version": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
@@ -241,10 +222,6 @@
       "version": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
     },
-    "async-foreach": {
-      "version": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
-    },
     "autoprefixer": {
       "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.4.0.tgz",
       "integrity": "sha1-TbYK9YWjA2FruJa1CzC73VhY0uM=",
@@ -263,7 +240,8 @@
     },
     "aws4": {
       "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-      "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE="
+      "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+      "optional": true
     },
     "babel-code-frame": {
       "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
@@ -494,17 +472,20 @@
     "bl": {
       "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "optional": true,
       "requires": {
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
       },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "optional": true
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "optional": true,
           "requires": {
             "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -519,13 +500,6 @@
     "blob": {
       "version": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
-    },
-    "block-stream": {
-      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-      }
     },
     "bluebird": {
       "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
@@ -585,9 +559,9 @@
       "integrity": "sha1-d5iHx5LqofZKRqIsjxBRzc2WdV8=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
         "umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
       }
@@ -723,6 +697,7 @@
       "integrity": "sha1-2BoBjpjdfKcG7AQlPSD4oDsq+K4=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "assert": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
         "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -743,7 +718,6 @@
         "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
         "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
         "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.7.tgz",
         "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
@@ -968,26 +942,9 @@
       "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
-    "camelcase-keys": {
-      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-      }
-    },
     "caniuse-db": {
       "version": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000525.tgz",
       "integrity": "sha1-v0zYX9MI6W3mcDn2Lzb8oa8vpMY="
-    },
-    "cardinal": {
-      "version": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
-      "integrity": "sha1-ANX2YdvUqr/ffUHOSKWlm8o1opE=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-        "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz"
-      }
     },
     "caseless": {
       "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
@@ -1089,38 +1046,6 @@
       "dev": true,
       "requires": {
         "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-      }
-    },
-    "cli-table": {
-      "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
-      "requires": {
-        "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
-      }
-    },
-    "cli-usage": {
-      "version": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.2.tgz",
-      "integrity": "sha1-SXwg6vEuwneTk6m/rCJcX2y5FS0=",
-      "dev": true,
-      "requires": {
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "marked-terminal": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.6.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
-          "dev": true
-        }
       }
     },
     "cli-width": {
@@ -1363,10 +1288,6 @@
         "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
       }
     },
-    "console-control-strings": {
-      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
     "constants-browserify": {
       "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
@@ -1539,16 +1460,10 @@
         "node-fingerprint": "0.0.2"
       }
     },
-    "currently-unhandled": {
-      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
-      }
-    },
     "d": {
       "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "dev": true,
       "requires": {
         "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
       }
@@ -1556,6 +1471,7 @@
     "dashdash": {
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+      "optional": true,
       "requires": {
         "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
       },
@@ -1630,10 +1546,6 @@
     "delayed-stream": {
       "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegates": {
-      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
@@ -1950,6 +1862,7 @@
     "es5-ext": {
       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
       "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
+      "dev": true,
       "requires": {
         "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
         "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
@@ -1958,6 +1871,7 @@
     "es6-iterator": {
       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+      "dev": true,
       "requires": {
         "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
         "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
@@ -1992,6 +1906,7 @@
     "es6-symbol": {
       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
+      "dev": true,
       "requires": {
         "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
         "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
@@ -2426,7 +2341,8 @@
     },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
@@ -3143,10 +3059,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
           "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
@@ -3155,6 +3067,10 @@
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
           }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "stringstream": {
           "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -3253,41 +3169,9 @@
         }
       }
     },
-    "fstream": {
-      "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-      "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz"
-      }
-    },
     "function-bind": {
       "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
-    },
-    "gauge": {
-      "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-      "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-      "requires": {
-        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-        "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-      }
-    },
-    "gaze": {
-      "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.1.tgz",
-      "integrity": "sha1-q4HVV9G1FfV1K9XxEX1vo8Tp20E=",
-      "requires": {
-        "globule": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz"
-      }
     },
     "generate-function": {
       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -3300,10 +3184,6 @@
         "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
       }
     },
-    "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
     "get-stdin": {
       "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
@@ -3311,6 +3191,7 @@
     "getpass": {
       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+      "optional": true,
       "requires": {
         "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
       },
@@ -3354,33 +3235,6 @@
       "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
       "dev": true
     },
-    "globule": {
-      "version": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz",
-      "integrity": "sha1-8irrqszgK+SSRT6XnDrptpg/HGw=",
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-          }
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
-          "integrity": "sha1-TCDXQvA86F3HAODderm8q4Xm/BQ="
-        }
-      }
-    },
     "graceful-fs": {
       "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz",
       "integrity": "sha1-9HRejK7V4N0u8hu14tIpoy6Ak8A="
@@ -3390,7 +3244,8 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growly": {
-      "version": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
@@ -3425,10 +3280,6 @@
         "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
       }
     },
-    "has-color": {
-      "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-    },
     "has-cors": {
       "version": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
@@ -3436,10 +3287,6 @@
     "has-flag": {
       "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-    },
-    "has-unicode": {
-      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash.js": {
       "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
@@ -3661,27 +3508,10 @@
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
       }
     },
-    "hexo-renderer-marked": {
-      "version": "https://registry.npmjs.org/hexo-renderer-marked/-/hexo-renderer-marked-0.2.11.tgz",
-      "integrity": "sha1-Mv04gNPDl5/XuAFewSGmxE/0n4Q=",
-      "requires": {
-        "hexo-util": "https://registry.npmjs.org/hexo-util/-/hexo-util-0.6.0.tgz",
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-      }
-    },
     "hexo-renderer-postcss": {
       "version": "git+https://github.com/arturi/hexo-renderer-postcss.git#afca2bc12f5816067b15a9d24017c70e077b9f0b",
       "requires": {
         "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.1.2.tgz"
-      }
-    },
-    "hexo-renderer-scss": {
-      "version": "https://registry.npmjs.org/hexo-renderer-scss/-/hexo-renderer-scss-1.0.2.tgz",
-      "integrity": "sha1-oXVhdAEBJy34aGPol0noISY8ppc=",
-      "requires": {
-        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-3.8.0.tgz"
       }
     },
     "hexo-server": {
@@ -3808,6 +3638,7 @@
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "optional": true,
       "requires": {
         "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
         "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
@@ -3837,17 +3668,6 @@
       "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
-    },
-    "in-publish": {
-      "version": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-    },
-    "indent-string": {
-      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-      }
     },
     "indexes-of": {
       "version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -3902,10 +3722,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
         "process": "https://registry.npmjs.org/process/-/process-0.11.8.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
@@ -3991,6 +3811,7 @@
     "is-finite": {
       "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
       "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
       }
@@ -4105,7 +3926,8 @@
     },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
     },
     "is-utf8": {
       "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4191,7 +4013,8 @@
     },
     "json-schema": {
       "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
+      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+      "optional": true
     },
     "json-stable-stringify": {
       "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
@@ -4231,17 +4054,10 @@
       "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk="
     },
-    "JSONStream": {
-      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
-      "integrity": "sha1-vhGklZOOiC0nd3PRGYbzl0qLo3o=",
-      "requires": {
-        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      }
-    },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
       "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+      "optional": true,
       "requires": {
         "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
         "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
@@ -4412,109 +4228,13 @@
       "version": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
       "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
     },
-    "lodash._arraycopy": {
-      "version": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-      "dev": true
-    },
-    "lodash._arrayeach": {
-      "version": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      }
-    },
-    "lodash._baseclone": {
-      "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true,
-      "requires": {
-        "lodash._arraycopy": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-        "lodash._arrayeach": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basefor": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basefor": {
-      "version": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-      }
-    },
-    "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash.assign": {
       "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
-    "lodash.clonedeep": {
-      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-      }
-    },
     "lodash.memoize": {
       "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "longest-streak": {
@@ -4537,14 +4257,6 @@
         }
       }
     },
-    "loud-rejection": {
-      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
-      }
-    },
     "lower-case": {
       "version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
       "integrity": "sha1-ySOT2XZ5Pu5bpO21g8+OrjW9m/s="
@@ -4561,10 +4273,6 @@
       "version": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
     },
-    "map-obj": {
-      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
     "markdown": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
@@ -4578,34 +4286,6 @@
       "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=",
       "dev": true
     },
-    "marked": {
-      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
-    },
-    "marked-terminal": {
-      "version": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.6.1.tgz",
-      "integrity": "sha1-BM0cfIsO9I2z9oAQ1zpXqWYcbM8=",
-      "dev": true,
-      "requires": {
-        "cardinal": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-        "node-emoji": "https://registry.npmjs.org/node-emoji/-/node-emoji-0.1.0.tgz"
-      },
-      "dependencies": {
-        "lodash.assign": {
-          "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "dev": true,
-          "requires": {
-            "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "lodash._createassigner": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-          }
-        }
-      }
-    },
     "mdast-util-inject": {
       "version": "https://registry.npmjs.org/mdast-util-inject/-/mdast-util-inject-1.1.0.tgz",
       "integrity": "sha1-2wa4tYW+lZotzS+H9HK6m3VvNnU=",
@@ -4618,28 +4298,6 @@
       "version": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.2.tgz",
       "integrity": "sha1-3JlqJNK1IReNP6w5k2gMA6aD4d0=",
       "dev": true
-    },
-    "meow": {
-      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "merge": {
       "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
@@ -4716,13 +4374,13 @@
       "integrity": "sha1-7f6zk3vnNZvBSmZywi7xJIh/btI=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
         "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
         "detective": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
         "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
         "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -4843,7 +4501,8 @@
     },
     "nan": {
       "version": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
+      "optional": true
     },
     "natural-compare": {
       "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4867,118 +4526,36 @@
         "lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
       }
     },
-    "node-emoji": {
-      "version": "https://registry.npmjs.org/node-emoji/-/node-emoji-0.1.0.tgz",
-      "integrity": "sha1-P0QkpVuo7VDCVKE4WLJEVPQYJgI=",
-      "dev": true
-    },
     "node-fingerprint": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/node-fingerprint/-/node-fingerprint-0.0.2.tgz",
       "integrity": "sha1-Mcur63GmeufdWn3AQuUcPHWGhQE="
     },
-    "node-gyp": {
-      "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
-      "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
-      "requires": {
-        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-        "path-array": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-          }
-        }
-      }
-    },
     "node-notifier": {
-      "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.0.tgz",
-      "integrity": "sha1-1hJdQXcpeCsi035ZKtX3HoPAgWs=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
       "requires": {
-        "cli-usage": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.2.tgz",
-        "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+        "growly": "1.3.0",
+        "semver": "5.4.1",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
       },
       "dependencies": {
-        "lodash.clonedeep": {
-          "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "lodash._baseclone": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-            "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-          }
-        },
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "node-sass": {
-      "version": "https://registry.npmjs.org/node-sass/-/node-sass-3.8.0.tgz",
-      "integrity": "sha1-7A+JrmYl4dmQ3H/3E7J16hXf7gU=",
-      "requires": {
-        "async-foreach": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-        "gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.1.tgz",
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-        "in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-        "sass-graph": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
-          }
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -5000,7 +4577,7 @@
       "requires": {
         "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
         "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "semver": "5.4.1",
         "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
       }
     },
@@ -5020,22 +4597,6 @@
         "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
         "query-string": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
         "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
-      }
-    },
-    "npmlog": {
-      "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-      "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
-      "requires": {
-        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-      },
-      "dependencies": {
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        }
       }
     },
     "nth-check": {
@@ -5181,15 +4742,8 @@
     },
     "os-tmpdir": {
       "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
-    },
-    "osenv": {
-      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-      "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-      }
+      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+      "dev": true
     },
     "outpipe": {
       "version": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
@@ -5285,13 +4839,6 @@
     "parseurl": {
       "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
-    },
-    "path-array": {
-      "version": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-      "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
-      "requires": {
-        "array-index": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
-      }
     },
     "path-browserify": {
       "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -5718,7 +5265,8 @@
     },
     "qs": {
       "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-      "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
+      "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+      "optional": true
     },
     "query-string": {
       "version": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
@@ -5857,29 +5405,6 @@
         "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
       }
     },
-    "redent": {
-      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-      }
-    },
-    "redeyed": {
-      "version": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
-      "integrity": "sha1-erAA5g7jh1rBFdKe2zLBQDxsJdE=",
-      "dev": true,
-      "requires": {
-        "esprima-fb": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
-      },
-      "dependencies": {
-        "esprima-fb": {
-          "version": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-2EQAOEupXOJnjGF60kp/QICNqRU=",
-          "dev": true
-        }
-      }
-    },
     "reduce-css-calc": {
       "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.4.tgz",
       "integrity": "sha1-5YXkhEBIAcgAOv/2uTbZa7dhGz8=",
@@ -5972,16 +5497,10 @@
       "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
       "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU="
     },
-    "repeating": {
-      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-      }
-    },
     "request": {
       "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+      "optional": true,
       "requires": {
         "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
         "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
@@ -6005,10 +5524,6 @@
         "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
         "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
       }
-    },
-    "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6107,64 +5622,14 @@
       "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
       "optional": true
     },
-    "sass-graph": {
-      "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
-      "integrity": "sha1-llEEviPoEDy35fcQ32WTWzF9pXs=",
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-          }
-        },
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "window-size": {
-          "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-        },
-        "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "requires": {
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
-          }
-        }
-      }
-    },
     "sax": {
       "version": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
@@ -6267,13 +5732,10 @@
       "dev": true
     },
     "shellwords": {
-      "version": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-      "integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
-    },
-    "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-      "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g="
     },
     "slash": {
       "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6430,6 +5892,7 @@
     "sshpk": {
       "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
       "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
+      "optional": true,
       "requires": {
         "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
         "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -6590,10 +6053,6 @@
       "version": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -6602,6 +6061,10 @@
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-entities": {
       "version": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.2.0.tgz",
@@ -6725,15 +6188,6 @@
         "xregexp": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz"
       }
     },
-    "tar": {
-      "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-      }
-    },
     "text-table": {
       "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
@@ -6828,10 +6282,6 @@
       "version": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
-    },
-    "trim-newlines": {
-      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-trailing-lines": {
       "version": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.0.0.tgz",
@@ -7059,6 +6509,7 @@
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "optional": true,
       "requires": {
         "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
       }
@@ -7086,11 +6537,11 @@
       "resolved": "https://registry.npmjs.org/warehouse/-/warehouse-2.2.0.tgz",
       "integrity": "sha1-XQnWSUKZK+Zn2PfIagnCuK6gQGI=",
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
         "cuid": "1.3.8",
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.5.tgz",
         "is-plain-object": "2.0.3",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
       }
     },
@@ -7150,17 +6601,6 @@
       "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
       "requires": {
         "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-      }
-    },
-    "which-module": {
-      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "wide-align": {
-      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-      "requires": {
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
       }
     },
     "window-size": {

--- a/website/package.json
+++ b/website/package.json
@@ -41,7 +41,7 @@
     "glob": "7.0.5",
     "mdast-util-inject": "1.1.0",
     "multi-glob": "1.0.1",
-    "node-notifier": "4.6.0",
+    "node-notifier": "^5.1.2",
     "remark": "5.0.1",
     "watchify": "3.7.0"
   }


### PR DESCRIPTION
This should remove the warnings about insecure dependencies we were
getting. node-notifier@4 depends on an old version of `marked` that has
an XSS vulnerability. We weren't really affected because we don't push
user input through node-notifier, but the warnings show up anyway :P 

I removed it from the root package because it looks like we were only
using it in the website build code.