### PR TITLE
Add wrapper function for emitter.on

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -87,7 +87,8 @@ class Uppy {
     this.upload = this.upload.bind(this)
 
     this.emitter = ee()
-    this.off = this.emitter.off.bind(this.emitter)
+    this.on = this.on.bind(this)
+    this.off = this.off.bind(this)
     this.once = this.emitter.once.bind(this.emitter)
     this.emit = this.emitter.emit.bind(this.emitter)
 
@@ -127,6 +128,11 @@ class Uppy {
 
   on (event, callback) {
     this.emitter.on(event, callback)
+    return this
+  }
+
+  off (event, callback) {
+    this.emitter.off(event, callback)
     return this
   }
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -87,7 +87,6 @@ class Uppy {
     this.upload = this.upload.bind(this)
 
     this.emitter = ee()
-    this.on = this.emitter.on.bind(this.emitter)
     this.off = this.emitter.off.bind(this.emitter)
     this.once = this.emitter.once.bind(this.emitter)
     this.emit = this.emitter.emit.bind(this.emitter)
@@ -124,6 +123,11 @@ class Uppy {
       global.uppyLog = ''
       global[this.opts.id] = this
     }
+  }
+
+  on (event, callback) {
+    this.emitter.on(event, callback)
+    return this
   }
 
   /**


### PR DESCRIPTION
Add wrapper function for emitter.on that returns uppy instance for easy chaining.

Kevin noticed this:

> It seems `.on` does not return the Uppy object.

This didn’t work:

<img width="504" alt="screen_shot_2018-02-06_at_12 13 53" src="https://user-images.githubusercontent.com/1199054/35900877-3513ae1c-0ba2-11e8-9433-96e03ee2c422.png">

This did:

<img width="553" alt="screen_shot_2018-02-06_at_12 10 25" src="https://user-images.githubusercontent.com/1199054/35900890-41b478c2-0ba2-11e8-9a0b-35275a3fa6ad.png">

Now both do.
