### PR TITLE
ci: Bump to Node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 6.11.3
+- 8.11.1
 addons:
   apt:
     sources:


### PR DESCRIPTION
Node 8 is the current LTS version.