### PR TITLE
Add try/catch to `addfile()` calls from UI plugins

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -448,7 +448,7 @@ class Uppy {
       this.scheduledAutoProceed = setTimeout(() => {
         this.scheduledAutoProceed = null
         this.upload().catch((err) => {
-          onError(err.stack || err.message || err)
+          console.error(err.stack || err.message || err)
         })
       }, 4)
     }

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -448,7 +448,7 @@ class Uppy {
       this.scheduledAutoProceed = setTimeout(() => {
         this.scheduledAutoProceed = null
         this.upload().catch((err) => {
-          console.error(err.stack || err.message || err)
+          onError(err.stack || err.message || err)
         })
       }, 4)
     }

--- a/src/plugins/Dashboard/index.js
+++ b/src/plugins/Dashboard/index.js
@@ -289,12 +289,16 @@ module.exports = class Dashboard extends Plugin {
         return
       }
       this.uppy.log('[Dashboard] File pasted')
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: blob
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: blob
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 
@@ -303,12 +307,16 @@ module.exports = class Dashboard extends Plugin {
     const files = toArray(ev.target.files)
 
     files.forEach((file) => {
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: file
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: file
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 
@@ -369,12 +377,16 @@ module.exports = class Dashboard extends Plugin {
     this.uppy.log('[Dashboard] Files were dropped')
 
     files.forEach((file) => {
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: file
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: file
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 

--- a/src/plugins/DragDrop/index.js
+++ b/src/plugins/DragDrop/index.js
@@ -79,12 +79,16 @@ module.exports = class DragDrop extends Plugin {
     this.uppy.log('[DragDrop] Files dropped')
 
     files.forEach((file) => {
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: file
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: file
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 
@@ -94,12 +98,16 @@ module.exports = class DragDrop extends Plugin {
     const files = toArray(ev.target.files)
 
     files.forEach((file) => {
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: file
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: file
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 

--- a/src/plugins/Dummy.js
+++ b/src/plugins/Dummy.js
@@ -35,7 +35,11 @@ module.exports = class Dummy extends Plugin {
       data: blob
     }
     this.props.log('Adding fake file blob')
-    this.props.addFile(file)
+    try {
+      this.props.addFile(file)
+    } catch (err) {
+      // Nothing, restriction errors handled in Core
+    }
   }
 
   render (state) {

--- a/src/plugins/FileInput.js
+++ b/src/plugins/FileInput.js
@@ -45,12 +45,16 @@ module.exports = class FileInput extends Plugin {
     const files = toArray(ev.target.files)
 
     files.forEach((file) => {
-      this.uppy.addFile({
-        source: this.id,
-        name: file.name,
-        type: file.type,
-        data: file
-      })
+      try {
+        this.uppy.addFile({
+          source: this.id,
+          name: file.name,
+          type: file.type,
+          data: file
+        })
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     })
   }
 

--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -135,7 +135,11 @@ module.exports = class Url extends Plugin {
       })
       .then((tagFile) => {
         this.uppy.log('[Url] Adding remote file')
-        return this.uppy.addFile(tagFile)
+        try {
+          this.uppy.addFile(tagFile)
+        } catch (err) {
+          // Nothing, restriction errors handled in Core
+        }
       })
       .then(() => {
         const dashboard = this.uppy.getPlugin('Dashboard')
@@ -158,7 +162,11 @@ module.exports = class Url extends Plugin {
         if (item.kind === 'string' && item.type === 'text/uri-list') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from dropped url: ${url}`)
-            this.addFile(url)
+            try {
+              this.addFile(url)
+            } catch (err) {
+              // Nothing, restriction errors handled in Core
+            }
           })
         }
       })
@@ -189,7 +197,11 @@ module.exports = class Url extends Plugin {
         if (item.kind === 'string' && item.type === 'text/plain') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from pasted url: ${url}`)
-            this.addFile(url)
+            try {
+              this.addFile(url)
+            } catch (err) {
+              // Nothing, restriction errors handled in Core
+            }
           })
         }
       })

--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -162,11 +162,7 @@ module.exports = class Url extends Plugin {
         if (item.kind === 'string' && item.type === 'text/uri-list') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from dropped url: ${url}`)
-            try {
-              this.addFile(url)
-            } catch (err) {
-              // Nothing, restriction errors handled in Core
-            }
+            this.addFile(url)
           })
         }
       })
@@ -197,11 +193,7 @@ module.exports = class Url extends Plugin {
         if (item.kind === 'string' && item.type === 'text/plain') {
           item.getAsString((url) => {
             this.uppy.log(`[URL] Adding file from pasted url: ${url}`)
-            try {
-              this.addFile(url)
-            } catch (err) {
-              // Nothing, restriction errors handled in Core
-            }
+            this.addFile(url)
           })
         }
       })

--- a/src/plugins/Webcam/index.js
+++ b/src/plugins/Webcam/index.js
@@ -173,7 +173,13 @@ module.exports = class Webcam extends Plugin {
       })
       return this.getVideo()
     })
-    .then((file) => this.uppy.addFile(file))
+    .then((file) => {
+      try {
+        this.uppy.addFile(file)
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
+    })
     .then(() => {
       this.recordingChunks = null
       this.recorder = null
@@ -238,7 +244,11 @@ module.exports = class Webcam extends Plugin {
       this.captureInProgress = false
       const dashboard = this.uppy.getPlugin('Dashboard')
       if (dashboard) dashboard.hideAllPanels()
-      return this.uppy.addFile(tagFile)
+      try {
+        this.uppy.addFile(tagFile)
+      } catch (err) {
+        // Nothing, restriction errors handled in Core
+      }
     }, (error) => {
       this.captureInProgress = false
       throw error

--- a/src/views/ProviderView/index.js
+++ b/src/views/ProviderView/index.js
@@ -174,7 +174,11 @@ module.exports = class ProviderView {
       tagFile.preview = this.plugin.getItemThumbnailUrl(file)
     }
     this.plugin.uppy.log('Adding remote file')
-    this.plugin.uppy.addFile(tagFile)
+    try {
+      this.plugin.uppy.addFile(tagFile)
+    } catch (err) {
+      // Nothing, restriction errors handled in Core
+    }
     if (!isCheckbox) {
       this.donePicking()
     }


### PR DESCRIPTION
Follow up to https://github.com/transloadit/uppy/pull/294

Otherwise when restrictions were not met, Uppy would throw an error (now just logs). But when you call `uppy.addFile()` yourself, it will throw as expected.