### PR TITLE
Pass allowedFileTypes and maxNumberOfFiles to input[type=file]

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -323,7 +323,18 @@ class Uppy {
     if (allowedFileTypes) {
       const isCorrectFileType = allowedFileTypes.filter((type) => {
         if (!file.type) return false
-        return match(file.type, type)
+
+        // is this is a mime-type
+        if (type.indexOf('/') > -1) {
+          return match(file.type, type)
+        }
+
+        // otherwise this is likely an extension
+        if (type.startsWith('.') > -1) {
+          if (file.extension === type.substr(1)) {
+            return file.extension
+          }
+        }
       }).length > 0
 
       if (!isCorrectFileType) {

--- a/src/plugins/Dashboard/ActionBrowseTagline.js
+++ b/src/plugins/Dashboard/ActionBrowseTagline.js
@@ -13,6 +13,7 @@ class ActionBrowseTagline extends Component {
   render () {
     // empty value=""  on file input, so we can select same file
     // after removing it from Uppy — otherwise OS thinks it’s selected
+
     return (
       <span>
         {this.props.acquirers.length === 0
@@ -27,8 +28,9 @@ class ActionBrowseTagline extends Component {
           tabindex="-1"
           type="file"
           name="files[]"
-          multiple="true"
+          multiple={this.props.maxNumberOfFiles !== 1 || !this.props.maxNumberOfFiles}
           onchange={this.props.handleInputChange}
+          accept={this.props.allowedFileTypes}
           value=""
           ref={(input) => {
             this.input = input

--- a/src/plugins/Dashboard/FileList.js
+++ b/src/plugins/Dashboard/FileList.js
@@ -18,7 +18,9 @@ module.exports = (props) => {
           {h(ActionBrowseTagline, {
             acquirers: props.acquirers,
             handleInputChange: props.handleInputChange,
-            i18n: props.i18n
+            i18n: props.i18n,
+            allowedFileTypes: props.allowedFileTypes,
+            maxNumberOfFiles: props.maxNumberOfFiles
           })}
         </div>
         { props.note && <div class="uppy-Dashboard-note">{props.note}</div> }

--- a/src/plugins/Dashboard/Tabs.js
+++ b/src/plugins/Dashboard/Tabs.js
@@ -49,7 +49,8 @@ class Tabs extends Component {
             tabindex="-1"
             type="file"
             name="files[]"
-            multiple="true"
+            multiple={this.props.maxNumberOfFiles !== 1 || !this.props.maxNumberOfFiles}
+            accept={this.props.allowedFileTypes}
             onchange={this.props.handleInputChange}
             value=""
             ref={(input) => { this.input = input }} />

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -486,7 +486,9 @@ module.exports = class Dashboard extends Plugin {
       proudlyDisplayPoweredByUppy: this.opts.proudlyDisplayPoweredByUppy,
       currentWidth: pluginState.containerWidth,
       isWide: pluginState.containerWidth > 400,
-      isTargetDOMEl: this.isTargetDOMEl
+      isTargetDOMEl: this.isTargetDOMEl,
+      allowedFileTypes: this.uppy.opts.restrictions.allowedFileTypes,
+      maxNumberOfFiles: this.uppy.opts.restrictions.maxNumberOfFiles
     })
   }
 

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -102,11 +102,21 @@ module.exports = class DragDrop extends Plugin {
   }
 
   render (state) {
-    const DragDropClass = `uppy uppy-DragDrop-container ${this.isDragDropSupported ? 'is-dragdrop-supported' : ''}`
+    /* http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/ */
+    const hiddenInputStyle = {
+      width: '0.1px',
+      height: '0.1px',
+      opacity: 0,
+      overflow: 'hidden',
+      position: 'absolute',
+      zIndex: -1
+    }
+    const DragDropClass = `uppy uppy-DragDrop-container ${this.isDragDropSupported ? 'uppy-DragDrop--is-dragdrop-supported' : ''}`
     const DragDropStyle = {
       width: this.opts.width,
       height: this.opts.height
     }
+    const restrictions = this.uppy.opts.restrictions
     return (
       <div class={DragDropClass} style={DragDropStyle}>
         <div class="uppy-DragDrop-inner">
@@ -114,10 +124,11 @@ module.exports = class DragDrop extends Plugin {
             <path d="M11 10V0H5v10H2l6 6 6-6h-3zm0 0" fill-rule="evenodd" />
           </svg>
           <label class="uppy-DragDrop-label">
-            <input class="uppy-DragDrop-input"
+            <input style={hiddenInputStyle}
               type="file"
               name="files[]"
-              multiple="true"
+              multiple={restrictions.maxNumberOfFiles !== 1 || !restrictions.maxNumberOfFiles}
+              accept={restrictions.allowedFileTypes}
               ref={(input) => {
                 this.input = input
               }}

--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -60,6 +60,7 @@ module.exports = class FileInput extends Plugin {
   }
 
   render (state) {
+    /* http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/ */
     const hiddenInputStyle = {
       width: '0.1px',
       height: '0.1px',
@@ -69,13 +70,16 @@ module.exports = class FileInput extends Plugin {
       zIndex: -1
     }
 
+    const restrictions = this.uppy.opts.restrictions
+
     return <div class="uppy uppy-FileInput-container">
       <input class="uppy-FileInput-input"
         style={this.opts.pretty && hiddenInputStyle}
         type="file"
         name={this.opts.inputName}
         onchange={this.handleInputChange}
-        multiple={this.opts.allowMultipleFiles}
+        multiple={restrictions.maxNumberOfFiles !== 1 || !restrictions.maxNumberOfFiles}
+        accept={restrictions.allowedFileTypes}
         ref={(input) => { this.input = input }} />
       {this.opts.pretty &&
         <button class="uppy-FileInput-btn" type="button" onclick={this.handleClick}>

--- a/src/scss/_dragdrop.scss
+++ b/src/scss/_dragdrop.scss
@@ -41,16 +41,6 @@
       fill: $color-gray;
     }
   
-  /* http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/ */
-  .uppy-DragDrop-input {
-    width: 0.1px;
-    height: 0.1px;
-    opacity: 0;
-    overflow: hidden;
-    position: absolute;
-    z-index: -1;
-  }
-  
   .uppy-DragDrop-label {
     display: block;
     cursor: pointer;


### PR DESCRIPTION
When selecting files via DragDrop “browse”, FileInput button, or Dashboard’s “browse” or “My Device”, restrictions were previously not visible in the system file dialog. Users were able to select 5 files of any type, only to find out later in Uppy’s Dashboard UI (or not all, when using DragDrop/FileInput) that they were only allowed 1 image.

This PR fixes that, as well as sets `multiple` option automatically based on `restrictions.maxNumberOfFiles`. 

Fixes #709.

todo: 
- [ ] tests