### PR TITLE
Add directories-dropped event

### DIFF
--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -29,7 +29,7 @@
     "@uppy/thumbnail-generator": "0.27.1",
     "@uppy/utils": "0.27.0",
     "classnames": "^2.2.6",
-    "drag-drop": "2.13.3",
+    "drag-drop": "^4.2.0",
     "lodash.throttle": "^4.1.1",
     "preact": "^8.2.9",
     "preact-css-transition-group": "^1.3.0",

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -437,8 +437,8 @@ module.exports = class Dashboard extends Plugin {
     }
 
     // Drag Drop
-    this.removeDragDropListener = dragDrop(this.el, (files) => {
-      this.handleDrop(files)
+    this.removeDragDropListener = dragDrop(this.el, (files, pos, fileList, directories) => {
+      this.handleDrop(files, directories)
     })
 
     this.updateDashboardElWidth()
@@ -484,8 +484,9 @@ module.exports = class Dashboard extends Plugin {
     })
   }
 
-  handleDrop (files) {
+  handleDrop (files, directories) {
     this.uppy.log('[Dashboard] Files were dropped')
+    this.uppy.emit('directories-dropped', directories)
 
     files.forEach((file) => {
       try {

--- a/packages/@uppy/drag-drop/package.json
+++ b/packages/@uppy/drag-drop/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@uppy/utils": "0.27.0",
-    "drag-drop": "2.13.3",
+    "drag-drop": "^4.2.0",
     "preact": "^8.2.9"
   },
   "devDependencies": {

--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -75,8 +75,9 @@ module.exports = class DragDrop extends Plugin {
     return true
   }
 
-  handleDrop (files) {
+  handleDrop (files, directories) {
     this.uppy.log('[DragDrop] Files dropped')
+    this.uppy.emit('directories-dropped', directories)
 
     files.forEach((file) => {
       try {
@@ -164,8 +165,8 @@ module.exports = class DragDrop extends Plugin {
     if (target) {
       this.mount(target, this)
     }
-    this.removeDragDropListener = dragDrop(this.el, (files) => {
-      this.handleDrop(files)
+    this.removeDragDropListener = dragDrop(this.el, (files, pos, fileList, directories) => {
+      this.handleDrop(files, directories)
       this.uppy.log(files)
     })
   }

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -448,6 +448,16 @@ Subscribe to an uppy-event. See below for the full list of events.
 
 Uppy exposes events that you can subscribe to in your app:
 
+### `directories-dropped`
+
+Fired each time a directory is drag-and-dropped in the `Dasboard` or `DragDrop` plugins.
+
+```javascript
+uppy.on('directories-dropped', (directories) => {
+  console.log('Dropped directories', directories)
+})
+```
+
 ### `file-added`
 
 Fired each time a file is added.


### PR DESCRIPTION
Add a `directories-dropped` event that fires every time a user drag-and-drops a bunch of files in the `Dashboard` or the `DragDrop` plugins.
This event contains the list of directories that were dropped.

This is particularly useful when trying to recreate the user file system on a server (#447).

Not sure if using an event is the right approach for this, but it was the easiest way to implement it right now. I wouldn't mind exposing this using a different API if someone suggests a better approach.

PS: In order to implement this, `drag-drop` had to be bumped to version `v4.2.0`.