### PR TITLE
Fix progress events causing errors for removed files

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -557,7 +557,7 @@ class Uppy {
 
     // skip progress event for a file that’s been removed
     if (!this.getFile(fileID)) {
-      this.log('Trying to set progress for a file that’s been removed: ', fileID)
+      this.log(`Not setting progress for a file that has been removed: ${fileID}`)
       return
     }
 
@@ -639,6 +639,10 @@ class Uppy {
     })
 
     this.on('upload-started', (fileID, upload) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       const file = this.getFile(fileID)
       this.setFileState(fileID, {
         progress: Object.assign({}, file.progress, {
@@ -660,6 +664,10 @@ class Uppy {
     this.on('upload-progress', _throttledCalculateProgress)
 
     this.on('upload-success', (fileID, uploadResp, uploadURL) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       this.setFileState(fileID, {
         progress: Object.assign({}, this.getState().files[fileID].progress, {
           uploadComplete: true,
@@ -673,6 +681,10 @@ class Uppy {
     })
 
     this.on('preprocess-progress', (fileID, progress) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       this.setFileState(fileID, {
         progress: Object.assign({}, this.getState().files[fileID].progress, {
           preprocess: progress
@@ -681,6 +693,10 @@ class Uppy {
     })
 
     this.on('preprocess-complete', (fileID) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       const files = Object.assign({}, this.getState().files)
       files[fileID] = Object.assign({}, files[fileID], {
         progress: Object.assign({}, files[fileID].progress)
@@ -691,6 +707,10 @@ class Uppy {
     })
 
     this.on('postprocess-progress', (fileID, progress) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       this.setFileState(fileID, {
         progress: Object.assign({}, this.getState().files[fileID].progress, {
           postprocess: progress
@@ -699,6 +719,10 @@ class Uppy {
     })
 
     this.on('postprocess-complete', (fileID) => {
+      if (!this.getFile(fileID)) {
+        this.log(`Not setting progress for a file that has been removed: ${fileID}`)
+        return
+      }
       const files = Object.assign({}, this.getState().files)
       files[fileID] = Object.assign({}, files[fileID], {
         progress: Object.assign({}, files[fileID].progress)
@@ -988,6 +1012,10 @@ class Uppy {
    * @param {object} data Data properties to add to the result object.
    */
   addResultData (uploadID, data) {
+    if (!this._getUpload(uploadID)) {
+      this.log(`Not setting result for an upload that has been removed: ${uploadID}`)
+      return
+    }
     const currentUploads = this.getState().currentUploads
     const currentUpload = Object.assign({}, currentUploads[uploadID], {
       result: Object.assign({}, currentUploads[uploadID].result, data)
@@ -1068,6 +1096,11 @@ class Uppy {
       this.addResultData(uploadID, { successful, failed, uploadID })
 
       const { currentUploads } = this.getState()
+      if (!currentUploads[uploadID]) {
+        this.log(`Not setting result for an upload that has been removed: ${uploadID}`)
+        return
+      }
+
       const result = currentUploads[uploadID].result
       this.emit('complete', result)
       // Compatibility with pre-0.21


### PR DESCRIPTION
When a file is removed in Uppy, progress events like `preprocess-complete`, `upload-progress`, `postprocess-progress` and the like are still emitted sometimes. This causes errors reported in #596 and by Alex in Slack:

![](https://user-images.githubusercontent.com/30501355/35836829-4f10a9b6-0a97-11e8-8cfe-02d23c120cb0.gif)

![kapture 2018-02-17 at 16 49 54](https://user-images.githubusercontent.com/1199054/36345940-b0156444-1402-11e8-9305-6a00f581a8b3.gif)

This PR fixes these issues by checking if the file exists in state before trying to set progress to it. Checks are added in Core and in Transloadit plugin in `onFileUploadComplete`. 

Questions:

- Should we instead prevent progress events from being emitted in the first place in uploader  and encoder plugins?
- Do we need to remove files from Transloadit plugin’s internal file state? I’ve added a method, but it seemed to me it doesn’t solve the issue.
- When you upload 4 files with Transloadit plugin and remove 1 during upload, `finish` event never fires, because Transloadit probably expects that one file to be uploaded and processed. So Uppy is stuck showing “encoding” forever.


