### PR TITLE
Fix Translator pluralization when counter is 0

### DIFF
--- a/src/core/Translator.js
+++ b/src/core/Translator.js
@@ -71,7 +71,7 @@ module.exports = class Translator {
    * @return {string} translated (and interpolated)
    */
   translate (key, options) {
-    if (options && options.smart_count) {
+    if (options && typeof options.smart_count !== 'undefined') {
       var plural = this.locale.pluralize(options.smart_count)
       return this.interpolate(this.opts.locale.strings[key][plural], options)
     }

--- a/src/core/Translator.test.js
+++ b/src/core/Translator.test.js
@@ -23,15 +23,15 @@ describe('core/translator', () => {
     it('should translate a string', () => {
       const core = new Core({ locale: russian })
       expect(
-        core.translator.translate('filesChosen', { smart_count: '18' })
+        core.translator.translate('filesChosen', { smart_count: 18 })
       ).toEqual('Выбрано 18 файлов')
 
       expect(
-        core.translator.translate('filesChosen', { smart_count: '1' })
+        core.translator.translate('filesChosen', { smart_count: 1 })
       ).toEqual('Выбран 1 файл')
 
       expect(
-        core.translator.translate('filesChosen', { smart_count: '0' })
+        core.translator.translate('filesChosen', { smart_count: 0 })
       ).toEqual('Выбрано 0 файлов')
     })
   })


### PR DESCRIPTION
`i18n('folderAdded', { smart_count: files.length })` would error if `files.length === 0`, because we used to check if `smart_count` was `true`.

Now we check that smart_count is not `undefined`.

Updated tests to use number as opposed to strings.