### PR TITLE
Fix auth when redirect URL contains hash

### DIFF
--- a/src/views/ProviderView/index.js
+++ b/src/views/ProviderView/index.js
@@ -498,7 +498,7 @@ module.exports = class ProviderView {
       }
 
       // split url because chrome adds '#' to redirects
-      if (authWindowUrl && authWindowUrl.split('#')[0] === redirect) {
+      if (authWindowUrl && (authWindowUrl === redirect || authWindowUrl.split('#')[0] === redirect)) {
         authWindow.close()
         this._loaderWrapper(this.Provider.checkAuth(), this.plugin.onAuth, this.handleError)
       } else {


### PR DESCRIPTION
If the source page URL (the page showing the uppy dialog) contains a hash (e.g.: `http://localhost/#/foo/bar`) the authentication did not complete properly.

This happened because the previous logic in `checkAuth` did not handle this case properly. 

More specifically, in the example above, both `authWindowUrl` and `redirect` URL will be: `http://localhost/#/foo/bar?id=12345`. But the previous logic only compared the part before the hash from `authWindowUrl` with the full `redirect` URL (`http://localhost/` != `http://localhost/#/foo/bar?id=12345`).

This PR attempts to fix that.