### PR TITLE
Dashboard: fix modal scroll

### DIFF
--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -28,7 +28,6 @@ module.exports = function Dashboard (props) {
     'uppy',
     'uppy-Dashboard',
     { 'Uppy--isTouchDevice': isTouchDevice() },
-    { 'uppy-Dashboard--semiTransparent': props.semiTransparent },
     { 'uppy-Dashboard--modal': !props.inline },
     { 'uppy-Dashboard--wide': props.isWide }
   )

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -201,20 +201,6 @@ module.exports = class Dashboard extends Plugin {
     }
   }
 
-  scrollBehaviour (toggle) {
-    if (!this.opts.disablePageScrollWhenModalOpen) return
-    const body = document.querySelector('body')
-    switch (toggle) {
-      case 'enable':
-        Object.assign(body.style, { overflow: 'initial', height: 'initial' })
-        break
-      case 'disable':
-        Object.assign(body.style, { overflow: 'hidden', height: '100vh' })
-        break
-      default:
-    }
-  }
-
   openModal () {
     this.setPluginState({
       isHidden: false
@@ -225,12 +211,10 @@ module.exports = class Dashboard extends Plugin {
     // save active element, so we can restore focus when modal is closed
     this.savedActiveElement = document.activeElement
 
-    // add class to body that sets position fixed, move everything back
-    // to scroll position
-    // document.body.classList.add('uppy-Dashboard-isOpen')
-    // document.body.style.top = `-${this.savedScrollPosition}px`
+    if (!this.opts.disablePageScrollWhenModalOpen) {
+      document.body.classList.remove('uppy-Dashboard-isOpen')
+    }
 
-    this.scrollBehaviour('disable')
     this.updateDashboardElWidth()
     this.setFocusToFirstNode()
   }
@@ -240,10 +224,11 @@ module.exports = class Dashboard extends Plugin {
       isHidden: true
     })
 
-    // document.body.classList.remove('uppy-Dashboard-isOpen')
-    this.scrollBehaviour('enable')
+    if (!this.opts.disablePageScrollWhenModalOpen) {
+      document.body.classList.remove('uppy-Dashboard-isOpen')
+    }
+
     this.savedActiveElement.focus()
-    // window.scrollTo(0, this.savedScrollPosition)
   }
 
   isModalOpen () {

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -211,8 +211,8 @@ module.exports = class Dashboard extends Plugin {
     // save active element, so we can restore focus when modal is closed
     this.savedActiveElement = document.activeElement
 
-    if (!this.opts.disablePageScrollWhenModalOpen) {
-      document.body.classList.remove('uppy-Dashboard-isOpen')
+    if (this.opts.disablePageScrollWhenModalOpen) {
+      document.body.classList.add('uppy-Dashboard-isOpen')
     }
 
     this.updateDashboardElWidth()
@@ -224,7 +224,7 @@ module.exports = class Dashboard extends Plugin {
       isHidden: true
     })
 
-    if (!this.opts.disablePageScrollWhenModalOpen) {
+    if (this.opts.disablePageScrollWhenModalOpen) {
       document.body.classList.remove('uppy-Dashboard-isOpen')
     }
 

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -73,7 +73,6 @@ module.exports = class Dashboard extends Plugin {
       width: 750,
       height: 550,
       thumbnailWidth: 280,
-      semiTransparent: false,
       defaultTabIcon: defaultTabIcon,
       showProgressDetails: false,
       hideUploadButton: false,
@@ -83,6 +82,7 @@ module.exports = class Dashboard extends Plugin {
       disableStatusBar: false,
       disableInformer: false,
       disableThumbnailGenerator: false,
+      disablePageScrollWhenModalOpen: true,
       onRequestCloseModal: () => this.closeModal(),
       locale: defaultLocale
     }
@@ -201,6 +201,20 @@ module.exports = class Dashboard extends Plugin {
     }
   }
 
+  scrollBehaviour (toggle) {
+    if (!this.opts.disablePageScrollWhenModalOpen) return
+    const body = document.querySelector('body')
+    switch (toggle) {
+      case 'enable':
+        Object.assign(body.style, { overflow: 'initial', height: 'initial' })
+        break
+      case 'disable':
+        Object.assign(body.style, { overflow: 'hidden', height: '100vh' })
+        break
+      default:
+    }
+  }
+
   openModal () {
     this.setPluginState({
       isHidden: false
@@ -213,9 +227,10 @@ module.exports = class Dashboard extends Plugin {
 
     // add class to body that sets position fixed, move everything back
     // to scroll position
-    document.body.classList.add('uppy-Dashboard-isOpen')
-    document.body.style.top = `-${this.savedScrollPosition}px`
+    // document.body.classList.add('uppy-Dashboard-isOpen')
+    // document.body.style.top = `-${this.savedScrollPosition}px`
 
+    this.scrollBehaviour('disable')
     this.updateDashboardElWidth()
     this.setFocusToFirstNode()
   }
@@ -225,9 +240,10 @@ module.exports = class Dashboard extends Plugin {
       isHidden: true
     })
 
-    document.body.classList.remove('uppy-Dashboard-isOpen')
+    // document.body.classList.remove('uppy-Dashboard-isOpen')
+    this.scrollBehaviour('enable')
     this.savedActiveElement.focus()
-    window.scrollTo(0, this.savedScrollPosition)
+    // window.scrollTo(0, this.savedScrollPosition)
   }
 
   isModalOpen () {

--- a/src/scss/_dashboard.scss
+++ b/src/scss/_dashboard.scss
@@ -9,9 +9,8 @@
 
 // Added to body to prevent the page from scrolling when Modal is open
 .uppy-Dashboard-isOpen {
-  width: 100%;
   overflow: hidden;
-  position: fixed;
+  height: 100vh;
 }
 
 .uppy-Dashboard--modal .uppy-Dashboard-overlay {

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "hexo": {
-    "version": "3.3.7"
+    "version": "3.5.0"
   },
   "dependencies": {
     "autoprefixer": "^7.2.5",


### PR DESCRIPTION
As described in #562, Dashboard modal fiddled with `document.body.style.top` which resulted in some layouts being broken. There seems to be a better solution, which I borrowed (with credit, as many other things) from their https://github.com/ghosh/micromodal/. 

This should fix the issue, plus there’s now an option to disable this and leave page scroll as is.