### PR TITLE
Check url in URL plugin

### DIFF
--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -29,7 +29,8 @@ module.exports = class Url extends Plugin {
         addUrl: 'Add url',
         import: 'Import',
         enterUrlToImport: 'Enter file url to import',
-        failedToFetch: 'Uppy Server failed to fetch this URL'
+        failedToFetch: 'Uppy Server failed to fetch this URL, please make sure it’s correct',
+        enterCorrectUrl: 'Please enter correct URL to add file'
       }
     }
 
@@ -83,6 +84,12 @@ module.exports = class Url extends Plugin {
   }
 
   addFile (url) {
+    if (!url) {
+      this.uppy.log('[URL] Incorrect URL entered')
+      this.uppy.info(this.i18n('enterCorrectUrl'), 'error', 4000)
+      return
+    }
+
     return this.getMeta(url).then((meta) => {
       const tagFile = {
         source: this.id,


### PR DESCRIPTION
Added check for empty URL with an error message.

Should we try to check the url for typos like `htps://`? I googled a bunch of url-regexes, but reading into this, it seems like introducing them might miss some actually valid urls, like `http://✪df.ws/123`, see https://mathiasbynens.be/demo/url-regex. @ifedapoolarewaju what do you think?