### PR TITLE
Document "headers" upload parameter in AwsS3 plugin

### DIFF
--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -65,7 +65,7 @@ module.exports = class AwsS3 extends Plugin {
       (params.method == null || /^(put|post)$/i.test(params.method))
 
     if (!valid) {
-      const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields }'.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+      const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields, headers }'.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
       console.error(err)
       throw err
     }

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -33,7 +33,7 @@ uppy.use(AwsS3, {
 > Note: When using [uppy-server][uppy-server docs] to sign S3 uploads, do not define this option.
 
 A function returning upload parameters for a file.
-Parameters should be returned as an object, or a Promise for an object, with keys `{ method, url, fields }`.
+Parameters should be returned as an object, or a Promise for an object, with keys `{ method, url, fields, headers }`.
 
 The `method` field is the HTTP method to use for the upload.
 This should be one of `PUT` or `POST`, depending on the type of upload used.
@@ -44,6 +44,8 @@ When using a POST upload with a policy document, this should be the root URL of 
 
 The `fields` field is an object with form fields to send along with the upload request.
 For presigned PUT uploads, this should be empty.
+
+The `headers` field is an object with request headers to send along with the upload request.
 
 ### `timeout: 30 * 1000`
 


### PR DESCRIPTION
The AwsS3 plugin appears to already support the `headers` field in upload parameters, indicating the request headers that should be sent along with the upload request, so we add it to the documentation.