### PR TITLE
Adds uploadID to complete event and promise callback

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -1042,14 +1042,14 @@ class Uppy {
       const files = fileIDs.map((fileID) => this.getFile(fileID))
       const successful = files.filter((file) => file && !file.error)
       const failed = files.filter((file) => file && file.error)
-      this.emit('complete', { successful, failed })
+      this.emit('complete', { successful, failed, uploadID })
 
       // Compatibility with pre-0.21
       this.emit('success', fileIDs)
 
       this._removeUpload(uploadID)
 
-      return { successful, failed }
+      return { successful, failed, uploadID }
     })
   }
 

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -605,20 +605,18 @@ describe('src/Core', () => {
   })
 
   describe('uploading a file', () => {
-    it('should return a { successful, failed } pair containing file objects', () => {
+    it('should return a { successful, failed, uploadId } object containing file objects and the uploadID', () => {
       const core = new Core().run()
       core.addUploader((fileIDs) => Promise.resolve())
       return Promise.all([
         core.addFile({ source: 'jest', name: 'foo.jpg', type: 'image/jpeg', data: new Uint8Array() }),
         core.addFile({ source: 'jest', name: 'bar.jpg', type: 'image/jpeg', data: new Uint8Array() })
       ]).then(() => {
-        return expect(core.upload()).resolves.toMatchObject({
-          successful: [
-            { name: 'foo.jpg' },
-            { name: 'bar.jpg' }
-          ],
-          failed: []
-        })
+        return core.upload()
+      }).then((result) => {
+        expect(result.uploadID.length).toEqual(25)
+        delete result.uploadID
+        expect(result).toMatchSnapshot()
       })
     })
 
@@ -637,14 +635,10 @@ describe('src/Core', () => {
         core.addFile({ source: 'jest', name: 'foo.jpg', type: 'image/jpeg', data: new Uint8Array() }),
         core.addFile({ source: 'jest', name: 'bar.jpg', type: 'image/jpeg', data: new Uint8Array() })
       ]).then(() => {
-        return expect(core.upload()).resolves.toMatchObject({
-          successful: [
-            { name: 'foo.jpg' }
-          ],
-          failed: [
-            { name: 'bar.jpg', error: 'This is bar and I do not like bar' }
-          ]
-        })
+        return core.upload()
+      }).then((result) => {
+        delete result.uploadID
+        expect(result).toMatchSnapshot()
       })
     })
   })

--- a/src/core/__snapshots__/Core.test.js.snap
+++ b/src/core/__snapshots__/Core.test.js.snap
@@ -14,3 +14,113 @@ exports[`src/Core plugins should prevent the same plugin from being added more t
         https://github.com/transloadit/uppy/issues/
         if you want us to reconsider."
 `;
+
+exports[`src/Core uploading a file should return a { successful, failed, uploadId } object containing file objects and the uploadID 1`] = `
+Object {
+  "failed": Array [],
+  "successful": Array [
+    Object {
+      "data": Uint8Array [],
+      "extension": "jpg",
+      "id": "uppy-foojpg-image/jpeg",
+      "isRemote": false,
+      "meta": Object {
+        "name": "foo.jpg",
+        "type": null,
+      },
+      "name": "foo.jpg",
+      "preview": undefined,
+      "progress": Object {
+        "bytesTotal": 0,
+        "bytesUploaded": 0,
+        "percentage": 0,
+        "uploadComplete": false,
+        "uploadStarted": false,
+      },
+      "remote": "",
+      "size": 0,
+      "source": "jest",
+      "type": null,
+    },
+    Object {
+      "data": Uint8Array [],
+      "extension": "jpg",
+      "id": "uppy-barjpg-image/jpeg",
+      "isRemote": false,
+      "meta": Object {
+        "name": "bar.jpg",
+        "type": null,
+      },
+      "name": "bar.jpg",
+      "preview": undefined,
+      "progress": Object {
+        "bytesTotal": 0,
+        "bytesUploaded": 0,
+        "percentage": 0,
+        "uploadComplete": false,
+        "uploadStarted": false,
+      },
+      "remote": "",
+      "size": 0,
+      "source": "jest",
+      "type": null,
+    },
+  ],
+}
+`;
+
+exports[`src/Core uploading a file should return files with errors in the { failed } key 1`] = `
+Object {
+  "failed": Array [
+    Object {
+      "data": Uint8Array [],
+      "error": "This is bar and I do not like bar",
+      "extension": "jpg",
+      "id": "uppy-barjpg-image/jpeg",
+      "isRemote": false,
+      "meta": Object {
+        "name": "bar.jpg",
+        "type": null,
+      },
+      "name": "bar.jpg",
+      "preview": undefined,
+      "progress": Object {
+        "bytesTotal": 0,
+        "bytesUploaded": 0,
+        "percentage": 0,
+        "uploadComplete": false,
+        "uploadStarted": false,
+      },
+      "remote": "",
+      "size": 0,
+      "source": "jest",
+      "type": null,
+    },
+  ],
+  "successful": Array [
+    Object {
+      "data": Uint8Array [],
+      "extension": "jpg",
+      "id": "uppy-foojpg-image/jpeg",
+      "isRemote": false,
+      "meta": Object {
+        "name": "foo.jpg",
+        "type": null,
+      },
+      "name": "foo.jpg",
+      "preview": undefined,
+      "progress": Object {
+        "bytesTotal": 0,
+        "bytesUploaded": 0,
+        "percentage": 0,
+        "uploadComplete": false,
+        "uploadStarted": false,
+      },
+      "remote": "",
+      "size": 0,
+      "source": "jest",
+      "type": null,
+    },
+  ],
+}
+`;


### PR DESCRIPTION
At the moment Uppy fires off a complete event on upload completion (and also offers a promise callback) which has the number of successful and failed files. When you have multiple uploads running it becomes difficult to work out which upload has completed. This PR adds the upload id into the event and promise callback.