### PR TITLE
Updated ThumbnailGenerator to work with IE

### DIFF
--- a/src/plugins/ThumbnailGenerator/index.js
+++ b/src/plugins/ThumbnailGenerator/index.js
@@ -105,7 +105,9 @@ module.exports = class ThumbnailGenerator extends Plugin {
 
     image = this.protect(image)
 
-    var steps = Math.ceil(Math.log2(image.width / targetWidth))
+    // Use the Polyfill for Math.log2() since IE doesn't support log2
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2#Polyfill
+    var steps = Math.ceil(Math.log(image.width / targetWidth) * Math.LOG2E);
     if (steps < 1) {
       steps = 1
     }

--- a/src/plugins/ThumbnailGenerator/index.js
+++ b/src/plugins/ThumbnailGenerator/index.js
@@ -107,7 +107,7 @@ module.exports = class ThumbnailGenerator extends Plugin {
 
     // Use the Polyfill for Math.log2() since IE doesn't support log2
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2#Polyfill
-    var steps = Math.ceil(Math.log(image.width / targetWidth) * Math.LOG2E);
+    var steps = Math.ceil(Math.log(image.width / targetWidth) * Math.LOG2E)
     if (steps < 1) {
       steps = 1
     }


### PR DESCRIPTION
Use the polyfill for Math.log2() since IE doesn't support this method

This fixes #891 

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2#Polyfill