### PR TITLE
 s3: Support fake XHR from remote uploads 

### DIFF
--- a/examples/aws-uppy-server/main.js
+++ b/examples/aws-uppy-server/main.js
@@ -1,4 +1,6 @@
 const Uppy = require('uppy/lib/core')
+const GoogleDrive = require('uppy/lib/plugins/GoogleDrive')
+const Webcam = require('uppy/lib/plugins/Webcam')
 const Dashboard = require('uppy/lib/plugins/Dashboard')
 const AwsS3 = require('uppy/lib/plugins/AwsS3')
 
@@ -7,9 +9,14 @@ const uppy = Uppy({
   autoProceed: false
 })
 
+uppy.use(GoogleDrive, {
+  host: 'http://localhost:3020'
+})
+uppy.use(Webcam)
 uppy.use(Dashboard, {
   inline: true,
-  target: 'body'
+  target: 'body',
+  plugins: ['GoogleDrive', 'Webcam']
 })
 uppy.use(AwsS3, {
   host: 'http://localhost:3020'

--- a/examples/aws-uppy-server/package-lock.json
+++ b/examples/aws-uppy-server/package-lock.json
@@ -739,6 +739,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -762,6 +771,11 @@
         "object-assign": "4.1.1",
         "vary": "1.1.2"
       }
+    },
+    "crc": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -1109,6 +1123,22 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
+      }
+    },
+    "express-session": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
+      "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "crc": "3.4.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "uid-safe": "2.1.5",
+        "utils-merge": "1.0.1"
       }
     },
     "extglob": {
@@ -1605,7 +1635,8 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -3243,6 +3274,11 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -3446,6 +3482,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "2.0.1",
@@ -3869,6 +3913,14 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "1.0.0"
+      }
     },
     "ultron": {
       "version": "1.0.2",

--- a/examples/aws-uppy-server/package.json
+++ b/examples/aws-uppy-server/package.json
@@ -13,8 +13,11 @@
     "babelify": "^7.3.0",
     "body-parser": "^1.18.2",
     "budo": "^10.0.4",
+    "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "express": "^4.16.2",
-    "npm-run-all": "^4.1.2"
+    "express-session": "^1.15.6",
+    "npm-run-all": "^4.1.2",
+    "rimraf": "^2.6.2"
   }
 }

--- a/examples/aws-uppy-server/server.js
+++ b/examples/aws-uppy-server/server.js
@@ -1,11 +1,27 @@
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
 const uppy = require('uppy-server')
 const app = require('express')()
 
-app.use(require('cors')())
+const DATA_DIR = path.join(__dirname, 'tmp')
+
+app.use(require('cors')({
+  origin: true,
+  credentials: true
+}))
+app.use(require('cookie-parser')())
 app.use(require('body-parser').json())
+app.use(require('express-session')({
+  secret: 'hello planet'
+}))
 
 const options = {
   providerOptions: {
+    google: {
+      key: process.env.UPPYSERVER_GOOGLE_KEY,
+      secret: process.env.UPPYSERVER_GOOGLE_SECRET
+    },
     s3: {
       getKey: (req, filename) =>
         `whatever/${Math.random().toString(32).slice(2)}/${filename}`,
@@ -15,8 +31,21 @@ const options = {
       region: process.env.UPPYSERVER_AWS_REGION
     }
   },
-  server: { host: 'localhost:3020' }
+  server: { host: 'localhost:3020' },
+  filePath: DATA_DIR,
+  secret: 'blah blah',
+  debug: true
 }
+
+// Create the data directory here for the sake of the example.
+try {
+  fs.accessSync(DATA_DIR)
+} catch (err) {
+  fs.mkdirSync(DATA_DIR)
+}
+process.on('exit', function () {
+  rimraf.sync(DATA_DIR)
+})
 
 app.use(uppy.app(options))
 

--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -4,7 +4,7 @@ const { limitPromises } = require('../../core/Utils')
 const XHRUpload = require('../XHRUpload')
 
 function isXml (xhr) {
-  const contentType = xhr.getResponseHeader('Content-Type')
+  const contentType = xhr.headers ? xhr.headers['content-type'] : xhr.getResponseHeader('Content-Type')
   return typeof contentType === 'string' && contentType.toLowerCase() === 'application/xml'
 }
 
@@ -160,10 +160,25 @@ module.exports = class AwsS3 extends Plugin {
         if (!isXml(xhr)) {
           return { location: xhr.responseURL }
         }
-        function getValue (key) {
-          const el = xhr.responseXML.querySelector(key)
-          return el ? el.textContent : ''
+
+        let getValue = () => ''
+        if (xhr.responseXML) {
+          getValue = (key) => {
+            const el = xhr.responseXML.querySelector(key)
+            return el ? el.textContent : ''
+          }
         }
+
+        if (xhr.responseText) {
+          getValue = (key) => {
+            const start = xhr.responseText.indexOf(`<${key}>`)
+            const end = xhr.responseText.indexOf(`</${key}>`)
+            return start !== -1 && end !== -1
+              ? xhr.responseText.slice(start + key.length + 2, end)
+              : ''
+          }
+        }
+
         return {
           location: getValue('Location'),
           bucket: getValue('Bucket'),


### PR DESCRIPTION
Added Google Drive to the AWS uppy-server example, which is what I used to test this.

Remote uploads via uppy-server do not have a `getResponseHeader`
function or a `responseXML` property. Instead, use the `headers` object,
and parse the XML manually.

Fixes transloadit/uppy-server#71