### PR TITLE
Regenerate thumbnails after restore.

### DIFF
--- a/src/plugins/GoldenRetriever/index.js
+++ b/src/plugins/GoldenRetriever/index.js
@@ -170,8 +170,6 @@ module.exports = class GoldenRetriever extends Plugin {
       }
       const updatedFile = Object.assign({}, originalFile, updatedFileData)
       updatedFiles[fileID] = updatedFile
-
-      this.uppy.generatePreview(updatedFile)
     })
 
     this.uppy.setState({


### PR DESCRIPTION
The `generatePreview()` method that GoldenRetriever used to create new
thumbnails after restoring files no longer exists. This patch makes the
ThumbnailGenerator go through all files after a restore, and tries to
generate a thumbnail for all blob URLs (http:// URLs from remote sources
don't need to be regenerated).