### PR TITLE
Fix dangling parenthesis

### DIFF
--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -59,7 +59,7 @@ Optionally provide rules and conditions for which files can be selected.
 
 `maxNumberOfFiles` affects the number of files user is able to select via the system file dialog in UI plugins like `DragDrop`, `FileInput` and `Dashboard`: when set to `1` they will only be able to select a single file, otherwise, when `null` or other number, they will be able to select multiple files.
 
-`allowedFileTypes` gets passed to the system file dialog via [`<input>`]((https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types))’s accept attribute, so only files matching these types will be selectable.
+`allowedFileTypes` gets passed to the system file dialog via [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types)’s accept attribute, so only files matching these types will be selectable.
 
 ### `meta: {}`
 


### PR DESCRIPTION
This part currently renders as "*`<input>`)’s accept attribute*" on the website, this PR should fix it.