### PR TITLE
Added merge of restrictions 

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -52,6 +52,7 @@ class Uppy {
 
     // Merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
+    this.opts.restrictions = Object.assign({}, defaultOptions.restrictions, this.opts.restrictions)
 
     this.locale = Object.assign({}, defaultLocale, this.opts.locale)
     this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -1213,4 +1213,17 @@ describe('src/Core', () => {
       expect(core.i18n('test')).toBe('beep boop')
     })
   })
+
+  describe('default restrictions', () => {
+    it.only('should be merged with supplied restrictions', () => {
+      const core = new Core({
+        restrictions: {
+          maxNumberOfFiles: 3
+        }
+      })
+
+      expect(core.opts.restrictions.maxNumberOfFiles).toBe(3)
+      expect(core.opts.restrictions.minNumberOfFiles).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
Supplied restrictions are now merged with default restrictions. (as described in #675)

I also added a small unit test that covers this change, but I was unsure where to put this.
I can (re)move it if needed.