### PR TITLE
 react: Allow overriding <DashboardModal /> `target` prop, fixes #739

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ To be released: 2018-03-29.
 - [ ] dashboard: allow minimizing the Dashboard during upload (Uppy then becomes just a tiny progress indicator) (@arturi)
 - [ ] dashboard: cancel button for any kind of uploads? currently resume/pause only for tus, and cancel for XHR (@arturi, @goto-bus-stop)
 - [ ] dashboard: cancel button for transloadit assemblies (@arturi, @goto-bus-stop)
-- [ ] dashboard: disallow removing files if `bundle: true` in XHRUpload (@arturi) 
+- [ ] dashboard: disallow removing files if `bundle: true` in XHRUpload (@arturi)
 - [ ] dashboard: optional alert `onbeforeunload` while upload is in progress, safeguarding from accidentaly navigating away from a page with an ongoing upload
 - [ ] dashboard: add image cropping, study https://github.com/MattKetmo/darkroomjs/, https://github.com/fengyuanchen/cropperjs #151
 - [ ] core: css-in-js, while keeping non-random classnames (ideally prefixed) and useful preprocessor features. also see simple https://github.com/codemirror/CodeMirror/blob/master/lib/codemirror.css (@arturi, @goto-bus-stop)
@@ -122,6 +122,7 @@ To be released: 2018-03-29.
 - [x] s3: fix xhr response handlers (#625, @goto-bus-stop)
 - [ ] test: add typescript with JSDoc (@arturi)
 - [ ] dragdrop: allow customizing arrow icon https://github.com/transloadit/uppy/pull/374#issuecomment-334116208 (@arturi)
+- [x] react: Allow overriding `<DashboardModal />` `target` prop (#740, @goto-bus-stop)
 
 ## 0.23.3
 

--- a/examples/react-example/App.js
+++ b/examples/react-example/App.js
@@ -73,6 +73,7 @@ module.exports = class App extends React.Component {
           <DashboardModal
             uppy={this.uppy2}
             open={this.state.open}
+            target={document.body}
             onRequestClose={() => this.setState({ open: false })}
           />
         </div>

--- a/src/react/DashboardModal.js
+++ b/src/react/DashboardModal.js
@@ -17,10 +17,14 @@ class DashboardModal extends React.Component {
       {},
       this.props,
       {
-        target: this.container,
         onRequestCloseModal: this.props.onRequestClose
       }
     )
+
+    if (!options.target) {
+      options.target = this.container
+    }
+
     delete options.uppy
     uppy.use(DashboardPlugin, options)
 
@@ -55,6 +59,8 @@ class DashboardModal extends React.Component {
 
 DashboardModal.propTypes = {
   uppy: PropTypes.instanceOf(UppyCore).isRequired,
+  // Only check this prop type in the browser.
+  target: typeof window !== 'undefined' ? PropTypes.instanceOf(window.HTMLElement) : PropTypes.any,
   open: PropTypes.bool,
   onRequestClose: PropTypes.func,
   plugins: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
This was always mounting the dashboard DOM element into the current
React container element, but that's not always the right thing to do,
for example if the container element is a small element with `overflow:
hidden` or some `position: relative` style.

This patch allows you to do `target={document.body}` and the like, so
you can mount the dashboard element anywhere.