### PR TITLE
form: Fix `getFormData` import

### DIFF
--- a/src/plugins/Form.js
+++ b/src/plugins/Form.js
@@ -1,6 +1,6 @@
 const Plugin = require('../core/Plugin')
 const { findDOMElement } = require('../core/Utils')
-const getFormData = require('get-form-data')
+const getFormData = require('get-form-data').default
 
 /**
  * Form


### PR DESCRIPTION
I missed this in #523 :confused: `get-form-data@2.x` exports an object
with a default property, like other transpiled ES modules.