### PR TITLE
xhrupload: Fix custom form fields in remote uploads

### DIFF
--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -226,7 +226,7 @@ module.exports = class XHRUpload extends Plugin {
           endpoint: opts.endpoint,
           size: file.data.size,
           fieldname: opts.fieldName,
-          fields,
+          metadata: fields,
           headers: opts.headers
         }))
       })


### PR DESCRIPTION
uppy-server calls this `metadata`. Part of allowing uppy-server to
upload to S3, see https://github.com/transloadit/uppy-server/issues/57