### PR TITLE
[WIP] Experimental first attempt at encapsulating UI plugin’s html/css with shadow dom

### DIFF
--- a/src/core/Plugin.js
+++ b/src/core/Plugin.js
@@ -61,7 +61,7 @@ module.exports = class Plugin {
       this.isTargetDOMEl = true
 
       this.updateUI = (state) => {
-        this.el = preact.render(this.render(state), targetElement, this.el)
+        this.el = preact.render(this.render(state), this.shadow, this.el)
       }
 
       this.uppy.log(`Installing ${callerPluginName} to a DOM element`)
@@ -71,7 +71,10 @@ module.exports = class Plugin {
         targetElement.innerHTML = ''
       }
 
-      this.el = preact.render(this.render(this.uppy.state), targetElement)
+      const wrapperEl = document.createElement('div')
+      targetElement.appendChild(wrapperEl)
+      this.shadow = wrapperEl.attachShadow({ mode: 'open' })
+      this.el = preact.render(this.render(this.uppy.state), this.shadow)
 
       return this.el
     }

--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -69,20 +69,45 @@ module.exports = class FileInput extends Plugin {
       zIndex: -1
     }
 
-    return <div class="uppy uppy-FileInput-container">
-      <input class="uppy-FileInput-input"
-        style={this.opts.pretty && hiddenInputStyle}
-        type="file"
-        name={this.opts.inputName}
-        onchange={this.handleInputChange}
-        multiple={this.opts.allowMultipleFiles}
-        ref={(input) => { this.input = input }} />
-      {this.opts.pretty &&
-        <button class="uppy-FileInput-btn" type="button" onclick={this.handleClick}>
-          {this.i18n('chooseFiles')}
-        </button>
-      }
-    </div>
+    return (
+      <div>
+        <style>{`
+          .uppy-FileInput-container {
+            margin-bottom: 15px;
+          }
+
+          .uppy-FileInput-btn {
+            font-family: sans-serif;
+            font-size: 0.85em;
+            padding: 10px 15px;
+            color: blue;
+            border: 1px solid blue;
+            border-radius: 8px;
+            cursor: pointer;
+          }
+
+          .uppy-FileInput-btn:hover {
+            background-color: blue;
+            color: white;
+          }
+          
+        `}</style>
+        <div class="uppy uppy-FileInput-container">
+          <input class="uppy-FileInput-input"
+            style={this.opts.pretty && hiddenInputStyle}
+            type="file"
+            name={this.opts.inputName}
+            onchange={this.handleInputChange}
+            multiple={this.opts.allowMultipleFiles}
+            ref={(input) => { this.input = input }} />
+          {this.opts.pretty &&
+            <button class="uppy-FileInput-btn" type="button" onclick={this.handleClick}>
+              {this.i18n('chooseFiles')}
+            </button>
+          }
+        </div>
+      </div>
+    )
   }
 
   install () {


### PR DESCRIPTION
- https://css-tricks.com/playing-shadow-dom/
- https://github.com/WebReflection/attachshadow — an iframe based Shadow DOM poorlyfill
- https://github.com/developit/preact-shadow-root

So this is how it could ideally work, for example: Uppy UI components are mounter to a wrapper `<div>` that gets a shadow-dom attached to it, and then everything is rendered inside that shadow-dom. 

Styles are injected into a `<style>` tag, we add a new method like `style()` to plugins, which returns a string that will be injected to that `<style>` tag. And then we maybe provide an `overrideStyle` option that accepts a string from a developer, that will also be injected, after our styles, so that those styles can be overriden. Or we just go with options, CSS variables for example.

This is polyfilled (with something like https://github.com/WebReflection/attachshadow), because shadow-dom is not everywhere yet, even in modern browsers. So we fall back to iframe.

(Styles can be processed with PostCSS on Babel transpilation using https://github.com/MunGell/babel-plugin-template-string-processing).

Maybe this needs to be a plugin, but I fear people won’t be using it, and then styles will leak and everything looks ugly(er) by default.