### PR TITLE
core: Add getFiles() method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ What we need to do to release Uppy 1.0
 - [ ] core: look into utilizing https://github.com/que-etc/resize-observer-polyfill for responsive components. See also https://github.com/transloadit/uppy/issues/750
 - [ ] docs: improve on React docs https://uppy.io/docs/react/, add small example for each component maybe? Dashboard, DragDrop, ProgressBar? No need to make separate pages for all of them, just headings on the same page. Right now docs are confusing, because they focus on DashboardModal. Also problems with syntax highlight on https://uppy.io/docs/react/dashboard-modal/.
 - [ ] docs: add note in docs or solve the .run() issue, see #756
+- [ ] core: add `uppy.getFiles()` method (@goto-bus-stop / #770)
 
 ## 0.24.2
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -285,6 +285,14 @@ class Uppy {
   }
 
   /**
+   * Get all files in an array.
+   */
+  getFiles () {
+    const { files } = this.getState()
+    return Object.keys(files).map((fileID) => files[fileID])
+  }
+
+  /**
   * Check if minNumberOfFiles restriction is reached before uploading.
   *
   * @private

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -786,6 +786,34 @@ describe('src/Core', () => {
     })
   })
 
+  describe('getFiles', () => {
+    it('should return an empty array if there are no files', () => {
+      const core = new Core()
+
+      expect(core.getFiles()).toEqual([])
+    })
+
+    it('should return all files as an array', () => {
+      const core = new Core()
+
+      core.addFile({
+        source: 'jest',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: new File([sampleImage], { type: 'image/jpeg' })
+      })
+      core.addFile({
+        source: 'jest',
+        name: 'empty.dat',
+        type: 'application/octet-stream',
+        data: new File([Buffer.alloc(1000)], { type: 'application/octet-stream' })
+      })
+
+      expect(core.getFiles()).toHaveLength(2)
+      expect(core.getFiles().map((file) => file.name).sort()).toEqual(['empty.dat', 'foo.jpg'])
+    })
+  })
+
   describe('meta data', () => {
     it('should set meta data by calling setMeta', () => {
       const core = new Core({

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -79,7 +79,7 @@ Metadata can also be added from a `<form>` element on your page via [Form](/docs
 <a id="onBeforeFileAdded"></a>
 ### `onBeforeFileAdded: (currentFile, files) => currentFile`
 
-A function run before a file is added to Uppy. Gets passed `(currentFile, files)` where `currentFile` is a file that is about to be added, and `files` is an object with all files that already are in Uppy. 
+A function run before a file is added to Uppy. Gets passed `(currentFile, files)` where `currentFile` is a file that is about to be added, and `files` is an object with all files that already are in Uppy.
 
 Use this function to run any number of custom checks on the selected file, or manipulating it, like optimizing a file name, for example.
 
@@ -96,8 +96,8 @@ onBeforeFileAdded: (currentFile, files) => {
 
 onBeforeFileAdded: (currentFile, files) => {
   const modifiedFile = Object.assign(
-    {}, 
-    currentFile, 
+    {},
+    currentFile,
     { name: currentFile + Date.now()
   })
   return modifiedFile
@@ -124,7 +124,7 @@ Note: it’s up to you to show a notification to the user about file not passing
 <a id="onBeforeUpload"></a>
 ### `onBeforeUpload: (files) => files`
 
-A function run before an upload begins. Gets passed `files` object with all the files that are already in Uppy. 
+A function run before an upload begins. Gets passed `files` object with all the files that are already in Uppy.
 
 Use this to check if all files or their total number match your requirements, or manipulate all the files at once before upload.
 
@@ -252,6 +252,18 @@ file.type      // 'image/jpeg'
 file.data      // the Blob object
 file.size      // 3947642 (returns 'N/A' if size cannot be determined)
 file.preview   // value that can be used to populate "src" attribute of an "img" tag
+```
+
+### `uppy.getFiles()`
+
+Get an array of all file objects in Uppy. See [uppy.getFile()](#uppy-getFile-fileID) for an example of the file object format.
+
+```js
+const prettyBytes = require('pretty-bytes')
+const items = uppy.getFiles().map(() =>
+  `<li>${file.name} - ${prettyBytes(file.size)}</li>`
+).join('')
+document.querySelector('.file-list').innerHTML = `<ul>${items}</ul>`
 ```
 
 ### `uppy.upload()`


### PR DESCRIPTION
`uppy.getFiles()` returns an array of all file objects. This way people
don't have to reach into the internal state object to do something with
the files.