### PR TITLE
Fix `get-form-data` being undefined when built with Rollup

### DIFF
--- a/src/plugins/Form.js
+++ b/src/plugins/Form.js
@@ -1,6 +1,8 @@
 const Plugin = require('../core/Plugin')
 const { findDOMElement } = require('../core/Utils')
-const getFormData = require('get-form-data').default
+// Rollup uses get-form-data's ES modules build, and rollup-plugin-commonjs automatically resolves `.default`.
+// So, if we are being built using rollup, this require() won't have a `.default` property.
+const getFormData = require('get-form-data').default || require('get-form-data')
 
 /**
  * Form


### PR DESCRIPTION
Fixes https://github.com/transloadit/uppy/issues/684

Rollup uses get-form-data's ES modules build, and rollup-plugin-commonjs automatically resolves `.default`.
So, if we are being built using rollup, this `require()` won't have a `.default` property.