### PR TITLE
Document Plugin `id` and Dashboard `plugins` options, closes #619

### DIFF
--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -20,8 +20,9 @@ Dashboard is a universal UI plugin for Uppy:
 ```js
 uppy.use(Dashboard, {
   target: 'body',
-  trigger: '#uppy-select-files',
   inline: false,
+  trigger: '#uppy-select-files',
+  plugins: [],
   maxWidth: 750,
   maxHeight: 550,
   semiTransparent: false,
@@ -74,6 +75,19 @@ By default Dashboard will be rendered as a modal, which is opened via clicking o
 ### `trigger: '#uppy-select-files'`
 
 String with a CSS selector for a button that will trigger opening Dashboard modal. Multiple buttons or links can be used, if it’s a class selector (`.uppy-choose`, for example).
+
+### `plugins: []`
+
+List of plugin IDs that should be shown in the Dashboard's top bar. For example, to show the Webcam plugin:
+
+```js
+uppy.use(Webcam)
+uppy.use(Dashboard, {
+  plugins: ['Webcam']
+})
+```
+
+Of course, you can also use the `target` option in the Webcam plugin to achieve this. However, that does not work with the React components. The `target` option may be changed in the future to only accept DOM elements, so it is recommended to use this `plugins` array instead.
 
 ### `maxWidth: 750`
 

--- a/website/src/docs/plugins.md
+++ b/website/src/docs/plugins.md
@@ -31,6 +31,10 @@ Plugins are what makes Uppy useful: they help select, manipulate and upload file
 
 Each plugin can have any number of options (please see specific plugin for details), but these are shared between some:
 
+### `id`
+
+A unique string identifying the plugin. By default, the plugin's name is used, so usually it does not need to be configured manually. Use this if you need to add multiple plugins of the same type.
+
 ### `target`
 
 Can be a `string` CSS selector, a DOM element, or a Plugin class. Consider the following example, where `DragDrop` plugin will be rendered into a `body` element:


### PR DESCRIPTION
I think we discussed once that `plugins` might be a better approach in general than `target: Plugin`; maybe we should update our examples etc to use the `plugins` option too? For now I'm just adding it to the dashboard options list.