### PR TITLE
Url: Add support for drag-dropping urls, links or images from webpages

### DIFF
--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -54,6 +54,9 @@ module.exports = class Url extends Plugin {
     // Bind all event handlers for referencability
     this.getMeta = this.getMeta.bind(this)
     this.addFile = this.addFile.bind(this)
+    this.handleDrop = this.handleDrop.bind(this)
+    this.handleDragOver = this.handleDragOver.bind(this)
+    this.handleDragLeave = this.handleDragLeave.bind(this)
 
     this.server = new RequestClient(uppy, {host: this.opts.host})
   }
@@ -144,6 +147,31 @@ module.exports = class Url extends Plugin {
       })
   }
 
+  handleDrop (e) {
+    e.preventDefault()
+    if (e.dataTransfer.items) {
+      const items = Array.from(e.dataTransfer.items)
+      items.forEach((item) => {
+        if (item.kind === 'string' && item.type.match('^text/uri-list')) {
+          item.getAsString((url) => {
+            this.uppy.log(`[URL] Adding file from dropped url: ${url}`)
+            this.addFile(url)
+          })
+        }
+      })
+    }
+  }
+
+  handleDragOver (e) {
+    e.preventDefault()
+    this.el.classList.add('drag')
+  }
+
+  handleDragLeave (e) {
+    e.preventDefault()
+    this.el.classList.remove('drag')
+  }
+
   render (state) {
     return <UrlUI
       i18n={this.i18n}
@@ -155,9 +183,17 @@ module.exports = class Url extends Plugin {
     if (target) {
       this.mount(target, this)
     }
+
+    this.el.addEventListener('drop', this.handleDrop)
+    this.el.addEventListener('dragover', this.handleDragOver)
+    this.el.addEventListener('dragleave', this.handleDragLeave)
   }
 
   uninstall () {
+    this.el.removeEventListener('drop', this.handleDrop)
+    this.el.removeEventListener('dragover', this.handleDragOver)
+    this.el.removeEventListener('dragleave', this.handleDragLeave)
+
     this.unmount()
   }
 }

--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -155,7 +155,7 @@ module.exports = class Url extends Plugin {
     if (e.dataTransfer.items) {
       const items = toArray(e.dataTransfer.items)
       items.forEach((item) => {
-        if (item.kind === 'string' && item.type.match('^text/uri-list')) {
+        if (item.kind === 'string' && item.type === 'text/uri-list') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from dropped url: ${url}`)
             this.addFile(url)
@@ -186,7 +186,7 @@ module.exports = class Url extends Plugin {
       if (hasFiles) return
 
       items.forEach((item) => {
-        if (item.kind === 'string' && item.type.match('text/plain')) {
+        if (item.kind === 'string' && item.type === 'text/plain') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from pasted url: ${url}`)
             this.addFile(url)


### PR DESCRIPTION
The way its currently done is I add event listeners in the Url plugin itself, and if the dropped thing is a url (works for text urls, urls from links and images), then the Url plugin takes it as a url.

<img width="1279" alt="screen shot 2018-05-16 at 3 13 50 pm" src="https://user-images.githubusercontent.com/1199054/40138935-3f629bea-591c-11e8-8344-96d5fdc42151.png">

- [x] Maybe add pasting too
- Maybe improve `.drag` css class addition/removal, add timeout