### PR TITLE
Revamp XHR response handling

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -436,7 +436,7 @@ class Uppy {
     })
 
     this._calculateTotalProgress()
-    this.emit('file-removed', fileID)
+    this.emit('file-removed', removedFile)
 
     // Clean up object URLs.
     if (removedFile.preview && Utils.isObjectURL(removedFile.preview)) {

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -717,10 +717,11 @@ describe('src/Core', () => {
             totalProgress: 50
           })
 
+          const file = core.getFile(fileId)
           core.removeFile(fileId)
 
           expect(Object.keys(core.state.files).length).toEqual(0)
-          expect(fileRemovedEventMock.mock.calls[0][0]).toEqual(fileId)
+          expect(fileRemovedEventMock.mock.calls[0][0]).toEqual(file)
           expect(core.state.totalProgress).toEqual(0)
         })
     })

--- a/src/plugins/Tus.js
+++ b/src/plugins/Tus.js
@@ -130,7 +130,7 @@ module.exports = class Tus extends Plugin {
 
       optsTus.onError = (err) => {
         this.uppy.log(err)
-        this.uppy.emit('upload-error', file.id, err)
+        this.uppy.emit('upload-error', file, err)
         err.message = `Failed because: ${err.message}`
 
         this.resetUploaderReferences(file.id)
@@ -148,7 +148,7 @@ module.exports = class Tus extends Plugin {
       }
 
       optsTus.onSuccess = () => {
-        this.uppy.emit('upload-success', file.id, upload, upload.url)
+        this.uppy.emit('upload-success', file, upload, upload.url)
 
         if (upload.url) {
           this.uppy.log('Download ' + upload.file.name + ' from ' + upload.url)
@@ -300,12 +300,12 @@ module.exports = class Tus extends Plugin {
       socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
 
       socket.on('error', (errData) => {
-        this.uppy.emit('upload-error', file.id, new Error(errData.error))
+        this.uppy.emit('upload-error', file, new Error(errData.error))
         reject(new Error(errData.error))
       })
 
       socket.on('success', (data) => {
-        this.uppy.emit('upload-success', file.id, data, data.url)
+        this.uppy.emit('upload-success', file, data, data.url)
         this.resetUploaderReferences(file.id)
         resolve()
       })

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -184,7 +184,7 @@ module.exports = class XHRUpload extends Plugin {
 
       const timer = this.createProgressTimeout(opts.timeout, (error) => {
         xhr.abort()
-        this.uppy.emit('upload-error', file.id, error)
+        this.uppy.emit('upload-error', file, error)
         reject(error)
       })
 
@@ -227,7 +227,7 @@ module.exports = class XHRUpload extends Plugin {
 
           this.uppy.setFileState(file.id, { response })
 
-          this.uppy.emit('upload-success', file.id, body, uploadURL)
+          this.uppy.emit('upload-success', file, body, uploadURL)
 
           if (uploadURL) {
             this.uppy.log(`Download ${file.name} from ${file.uploadURL}`)
@@ -245,7 +245,7 @@ module.exports = class XHRUpload extends Plugin {
 
           this.uppy.setFileState(file.id, { response })
 
-          this.uppy.emit('upload-error', file.id, error)
+          this.uppy.emit('upload-error', file, error)
           return reject(error)
         }
       })
@@ -255,7 +255,7 @@ module.exports = class XHRUpload extends Plugin {
         timer.done()
 
         const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
-        this.uppy.emit('upload-error', file.id, error)
+        this.uppy.emit('upload-error', file, error)
         return reject(error)
       })
 
@@ -324,7 +324,7 @@ module.exports = class XHRUpload extends Plugin {
           socket.on('success', (data) => {
             const resp = opts.getResponseData(data.response.responseText, data.response)
             const uploadURL = resp[opts.responseUrlFieldName]
-            this.uppy.emit('upload-success', file.id, resp, uploadURL)
+            this.uppy.emit('upload-success', file, resp, uploadURL)
             socket.close()
             return resolve()
           })
@@ -332,7 +332,7 @@ module.exports = class XHRUpload extends Plugin {
           socket.on('error', (errData) => {
             const resp = errData.response
             const error = resp ? opts.getResponseError(resp.responseText, resp) : new Error(errData.error)
-            this.uppy.emit('upload-error', file.id, error)
+            this.uppy.emit('upload-error', file, error)
             reject(new Error(errData.error))
           })
         })
@@ -361,7 +361,7 @@ module.exports = class XHRUpload extends Plugin {
 
       const emitError = (error) => {
         files.forEach((file) => {
-          this.uppy.emit('upload-error', file.id, error)
+          this.uppy.emit('upload-error', file, error)
         })
       }
 
@@ -391,7 +391,7 @@ module.exports = class XHRUpload extends Plugin {
         if (ev.target.status >= 200 && ev.target.status < 300) {
           const resp = this.opts.getResponseData(xhr.responseText, xhr)
           files.forEach((file) => {
-            this.uppy.emit('upload-success', file.id, resp)
+            this.uppy.emit('upload-success', file, resp)
           })
           return resolve()
         }

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -333,8 +333,8 @@ uppy.on('file-added', (file) => {
 Fired each time file is removed.
 
 ```javascript
-uppy.on('file-removed', (fileID) => {
-  console.log('Removed file', fileID)
+uppy.on('file-removed', (file) => {
+  console.log('Removed file', file)
 })
 ```
 

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -72,11 +72,16 @@ uppy.setFileState(otherFileID, {
 
 ### `getResponseData(xhr)`
 
-When an upload has completed, Uppy will extract response data from the upload endpoint and send it back in the `upload-success` event:
+When an upload has completed, Uppy will extract response data from the upload endpoint. This response data will be available on the file's `.response` property, and be emitted in the `upload-success` event:
 
 ```js
-uppy.on('upload-success', (fileId, resp, uploadURL) => {
-  // do something with resp
+uppy.getFile(fileID).response
+// { status: HTTP status code,
+//   body: extracted response data }
+
+uppy.on('upload-success', (fileID, body) => {
+  // do something with extracted response data
+  // (`body` is equivalent to `uppy.getFile(fileID).response.body`)
 })
 ```
 


### PR DESCRIPTION
Basically, this: #521 

This adds a `response` key to files when the upload completed (regardless of whether it succeeded). `file.response` contains a `status` and a `data` property. `data` is the result of `getResponseData`. One change here is that `getResponseData` is also called if there was an error, not sure if that's a good idea.

Also changing events to emit file objects instead of IDs here because it touches many of the same places.