### PR TITLE
Retain uppy-server error messages, fixes #707

### DIFF
--- a/src/plugins/Tus.js
+++ b/src/plugins/Tus.js
@@ -302,8 +302,10 @@ module.exports = class Tus extends Plugin {
       socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
 
       socket.on('error', (errData) => {
-        this.uppy.emit('upload-error', file, new Error(errData.error))
-        reject(new Error(errData.error))
+        const { message } = errData.error
+        const error = Object.assign(new Error(message), { cause: errData.error })
+        this.uppy.emit('upload-error', file, error)
+        reject(error)
       })
 
       socket.on('success', (data) => {

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -338,9 +338,11 @@ module.exports = class XHRUpload extends Plugin {
 
           socket.on('error', (errData) => {
             const resp = errData.response
-            const error = resp ? opts.getResponseError(resp.responseText, resp) : new Error(errData.error)
+            const error = resp
+              ? opts.getResponseError(resp.responseText, resp)
+              : Object.assign(new Error(errData.error.message), { cause: errData.error })
             this.uppy.emit('upload-error', file, error)
-            reject(new Error(errData.error))
+            reject(error)
           })
         })
       })


### PR DESCRIPTION
Move the error objects from Uppy Server to a `.cause` property on the
Error instances we emit in `upload-error`. The Error instances now
correctly use the message from the error object reported by Uppy Server.