### PR TITLE
Attach upload response to file object

### DIFF
--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -703,6 +703,7 @@ class Uppy {
           uploadComplete: true,
           percentage: 100
         }),
+        response: uploadResp,
         uploadURL: uploadURL,
         isPaused: false
       })


### PR DESCRIPTION
As stated here: [https://uppy.io/docs/xhrupload/#getResponseData-responseText-response](https://uppy.io/docs/xhrupload/#getResponseData-responseText-response) the response should be attached to file object after a successful upload.
