### PR TITLE
transloadit: Easily pass form fields

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -3,14 +3,6 @@ const Plugin = require('../../core/Plugin')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')
 
-function defaultGetAssemblyOptions (file, options) {
-  return {
-    params: options.params,
-    signature: options.signature,
-    fields: options.fields
-  }
-}
-
 /**
  * Upload files to Transloadit using Tus.
  */
@@ -37,7 +29,13 @@ module.exports = class Transloadit extends Plugin {
       signature: null,
       params: null,
       fields: {},
-      getAssemblyOptions: defaultGetAssemblyOptions,
+      getAssemblyOptions: (file, options) => ({
+        params: options.params,
+        signature: options.signature,
+        // Include global metadata as fields by default.
+        // Works great together with the Form plugin :)
+        fields: Object.assign({}, this.uppy.getState().meta, options.fields)
+      }),
       locale: defaultLocale
     }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -87,11 +87,25 @@ module.exports = class Transloadit extends Plugin {
 
   getAssemblyOptions (fileIDs) {
     const options = this.opts
+
+    const normalizeAssemblyOptions = (assemblyOptions) => {
+      const globalMeta = this.uppy.getState().meta
+      // Include global metadata as fields. Works great together with the Form plugin :)
+      if (assemblyOptions.fields === true) {
+        assemblyOptions.fields = Object.assign({}, globalMeta)
+      }
+      if (!assemblyOptions.fields) {
+        assemblyOptions.fields = {}
+      }
+      return assemblyOptions
+    }
+
     return Promise.all(
       fileIDs.map((fileID) => {
         const file = this.uppy.getFile(fileID)
         const promise = Promise.resolve()
           .then(() => options.getAssemblyOptions(file, options))
+          .then(normalizeAssemblyOptions)
         return promise.then((assemblyOptions) => {
           this.validateParams(assemblyOptions.params)
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -3,6 +3,14 @@ const Plugin = require('../../core/Plugin')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')
 
+function defaultGetAssemblyOptions (file, options) {
+  return {
+    params: options.params,
+    signature: options.signature,
+    fields: options.fields
+  }
+}
+
 /**
  * Upload files to Transloadit using Tus.
  */
@@ -29,13 +37,7 @@ module.exports = class Transloadit extends Plugin {
       signature: null,
       params: null,
       fields: {},
-      getAssemblyOptions: (file, options) => ({
-        params: options.params,
-        signature: options.signature,
-        // Include global metadata as fields by default.
-        // Works great together with the Form plugin :)
-        fields: Object.assign({}, this.uppy.getState().meta, options.fields)
-      }),
+      getAssemblyOptions: defaultGetAssemblyOptions,
       locale: defaultLocale
     }
 

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -88,11 +88,13 @@ module.exports = class Transloadit extends Plugin {
   getAssemblyOptions (fileIDs) {
     const options = this.opts
 
-    const normalizeAssemblyOptions = (assemblyOptions) => {
-      const globalMeta = this.uppy.getState().meta
-      // Include global metadata as fields. Works great together with the Form plugin :)
-      if (assemblyOptions.fields === true) {
-        assemblyOptions.fields = Object.assign({}, globalMeta)
+    const normalizeAssemblyOptions = (file, assemblyOptions) => {
+      if (Array.isArray(assemblyOptions.fields)) {
+        const fieldNames = assemblyOptions.fields
+        assemblyOptions.fields = {}
+        fieldNames.forEach((fieldName) => {
+          assemblyOptions.fields[fieldName] = file.meta[fieldName]
+        })
       }
       if (!assemblyOptions.fields) {
         assemblyOptions.fields = {}
@@ -105,7 +107,7 @@ module.exports = class Transloadit extends Plugin {
         const file = this.uppy.getFile(fileID)
         const promise = Promise.resolve()
           .then(() => options.getAssemblyOptions(file, options))
-          .then(normalizeAssemblyOptions)
+          .then((assemblyOptions) => normalizeAssemblyOptions(file, assemblyOptions))
         return promise.then((assemblyOptions) => {
           this.validateParams(assemblyOptions.params)
 


### PR DESCRIPTION
Set `fields: true` to send along `fields` from global metadata when creating an assembly. This works nicely with the Form plugin, which adds form field values to the global metadata.

Mimicks the jQuery SDK's `fields: true` option.

I'll add docs for this in https://github.com/transloadit/uppy/pull/546, to prevent merge conflicts