### PR TITLE
S3 Multipart upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ PRs are welcome! Please do open an issue to discuss first if it's a big feature,
 - [ ] maybe restrict system file picking dialog too https://github.com/transloadit/uppy/issues/253
 - [ ] uppy-server: what happens if access token expires amid an upload/download process.
 - [ ] good way to change plugin options at runtime—maybe `this.state.options`?
-- [ ] s3: multipart/"resumable" uploads for large files (@goto-bus-stop)
+- [x] s3: multipart/"resumable" uploads for large files (@goto-bus-stop)
 - [ ] DnD Bar: drag and drop + statusbar or progressbar ? (@arturi)
 - [ ] possibility to work on already uploaded / in progress files #112, #113
 - [ ] possibility to edit/delete more than one file at once #118, #97
@@ -129,6 +129,7 @@ To Be Released: 2018-05-31.
 - [ ] docs: improve on React docs https://uppy.io/docs/react/, add small example for each component maybe? Dashboard, DragDrop, ProgressBar? No need to make separate pages for all of them, just headings on the same page. Right now docs are confusing, because they focus on DashboardModal. Also problems with syntax highlight on https://uppy.io/docs/react/dashboard-modal/ (@goto-bus-stop)
 - [ ] core: customizing metadata fields, boolean metadata; see #809, #454 and related (@arturi)
 - [ ] providers: Add user/account names to Uppy provider views (@ifedapoolarewaju)
+- [x] s3: implement multipart uploads (#726, @goto-bus-stop)
 
 ## 0.24.4
 

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -1,5 +1,10 @@
 const Plugin = require('../../core/Plugin')
-const { limitPromises } = require('../../core/Utils')
+const UppySocket = require('../../core/UppySocket')
+const {
+  emitSocketProgress,
+  getSocketHost,
+  limitPromises
+} = require('../../core/Utils')
 const Uploader = require('./MultipartUploader')
 
 function handleResponse (response) {
@@ -7,6 +12,25 @@ function handleResponse (response) {
   return response.json().then((err) => {
     throw err
   })
+}
+
+/**
+ * Create a wrapper around an event emitter with a `remove` method to remove
+ * all events that were added using the wrapped emitter.
+ */
+function createEventTracker (emitter) {
+  const events = []
+  return {
+    on (event, fn) {
+      events.push([ event, fn ])
+      return emitter.on(event, fn)
+    },
+    remove () {
+      events.forEach(([ event, fn ]) => {
+        emitter.off(event, fn)
+      })
+    }
+  }
 }
 
 module.exports = class AwsS3Multipart extends Plugin {
@@ -34,6 +58,29 @@ module.exports = class AwsS3Multipart extends Plugin {
       this.limitRequests = limitPromises(this.opts.limit)
     } else {
       this.limitRequests = (fn) => fn
+    }
+
+    this.uploaders = Object.create(null)
+    this.uploaderEvents = Object.create(null)
+    this.uploaderSockets = Object.create(null)
+  }
+
+  /**
+   * Clean up all references for a file's upload: the MultipartUploader instance,
+   * any events related to the file, and the uppy-server WebSocket connection.
+   */
+  resetUploaderReferences (fileID) {
+    if (this.uploaders[fileID]) {
+      this.uploaders[fileID].abort()
+      this.uploaders[fileID] = null
+    }
+    if (this.uploaderEvents[fileID]) {
+      this.uploaderEvents[fileID].remove()
+      this.uploaderEvents[fileID] = null
+    }
+    if (this.uploaderSockets[fileID]) {
+      this.uploaderSockets[fileID].close()
+      this.uploaderSockets[fileID] = null
     }
   }
 
@@ -132,6 +179,8 @@ module.exports = class AwsS3Multipart extends Plugin {
           this.uppy.log(err)
           this.uppy.emit('upload-error', file, err)
           err.message = `Failed because: ${err.message}`
+
+          this.resetUploaderReferences(file.id)
           reject(err)
         },
         onSuccess: (result) => {
@@ -141,6 +190,7 @@ module.exports = class AwsS3Multipart extends Plugin {
             this.uppy.log('Download ' + upload.file.name + ' from ' + result.location)
           }
 
+          this.resetUploaderReferences(file.id)
           resolve(upload)
         },
         onPartComplete: (part) => {
@@ -159,14 +209,15 @@ module.exports = class AwsS3Multipart extends Plugin {
         }
       }, file.s3Multipart))
 
-      this.uppy.on('file-removed', (removed) => {
-        if (file.id !== removed.id) return
-        upload.abort({ really: true })
+      this.uploaders[file.id] = upload
+      this.uploaderEvents[file.id] = createEventTracker(this.uppy)
+
+      this.onFileRemove(file.id, (removed) => {
+        this.resetUploaderReferences(file.id)
         resolve(`upload ${removed.id} was removed`)
       })
 
-      this.uppy.on('upload-pause', (pausee, isPaused) => {
-        if (pausee.id !== file.id) return
+      this.onFilePause(file.id, (isPaused) => {
         if (isPaused) {
           upload.pause()
         } else {
@@ -174,15 +225,15 @@ module.exports = class AwsS3Multipart extends Plugin {
         }
       })
 
-      this.uppy.on('pause-all', () => {
+      this.onPauseAll(file.id, () => {
         upload.pause()
       })
 
-      this.uppy.on('cancel-all', () => {
+      this.onCancelAll(file.id, () => {
         upload.abort({ really: true })
       })
 
-      this.uppy.on('resume-all', () => {
+      this.onResumeAll(file.id, () => {
         upload.start()
       })
 
@@ -196,13 +247,116 @@ module.exports = class AwsS3Multipart extends Plugin {
     })
   }
 
+  uploadRemote (file) {
+    this.resetUploaderReferences(file.id)
+
+    return new Promise((resolve, reject) => {
+      if (file.serverToken) {
+        return this.connectToServerSocket(file)
+          .then(() => resolve())
+          .catch(reject)
+      }
+
+      this.uppy.emit('upload-started', file)
+
+      fetch(file.remote.url, {
+        method: 'post',
+        credentials: 'include',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(Object.assign({}, file.remote.body, {
+          protocol: 's3-multipart',
+          size: file.data.size,
+          metadata: file.meta
+        }))
+      })
+      .then((res) => {
+        if (res.status < 200 || res.status > 300) {
+          return reject(res.statusText)
+        }
+
+        return res.json().then((data) => {
+          this.uppy.setFileState(file.id, { serverToken: data.token })
+          return this.uppy.getFile(file.id)
+        })
+      })
+      .then((file) => {
+        return this.connectToServerSocket(file)
+      })
+      .then(() => {
+        resolve()
+      })
+      .catch((err) => {
+        reject(new Error(err))
+      })
+    })
+  }
+
+  connectToServerSocket (file) {
+    return new Promise((resolve, reject) => {
+      const token = file.serverToken
+      const host = getSocketHost(file.remote.host)
+      const socket = new UppySocket({ target: `${host}/api/${token}` })
+      this.uploaderSockets[socket] = socket
+      this.uploaderEvents[file.id] = createEventTracker(this.uppy)
+
+      this.onFileRemove(file.id, (removed) => {
+        socket.send('pause', {})
+        resolve(`upload ${file.id} was removed`)
+      })
+
+      this.onFilePause(file.id, (isPaused) => {
+        socket.send(isPaused ? 'pause' : 'resume', {})
+      })
+
+      this.onPauseAll(file.id, () => socket.send('pause', {}))
+
+      this.onCancelAll(file.id, () => socket.send('pause', {}))
+
+      this.onResumeAll(file.id, () => {
+        if (file.error) {
+          socket.send('pause', {})
+        }
+        socket.send('resume', {})
+      })
+
+      this.onRetry(file.id, () => {
+        socket.send('pause', {})
+        socket.send('resume', {})
+      })
+
+      this.onRetryAll(file.id, () => {
+        socket.send('pause', {})
+        socket.send('resume', {})
+      })
+
+      if (file.isPaused) {
+        socket.send('pause', {})
+      }
+
+      socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
+
+      socket.on('error', (errData) => {
+        this.uppy.emit('upload-error', file, new Error(errData.error))
+        reject(new Error(errData.error))
+      })
+
+      socket.on('success', (data) => {
+        this.uppy.emit('upload-success', file, data, data.url)
+        resolve()
+      })
+    })
+  }
+
   upload (fileIDs) {
     if (fileIDs.length === 0) return Promise.resolve()
 
     const promises = fileIDs.map((id) => {
       const file = this.uppy.getFile(id)
       if (file.isRemote) {
-        return Promise.reject(new Error('AwsS3/Multipart: Remote file uploads are not currently supported.'))
+        return this.uploadRemote(file)
       }
       return this.uploadFile(file)
     })
@@ -215,6 +369,57 @@ module.exports = class AwsS3Multipart extends Plugin {
       capabilities: Object.assign({}, this.uppy.getState().capabilities, {
         resumableUploads: true
       })
+    })
+  }
+
+  onFileRemove (fileID, cb) {
+    this.uploaderEvents[fileID].on('file-removed', (file) => {
+      if (fileID === file.id) cb(file.id)
+    })
+  }
+
+  onFilePause (fileID, cb) {
+    this.uploaderEvents[fileID].on('upload-pause', (targetFileID, isPaused) => {
+      if (fileID === targetFileID) {
+        // const isPaused = this.uppy.pauseResume(fileID)
+        cb(isPaused)
+      }
+    })
+  }
+
+  onRetry (fileID, cb) {
+    this.uploaderEvents[fileID].on('upload-retry', (targetFileID) => {
+      if (fileID === targetFileID) {
+        cb()
+      }
+    })
+  }
+
+  onRetryAll (fileID, cb) {
+    this.uploaderEvents[fileID].on('retry-all', (filesToRetry) => {
+      if (!this.uppy.getFile(fileID)) return
+      cb()
+    })
+  }
+
+  onPauseAll (fileID, cb) {
+    this.uploaderEvents[fileID].on('pause-all', () => {
+      if (!this.uppy.getFile(fileID)) return
+      cb()
+    })
+  }
+
+  onCancelAll (fileID, cb) {
+    this.uploaderEvents[fileID].on('cancel-all', () => {
+      if (!this.uppy.getFile(fileID)) return
+      cb()
+    })
+  }
+
+  onResumeAll (fileID, cb) {
+    this.uploaderEvents[fileID].on('resume-all', () => {
+      if (!this.uppy.getFile(fileID)) return
+      cb()
     })
   }
 

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -220,7 +220,7 @@ module.exports = class AwsS3Multipart extends Plugin {
 
       this.uppy.on('file-removed', (removed) => {
         if (file.id !== removed.id) return
-        upload.abort()
+        upload.abort({ really: true })
         resolve(`upload ${removed.id} was removed`)
       })
 
@@ -238,7 +238,7 @@ module.exports = class AwsS3Multipart extends Plugin {
       })
 
       this.uppy.on('cancel-all', () => {
-        upload.abort()
+        upload.abort({ really: true })
       })
 
       this.uppy.on('resume-all', () => {

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -1,0 +1,277 @@
+const Plugin = require('../../core/Plugin')
+const Translator = require('../../core/Translator')
+const { limitPromises } = require('../../core/Utils')
+
+const MB = 1024 * 1024
+
+module.exports = class AwsS3Multipart extends Plugin {
+  constructor (uppy, opts) {
+    super(uppy, opts)
+    this.type = 'uploader'
+    this.id = 'AwsS3'
+    this.title = 'AWS S3'
+
+    const defaultLocale = {
+      strings: {
+        preparingUpload: 'Preparing upload...'
+      }
+    }
+
+    const defaultOptions = {
+      timeout: 30 * 1000,
+      limit: 0,
+      createMultipartUpload: this.createMultipartUpload.bind(this),
+      prepareUploadPart: this.prepareUploadPart.bind(this),
+      abortMultipartUpload: this.abortMultipartUpload.bind(this),
+      completeMultipartUpload: this.completeMultipartUpload.bind(this),
+      locale: defaultLocale
+    }
+
+    this.opts = Object.assign({}, defaultOptions, opts)
+    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
+    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
+
+    this.translator = new Translator({ locale: this.locale })
+    this.i18n = this.translator.translate.bind(this.translator)
+
+    this.prepareUpload = this.prepareUpload.bind(this)
+    this.upload = this.upload.bind(this)
+
+    if (typeof this.opts.limit === 'number' && this.opts.limit !== 0) {
+      this.limitRequests = limitPromises(this.opts.limit)
+    } else {
+      this.limitRequests = (fn) => fn
+    }
+  }
+
+  splitFile (file) {
+    const chunks = []
+    const chunkSize = Math.max(Math.ceil(file.size / 10000), 5 * MB)
+
+    for (let i = 0; i < file.size; i += chunkSize) {
+      const end = Math.min(file.size, i + chunkSize)
+      chunks.push(file.slice(i, end))
+    }
+
+    return chunks
+  }
+
+  assertHost () {
+    if (!this.opts.host) {
+      throw new Error('Expected a `host` option containing an uppy-server address.')
+    }
+  }
+
+  createMultipartUpload (file) {
+    this.assertHost()
+
+    const filename = encodeURIComponent(file.name)
+    const type = encodeURIComponent(file.type)
+    return fetch(`${this.opts.host}/s3/multipart?filename=${filename}&type=${type}`, {
+      method: 'post',
+      headers: { accept: 'application/json' }
+    }).then((response) => response.json())
+  }
+
+  prepareUploadPart (file, { key, uploadId, number }) {
+    this.assertHost()
+
+    const filename = encodeURIComponent(key)
+    return fetch(`${this.opts.host}/s3/multipart/${uploadId}/${number}?key=${filename}`, {
+      method: 'get',
+      headers: { accept: 'application/json' }
+    }).then((response) => response.json())
+  }
+
+  uploadPart (url, body, onProgress) {
+    this.uppy.log(`Uploading a chunk of ${body.size} bytes to ${url}`)
+    return new Promise((resolve, reject) => {
+      var xhr = new XMLHttpRequest()
+      xhr.open('PUT', url, true)
+
+      xhr.upload.addEventListener('progress', (ev) => {
+        if (!ev.lengthComputable) return
+
+        onProgress(ev.loaded, ev.total)
+      })
+
+      xhr.addEventListener('load', (ev) => {
+        if (ev.target.status < 200 || ev.target.status >= 300) {
+          reject(new Error('Non 2xx'))
+          return
+        }
+
+        onProgress(body.size)
+
+        // NOTE This must be allowed by CORS.
+        const etag = ev.target.getResponseHeader('ETag')
+        resolve({ etag })
+      })
+
+      xhr.addEventListener('error', (ev) => {
+        const error = new Error('Unknown error')
+        error.source = ev.target
+        reject(error)
+      })
+
+      xhr.send(body)
+    })
+  }
+
+  completeMultipartUpload (file, { key, uploadId, parts }) {
+    this.assertHost()
+
+    const filename = encodeURIComponent(key)
+    const uploadIdEnc = encodeURIComponent(uploadId)
+    return fetch(`${this.opts.host}/s3/multipart/${uploadIdEnc}/complete?key=${filename}`, {
+      method: 'post',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ parts })
+    }).then((response) => response.json())
+  }
+
+  abortMultipartUpload (file, { key, uploadId }) {
+    this.assertHost()
+
+    const filename = encodeURIComponent(key)
+    const uploadIdEnc = encodeURIComponent(uploadId)
+    return fetch(`${this.opts.host}/s3/multipart/${uploadIdEnc}?key=${filename}`, {
+      method: 'delete',
+      headers: { accept: 'application/json' }
+    }).then((response) => response.json())
+  }
+
+  prepareUpload (fileIDs) {
+    fileIDs.forEach((id) => {
+      const file = this.uppy.getFile(id)
+      this.uppy.emit('preprocess-progress', file, {
+        mode: 'determinate',
+        message: this.i18n('preparingUpload'),
+        value: 0
+      })
+    })
+
+    const createMultipartUpload = this.limitRequests(this.opts.createMultipartUpload)
+
+    return Promise.all(
+      fileIDs.map((id) => {
+        const file = this.uppy.getFile(id)
+        const createPromise = Promise.resolve()
+          .then(() => createMultipartUpload(file))
+        return createPromise.then((result) => {
+          const valid = typeof result === 'object' && result &&
+            typeof result.uploadId === 'string' &&
+            typeof result.key === 'string'
+          if (!valid) {
+            throw new TypeError(`AwsS3/Multipart: Got incorrect result from 'createMultipartUpload()' for file '${file.name}', expected an object '{ uploadId, key }'.`)
+          }
+          return result
+        }).then((result) => {
+          this.uppy.emit('preprocess-progress', file, {
+            mode: 'determinate',
+            message: this.i18n('preparingUpload'),
+            value: 1
+          })
+
+          this.uppy.setFileState(file.id, {
+            s3Multipart: result
+          })
+          this.uppy.emit('preprocess-complete', file)
+
+          return result
+        }).catch((error) => {
+          this.uppy.emit('upload-error', file, error)
+          throw error
+        })
+      })
+    )
+  }
+
+  uploadFile (file) {
+    const chunks = this.splitFile(file.data)
+
+    const completeMultipartUpload = this.limitRequests(this.opts.completeMultipartUpload)
+
+    this.uppy.emit('upload-started', file)
+
+    const total = file.size
+    // Keep track of progress for chunks individually, so it's easy to reset progress if one of them fails.
+    const currentProgress = chunks.map(() => 0)
+
+    const doUploadPart = (chunk, index) => {
+      return Promise.resolve(
+        this.opts.prepareUploadPart(file, {
+          key: file.s3Multipart.key,
+          uploadId: file.s3Multipart.uploadId,
+          body: chunk,
+          number: index + 1
+        })
+      ).then((result) => {
+        const valid = typeof result === 'object' && result &&
+          typeof result.url === 'string'
+        if (!valid) {
+          throw new TypeError(`AwsS3/Multipart: Got incorrect result from 'prepareUploadPart()' for file '${file.name}', expected an object '{ url }'.`)
+        }
+        return result
+      }).then(({ url }) => {
+        return this.uploadPart(url, chunk, (current) => {
+          currentProgress[index] = current
+
+          this.uppy.emit('upload-progress', this.uppy.getFile(file.id), {
+            uploader: this,
+            bytesUploaded: currentProgress.reduce((a, b) => a + b),
+            bytesTotal: total
+          })
+        }).then(({ etag }) => ({
+          ETag: etag,
+          PartNumber: index + 1
+        }))
+      })
+    }
+
+    // Limit this bundle of Prepare + Upload request instead of the individual requests;
+    // otherwise there might be too much time between Prepare and Upload (> 5 minutes).
+    const uploadPart = this.limitRequests(doUploadPart)
+
+    const partUploads = chunks.map((chunk, index) => {
+      return uploadPart(chunk, index)
+    })
+
+    return Promise.all(partUploads).then((parts) => {
+      return completeMultipartUpload(file, {
+        key: file.s3Multipart.key,
+        uploadId: file.s3Multipart.uploadId,
+        parts
+      })
+    }).then(() => {
+      this.uppy.emit('upload-success', this.uppy.getFile(file.id))
+    })
+  }
+
+  upload (fileIDs) {
+    if (fileIDs.length === 0) return Promise.resolve()
+
+    const promises = fileIDs.map((id) => {
+      const file = this.uppy.getFile(id)
+      if (file.isRemote) {
+        return Promise.reject(new Error('AwsS3/Multipart: Remote file uploads are not currently supported.'))
+      }
+      return this.uploadFile(file)
+    })
+
+    return Promise.all(promises)
+  }
+
+  install () {
+    this.uppy.addPreProcessor(this.prepareUpload)
+    this.uppy.addUploader(this.upload)
+  }
+
+  uninstall () {
+    this.uppy.removeUploader(this.upload)
+    this.uppy.removePreProcessor(this.prepareUpload)
+  }
+}

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -134,11 +134,11 @@ module.exports = class AwsS3Multipart extends Plugin {
           err.message = `Failed because: ${err.message}`
           reject(err)
         },
-        onSuccess: () => {
-          this.uppy.emit('upload-success', file, upload, upload.url)
+        onSuccess: ({ location }) => {
+          this.uppy.emit('upload-success', file, upload, location)
 
-          if (upload.url) {
-            this.uppy.log('Download ' + upload.file.name + ' from ' + upload.url)
+          if (location) {
+            this.uppy.log('Download ' + upload.file.name + ' from ' + location)
           }
 
           resolve(upload)

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -93,11 +93,16 @@ module.exports = class AwsS3Multipart extends Plugin {
   createMultipartUpload (file) {
     this.assertHost()
 
-    const filename = encodeURIComponent(file.name)
-    const type = encodeURIComponent(file.type)
-    return fetch(`${this.opts.host}/s3/multipart?filename=${filename}&type=${type}`, {
+    return fetch(`${this.opts.host}/s3/multipart`, {
       method: 'post',
-      headers: { accept: 'application/json' }
+      body: JSON.stringify({
+        filename: file.name,
+        type: file.type
+      }),
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      }
     }).then(handleResponse)
   }
 

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -134,11 +134,11 @@ module.exports = class AwsS3Multipart extends Plugin {
           err.message = `Failed because: ${err.message}`
           reject(err)
         },
-        onSuccess: ({ location }) => {
-          this.uppy.emit('upload-success', file, upload, location)
+        onSuccess: (result) => {
+          this.uppy.emit('upload-success', file, upload, result.location)
 
-          if (location) {
-            this.uppy.log('Download ' + upload.file.name + ' from ' + location)
+          if (result.location) {
+            this.uppy.log('Download ' + upload.file.name + ' from ' + result.location)
           }
 
           resolve(upload)
@@ -158,8 +158,6 @@ module.exports = class AwsS3Multipart extends Plugin {
           this.uppy.emit('s3-multipart:part-uploaded', cFile, part)
         }
       }, file.s3Multipart))
-
-      console.log('uploader', upload)
 
       this.uppy.on('file-removed', (removed) => {
         if (file.id !== removed.id) return

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -201,6 +201,10 @@ class MultipartUploader {
 
       // NOTE This must be allowed by CORS.
       const etag = ev.target.getResponseHeader('ETag')
+      if (etag === null) {
+        this._onError(new Error('AwsS3/Multipart: Could not read the ETag header. This likely means CORS is not configured correctly on the S3 Bucket. Seee https://uppy.io/docs/aws-s3-multipart#S3-Bucket-Configuration for instructions.'))
+        return
+      }
 
       this._onPartComplete(index, etag)
     })

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -6,7 +6,9 @@ const defaultOptions = {
   onProgress () {},
   onPartComplete () {},
   onSuccess () {},
-  onError (err) { console.error(err) }
+  onError (err) {
+    throw err
+  }
 }
 
 function remove (arr, el) {
@@ -237,6 +239,10 @@ class MultipartUploader {
       key: this.key,
       uploadId: this.uploadId
     })
+  }
+
+  _onError (err) {
+    this.options.onError(err)
   }
 
   start () {

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -249,7 +249,10 @@ class MultipartUploader {
   }
 
   pause () {
-    this.uploading.forEach((xhr) => xhr.abort())
+    const inProgress = this.uploading.slice()
+    inProgress.forEach((xhr) => {
+      xhr.abort()
+    })
     this.isPaused = true
   }
 

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -226,6 +226,7 @@ class MultipartUploader {
 
   _abortUpload () {
     this.options.abortMultipartUpload({
+      key: this.key,
       uploadId: this.uploadId
     })
   }
@@ -243,7 +244,9 @@ class MultipartUploader {
     this.isPaused = true
   }
 
-  abort (really = false) {
+  abort (opts = {}) {
+    const really = opts.really || false
+
     if (!really) return this.pause()
 
     this._abortUpload()

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -1,0 +1,253 @@
+const MB = 1024 * 1024
+
+const defaultOptions = {
+  limit: 1,
+  onStart () {},
+  onProgress () {},
+  onPartComplete () {},
+  onSuccess () {},
+  onError (err) { console.error(err) }
+}
+
+function remove (arr, el) {
+  const i = arr.indexOf(el)
+  if (i !== -1) arr.splice(i, 1)
+}
+
+class MultipartUploader {
+  constructor (file, options) {
+    this.options = Object.assign({}, defaultOptions, options)
+    this.file = file
+
+    this.key = this.options.key || null
+    this.uploadId = this.options.uploadId || null
+    this.parts = this.options.parts || []
+
+    this.isPaused = false
+    this.chunks = null
+    this.chunkState = null
+    this.uploading = []
+
+    this._initChunks()
+  }
+
+  _initChunks () {
+    const chunks = []
+    const chunkSize = Math.max(Math.ceil(this.file.size / 10000), 5 * MB)
+
+    for (let i = 0; i < this.file.size; i += chunkSize) {
+      const end = Math.min(this.file.size, i + chunkSize)
+      chunks.push(this.file.slice(i, end))
+    }
+
+    this.chunks = chunks
+    this.chunkState = chunks.map(() => ({
+      uploaded: 0,
+      done: false
+    }))
+  }
+
+  _createUpload () {
+    return this.options.createMultipartUpload().then((result) => {
+      const valid = typeof result === 'object' && result &&
+        typeof result.uploadId === 'string' &&
+        typeof result.key === 'string'
+      if (!valid) {
+        throw new TypeError(`AwsS3/Multipart: Got incorrect result from 'createMultipartUpload()', expected an object '{ uploadId, key }'.`)
+      }
+      return result
+    }).then((result) => {
+      this.key = result.key
+      this.uploadId = result.uploadId
+
+      this.options.onStart(result)
+    }).then(() => {
+      if (!this.isPaused) this._uploadParts()
+    })
+  }
+
+  _resumeUpload () {
+    this.options.listParts({
+      uploadId: this.uploadId,
+      key: this.key
+    }).then((parts) => {
+      parts.forEach((part) => {
+        const i = part.PartNumber - 1
+        this.chunkState[i] = {
+          uploaded: part.Size,
+          etag: part.ETag,
+          done: true
+        }
+
+        // Only add if we did not yet know about this part.
+        if (!this.parts.some((p) => p.PartNumber === part.PartNumber)) {
+          this.parts.push({
+            PartNumber: part.PartNumber,
+            ETag: part.ETag
+          })
+        }
+      })
+      this._uploadParts()
+    }).catch((err) => {
+      this._onError(err)
+    })
+  }
+
+  _uploadParts () {
+    const need = this.options.limit - this.uploading.length
+    if (need === 0) return
+
+    // All parts are uploaded.
+    if (this.chunkState.every((state) => state.done)) {
+      this._completeUpload()
+      return
+    }
+
+    const candidates = []
+    for (let i = 0; i < this.chunkState.length; i++) {
+      const state = this.chunkState[i]
+      if (state.done) continue
+
+      candidates.push(i)
+      if (candidates.length >= need) {
+        break
+      }
+    }
+
+    candidates.forEach((index) => {
+      this._uploadPart(index)
+    })
+  }
+
+  _uploadPart (index) {
+    const body = this.chunks[index]
+    return Promise.resolve(
+      this.options.prepareUploadPart({
+        key: this.key,
+        uploadId: this.uploadId,
+        body,
+        number: index + 1
+      })
+    ).then((result) => {
+      const valid = typeof result === 'object' && result &&
+        typeof result.url === 'string'
+      if (!valid) {
+        throw new TypeError(`AwsS3/Multipart: Got incorrect result from 'prepareUploadPart()', expected an object '{ url }'.`)
+      }
+      return result
+    }).then(({ url }) => {
+      this._uploadPartBytes(index, url)
+    })
+  }
+
+  _onPartProgress (index, sent, total) {
+    this.chunkState[index].uploaded = sent
+
+    const totalUploaded = this.chunkState.reduce((n, c) => n + c.uploaded, 0)
+    this.options.onProgress(totalUploaded, this.file.size)
+  }
+
+  _onPartComplete (index, etag) {
+    this.chunkState[index].etag = etag
+    this.chunkState[index].done = true
+
+    const part = {
+      PartNumber: index + 1,
+      ETag: etag
+    }
+    this.parts.push(part)
+
+    this.options.onPartComplete(part)
+
+    this._uploadParts()
+  }
+
+  _uploadPartBytes (index, url) {
+    const body = this.chunks[index]
+    const xhr = new XMLHttpRequest()
+    xhr.open('PUT', url, true)
+    xhr.responseType = 'text'
+
+    xhr._id = Math.random()
+
+    this.uploading.push(xhr)
+
+    xhr.upload.addEventListener('progress', (ev) => {
+      if (!ev.lengthComputable) return
+
+      this._onPartProgress(index, ev.loaded, ev.total)
+    })
+
+    xhr.addEventListener('abort', (ev) => {
+      console.log('abort', ev)
+      remove(this.uploading, ev.target)
+    })
+
+    xhr.addEventListener('load', (ev) => {
+      console.log('load', ev)
+      remove(this.uploading, ev.target)
+      if (ev.target.status < 200 || ev.target.status >= 300) {
+        this._onError(new Error('Non 2xx'))
+        return
+      }
+
+      this._onPartProgress(index, body.size, body.size)
+
+      // NOTE This must be allowed by CORS.
+      const etag = ev.target.getResponseHeader('ETag')
+
+      this._onPartComplete(index, etag)
+    })
+
+    xhr.addEventListener('error', (ev) => {
+      remove(this.uploading, ev.target)
+
+      const error = new Error('Unknown error')
+      error.source = ev.target
+      this._onError(error)
+    })
+
+    xhr.send(body)
+  }
+
+  _completeUpload () {
+    return Promise.resolve(
+      this.options.completeMultipartUpload({
+        key: this.key,
+        uploadId: this.uploadId,
+        parts: this.parts
+      })
+    ).then((result) => {
+      this.options.onSuccess()
+    }, (err) => {
+      this._onError(err)
+    })
+  }
+
+  _abortUpload () {
+    this.options.abortMultipartUpload({
+      uploadId: this.uploadId
+    })
+  }
+
+  start () {
+    if (this.uploadId) {
+      this._resumeUpload()
+    } else {
+      this._createUpload()
+    }
+  }
+
+  pause () {
+    this.uploading.forEach((xhr) => xhr.abort())
+    this.isPaused = true
+  }
+
+  abort (really = false) {
+    if (!really) return this.pause()
+
+    this._abortUpload()
+  }
+}
+
+module.exports = MultipartUploader

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -226,7 +226,7 @@ class MultipartUploader {
         parts: this.parts
       })
     ).then((result) => {
-      this.options.onSuccess()
+      this.options.onSuccess(result)
     }, (err) => {
       this._onError(err)
     })

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -66,6 +66,8 @@ class MultipartUploader {
       this.options.onStart(result)
     }).then(() => {
       this._uploadParts()
+    }).catch((err) => {
+      this._onError(err)
     })
   }
 

--- a/src/plugins/AwsS3/MultipartUploader.js
+++ b/src/plugins/AwsS3/MultipartUploader.js
@@ -51,7 +51,9 @@ class MultipartUploader {
   }
 
   _createUpload () {
-    return this.options.createMultipartUpload().then((result) => {
+    return Promise.resolve().then(() =>
+      this.options.createMultipartUpload()
+    ).then((result) => {
       const valid = typeof result === 'object' && result &&
         typeof result.uploadId === 'string' &&
         typeof result.key === 'string'
@@ -72,10 +74,12 @@ class MultipartUploader {
   }
 
   _resumeUpload () {
-    this.options.listParts({
-      uploadId: this.uploadId,
-      key: this.key
-    }).then((parts) => {
+    return Promise.resolve().then(() =>
+      this.options.listParts({
+        uploadId: this.uploadId,
+        key: this.key
+      })
+    ).then((parts) => {
       parts.forEach((part) => {
         const i = part.PartNumber - 1
         this.chunkState[i] = {
@@ -130,7 +134,7 @@ class MultipartUploader {
     const body = this.chunks[index]
     this.chunkState[index].busy = true
 
-    return Promise.resolve(
+    return Promise.resolve().then(() =>
       this.options.prepareUploadPart({
         key: this.key,
         uploadId: this.uploadId,
@@ -227,7 +231,7 @@ class MultipartUploader {
     // Parts may not have completed uploading in sorted order, if limit > 1.
     this.parts.sort((a, b) => a.PartNumber - b.PartNumber)
 
-    return Promise.resolve(
+    return Promise.resolve().then(() =>
       this.options.completeMultipartUpload({
         key: this.key,
         uploadId: this.uploadId,

--- a/src/server/RequestClient.js
+++ b/src/server/RequestClient.js
@@ -61,7 +61,7 @@ module.exports = class RequestClient {
 
   delete (path, data) {
     return fetch(`${this.hostname}/${path}`, {
-      method: 'post',
+      method: 'delete',
       credentials: 'include',
       headers: {
         'Accept': 'application/json',

--- a/src/server/RequestClient.js
+++ b/src/server/RequestClient.js
@@ -58,4 +58,19 @@ module.exports = class RequestClient {
       // @todo validate response status before calling json
       .then((res) => res.json())
   }
+
+  delete (path, data) {
+    return fetch(`${this.hostname}/${path}`, {
+      method: 'post',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: data ? JSON.stringify(data) : null
+    })
+      .then(this.onReceiveResponse)
+      // @todo validate response status before calling json
+      .then((res) => res.json())
+  }
 }

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -99,3 +99,21 @@ Return a Promise for an object with properties:
  - `location` - **(Optional)** A publically accessible URL to the object in the S3 bucket.
 
 The default implementation calls out to Uppy Server's S3 signing endpoints.
+
+## S3 Bucket Configuration
+
+S3 buckets do not allow public uploads by default.  In order to allow Uppy to upload to a bucket directly, its CORS permissions need to be configured.
+
+This process is described in the [AwsS3 documentation](/docs/aws-s3/#S3-Bucket-configuration).
+
+On top of the configuration mentioned there, the `ETag` header must also be whitelisted:
+
+```xml
+<CORSRule>
+  <AllowedMethod>PUT</AllowedMethod>
+  <!-- ... all your existingCORS config goes here ... -->
+
+  <!-- The magic: -->
+  <ExposeHeader>ETag</ExposeHeader>
+</CORSRule>
+```

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -1,0 +1,101 @@
+---
+type: docs
+order: 33
+title: "AwsS3Multipart"
+permalink: docs/aws-s3-multipart/
+---
+
+The `AwsS3Multipart` plugin can be used to upload files directly to an S3 bucket using S3's Multipart upload strategy. With this strategy, files are chopped up in parts of 5MB+ each, so they can be uploaded concurrently. It's also very reliable: if a single part fails to upload, only that 5MB has to be retried.
+
+```js
+const AwsS3Multipart = require('uppy/lib/plugins/AwsS3/Multipart')
+uppy.use(AwsS3Multipart, {
+  limit: 4,
+  host: 'https://uppy-server.myapp.net/'
+})
+```
+
+## Options
+
+### limit: 0
+
+The maximum amount of chunks to upload simultaneously. `0` means unlimited.
+
+### host: null
+
+The Uppy Server URL to use to proxy calls to the S3 Multipart API.
+
+### createMultipartUpload(file)
+
+A function that calls the S3 Multipart API to create a new upload. `file` is the file object from Uppy's state. The most relevant keys are `file.name` and `file.type`.
+
+Return a Promise for an object with keys:
+
+ - `uploadId` - The UploadID returned by S3.
+ - `key` - The object key for the file. This needs to be returned to allow it to be different from the `file.name`.
+
+The default implementation calls out to Uppy Server's S3 signing endpoints.
+
+### listParts({ uploadId, key })
+
+A function that calls the S3 Multipart API to list the parts of a file that have already been uploaded. Receives an object with keys:
+
+ - `uploadId` - The UploadID of this Multipart upload.
+ - `key` - The object key of this Multipart upload.
+
+Return a Promise for an array of S3 Part objects, as returned by the S3 Multipart API. Each object has keys:
+
+ - `PartNumber` - The index in the file of the uploaded part.
+ - `Size` - The size of the part in bytes.
+ - `ETag` - The ETag of the part, used to identify it when completing the multipart upload and combining all parts into a single file.
+
+The default implementation calls out to Uppy Server's S3 signing endpoints.
+
+### prepareUploadPart(partData)
+
+A function that generates a signed URL to upload a single part. The `partData` argument is an object with keys:
+
+ - `uploadId` - The UploadID of this Multipart upload.
+ - `key` - The object key in the S3 bucket.
+ - `body` - A [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) of this part's contents.
+ - `number` - The index of this part in the file (`PartNumber` in S3 terminology).
+
+Return a Promise for an object with keys:
+
+ - `url` - The presigned URL to upload a part. This can be generated using the S3 SDK like so:
+
+   ```js
+   sdkInstance.getSignedUrl('uploadPart', {
+     Bucket: 'target',
+     Key: partData.key,
+     UploadId: partData.uploadId,
+     PartNumber: partData.number,
+     Body: '', // Empty, because it's uploaded later
+     Expires: Date.now() + 5 * 60 * 1000
+   }, (err, url) => { /* there's the url! */ })
+   ```
+
+### abortMultipartUpload({ uploadId, key })
+
+A function that calls the S3 Multipart API to abort a Multipart upload, and delete all parts that have been uploaded so far. Receives an object with keys:
+
+ - `uploadId` - The UploadID of this Multipart upload.
+ - `key` - The object key of this Multipart upload.
+
+This is typically called when the user cancels an upload. Cancellation cannot fail in Uppy, so the result of this function is ignored.
+
+The default implementation calls out to Uppy Server's S3 signing endpoints.
+
+### completeMultipartUpload({ uploadId, key, parts })
+
+A function that calls the S3 Multipart API to complete a Multipart upload, combining all parts into a single object in the S3 bucket. Receives an object with keys:
+
+ - `uploadId` - The UploadID of this Multipart upload.
+ - `key` - The object key of this Multipart upload.
+ - `parts` - S3-style list of parts, an array of objects with `ETag` and `PartNumber` properties. This can be passed straight to S3's Multipart API.
+
+Return a Promise for an object with properties:
+
+ - `location` - **(Optional)** A publically accessible URL to the object in the S3 bucket.
+
+The default implementation calls out to Uppy Server's S3 signing endpoints.

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -9,12 +9,16 @@ The `AwsS3` plugin can be used to upload files directly to an S3 bucket.
 Uploads can be signed using [uppy-server][uppy-server docs] or a custom signing function.
 
 ```js
+const AwsS3 = require('uppy/lib/plugins/AwsS3')
+
 uppy.use(AwsS3, {
   // Options
 })
 ```
 
 There are broadly two ways to upload to S3 in a browser. A server can generate a presigned URL for a [PUT upload](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html), or a server can generate form data for a [POST upload](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html). uppy-server uses a POST upload. See [POST uPloads](#post-uploads) for some caveats if you would like to use POST uploads without uppy-server. See [Generating a presigned upload URL server-side](#example-presigned-url) for an example of a PUT upload.
+
+There is also a separate plugin for S3 Multipart uploads. Multipart in this sense is Amazon's proprietary chunked, resumable upload mechanism for large files. See the [AwsS3Multipart](/docs/aws-s3-multipart) documentation.
 
 ## Options
 

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -10,9 +10,12 @@ Uploads can be signed using [uppy-server][uppy-server docs] or a custom signing 
 
 ```js
 const AwsS3 = require('uppy/lib/plugins/AwsS3')
+const ms = require('ms')
 
 uppy.use(AwsS3, {
-  // Options
+  limit: 2,
+  timeout: ms('1 minute'),
+  host: 'https://uppy-server.myapp.com/'
 })
 ```
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -1,6 +1,6 @@
 ---
 type: docs
-order: 33
+order: 34
 title: "Transloadit"
 permalink: docs/transloadit/
 ---


### PR DESCRIPTION
This patch adds a new resumable upload plugin, using S3's Multipart uploads. S3 Multipart is different from the "multipart" in XHR FormData uploads; it allows you to upload a file in multiple requests (each 5MB+).

This is a separate plugin because the upload process is completely different from the standard AwsS3 upload plugin.

The implementation mirrors the tus upload plugin. There is a MultipartUploader class, very similar to the Upload class in tus-js-client. The MultipartUploader class is used by the AwsS3Multipart plugin to control the upload. (I tried to do everything in the plugin class initially, but it was getting really unwieldy with multiple files each having multiple chunks and each chunk having its individual upload progress etc.) The MultipartUploader class handles the uploading stuff, while the plugin class does the uppy state stuff.

An S3 Multipart upload consists of multiple steps:

 - Create the multipart upload, returning an UploadID (uppy-server)
 - Upload parts to the UploadID, up to `opts.limit` simultaneously
   - Each part has a PartNumber
   - Part uploads must be authenticated, so for browser uploads a presigned URL needs to be generated (uppy-server)
   - Returns an ETag
 - Finalise the multipart upload, sending along the UploadID and the list of part ETags (uppy-server)

When an upload is paused with the AwsS3Multipart plugin, it cancels all current part uploads. If you're unlucky you'll have to reupload a few MBs.

When an upload is resumed with the AwsS3Multipart plugin, it:

 - Asks S3 for the list of already-uploaded parts (uppy-server)
 - Begins uploading parts that were not yet fully uploaded

TODO:

 - [x] uppy-server implementation of this, for remote uploads. https://github.com/transloadit/uppy-server/pull/75