### PR TITLE
Document Google Cloud Storage setup for the AwsS3 plugin

### DIFF
--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -206,7 +206,13 @@ The JSON format consists of an array of CORS configuration objects. An example u
 
 Most AWS configurations should be fairly simple to port to this format.
 
-To enable this configuration, do:
+If you have the [gsutil](https://cloud.google.com/storage/docs/gsutil) command-line tool, you can apply this configuration using the [gsutil cors](https://cloud.google.com/storage/docs/configuring-cors#configure-cors-bucket) command.
+
+```bash
+gsutil cors set THAT-FILE.json gs://BUCKET-NAME
+```
+
+Otherwise, you can manually apply it through the OAuth playground:
 
  1. Get a temporary API token from the [Google OAuth2.0 playground](https://developers.google.com/oauthplayground/)
    1. Select the "Cloud Storage JSON API v1" » "devstorage.full_control" scope

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -157,7 +157,7 @@ Many other object storage providers have an identical API to S3, so you can use 
 
 For example, with DigitalOcean Spaces, you could do something like this:
 
-```
+```bash
 export UPPYSERVER_AWS_ENDPOINT="https://{region}.digitaloceanspaces.com"
 export UPPYSERVER_AWS_BUCKET="my-space-name"
 ```
@@ -170,7 +170,7 @@ For a working example that you can run and play around with, see the [digitaloce
 
 For Google Cloud Storage, you need to take a few more steps. For the AwsS3 plugin to be able to upload to a GCS bucket, it needs the Interoperability setting enabled. You can enable the Interoperability setting and [generate interoperable storage access keys](https://cloud.google.com/storage/docs/migrating#keys) by going to [Google Cloud Storage](https://console.cloud.google.com/storage) » Settings » Interoperability. Then set the environment variables for Uppy Server like below:
 
-```
+```bash
 export UPPYSERVER_AWS_ENDPOINT="https://storage.googleapis.com"
 export UPPYSERVER_AWS_BUCKET="YOUR-GCS-BUCKET-NAME"
 export UPPYSERVER_AWS_KEY="GOOGxxxxxxxxx" # The Access Key

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -181,7 +181,7 @@ You do not need to configure the region with GCS.
 
 You also need to configure CORS differently. Unlike Amazon, Google does not offer a UI for CORS configurations. Instead an HTTP API must be used. If you haven't done this already, see [Configuring CORS on a Bucket](https://cloud.google.com/storage/docs/configuring-cors#Configuring-CORS-on-a-Bucket) in the GCS documentation, or follow the below steps to do it using Google's API playground.
 
-GCS has multiple CORS formats, both XML and JSON. Unfortunately their XML format is different from Amazon's, so we can't simply use the one from the [S3 Bucket configuration](#S3-Bucket-configuration) section.
+GCS has multiple CORS formats, both XML and JSON. Unfortunately their XML format is different from Amazon's, so we can't simply use the one from the [S3 Bucket configuration](#S3-Bucket-configuration) section. Google appears to favour the JSON format, so we'll use that.
 
 #### JSON CORS Configuration
 
@@ -204,7 +204,7 @@ The JSON format consists of an array of CORS configuration objects. An example u
 }
 ```
 
-Most AWS configurations should be fairly simple to port to this format.
+Most AWS configurations should be fairly simple to port to this format. When using presigned `PUT` uploads, replace the `"POST"` method by `"PUT"` in the first entry.
 
 If you have the [gsutil](https://cloud.google.com/storage/docs/gsutil) command-line tool, you can apply this configuration using the [gsutil cors](https://cloud.google.com/storage/docs/configuring-cors#configure-cors-bucket) command.
 
@@ -222,51 +222,6 @@ Otherwise, you can manually apply it through the OAuth playground:
    - HTTP Method: PATCH
    - Request URI: `https://www.googleapis.com/storage/v1/b/YOUR_BUCKET_NAME`
    - Content-Type: application/json (should be the default)
-   - Press "Enter request body" and input your CORS configuration
- 1. Then, finally, press "Send the request".
-
-#### XML CORS Configuration
-
-The XML format consists of `<Cors>` tags. Instead of having multiple `<AllowedOrigin>` and other tags at the top level, GCS's format nests origins and methods inside `<Origins>` and `<Methods>` tags. An example using POST policy document uploads is shown here:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CorsConfig>
-  <Cors>
-    <Origins>
-      <Origin>https://my-app.com</Origin>
-    </Origins>
-    <Methods>
-      <Method>GET</Method>
-      <Method>POST</Method>
-    </Methods>
-    <MaxAgeSec>3000</MaxAgeSec>
-  </Cors>
-  <Cors>
-    <Origins>
-      <Origin>*</Origin>
-    </Origins>
-    <Methods>
-      <Method>GET</Method>
-    </Methods>
-    <MaxAgeSec>3000</MaxAgeSec>
-  </Cors>
-</CorsConfig>
-```
-
-Most AWS configurations should be fairly simple to port to this format.
-
- 1. Get a temporary API token from the [Google OAuth2.0 playground](https://developers.google.com/oauthplayground/)
-   1. Select the "Cloud Storage API v1" » "full_control" scope
-   1. Press "Authorize APIs" and allow access
- 1. Click "Step 3 - Configure request to API"
- 1. Configure it like below:
-   - HTTP Method: PUT
-   - Request URI: `https://storage.googleapis.com/YOUR_BUCKET_NAME?cors`
-   - Content-Type: Custom…
-     1. A small popover to add a Content-Type header will open
-     1. Enter `text/xml` in the "Header Value" field and click "Add"
-     1. Close the popover
    - Press "Enter request body" and input your CORS configuration
  1. Then, finally, press "Send the request".
 

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -194,6 +194,8 @@ See the [aws-presigned-url example in the uppy repository](https://github.com/tr
 
 Many other object storage providers have an identical API to S3, so you can use the AwsS3 plugin with them. To use them with uppy-server, you can set the `UPPYSERVER_AWS_ENDPOINT` variable to the endpoint of your preferred service.
 
+#### DigitalOcean Spaces
+
 For example, with DigitalOcean Spaces, you could do something like this:
 
 ```
@@ -204,6 +206,36 @@ export UPPYSERVER_AWS_BUCKET="my-space-name"
 The `{region}` string will be replaced by the contents of the `UPPYSERVER_AWS_REGION` environment variable.
 
 For a working example that you can run and play around with, see the [digitalocean-spaces](https://github.com/transloadit/uppy/tree/master/examples/digitalocean-spaces) folder in the Uppy repository.
+
+#### Google Cloud Storage
+
+For Google Cloud Storage, you need to take a few more steps. First enable the Interoperability setting and [generate interoperable storage access keys](https://cloud.google.com/storage/docs/migrating#keys) by going to [Google Cloud Storage](https://console.cloud.google.com/storage) » Settings » Interoperability. Then set the environment variables like below:
+
+```
+export UPPYSERVER_AWS_ENDPOINT="https://storage.googleapis.com"
+export UPPYSERVER_AWS_BUCKET="YOUR-GCS-BUCKET-NAME"
+export UPPYSERVER_AWS_KEY="GOOGxxxxxxxxx" # The Access Key
+export UPPYSERVER_AWS_SECRET="YOUR-GCS-SECRET" # The Secret
+``
+
+You do not need to configure the region with GCS.
+
+You also need to configure CORS differently. Unlike Amazon, Google does not offer a UI for CORS configurations. Instead an HTTP API must be used. If you haven't done this already, see [Configuring CORS on a Bucket](https://cloud.google.com/storage/docs/configuring-cors#Configuring-CORS-on-a-Bucket) in the GCS documentation, or follow the below steps to do it using Google's API playground:
+
+ - Create an AWS-style CORS configuration as described above and save it in an XML file (eg. `cors.xml`)
+ - Get a temporary API token from the [Google OAuth2.0 playground](https://developers.google.com/oauthplayground/)
+   - Select the "Cloud Storage API v1" » "full_control" scope
+   - Press "Authorize APIs"
+ - Click "Step 3 - Configure request to API"
+ - Configure it like below:
+   - HTTP Method: PUT
+   - Request URI: `https://storage.googleapis.com/YOUR_BUCKET_NAME?cors`
+   - Content-Type: "Custom…"
+     - A small popover to add a Content-Type header will open.
+     - Enter `text/xml` in the "Header Value" field and click "Add".
+     - Close the popover.
+ - Then, finally, press "Send the request".
+
 
 ### Retrieving presign parameters of the uploaded file
 


### PR DESCRIPTION
Ugh they use a different CORS format :weary: 

Moved the DO and GCS docs to a new section "S3 Alternatives", instead of shoving both under "Examples".

GCS needs some configuration to enter compatibility mode with S3, and setting CORS options on a bucket is more complicated because they don't have a UI for it. Instead you need to use the gsutil tool. I added steps for doing it without gsutil too for people like me who don't want to install things.