### PR TITLE
restore: Catch rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ To be released: 2018-03-01.
 - [ ] goldenretriever: add “ghost” files (@arturi)
 - [ ] core: i18n all strings + document them
 - [ ] core: update file-type
-- [ ] goldenretriever: warn, not error, when files cannot be saved by goldenretriever (@goto-bus-stop)
+- [x] goldenretriever: warn, not error, when files cannot be saved by goldenretriever (#641 / @goto-bus-stop)
 - [ ] docs: quick start guide: https://community.transloadit.com/t/quick-start-guide-would-be-really-helpful/14605 (@arturi)
 - [ ] docs: on writing plugins (@goto-bus-stop)
 - [ ] docs: all useful events (@arturi)

--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -126,11 +126,13 @@ module.exports = class GoldenRetriever extends Plugin {
       if (numberOfFilesRecovered === numberOfFilesTryingToRecover) {
         this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from Service Worker!`)
         this.uppy.info(`Successfully recovered ${numberOfFilesRecovered} files`, 'success', 3000)
-        this.onBlobsLoaded(blobs)
-      } else {
-        this.uppy.log('[GoldenRetriever] Failed to recover blobs from Service Worker, trying IndexedDB now...')
-        this.loadFileBlobsFromIndexedDB()
+        return this.onBlobsLoaded(blobs)
       }
+      this.uppy.log('[GoldenRetriever] No blobs found in Service Worker, trying IndexedDB now...')
+      return this.loadFileBlobsFromIndexedDB()
+    }).catch((err) => {
+      this.uppy.log('[GoldenRetriever] Failed to recover blobs from Service Worker', 'warning')
+      this.uppy.log(err)
     })
   }
 
@@ -139,11 +141,14 @@ module.exports = class GoldenRetriever extends Plugin {
       const numberOfFilesRecovered = Object.keys(blobs).length
 
       if (numberOfFilesRecovered > 0) {
-        this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from Indexed DB!`)
+        this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from IndexedDB!`)
         this.uppy.info(`Successfully recovered ${numberOfFilesRecovered} files`, 'success', 3000)
         return this.onBlobsLoaded(blobs)
       }
-      this.uppy.log('[GoldenRetriever] Couldn’t recover anything from IndexedDB :(')
+      this.uppy.log('[GoldenRetriever] No blobs found in IndexedDB')
+    }).catch((err) => {
+      this.uppy.log('[GoldenRetriever] Failed to recover blobs from IndexedDB', 'warning')
+      this.uppy.log(err)
     })
   }
 
@@ -178,6 +183,9 @@ module.exports = class GoldenRetriever extends Plugin {
     if (obsoleteBlobs.length) {
       this.deleteBlobs(obsoleteBlobs).then(() => {
         this.uppy.log(`[GoldenRetriever] Cleaned up ${obsoleteBlobs.length} old files`)
+      }).catch((err) => {
+        this.uppy.log(`[GoldenRetriever] Could not clean up ${obsoleteBlobs.length} old files`, 'warning')
+        this.uppy.log(err)
       })
     }
   }
@@ -216,26 +224,37 @@ module.exports = class GoldenRetriever extends Plugin {
 
       if (this.ServiceWorkerStore) {
         this.ServiceWorkerStore.put(file).catch((err) => {
-          this.uppy.log('[GoldenRetriever] Could not store file', 'error')
+          this.uppy.log('[GoldenRetriever] Could not store file', 'warning')
           this.uppy.log(err)
         })
       }
 
       this.IndexedDBStore.put(file).catch((err) => {
-        this.uppy.log('[GoldenRetriever] Could not store file', 'error')
+        this.uppy.log('[GoldenRetriever] Could not store file', 'warning')
         this.uppy.log(err)
       })
     })
 
     this.uppy.on('file-removed', (fileID) => {
-      if (this.ServiceWorkerStore) this.ServiceWorkerStore.delete(fileID)
-      this.IndexedDBStore.delete(fileID)
+      if (this.ServiceWorkerStore) {
+        this.ServiceWorkerStore.delete(fileID).catch((err) => {
+          this.uppy.log('[GoldenRetriever] Failed to remove file', 'warning')
+          this.uppy.log(err)
+        })
+      }
+      this.IndexedDBStore.delete(fileID).catch((err) => {
+        this.uppy.log('[GoldenRetriever] Failed to remove file', 'warning')
+        this.uppy.log(err)
+      })
     })
 
     this.uppy.on('complete', ({ successful }) => {
       const fileIDs = successful.map((file) => file.id)
       this.deleteBlobs(fileIDs).then(() => {
         this.uppy.log(`[GoldenRetriever] Removed ${successful.length} files that finished uploading`)
+      }).catch((err) => {
+        this.uppy.log(`[GoldenRetriever] Could not remove ${successful.length} files that finished uploading`, 'warning')
+        this.uppy.log(err)
       })
     })
 


### PR DESCRIPTION
When the ServiceWorker or IndexedDB store reject Promises, log a
warning. Suppresses unhandled rejection errors in the console
that users cannot catch themselves.