### PR TITLE
s3: Fix uploadURL for presigned PUT uploads

### DIFF
--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -159,7 +159,10 @@ module.exports = class AwsS3 extends Plugin {
         // If no response, we've hopefully done a PUT request to the file
         // in the bucket on its full URL.
         if (!isXml(xhr)) {
-          return { location: xhr.responseURL }
+          // Trim the query string because it's going to be a bunch of presign
+          // parameters for a PUT request—doing a GET request with those will
+          // always result in an error
+          return { location: xhr.responseURL.replace(/\?.*$/, '') }
         }
 
         let getValue = () => ''


### PR DESCRIPTION
This strips the query string from the URL used for a successful PUT
upload to determine the `uploadURL`. For PUT uploads, the path that you
use for the upload is the same as the path you use to access the object.
But the query string contains a signature for a PUT request, so it can't
be used for a GET request. Simply removing it is not always enough (the
bucket may restrict GET requests) but it's better than having a PUT
signature in there.

Ref https://github.com/transloadit/uppy/issues/815