### PR TITLE
s3: fix isXml() check when no content-type is available

### DIFF
--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -3,7 +3,8 @@ const Translator = require('../../core/Translator')
 const XHRUpload = require('../XHRUpload')
 
 function isXml (xhr) {
-  return xhr.getResponseHeader('Content-Type').toLowerCase() === 'application/xml'
+  const contentType = xhr.getResponseHeader('Content-Type')
+  return typeof contentType === 'string' && contentType.toLowerCase() === 'application/xml'
 }
 
 module.exports = class AwsS3 extends Plugin {


### PR DESCRIPTION
Fixes a crash when using presigned PUT uploads. The result of `getResponseHeader()` can be `null` so we can't always lowercase it. Ref https://github.com/transloadit/uppy/issues/518#issuecomment-358770704