### PR TITLE
Tolerate trailing slashes in `host` options.

### DIFF
--- a/src/server/RequestClient.js
+++ b/src/server/RequestClient.js
@@ -2,6 +2,11 @@
 
 require('whatwg-fetch')
 
+// Remove the trailing slash so we can always safely append /xyz.
+function stripSlash (url) {
+  return url.replace(/\/$/, '')
+}
+
 module.exports = class RequestClient {
   constructor (uppy, opts) {
     this.uppy = uppy
@@ -12,7 +17,7 @@ module.exports = class RequestClient {
   get hostname () {
     const { uppyServer } = this.uppy.getState()
     const host = this.opts.host
-    return uppyServer && uppyServer[host] ? uppyServer[host] : host
+    return stripSlash(uppyServer && uppyServer[host] ? uppyServer[host] : host)
   }
 
   get defaultHeaders () {

--- a/src/server/RequestClient.test.js
+++ b/src/server/RequestClient.test.js
@@ -1,0 +1,12 @@
+const RequestClient = require('./RequestClient')
+
+describe('RequestClient', () => {
+  it('has a hostname without trailing slash', () => {
+    const mockCore = { getState: () => ({}) }
+    const a = new RequestClient(mockCore, { host: 'http://server.uppy.io' })
+    const b = new RequestClient(mockCore, { host: 'http://server.uppy.io/' })
+
+    expect(a.hostname).toBe('http://server.uppy.io')
+    expect(b.hostname).toBe('http://server.uppy.io')
+  })
+})


### PR DESCRIPTION
As seen in #879, having a trailing slash in a `host` option breaks
providers:

```js
// does not work: does requests like https://server.uppy.io//drive/list
uppy.use(GoogleDrive, { host: 'https://server.uppy.io/' })
```

This patch strips the trailing slash if it exists so we can always
safely append `/drive/list` and get a well formed URL back.

Closes #879