### PR TITLE
transloadit: Emit 'upload-error' when preprocess fails, fixes #615

### DIFF
--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -596,6 +596,14 @@ module.exports = class Transloadit extends Plugin {
         fileIDs.forEach((fileID) => {
           this.uppy.emit('preprocess-complete', fileID)
         })
+      }).catch((err) => {
+        // Clear preprocessing state when the assembly could not be created,
+        // otherwise the UI gets confused about the lingering progress keys
+        fileIDs.forEach((fileID) => {
+          this.uppy.emit('preprocess-complete', fileID)
+          this.uppy.emit('upload-error', fileID, err)
+        })
+        throw err
       })
     }
 


### PR DESCRIPTION
And also finish the preprocessing step.

We already do this in the postprocessing step if an error occurs later during assembly execution, so I didnt change anything there.

Turned out to be simpler than I thought :)