### PR TITLE
Allowing custom form data to be sent together with each file upload.

### DIFF
--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -25,6 +25,7 @@ module.exports = class XHRUpload extends Plugin {
     // Default options
     const defaultOptions = {
       formData: true,
+      data: {},
       fieldName: 'files[]',
       method: 'post',
       metaFields: null,
@@ -89,6 +90,19 @@ module.exports = class XHRUpload extends Plugin {
     metaFields.forEach((item) => {
       formPost.append(item, file.meta[item])
     })
+
+    let data = opts.data
+    if (typeof opts.data === 'function') {
+      data = opts.data(file)
+    }
+
+    if (data != null) {
+      (typeof data === 'object')
+        ? Object.keys(data).forEach((key) => {
+          formPost.append(key, data[key])
+        })
+        : formPost.append('data', data)
+    }
 
     formPost.append(opts.fieldName, file.data)
 

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -32,6 +32,37 @@ This works similarly to using a `<form>` element with an `<input type="file">` f
 When `true`, file metadata is also sent to the endpoint as separate form fields.
 When `false`, only the file contents are sent.
 
+### `data: {}`
+
+A hash with additional data that you want included in the [FormData][] for every upload.
+```js
+...
+data: {
+  // Static include for all files of this instance
+  mySuperCoolProperty: 'This is value for "mySuperCoolProperty" key in the FormData'
+},
+...
+```
+You may also supply a function that returns a hash with the data to be included for each file. 
+```js
+...
+data: (file) => {
+  return {
+    extension: file.extension
+  }
+},
+...
+```
+Alternatively, the function may return a non-object (i.e. string, number) which will be included in each upload's form  
+data with the key of "data".
+```js
+...
+data: (file) => {
+  return file.extension // the extension will go in the form data with the key of "data"
+},
+...
+```
+
 ### `fieldName: 'files[]'`
 
 When `formData` is true, this is used as the form field name for the file to be uploaded.

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -43,7 +43,7 @@ data: {
 },
 ...
 ```
-You may also supply a function that returns a hash with the data to be included for each file. 
+You may alternatively supply a function that returns a hash with the data to be included for each file. 
 ```js
 ...
 data: (file) => {
@@ -53,7 +53,7 @@ data: (file) => {
 },
 ...
 ```
-Alternatively, the function may return a non-object (i.e. string, number) which will be included in each upload's form  
+Finally, the function may return a non-object (i.e. string, number) which will be included in each upload's form  
 data with the key of "data".
 ```js
 ...
@@ -62,6 +62,10 @@ data: (file) => {
 },
 ...
 ```
+
+*Pro Tip:* if you return `null` or `undefined` in your generator function, no data will be included for that 
+upload. This means you could include data conditionally for each file based on anything your 
+creativity can come up with.
 
 ### `fieldName: 'files[]'`
 


### PR DESCRIPTION
Currently supporting a static hash with key/value pairs or, through a function, dynamic values which might be generated by getting the "file" as an input parameter. e.g. 
```js
{
  formData: true,
  data: {
    // The myCustomProp key is added to all upload with 'custom value' as value
    myCustomProp: 'custom value'
  },
  ...
```

The generator function *path* is invoked with the file as a single parameter and is expected to return either a hash of key/value pairs or a single non-object value to be included with the FormData under the name of "data". For example:

- Hash option
```js
{
  formData: true,
  data: (file) => {
    return {
      // FormData will have a key "extension" with a value of the current upload's extension
      extension: file.extension
    }
  },
  ...
```
- Single value
```js
{
  formData: true,
  data: (file) => {
    // FormData will have a key of "data" with the current upload's extension as it's value
    return file.extension
  } 
}
```