### PR TITLE
Fix XHRUpload.js error handling

### DIFF
--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -235,7 +235,7 @@ module.exports = class XHRUpload extends Plugin {
 
           return resolve(file)
         } else {
-          const body = opts.getResponseData(xhr)
+          const body = opts.getResponseData(xhr.responseText, xhr)
           const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
 
           const response = {


### PR DESCRIPTION
There's an error introduced by https://github.com/transloadit/uppy/pull/612 here https://github.com/transloadit/uppy/pull/612/files#diff-ca5a310a56869b8b55189737dc65736cR238

It should be called with the response text and the xhr object.

This fixes #645