### PR TITLE
 s3: Check upload parameters shape, fixes #653

### DIFF
--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -64,8 +64,12 @@ module.exports = class AwsS3 extends Plugin {
       (params.method == null || /^(put|post)$/i.test(params.method))
 
     if (!valid) {
-      throw new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields }'.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+      const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields }'.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+      console.error(err)
+      throw err
     }
+
+    return params
   }
 
   prepareUpload (fileIDs) {
@@ -86,7 +90,8 @@ module.exports = class AwsS3 extends Plugin {
         const paramsPromise = Promise.resolve()
           .then(() => getUploadParameters(file))
         return paramsPromise.then((params) => {
-          this.validateParameters(file, params)
+          return this.validateParameters(file, params)
+        }).then((params) => {
           this.uppy.emit('preprocess-progress', file, {
             mode: 'determinate',
             message: this.i18n('preparingUpload'),

--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -57,6 +57,17 @@ module.exports = class AwsS3 extends Plugin {
     }).then((response) => response.json())
   }
 
+  validateParameters (file, params) {
+    const valid = typeof params === 'object' && params &&
+      typeof params.url === 'string' &&
+      (typeof params.fields === 'object' || params.fields == null) &&
+      (params.method == null || /^(put|post)$/i.test(params.method))
+
+    if (!valid) {
+      throw new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields }'.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+    }
+  }
+
   prepareUpload (fileIDs) {
     fileIDs.forEach((id) => {
       const file = this.uppy.getFile(id)
@@ -75,6 +86,7 @@ module.exports = class AwsS3 extends Plugin {
         const paramsPromise = Promise.resolve()
           .then(() => getUploadParameters(file))
         return paramsPromise.then((params) => {
+          this.validateParameters(file, params)
           this.uppy.emit('preprocess-progress', file, {
             mode: 'determinate',
             message: this.i18n('preparingUpload'),


### PR DESCRIPTION
Similar to the Transloadit plugin, check that parameters are formatted correctly.

This patch explicitly logs the error so it shows up in the console and not just the Informer…feels like we need a way to distinguish between "user errors" like files that fail to meet restrictions and real errors like this or like a failed upload. The former shouldn't be logged to the console but the latter two should.