### PR TITLE
Fix merging locale strings in Core.

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -63,8 +63,6 @@ class Uppy {
     // Container for different types of plugins
     this.plugins = {}
 
-    this.translator = new Translator({locale: this.opts.locale})
-    this.i18n = this.translator.translate.bind(this.translator)
     this.getState = this.getState.bind(this)
     this.getPlugin = this.getPlugin.bind(this)
     this.setFileMeta = this.setFileMeta.bind(this)

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -1187,4 +1187,19 @@ describe('src/Core', () => {
       })
     })
   })
+
+  describe('i18n', () => {
+    it('merges in custom locale strings', () => {
+      const core = new Core({
+        locale: {
+          strings: {
+            test: 'beep boop'
+          }
+        }
+      })
+
+      expect(core.i18n('exceedsSize')).toBe('This file exceeds maximum allowed size of')
+      expect(core.i18n('test')).toBe('beep boop')
+    })
+  })
 })


### PR DESCRIPTION
When specifying custom locale strings, the default strings were no
longer used. That's because we were creating the Translator instance
twice; first with custom locale strings merged into `defaultLocale`,
but then again later with just `this.opts.locale` (no defaults).

This came up in #654, where incomplete custom locale strings were
used, causing some strings to return `undefined`.

This patch removes the latter instantiation so we only keep the one with
the defaults.