### PR TITLE
Add timer.done() to `cancel-all` events

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -582,7 +582,8 @@ class Uppy {
 
     this.setState({
       files: {},
-      totalProgress: 0
+      totalProgress: 0,
+      error: null
     })
   }
 

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -182,6 +182,10 @@ class Uppy {
   * Shorthand to set state for a specific file.
   */
   setFileState (fileID, state) {
+    if (!this.getState().files[fileID]) {
+      throw new Error(`Can’t set state for ${fileID} (the file could have been removed)`)
+    }
+
     this.setState({
       files: Object.assign({}, this.getState().files, {
         [fileID]: Object.assign({}, this.getState().files[fileID], state)

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -232,6 +232,7 @@ describe('src/Core', () => {
       capabilities: { resumableUploads: false },
       files: {},
       currentUploads: {},
+      error: null,
       foo: 'bar',
       info: { isHidden: true, message: '', type: 'info' },
       meta: {},
@@ -271,6 +272,7 @@ describe('src/Core', () => {
       capabilities: { resumableUploads: false },
       files: {},
       currentUploads: {},
+      error: null,
       info: { isHidden: true, message: '', type: 'info' },
       meta: {},
       plugins: {},
@@ -1106,9 +1108,10 @@ describe('src/Core', () => {
     it('should update the state when receiving the upload-error event', () => {
       const core = new Core()
       core.state.files['fileId'] = {
+        id: 'fileId',
         name: 'filename'
       }
-      core.emit('upload-error', core.state.files['fileId'], new Error('this is the error'))
+      core.emit('upload-error', core.getState().files['fileId'], new Error('this is the error'))
       expect(core.state.info).toEqual({'message': 'Failed to upload filename', 'details': 'this is the error', 'isHidden': false, 'type': 'error'})
     })
 

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -281,8 +281,7 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       this.uppy.on('cancel-all', () => {
-        // const files = this.uppy.getState().files
-        // if (!files[file.id]) return
+        timer.done()
         xhr.abort()
       })
     })
@@ -419,6 +418,7 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       this.uppy.on('cancel-all', () => {
+        timer.done()
         xhr.abort()
       })
 

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -386,8 +386,8 @@ module.exports = class XHRUpload extends Plugin {
         files.forEach((file) => {
           this.uppy.emit('upload-progress', file, {
             uploader: this,
-            bytesUploaded: ev.loaded,
-            bytesTotal: ev.total
+            bytesUploaded: ev.loaded / ev.total * file.size,
+            bytesTotal: file.size
           })
         })
       })


### PR DESCRIPTION
- Add `timer.done()` and `error: null` to `cancel-all` events
- Ignore progress events in timeout tracker after upload was aborted
- Remove throttling, it was causing issues with `bundle: true` (“with `bundle:false` that doesnt show up so much because the order of events will be different each time, but with `bundle: true` it always  emits those 4 in the same order so it calculates the first one on the leading edge and the last one on the trailing edge, but drops the middle ones”)