### PR TITLE
Change Unicode characters to HTML entities and \u escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ What we need to do to release Uppy 1.0
 - [x] core: add `uppy.getFiles()` method (@goto-bus-stop / #770)
 - [x] dashboard: fix duplicate plugin IDs, see #702 (@goto-bus-stop)
 - [x] react: update propTypes (#776 / @goto-bus-stop)
+- [x] dashboard/statusbar: fix some unicode characters showing up as gibberish (#787 / @goto-bus-stop)
 
 ## 0.24.2
 

--- a/src/plugins/Dashboard/Dashboard.js
+++ b/src/plugins/Dashboard/Dashboard.js
@@ -57,7 +57,7 @@ module.exports = function Dashboard (props) {
           aria-label={props.i18n('closeModal')}
           title={props.i18n('closeModal')}
           onclick={props.closeModal}>
-          <span aria-hidden="true">×</span>
+          <span aria-hidden="true">&times;</span>
         </button>
 
         <div class="uppy-Dashboard-innerWrap">

--- a/src/plugins/StatusBar/StatusBar.js
+++ b/src/plugins/StatusBar/StatusBar.js
@@ -172,15 +172,15 @@ const ProgressBarProcessing = (props) => {
   const value = Math.round(props.value * 100)
 
   return <div class="uppy-StatusBar-content">
-    {props.mode === 'determinate' ? `${value}%・` : ''}
+    {props.mode === 'determinate' ? `${value}% \u00B7 ` : ''}
     {props.message}
   </div>
 }
 
 const progressDetails = (props) => {
   return <span class="uppy-StatusBar-statusSecondary">
-    { props.inProgress > 1 && props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.inProgress }) + '・' }
-    { props.i18n('dataUploadedOfTotal', { complete: props.totalUploadedSize, total: props.totalSize }) }・
+    { props.inProgress > 1 && props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.inProgress }) + ' \u00B7 ' }
+    { props.i18n('dataUploadedOfTotal', { complete: props.totalUploadedSize, total: props.totalSize }) + ' \u00B7 ' }
     { props.i18n('xTimeLeft', { time: props.totalETA }) }
   </span>
 }


### PR DESCRIPTION
Fixes #774

This way there is no confusion about the encoding. According to an old
React doc page that $SEARCH_ENGINE dug up: https://shripadk.github.io/react/docs/jsx-gotchas.html