### PR TITLE
statusbar: Fix status text still showing when statusbar is hidden

### DIFF
--- a/src/scss/_statusbar.scss
+++ b/src/scss/_statusbar.scss
@@ -13,6 +13,7 @@
 }
 
 .uppy-StatusBar[aria-hidden=true] {
+  overflow-y: hidden;
   height: 0;
 }
 


### PR DESCRIPTION
(Should we use `display: none;` here instead? I am not sure how that
would interact with the animation though.)

Fixes https://transloadit.slack.com/files/U4D4GMZ5H/F8S75H11N/image.png