### PR TITLE
Improve Transloadit plugin docs

### DIFF
--- a/src/plugins/Transloadit/Client.js
+++ b/src/plugins/Transloadit/Client.js
@@ -3,7 +3,6 @@
  */
 module.exports = class Client {
   constructor (opts = {}) {
-    this.apiUrl = 'https://api2.transloadit.com'
     this.opts = opts
   }
 
@@ -32,7 +31,7 @@ module.exports = class Client {
     })
     data.append('num_expected_upload_files', expectedFiles)
 
-    return fetch(`${this.apiUrl}/assemblies`, {
+    return fetch(`${this.opts.service}/assemblies`, {
       method: 'post',
       body: data
     }).then((response) => response.json()).then((assembly) => {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -30,6 +30,7 @@ module.exports = class Transloadit extends Plugin {
     }
 
     const defaultOptions = {
+      service: 'https://api2.transloadit.com',
       waitForEncoding: false,
       waitForMetadata: false,
       alwaysRunAssembly: false,
@@ -59,7 +60,9 @@ module.exports = class Transloadit extends Plugin {
       this.validateParams(this.opts.params)
     }
 
-    this.client = new Client()
+    this.client = new Client({
+      service: this.opts.service
+    })
     this.sockets = {}
   }
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -20,6 +20,13 @@ uppy.use(Tus, {
 })
 uppy.use(Transloadit, {
   // Transloadit plugin options
+  waitForEncoding: false,
+  waitForMetadata: false,
+  importFromUploadURLs: false,
+  alwaysRunAssembly: false,
+  params: null,
+  signature: null,
+  fields: {}
 })
 ```
 
@@ -60,9 +67,13 @@ uppy.use(Transloadit, {
 
 In order for this to work, the upload plugin must assign a publically accessible `uploadURL` property to the uploaded file object. The Tus and S3 plugins both do this—for the XHRUpload plugin, you may have to specify a custom `getUploadResponse` function.
 
+### `alwaysRunAssembly`
+
+When true, always create and run an Assembly when `uppy.upload()` is called, even if no files were selected. This allows running Assemblies that do not receive files, but instead use a robot like [`/s3/import`](https://transloadit.com/docs/transcoding/#s3-import) to download the files from elsewhere, for example for a bulk transcoding job.
+
 ### `params`
 
-The Assembly parameters to use for the upload. See the Transloadit documentation on [Assembly Instructions](https://transloadit.com/docs/#14-assembly-instructions).
+The Assembly parameters to use for the upload. See the Transloadit documentation on [Assembly Instructions](https://transloadit.com/docs/#14-assembly-instructions). `params` should be a plain JavaScript object, or a JSON string if you are using the [`signature`](#signature) option.
 
 The `auth.key` Assembly parameter is required. You can also use the `steps` or `template_id` options here as described in the Transloadit documentation.
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -119,7 +119,14 @@ uppy.use(Transloadit, {
 })
 ```
 
-Using the `fields` option, form fields have to be determined ahead of time. Form fields can also be computed dynamically however, by using the `getAssemblyOptions(file)` option.
+You can also set `fields: true` to send all global metadata along to the Assembly. Global metadata is set using the [`meta` option](/docs/uppy/#meta) in the Uppy constructor, or using the [`setMeta` method](/docs/uppy/#uppy-setMeta-data). The [Form](/docs/form) plugin also sets global metadata, providing a handy way to use values from HTML form fields:
+
+```js
+uppy.use(Form, { target: 'form#my-form', getMetaFromForm: true })
+uppy.use(Transloadit, { fields: true, params: { ... } })
+```
+
+Form fields can also be computed dynamically using custom logic, by using the [`getAssemblyOptions(file)`](/docs/transloadit/#getAssemblyOptions-file) option.
 
 ### `getAssemblyOptions(file)`
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -44,9 +44,9 @@ Whether to wait for metadata to be extracted from uploaded files before completi
 
 ### `importFromUploadURLs`
 
-Instead of uploading to Transloadit's servers directly, allow another plugin to upload files, and then import those files into the Transloadit assembly. Default `false`.
+Instead of uploading to Transloadit's servers directly, allow another plugin to upload files, and then import those files into the Transloadit Assembly. Default `false`.
 
-When enabling this option, Transloadit will *not* configure the Tus plugin to upload to Transloadit. Instead, a separate upload plugin must be used. Once the upload completes, the Transloadit plugin adds the uploaded file to the assembly.
+When enabling this option, Transloadit will *not* configure the Tus plugin to upload to Transloadit. Instead, a separate upload plugin must be used. Once the upload completes, the Transloadit plugin adds the uploaded file to the Assembly.
 
 For example, to upload files to an S3 bucket and then transcode them:
 
@@ -143,19 +143,7 @@ uppy.use(Transloadit, {
 })
 ```
 
-Now, the `${fields.caption}` variable will be available in the assembly template.
-
-`getAssemblyOptions()` may also return a Promise, so it could retrieve signed assembly parameters from a server. For example, assuming an endpoint `/transloadit-params` that responds with a JSON object with `{ params, signature }` properties:
-
-```js
-uppy.use(Transloadit, {
-  getAssemblyOptions (file) {
-    return fetch('/transloadit-params').then((response) => {
-      return response.json()
-    })
-  }
-})
-```
+Now, the `${fields.caption}` variable will be available in the Assembly template.
 
 Combine the `getAssemblyOptions()` option with the [Form](/docs/form) plugin to pass user input from a `<form>` to a Transloadit Assembly:
 
@@ -175,16 +163,28 @@ uppy.use(Transloadit, {
 })
 ```
 
+`getAssemblyOptions()` may also return a Promise, so it could retrieve signed Assembly parameters from a server. For example, assuming an endpoint `/transloadit-params` that responds with a JSON object with `{ params, signature }` properties:
+
+```js
+uppy.use(Transloadit, {
+  getAssemblyOptions (file) {
+    return fetch('/transloadit-params').then((response) => {
+      return response.json()
+    })
+  }
+})
+```
+
 ## Events
 
 ### `transloadit:assembly-created`
 
-Fired when an assembly is created.
+Fired when an Assembly is created.
 
 **Parameters**
 
-  - `assembly` - The initial assembly status.
-  - `fileIDs` - The IDs of the files that will be uploaded to this assembly.
+  - `assembly` - The initial [Assembly Status][assembly-status].
+  - `fileIDs` - The IDs of the files that will be uploaded to this Assembly.
 
 ```js
 uppy.on('transloadit:assembly-created', (assembly, fileIDs) => {
@@ -203,7 +203,7 @@ Fired when Transloadit has received an upload.
 **Parameters**
 
   - `file` - The Transloadit file object that was uploaded.
-  - `assembly` - The assembly status of the assembly the file was uploaded to.
+  - `assembly` - The [Assembly Status][assembly-status] of the Assembly the file was uploaded to.
 
 ### `transloadit:assembly-executing`
 
@@ -215,15 +215,15 @@ Fired when Transloadit has received all uploads, and is now executing the Assemb
 
 ### `transloadit:result`
 
-Fired when a result came in from an assembly.
+Fired when a result came in from an Assembly.
 
 **Parameters**
 
-  - `stepName` - The name of the assembly step that generated this result.
+  - `stepName` - The name of the Assembly step that generated this result.
   - `result` - The result object from Transloadit.
     This result object contains one additional property, namely `localId`.
     This is the ID of the file in Uppy's local state, and can be used with `uppy.getFile(id)`.
-  - `assembly` - The assembly status of the assembly that generated this result.
+  - `assembly` - The [Assembly Status][assembly-status] of the Assembly that generated this result.
 
 ```js
 uppy.on('transloadit:result', (stepName, result) => {
@@ -239,11 +239,11 @@ uppy.on('transloadit:result', (stepName, result) => {
 
 ### `transloadit:complete`
 
-Fired when an assembly completed.
+Fired when an Assembly completed.
 
 **Parameters**
 
-  - `assembly` - The final assembly status of the completed assembly.
+  - `assembly` - The final [Assembly Status][assembly-status] of the completed Assembly.
 
 ```js
 uppy.on('transloadit:complete', (assembly) => {
@@ -251,3 +251,5 @@ uppy.on('transloadit:complete', (assembly) => {
   console.log(assembly.results)
 })
 ```
+
+[assembly-status]: https://transloadit.com/docs/api-docs/#assembly-status-response

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -119,11 +119,14 @@ uppy.use(Transloadit, {
 })
 ```
 
-You can also set `fields: true` to send all global metadata along to the Assembly. Global metadata is set using the [`meta` option](/docs/uppy/#meta) in the Uppy constructor, or using the [`setMeta` method](/docs/uppy/#uppy-setMeta-data). The [Form](/docs/form) plugin also sets global metadata, providing a handy way to use values from HTML form fields:
+You can also pass an array of field names to send global or file metadata along to the Assembly. Global metadata is set using the [`meta` option](/docs/uppy/#meta) in the Uppy constructor, or using the [`setMeta` method](/docs/uppy/#uppy-setMeta-data). File metadata is set using the [`setFileMeta`](/docs/uppy/#uppy-setFileMeta-fileID-data) method. The [Form](/docs/form) plugin also sets global metadata based on the values of `<input />`s in the form, providing a handy way to use values from HTML form fields:
 
 ```js
 uppy.use(Form, { target: 'form#my-form', getMetaFromForm: true })
-uppy.use(Transloadit, { fields: true, params: { ... } })
+uppy.use(Transloadit, {
+  fields: ['field_name', 'other_field_name'],
+  params: { ... }
+})
 ```
 
 Form fields can also be computed dynamically using custom logic, by using the [`getAssemblyOptions(file)`](/docs/transloadit/#getAssemblyOptions-file) option.

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -9,17 +9,8 @@ The Transloadit plugin can be used to upload files to [Transloadit](https://tran
 
 [Try it live](/examples/transloadit/)
 
-The Transloadit plugin uses the [Tus plugin](/docs/tus) for the uploading itself. To upload files to Transloadit directly, both the Tus and Transloadit plugins must be used:
-
 ```js
-// The `resume: false` option _must_ be provided to the Tus plugin.
-// Otherwise, the Tus plugin remembers the URLs used to upload to Transloadit,
-// which can cause future uploads to go to old Assemblies.
-uppy.use(Tus, {
-  resume: false
-})
 uppy.use(Transloadit, {
-  // Transloadit plugin options
   service: 'https://api2.transloadit.com',
   waitForEncoding: false,
   waitForMetadata: false,
@@ -31,7 +22,7 @@ uppy.use(Transloadit, {
 })
 ```
 
-Note: It is not required to use the `Tus` plugin if [`importFromUploadURLs`](#importFromUploadURLs) is enabled.
+As of Uppy 0.24 the Transloadit plugin includes the [Tus](/docs/tus) plugin to handle the uploading, so you no longer have to add it manually.
 
 ## Options
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -20,6 +20,7 @@ uppy.use(Tus, {
 })
 uppy.use(Transloadit, {
   // Transloadit plugin options
+  service: 'https://api2.transloadit.com',
   waitForEncoding: false,
   waitForMetadata: false,
   importFromUploadURLs: false,
@@ -33,6 +34,10 @@ uppy.use(Transloadit, {
 Note: It is not required to use the `Tus` plugin if [`importFromUploadURLs`](#importFromUploadURLs) is enabled.
 
 ## Options
+
+### `service`
+
+The Transloadit API URL to use. Defaults to `https://api2.transloadit.com`, which will attempt to route traffic efficiently based on where your users are. You can set this to something like `https://api2-us-east-1.transloadit.com` if you want to use a particular region.
 
 ### `waitForEncoding`
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -64,8 +64,8 @@ uppy.use(AwsS3, {
 uppy.use(Transloadit, {
   importFromUploadURLs: true,
   params: {
-    auth: { key: /* secret */ },
-    template_id: /* not secret */
+    auth: { key: 'YOUR_API_KEY' },
+    template_id: 'YOUR_TEMPLATE_ID'
   }
 })
 ```


### PR DESCRIPTION
Addressing @tim-kos's feedback on the Transloadit plugin documentation, opening PR to make it easy to keep a checklist:

- [x] "NB:" - I have no idea what NB stands for. :D
- [x] "assemblies" - I wonder if we should also uppercase them here like we do in the TL docs. I don't have a strong opinion here, though.
- [x] "params" - I think we should link to our TL docs here to help people get started.
- [x] "params" - It does not state if this should be a JS object or a string. An example would be nice, including auth credentials, a template_id, etc. That's the important parameters that people will want to know where to put them.
- [x] <strike>"If a signature" - I think there is missing whitespace after the "If".</strike>
- [x] "fields" - Would be nice to add an example here. Also, do I need to compile this myself, or will this be auto-magically sent like the "fields" property in the jQuery SDK? Will this use the "Form" plugin internally to do magic for me, or will this work automagically if I add the Form plugin to my Uppy setup? This definitely needs a more verbose description. It's a very important feature for a lot of customers. - https://github.com/transloadit/uppy/pull/593
- [x] "getAssemblyOptions" - ok, here we have the dynamic way of setting fields. Would be nice to add a reference to this option from the "fields" option.
- [x] Events: We should add an "assembly-executing" event, which is fired when all uploading is complete and the assembly is in the executing stage. This is to get compatibility with the jQuery SDK.
- [ ] transloadit:complete - does this also fire when the assembly ends in an error?
- [x] <strike>Would the "endpoint" option already work here? Can I define, which Transloadit region I want my uploads to go to? With other plugins I saw the "Common options" listed out and then linked to.</strike> Implemented `service` option
- [x] Does the use case work that I do not need to select any files for uploading, but the upload button is more or less a "Start assembly" button? Useful if an assembly uses only import robots, such as /s3/import to start a batch transcoding job.