### PR TITLE
`addFile()` rejections revamp

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -389,13 +389,7 @@ class Uppy {
       .catch((err) => {
         const message = typeof err === 'object' ? err.message : err
         this.info(message, 'error', 5000)
-        const rejected = Promise.reject(typeof err === 'object' ? err : new Error(err))
-        // Silence the unhandled rejection; we have already shown it to the user,
-        // so the consumer may not need to do anything with this result.
-        // Note that the result is still a rejected Promise, it will just not
-        // trigger unhandled rejection warnings in the browser console.
-        rejected.catch(() => {})
-        return rejected
+        return Promise.reject(typeof err === 'object' ? err : new Error(err))
       })
   }
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -389,7 +389,13 @@ class Uppy {
       .catch((err) => {
         const message = typeof err === 'object' ? err.message : err
         this.info(message, 'error', 5000)
-        return Promise.reject(typeof err === 'object' ? err : new Error(err))
+        const rejected = Promise.reject(typeof err === 'object' ? err : new Error(err))
+        // Silence the unhandled rejection; we have already shown it to the user,
+        // so the consumer may not need to do anything with this result.
+        // Note that the result is still a rejected Promise, it will just not
+        // trigger unhandled rejection warnings in the browser console.
+        rejected.catch(() => {})
+        return rejected
       })
   }
 

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -610,7 +610,7 @@ describe('src/Core', () => {
           throw new Error('File was allowed through')
         })
         .catch(e => {
-          expect(e.message).toEqual('File not allowed')
+          expect(e.message).toEqual('You can only upload: image/gif')
         })
     })
 
@@ -625,7 +625,7 @@ describe('src/Core', () => {
         name: 'foo.jpg',
         type: 'image/jpeg',
         data: null
-      })).rejects.toMatchObject(new Error('onBeforeFileAdded: a plain string'))
+      })).rejects.toMatchObject(new Error('a plain string'))
     })
   })
 
@@ -955,7 +955,7 @@ describe('src/Core', () => {
         name: 'foo2.jpg',
         type: 'image/jpeg',
         data: utils.dataURItoFile(sampleImageDataURI, {})
-      })).rejects.toMatchObject(new Error('File not allowed')).then(() => {
+      })).rejects.toMatchObject(new Error('You can only upload 1 file')).then(() => {
         expect(core.state.info.message).toEqual('You can only upload 1 file')
       })
     })
@@ -975,7 +975,7 @@ describe('src/Core', () => {
         name: 'foo2.jpg',
         type: 'image/jpeg',
         data: utils.dataURItoFile(sampleImageDataURI, {})
-      })).rejects.toMatchObject(new Error('File not allowed')).then(() => {
+      })).rejects.toMatchObject(new Error('You can only upload: image/gif, image/png')).then(() => {
         expect(core.state.info.message).toEqual('You can only upload: image/gif, image/png')
       })
     })
@@ -993,7 +993,7 @@ describe('src/Core', () => {
         name: 'foo.jpg',
         type: 'image/jpeg',
         data: utils.dataURItoFile(sampleImageDataURI, {})
-      })).rejects.toMatchObject(new Error('File not allowed')).then(() => {
+      })).rejects.toMatchObject(new Error('This file exceeds maximum allowed size of 1.2 KB')).then(() => {
         expect(core.state.info.message).toEqual('This file exceeds maximum allowed size of 1.2 KB')
       })
     })

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -277,6 +277,8 @@ module.exports = class Dashboard extends Plugin {
         name: file.name,
         type: file.type,
         data: blob
+      }).catch(() => {
+        // Ignore
       })
     })
   }
@@ -291,6 +293,8 @@ module.exports = class Dashboard extends Plugin {
         name: file.name,
         type: file.type,
         data: file
+      }).catch(() => {
+        // Ignore
       })
     })
   }
@@ -360,6 +364,8 @@ module.exports = class Dashboard extends Plugin {
         name: file.name,
         type: file.type,
         data: file
+      }).catch(() => {
+        // Ignore
       })
     })
   }

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -83,6 +83,8 @@ module.exports = class DragDrop extends Plugin {
         name: file.name,
         type: file.type,
         data: file
+      }).catch(() => {
+        // Ignore
       })
     })
   }
@@ -98,6 +100,8 @@ module.exports = class DragDrop extends Plugin {
         name: file.name,
         type: file.type,
         data: file
+      }).catch(() => {
+        // Ignore
       })
     })
   }

--- a/src/plugins/Dummy.js
+++ b/src/plugins/Dummy.js
@@ -35,7 +35,9 @@ module.exports = class Dummy extends Plugin {
       data: blob
     }
     this.props.log('Adding fake file blob')
-    this.props.addFile(file)
+    this.props.addFile(file).catch(() => {
+      // Ignore
+    })
   }
 
   render (state) {

--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -51,6 +51,8 @@ module.exports = class FileInput extends Plugin {
         name: file.name,
         type: file.type,
         data: file
+      }).catch(() => {
+        // Ignore
       })
     })
   }

--- a/src/plugins/Provider/view/index.js
+++ b/src/plugins/Provider/view/index.js
@@ -169,7 +169,9 @@ module.exports = class View {
         tagFile.preview = this.plugin.getItemThumbnailUrl(file)
       }
       this.plugin.uppy.log('Adding remote file')
-      this.plugin.uppy.addFile(tagFile)
+      this.plugin.uppy.addFile(tagFile).catch(() => {
+        // Ignore
+      })
       if (!isCheckbox) {
         this.donePicking()
       }

--- a/src/plugins/Transloadit/index.test.js
+++ b/src/plugins/Transloadit/index.test.js
@@ -168,6 +168,6 @@ describe('Transloadit', () => {
       }
     })
 
-    return expect(uppy.upload()).rejects.toBe('short-circuited')
+    return expect(uppy.upload()).rejects.toEqual(new Error('short-circuited'))
   })
 })

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -169,7 +169,7 @@ module.exports = class Webcam extends Plugin {
       })
       return this.getVideo()
     })
-    .then(this.uppy.addFile)
+    .then((file) => this.uppy.addFile(file))
     .then(() => {
       this.recordingChunks = null
       this.recorder = null
@@ -233,9 +233,11 @@ module.exports = class Webcam extends Plugin {
       return this.getImage()
     }).then((tagFile) => {
       this.captureInProgress = false
-      this.uppy.addFile(tagFile)
       const dashboard = this.uppy.getPlugin('Dashboard')
       if (dashboard) dashboard.hideAllPanels()
+      return this.uppy.addFile(tagFile).catch(() => {
+        // Ignore
+      })
     }, (error) => {
       this.captureInProgress = false
       throw error


### PR DESCRIPTION
- restriction errors now reuse the Informer error code in `addFile()`, so all errors in addFile go through the same path
- UI plugins swallow rejection errors so they don't end up in the console with no way to fix
- **check min number of files _after_ `onBeforeUpload`** - this is so it works the same way as `onBeforeFileAdded`, which is also called before restriction checks