### PR TITLE
Clear uploads on `cancelAll`, fixes #660

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -530,7 +530,19 @@ class Uppy {
 
   cancelAll () {
     this.emit('cancel-all')
-    this.setState({ files: {}, totalProgress: 0 })
+
+    // TODO Or should we just call removeFile on all files?
+    const { currentUploads } = this.getState()
+    const uploadIDs = Object.keys(currentUploads)
+
+    uploadIDs.forEach((id) => {
+      this._removeUpload(id)
+    })
+
+    this.setState({
+      files: {},
+      totalProgress: 0
+    })
   }
 
   retryUpload (fileID) {

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -244,6 +244,17 @@ describe('src/Core', () => {
     })
   })
 
+  it('should clear all uploads on cancelAll()', () => {
+    const core = new Core()
+    const id = core._createUpload([ 'a', 'b' ])
+
+    expect(core.state.currentUploads[id]).toBeDefined()
+
+    core.cancelAll()
+
+    expect(core.state.currentUploads[id]).toBeUndefined()
+  })
+
   it('should close, reset and uninstall when the close method is called', () => {
     const core = new Core()
     core.use(AcquirerPlugin1)


### PR DESCRIPTION
When doing `cancelAll` (or `reset`), all files are removed but the currentUploads key is not cleared. When you select a file that you had previously also selected, the fileID is the same because file IDs are deterministic. So the file ID was still part of one of the currentUploads, causing it to not be uploaded again (since #552).

This patch also removes all uploads in `cancelAll`.