### PR TITLE
refactor: rename host option to serverUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ const Tus = require('uppy/lib/plugins/Tus')
 
 const uppy = Uppy({ autoProceed: false })
   .use(Dashboard, { trigger: '#select-files' })
-  .use(GoogleDrive, { target: Dashboard, host: 'https://server.uppy.io' })
-  .use(Instagram, { target: Dashboard, host: 'https://server.uppy.io' })
+  .use(GoogleDrive, { target: Dashboard, serverUrl: 'https://server.uppy.io' })
+  .use(Instagram, { target: Dashboard, serverUrl: 'https://server.uppy.io' })
   .use(Webcam, { target: Dashboard })
   .use(Tus, { endpoint: 'https://master.tus.io/files/' })
   .on('complete', (result) => {

--- a/bin/start-server.js
+++ b/bin/start-server.js
@@ -9,7 +9,7 @@ Object.assign(process.env, {
   UPPYSERVER_PROTOCOL: 'http',
   UPPYSERVER_PORT: '3020',
   UPPY_ENDPOINT: 'localhost:3452',
-  UPPY_ENDPOINTS: 'localhost:3452'
+  UPPY_ENDPOINTS: 'localhost:3452,localhost:4000'
 })
 
 require('uppy-server/lib/standalone/start-server')

--- a/examples/aws-uppy-server/main.js
+++ b/examples/aws-uppy-server/main.js
@@ -10,7 +10,7 @@ const uppy = Uppy({
 })
 
 uppy.use(GoogleDrive, {
-  host: 'http://localhost:3020'
+  serverUrl: 'http://localhost:3020'
 })
 uppy.use(Webcam)
 uppy.use(Dashboard, {
@@ -19,5 +19,5 @@ uppy.use(Dashboard, {
   plugins: ['GoogleDrive', 'Webcam']
 })
 uppy.use(AwsS3, {
-  host: 'http://localhost:3020'
+  serverUrl: 'http://localhost:3020'
 })

--- a/examples/aws-uppy-server/server.js
+++ b/examples/aws-uppy-server/server.js
@@ -31,7 +31,7 @@ const options = {
       region: process.env.UPPYSERVER_AWS_REGION
     }
   },
-  server: { host: 'localhost:3020' },
+  server: { serverUrl: 'localhost:3020' },
   filePath: DATA_DIR,
   secret: 'blah blah',
   debug: true

--- a/examples/bundled-example/main.js
+++ b/examples/bundled-example/main.js
@@ -28,8 +28,8 @@ const uppy = Uppy({
     proudlyDisplayPoweredByUppy: true,
     note: '2 files, images and video only'
   })
-  .use(GoogleDrive, { target: Dashboard, host: 'http://localhost:3020' })
-  .use(Instagram, { target: Dashboard, host: 'http://localhost:3020' })
+  .use(GoogleDrive, { target: Dashboard, serverUrl: 'http://localhost:3020' })
+  .use(Instagram, { target: Dashboard, serverUrl: 'http://localhost:3020' })
   .use(Webcam, { target: Dashboard })
   .use(Tus, { endpoint: TUS_ENDPOINT })
   .use(Form, { target: '#upload-form' })

--- a/examples/custom-provider/client/MyCustomProvider.js
+++ b/examples/custom-provider/client/MyCustomProvider.js
@@ -16,7 +16,7 @@ module.exports = class MyCustomProvider extends Plugin {
     // writing out the key explicitly for readability the key used to store
     // the provider instance must be equal to this.id.
     this[this.id] = new Provider(uppy, {
-      host: this.opts.host,
+      serverUrl: this.opts.serverUrl,
       provider: 'mycustomprovider'
     })
 

--- a/examples/custom-provider/client/main.js
+++ b/examples/custom-provider/client/main.js
@@ -10,11 +10,11 @@ const uppy = Uppy({
 })
 
 uppy.use(GoogleDrive, {
-  host: 'http://localhost:3020'
+  serverUrl: 'http://localhost:3020'
 })
 
 uppy.use(MyCustomProvider, {
-  host: 'http://localhost:3020'
+  serverUrl: 'http://localhost:3020'
 })
 
 uppy.use(Dashboard, {

--- a/examples/digitalocean-spaces/main.js
+++ b/examples/digitalocean-spaces/main.js
@@ -13,4 +13,4 @@ uppy.use(Dashboard, {
 })
 
 // No client side changes needed!
-uppy.use(AwsS3, { host: '/uppy-server' })
+uppy.use(AwsS3, { serverUrl: '/uppy-server' })

--- a/examples/digitalocean-spaces/server.js
+++ b/examples/digitalocean-spaces/server.js
@@ -39,7 +39,7 @@ app.use('/uppy-server', uppy.app({
       region: process.env.UPPYSERVER_AWS_REGION
     }
   },
-  server: { host: `localhost:${PORT}` }
+  server: { serverUrl: `localhost:${PORT}` }
 }))
 
 // Serve the built CSS file.

--- a/examples/react-example/App.js
+++ b/examples/react-example/App.js
@@ -20,7 +20,7 @@ module.exports = class App extends React.Component {
   componentWillMount () {
     this.uppy = new Uppy({ id: 'uppy1', autoProceed: true, debug: true })
       .use(Tus, { endpoint: 'https://master.tus.io/files/' })
-      .use(GoogleDrive, { host: 'https://server.uppy.io' })
+      .use(GoogleDrive, { serverUrl: 'https://server.uppy.io' })
 
     this.uppy2 = new Uppy({ id: 'uppy2', autoProceed: false, debug: true })
       .use(Tus, { endpoint: 'https://master.tus.io/files/' })

--- a/examples/uppy-with-server/client/index.html
+++ b/examples/uppy-with-server/client/index.html
@@ -12,8 +12,8 @@
     <script>
       const uppy = Uppy.Core({debug: true, autoProceed: false})
         .use(Uppy.Dashboard, { trigger: '#uppyModalOpener' })
-        .use(Uppy.Instagram, { target: Uppy.Dashboard, host: 'http://localhost:3020' })
-        .use(Uppy.GoogleDrive, { target: Uppy.Dashboard, host: 'http://localhost:3020' })
+        .use(Uppy.Instagram, { target: Uppy.Dashboard, serverUrl: 'http://localhost:3020' })
+        .use(Uppy.GoogleDrive, { target: Uppy.Dashboard, serverUrl: 'http://localhost:3020' })
         .use(Uppy.Tus, { endpoint: 'https://master.tus.io/files/' })
 
       uppy.on('success', (fileCount) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,15 @@
       "integrity": "sha512-GiCx7dRvta0hbxXoJFAUxz+CKX6bZSCKjM5slq2vPp/5zwK01T4ibYZkGr6EN4F2QmxDQR76/ZHg6q+7iFWCWw==",
       "dev": true
     },
+    "@uppy/fs-tail-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@uppy/fs-tail-stream/-/fs-tail-stream-1.2.0.tgz",
+      "integrity": "sha512-Yil6Z4phfYBHneLK5aimQ4AtVleorcTRuy0TzJrhFx4OEdbGUQ8haLQklQUOhaFJbaeu20VGishz/kLWzQiiTg==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -609,20 +618,20 @@
       }
     },
     "aws-sdk": {
-      "version": "2.211.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.211.0.tgz",
-      "integrity": "sha1-kCt1Jedv+fpyzQOLc7ikfIxnGmI=",
+      "version": "2.257.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.257.1.tgz",
+      "integrity": "sha512-Bfzm8DoGFxW3oegCbKwid67TNUmF3Tn3v+ynCI0YauEiDw7t0lKwzJ2NrFOHh2G00cNN/evMhFHBP7TGN/LVfQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
-        "events": "^1.1.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
         "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
+        "xml2js": "0.4.17"
       },
       "dependencies": {
         "buffer": {
@@ -2025,12 +2034,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-      "dev": true
-    },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
       "dev": true
     },
     "basic-auth": {
@@ -3895,9 +3898,9 @@
       }
     },
     "cron-parser": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.4.5.tgz",
-      "integrity": "sha512-J/BXGGFLQCxrLqcGT9Zp1Yz9H1LfZqlUJ7JRgfbtwt6fkWGVKKtMskF/iDxkA7MXJoaYerwyHX48lZuZoOJ1Eg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.5.0.tgz",
+      "integrity": "sha512-gzmXu16/prizIbKPPKJo+WgBpV7k8Rxxu9FgaANW+vx5DebCXavfRqbROjKkr9ETvVPqs+IO+NXj4GG/eLf8zQ==",
       "dev": true,
       "requires": {
         "is-nan": "^1.2.1",
@@ -4697,12 +4700,11 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "dev": true,
       "requires": {
-        "base64url": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -6924,7 +6926,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -6941,12 +6944,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6959,12 +6964,14 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -7009,7 +7016,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -7041,7 +7049,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -7211,6 +7220,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -7224,7 +7234,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -7297,12 +7308,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -7378,7 +7391,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -7436,7 +7450,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -7474,6 +7489,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -7582,6 +7598,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7592,6 +7609,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -7675,7 +7693,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -7976,23 +7995,32 @@
       "dev": true
     },
     "grant": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/grant/-/grant-3.8.0.tgz",
-      "integrity": "sha512-Q8UN1j9JQmmb/Wf7PlYXJn92IjX9Tio21rEV5jOte/novOaZ/l0xMWNel7CDbRw0zqFEnYIIAyh1Cri2u3poUw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/grant/-/grant-4.1.1.tgz",
+      "integrity": "sha512-YeJyTCud72x0oeeUwJvDc24JYN+E4ItcVYdVOrEh4bopFmXpvByVFqtnalsxYNL2xkzrfxzO5AQ4JPygydOGMA==",
       "dev": true,
       "requires": {
-        "deep-copy": "^1.2.0",
-        "qs": "6.4.0",
-        "request": "2.81.0"
+        "deep-copy": "^1.4.2",
+        "qs": "^6.5.1",
+        "request-compose": "0.0.12",
+        "request-oauth": "0.0.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "grant-express": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/grant-express/-/grant-express-3.8.0.tgz",
-      "integrity": "sha512-Ph3SSr8vQTt9igZn4GAARjfOYPlB3nxngs0NwBqFNPbBdSPf+m5keEibfrP2GfeYK1GCYoz85BPQzQQZYbBzpQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/grant-express/-/grant-express-4.1.1.tgz",
+      "integrity": "sha512-VfvLWpAApx39VxIaTeJ4TFwVZUoG+kz6XkfQIeXHJQMmVqcjAjpOfJsVp+ll5GS4J3036T+mn1q1X3/DKrpYQg==",
       "dev": true,
       "requires": {
-        "grant": "3.8.0"
+        "grant": "4.1.1"
       }
     },
     "growly": {
@@ -11075,12 +11103,12 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.0.tgz",
-      "integrity": "sha512-1Wxh8ADP3cNyPl8tZ95WtraHXCAyXupgc0AhMHjU9er98BV+UcKsO7OJUjfhIu0Uba9A40n1oSx8dbJYrm+EoQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "dev": true,
       "requires": {
-        "jws": "^3.1.4",
+        "jws": "^3.1.5",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -11088,8 +11116,7 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "xtend": "^4.0.1"
+        "ms": "^2.1.1"
       },
       "dependencies": {
         "ms": {
@@ -11130,25 +11157,23 @@
       }
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "dev": true,
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "dev": true,
       "requires": {
-        "base64url": "^2.0.0",
-        "jwa": "^1.1.4",
+        "jwa": "^1.1.5",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -12163,15 +12188,15 @@
       }
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
+      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
@@ -15533,6 +15558,37 @@
         "uuid": "^3.0.0"
       }
     },
+    "request-compose": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-0.0.12.tgz",
+      "integrity": "sha512-vseyB7g1Fx/HQ4hCm9Tn1tEQHuRQ+9bjWEE2rt8DAf4cHYSVTxBt3rLcxKUIR3SehZz733PS+R7blCUQhBEQrQ==",
+      "dev": true
+    },
+    "request-oauth": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/request-oauth/-/request-oauth-0.0.2.tgz",
+      "integrity": "sha512-3fVvSCEgJ17zh2RtgjgGSK1PcozJXffXsjYQB6cjzgMp2NG+rlqTm5OwwGCe3Y1KcDqanuYb7G7A5iPnJauu4Q==",
+      "dev": true,
+      "requires": {
+        "oauth-sign": "^0.8.2",
+        "qs": "^6.5.1",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
+        }
+      }
+    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
@@ -15989,23 +16045,15 @@
           "dev": true
         },
         "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "1.1.1",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-              "dev": true
-            }
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "ms": {
@@ -16015,9 +16063,9 @@
           "dev": true
         },
         "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
         "statuses": {
@@ -16263,9 +16311,9 @@
       }
     },
     "sorted-array-functions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.1.0.tgz",
-      "integrity": "sha512-zq6fLdGQixb9VZfT/tLgU+LzoedJyTbcf1I/TKETFeUVoWIfcs5HNr+SJSvQJLXRlEZjB1gpILTrxamxAdCcgA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
+      "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg==",
       "dev": true
     },
     "source-map": {
@@ -17496,13 +17544,14 @@
       }
     },
     "uppy-server": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/uppy-server/-/uppy-server-0.11.2.tgz",
-      "integrity": "sha512-aAvPqlCZxaOCeeu9/92N6HjdYtZx8a/qvnrzlWTv/9vTSIwS1fDgYhrGv6rfIqZblfV242OpJxKzwE+8iGMAag==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/uppy-server/-/uppy-server-0.13.1.tgz",
+      "integrity": "sha512-rKec3evxtWZoZY2Me/q3lO3DG7eWM8bcDWwkntBVcr/WjZ+dNVCf9bdAXlhpzuILGbUWDN6HHDH+TBeYN3Tx9Q==",
       "dev": true,
       "requires": {
         "@purest/providers": "1.0.0",
-        "atob": "2.0.3",
+        "@uppy/fs-tail-stream": "^1.2.0",
+        "atob": "2.1.0",
         "aws-sdk": "^2.77.0",
         "body-parser": "1.18.2",
         "common-tags": "^1.7.2",
@@ -17512,8 +17561,9 @@
         "express-interceptor": "^1.2.0",
         "express-prom-bundle": "^3.1.0",
         "express-session": "1.15.6",
-        "grant-express": "3.8.0",
+        "grant-express": "^4.0.1",
         "helmet": "3.8.2",
+        "isobject": "3.0.1",
         "jsonwebtoken": "^8.0.1",
         "lodash.merge": "^4.6.0",
         "morgan": "1.9.0",
@@ -17522,7 +17572,7 @@
         "prom-client": "^10.0.2",
         "purest": "3.0.0",
         "redis": "^2.7.1",
-        "request": "^2.81.0",
+        "request": "^2.83.0",
         "serialize-error": "^2.1.0",
         "tus-js-client": "1.4.5",
         "uuid": "2.0.2",
@@ -17530,29 +17580,110 @@
         "ws": "1.1.5"
       },
       "dependencies": {
-        "atob": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-          "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
-          "dev": true
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+          "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
         "common-tags": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
-          "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+          "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0"
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
           }
         },
         "ms": {
@@ -17561,11 +17692,68 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+              "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+              "dev": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
         },
         "ultron": {
           "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "temp-write": "^3.4.0",
     "tinyify": "^2.4.0",
     "typescript": "^2.8.1",
-    "uppy-server": "^0.11.2",
+    "uppy-server": "^0.13.1",
     "watchify": "^3.9.0",
     "wdio-mocha-framework": "^0.5.12",
     "wdio-sauce-service": "^0.4.6",

--- a/src/plugins/AwsS3/Multipart.js
+++ b/src/plugins/AwsS3/Multipart.js
@@ -89,8 +89,8 @@ module.exports = class AwsS3Multipart extends Plugin {
   }
 
   assertHost () {
-    if (!this.opts.host) {
-      throw new Error('Expected a `host` option containing an uppy-server address.')
+    if (!this.opts.serverUrl) {
+      throw new Error('Expected a `serverUrl` option containing an uppy-server address.')
     }
   }
 
@@ -287,7 +287,7 @@ module.exports = class AwsS3Multipart extends Plugin {
   connectToServerSocket (file) {
     return new Promise((resolve, reject) => {
       const token = file.serverToken
-      const host = getSocketHost(file.remote.host)
+      const host = getSocketHost(file.remote.serverUrl)
       const socket = new UppySocket({ target: `${host}/api/${token}` })
       this.uploaderSockets[socket] = socket
       this.uploaderEvents[file.id] = createEventTracker(this.uppy)

--- a/src/plugins/AwsS3/index.js
+++ b/src/plugins/AwsS3/index.js
@@ -46,13 +46,13 @@ module.exports = class AwsS3 extends Plugin {
   }
 
   getUploadParameters (file) {
-    if (!this.opts.host) {
-      throw new Error('Expected a `host` option containing an uppy-server address.')
+    if (!this.opts.serverUrl) {
+      throw new Error('Expected a `serverUrl` option containing an uppy-server address.')
     }
 
     const filename = encodeURIComponent(file.name)
     const type = encodeURIComponent(file.type)
-    return fetch(`${this.opts.host}/s3/params?filename=${filename}&type=${type}`, {
+    return fetch(`${this.opts.serverUrl}/s3/params?filename=${filename}&type=${type}`, {
       method: 'get',
       headers: { accept: 'application/json' }
     }).then((response) => response.json())

--- a/src/plugins/Dropbox/index.js
+++ b/src/plugins/Dropbox/index.js
@@ -21,7 +21,7 @@ module.exports = class Dropbox extends Plugin {
     // writing out the key explicitly for readability the key used to store
     // the provider instance must be equal to this.id.
     this[this.id] = new Provider(uppy, {
-      host: this.opts.host,
+      serverUrl: this.opts.serverUrl,
       provider: 'dropbox'
     })
 
@@ -35,7 +35,7 @@ module.exports = class Dropbox extends Plugin {
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
-    this.opts.hostPattern = opts.hostPattern || opts.host
+    this.opts.serverPattern = opts.serverPattern || opts.serverUrl
   }
 
   install () {
@@ -111,7 +111,7 @@ module.exports = class Dropbox extends Plugin {
   }
 
   getItemThumbnailUrl (item) {
-    return `${this.opts.host}/${this.Dropbox.id}/thumbnail/${this.getItemRequestPath(item)}`
+    return `${this.opts.serverUrl}/${this.Dropbox.id}/thumbnail/${this.getItemRequestPath(item)}`
   }
 
   render (state) {

--- a/src/plugins/GoogleDrive/index.js
+++ b/src/plugins/GoogleDrive/index.js
@@ -15,7 +15,7 @@ module.exports = class GoogleDrive extends Plugin {
       </svg>
 
     this[this.id] = new Provider(uppy, {
-      host: this.opts.host,
+      serverUrl: this.opts.serverUrl,
       provider: 'drive',
       authProvider: 'google'
     })
@@ -30,7 +30,7 @@ module.exports = class GoogleDrive extends Plugin {
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
-    this.opts.hostPattern = opts.hostPattern || opts.host
+    this.opts.serverPattern = opts.serverPattern || opts.serverUrl
   }
 
   install () {
@@ -115,7 +115,7 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemThumbnailUrl (item) {
-    return `${this.opts.host}/${this.GoogleDrive.id}/thumbnail/${this.getItemRequestPath(item)}`
+    return `${this.opts.serverUrl}/${this.GoogleDrive.id}/thumbnail/${this.getItemRequestPath(item)}`
   }
 
   render (state) {

--- a/src/plugins/Instagram/index.js
+++ b/src/plugins/Instagram/index.js
@@ -18,7 +18,7 @@ module.exports = class Instagram extends Plugin {
     )
 
     this[this.id] = new Provider(uppy, {
-      host: this.opts.host,
+      serverUrl: this.opts.serverUrl,
       provider: 'instagram',
       authProvider: 'instagram'
     })
@@ -33,7 +33,7 @@ module.exports = class Instagram extends Plugin {
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
-    this.opts.hostPattern = opts.hostPattern || opts.host
+    this.opts.serverPattern = opts.serverPattern || opts.serverUrl
   }
 
   install () {

--- a/src/plugins/Transloadit/index.js
+++ b/src/plugins/Transloadit/index.js
@@ -190,16 +190,16 @@ module.exports = class Transloadit extends Plugin {
         // We only replace the hostname for Transloadit's uppy-servers, so that
         // people can self-host them while still using Transloadit for encoding.
         let remote = file.remote
-        if (file.remote && TL_UPPY_SERVER.test(file.remote.host)) {
+        if (file.remote && TL_UPPY_SERVER.test(file.remote.serverUrl)) {
           let newHost = assembly.uppyserver_url
-          let path = file.remote.url.replace(file.remote.host, '')
+          let path = file.remote.url.replace(file.remote.serverUrl, '')
           // remove tailing slash
           newHost = newHost.replace(/\/$/, '')
           // remove leading slash
           path = path.replace(/^\//, '')
 
           remote = Object.assign({}, file.remote, {
-            host: newHost,
+            serverUrl: newHost,
             url: `${newHost}/${path}`
           })
         }

--- a/src/plugins/Tus.js
+++ b/src/plugins/Tus.js
@@ -271,7 +271,7 @@ module.exports = class Tus extends Plugin {
   connectToServerSocket (file) {
     return new Promise((resolve, reject) => {
       const token = file.serverToken
-      const host = getSocketHost(file.remote.host)
+      const host = getSocketHost(file.remote.serverUrl)
       const socket = new UppySocket({ target: `${host}/api/${token}` })
       this.uploaderSockets[file.id] = socket
       this.uploaderEvents[file.id] = createEventTracker(this.uppy)

--- a/src/plugins/Url/index.js
+++ b/src/plugins/Url/index.js
@@ -45,7 +45,7 @@ module.exports = class Url extends Plugin {
     this.translator = new Translator({locale: this.locale})
     this.i18n = this.translator.translate.bind(this.translator)
 
-    this.hostname = this.opts.host
+    this.hostname = this.opts.serverUrl
 
     if (!this.hostname) {
       throw new Error('Uppy Server hostname is required, please consult https://uppy.io/docs/server')
@@ -60,7 +60,7 @@ module.exports = class Url extends Plugin {
 
     this.handlePaste = this.handlePaste.bind(this)
 
-    this.client = new RequestClient(uppy, {host: this.opts.host})
+    this.client = new RequestClient(uppy, { serverUrl: this.opts.serverUrl })
   }
 
   getFileNameFromUrl (url) {
@@ -122,7 +122,7 @@ module.exports = class Url extends Plugin {
             url: url
           },
           remote: {
-            host: this.opts.host,
+            serverUrl: this.opts.serverUrl,
             url: `${this.hostname}/url/get`,
             body: {
               fileId: url,

--- a/src/plugins/XHRUpload.js
+++ b/src/plugins/XHRUpload.js
@@ -327,7 +327,7 @@ module.exports = class XHRUpload extends Plugin {
       )
       .then((res) => {
         const token = res.token
-        const host = getSocketHost(file.remote.host)
+        const host = getSocketHost(file.remote.serverUrl)
         const socket = new UppySocket({ target: `${host}/api/${token}` })
 
         socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))

--- a/src/server/RequestClient.js
+++ b/src/server/RequestClient.js
@@ -16,7 +16,7 @@ module.exports = class RequestClient {
 
   get hostname () {
     const { uppyServer } = this.uppy.getState()
-    const host = this.opts.host
+    const host = this.opts.serverUrl
     return stripSlash(uppyServer && uppyServer[host] ? uppyServer[host] : host)
   }
 
@@ -30,7 +30,7 @@ module.exports = class RequestClient {
   onReceiveResponse (response) {
     const state = this.uppy.getState()
     const uppyServer = state.uppyServer || {}
-    const host = this.opts.host
+    const host = this.opts.serverUrl
     const headers = response.headers
     // Store the self-identified domain name for the uppy-server we just hit.
     if (headers.has('i-am') && headers.get('i-am') !== uppyServer[host]) {

--- a/src/server/RequestClient.test.js
+++ b/src/server/RequestClient.test.js
@@ -3,8 +3,8 @@ const RequestClient = require('./RequestClient')
 describe('RequestClient', () => {
   it('has a hostname without trailing slash', () => {
     const mockCore = { getState: () => ({}) }
-    const a = new RequestClient(mockCore, { host: 'http://server.uppy.io' })
-    const b = new RequestClient(mockCore, { host: 'http://server.uppy.io/' })
+    const a = new RequestClient(mockCore, { serverUrl: 'http://server.uppy.io' })
+    const b = new RequestClient(mockCore, { serverUrl: 'http://server.uppy.io/' })
 
     expect(a.hostname).toBe('http://server.uppy.io')
     expect(b.hostname).toBe('http://server.uppy.io')

--- a/src/views/ProviderView/index.js
+++ b/src/views/ProviderView/index.js
@@ -182,7 +182,7 @@ module.exports = class ProviderView {
         fileId: this.plugin.getItemId(file)
       },
       remote: {
-        host: this.plugin.opts.host,
+        serverUrl: this.plugin.opts.serverUrl,
         url: `${this.Provider.fileUrl(this.plugin.getItemRequestPath(file))}`,
         body: {
           fileId: this.plugin.getItemId(file)
@@ -453,9 +453,9 @@ module.exports = class ProviderView {
     const authWindow = window.open(link, '_blank')
     const noProtocol = (url) => url.replace(/^(https?:|)\/\//, '')
     const handleToken = (e) => {
-      const allowedOrigin = new RegExp(noProtocol(this.plugin.opts.hostPattern))
+      const allowedOrigin = new RegExp(noProtocol(this.plugin.opts.serverPattern))
       if (!allowedOrigin.test(noProtocol(e.origin)) || e.source !== authWindow) {
-        this.plugin.uppy.log(`rejecting event from ${e.origin} vs allowed pattern ${this.plugin.opts.hostPattern}`)
+        this.plugin.uppy.log(`rejecting event from ${e.origin} vs allowed pattern ${this.plugin.opts.serverPattern}`)
         return
       }
       authWindow.close()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -283,7 +283,7 @@ declare namespace plugins {
 		expires: number;
 		serviceWorker: boolean;
 		indexedDB: any;
-		host: string;
+		serverUrl: string;
 	}
 	class GoogleDrive extends core.Plugin {
 		constructor(uppy: core.Uppy, opts: Partial<GoogleDriveOptions>);
@@ -296,7 +296,7 @@ declare namespace plugins {
 		deleteBlobs(): Promise<any>;
 	}
 	interface InstagramOptions extends core.CoreConfig {
-		host: string;
+		serverUrl: string;
 	}
 	class Instagram extends core.Plugin {
 		constructor(uppy: core.Uppy, opts: Partial<InstagramOptions>);
@@ -345,20 +345,20 @@ declare namespace plugins {
 		constructor(uppy: core.Uppy, opts: Partial<StatusBarOptions>);
 	}
 	interface UrlOptions extends core.CoreConfig {
-		host: string;
+		serverUrl: string;
 	}
 	class Url extends core.Plugin {
 		constructor(uppy: core.Uppy, opts: Partial<UrlOptions>);
 	}
 	interface DropboxOptions extends core.CoreConfig {
-		host: string;
+		serverUrl: string;
 	}
 	class Dropbox extends core.Plugin {
 		constructor(uppy: core.Uppy, opts: Partial<DropboxOptions>);
 	}
 	interface AwsS3Options extends core.CoreConfig {
 		limit: number;
-		host: string;
+		serverUrl: string;
 		timeout: number;
 	}
 	class AwsS3 extends core.Plugin {

--- a/types/uppy-tests.ts
+++ b/types/uppy-tests.ts
@@ -18,8 +18,8 @@ import Uppy = require('uppy');
 (() => {
 	const uppy = Uppy.Core({ autoProceed: false })
 		.use(Uppy.Dashboard, { trigger: '#select-files' })
-		.use(Uppy.GoogleDrive, { target: Uppy.Dashboard, host: 'https://server.uppy.io' })
-		.use(Uppy.Instagram, { target: Uppy.Dashboard, host: 'https://server.uppy.io' })
+		.use(Uppy.GoogleDrive, { target: Uppy.Dashboard, serverUrl: 'https://server.uppy.io' })
+		.use(Uppy.Instagram, { target: Uppy.Dashboard, serverUrl: 'https://server.uppy.io' })
 		.use(Uppy.Webcam, { target: Uppy.Dashboard })
 		.use(Uppy.Tus, { endpoint: 'https://master.tus.io/files/' })
 		.run()

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -11,7 +11,7 @@ The `AwsS3Multipart` plugin can be used to upload files directly to an S3 bucket
 const AwsS3Multipart = require('uppy/lib/plugins/AwsS3/Multipart')
 uppy.use(AwsS3Multipart, {
   limit: 4,
-  host: 'https://uppy-server.myapp.net/'
+  serverUrl: 'https://uppy-server.myapp.net/'
 })
 ```
 
@@ -21,7 +21,7 @@ uppy.use(AwsS3Multipart, {
 
 The maximum amount of chunks to upload simultaneously. `0` means unlimited.
 
-### host: null
+### serverUrl: null
 
 The Uppy Server URL to use to proxy calls to the S3 Multipart API.
 

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -15,7 +15,7 @@ const ms = require('ms')
 uppy.use(AwsS3, {
   limit: 2,
   timeout: ms('1 minute'),
-  host: 'https://uppy-server.myapp.com/'
+  serverUrl: 'https://uppy-server.myapp.com/'
 })
 ```
 
@@ -29,13 +29,13 @@ There is also a separate plugin for S3 Multipart uploads. Multipart in this sens
 
 A unique identifier for this plugin. Defaults to `'AwsS3'`.
 
-### `host`
+### `serverUrl`
 
 When using [uppy-server][uppy-server docs] to sign S3 uploads, set this option to the root URL of the uppy-server.
 
 ```js
 uppy.use(AwsS3, {
-  host: 'https://uppy-server.my-app.com/'
+  serverUrl: 'https://uppy-server.my-app.com/'
 })
 ```
 

--- a/website/src/docs/dropbox.md
+++ b/website/src/docs/dropbox.md
@@ -24,7 +24,7 @@ uppy.use(Dropbox, {
 ```js
 uppy.use(Dropbox, {
   target: Dashboard,
-  host: 'https://server.uppy.io/',
+  serverUrl: 'https://server.uppy.io/',
 })
 ```
 
@@ -36,7 +36,7 @@ A unique identifier for this plugin. Defaults to `'Dropbox'`.
 
 DOM element, CSS selector, or plugin to mount the Dropbox provider into. This should normally be the Dashboard.
 
-### `host: null`
+### `serverUrl: null`
 
 URL to an Uppy Server instance.
 

--- a/website/src/docs/google-drive.md
+++ b/website/src/docs/google-drive.md
@@ -24,7 +24,7 @@ uppy.use(GoogleDrive, {
 ```js
 uppy.use(GoogleDrive, {
   target: Dashboard,
-  host: 'https://server.uppy.io/',
+  serverUrl: 'https://server.uppy.io/',
 })
 ```
 
@@ -36,7 +36,7 @@ A unique identifier for this plugin. Defaults to `'GoogleDrive'`.
 
 DOM element, CSS selector, or plugin to mount the GoogleDrive provider into. This should normally be the Dashboard.
 
-### `host: null`
+### `serverUrl: null`
 
 URL to an Uppy Server instance.
 

--- a/website/src/docs/instagram.md
+++ b/website/src/docs/instagram.md
@@ -24,7 +24,7 @@ uppy.use(Instagram, {
 ```js
 uppy.use(Instagram, {
   target: Dashboard,
-  host: 'https://server.uppy.io/',
+  serverUrl: 'https://server.uppy.io/',
 })
 ```
 
@@ -36,7 +36,7 @@ A unique identifier for this plugin. Defaults to `'Instagram'`.
 
 DOM element, CSS selector, or plugin to mount the Instagram provider into. This should normally be the Dashboard.
 
-### `host: null`
+### `serverUrl: null`
 
 URL to an Uppy Server instance.
 

--- a/website/src/docs/providers.md
+++ b/website/src/docs/providers.md
@@ -9,7 +9,7 @@ The Provider plugins help you connect to your accounts with remote file provider
 
 As of now, the supported providers are [**Dropbox**](/docs/dropbox), [**GoogleDrive**](/docs/google-drive), [**Instagram**](/docs/instagram), and [**Url**](/docs/url).
 
-Usage of the Provider plugins is not that different from any other *acquirer* plugin, except that it takes an extra option `host`, which specifies the url to your running `uppy-server`. This allows Uppy to know what server to connect to when server related operations are required by the provider plugin. Here's a quick example.
+Usage of the Provider plugins is not that different from any other *acquirer* plugin, except that it takes an extra option `serverUrl`, which specifies the url to your running `uppy-server`. This allows Uppy to know what server to connect to when server related operations are required by the provider plugin. Here's a quick example.
 
 ```js
 const Uppy = require('uppy/lib/core')
@@ -21,17 +21,17 @@ uppy.use(Dashboard, {
 
 // for Google Drive
 const GoogleDrive = require('uppy/lib/plugins/GoogleDrive')
-uppy.use(GoogleDrive, {target: Dashboard, host: 'http://localhost:3020'})
+uppy.use(GoogleDrive, {target: Dashboard, serverUrl: 'http://localhost:3020'})
 
 // for Dropbox
 const Dropbox = require('uppy/lib/plugins/Dropbox')
-uppy.use(Dropbox, {target: Dashboard, host: 'http://localhost:3020'})
+uppy.use(Dropbox, {target: Dashboard, serverUrl: 'http://localhost:3020'})
 
 // for Instagram
 const Instagram = require('uppy/lib/plugins/Instagram')
-uppy.use(Instagram, {target: Dashboard, host: 'http://localhost:3020'})
+uppy.use(Instagram, {target: Dashboard, serverUrl: 'http://localhost:3020'})
 
 // for Url
 const Url = require('uppy/lib/plugins/Url')
-uppy.use(Url, {target: Dashboard, host: 'http://localhost:3020'})
+uppy.use(Url, {target: Dashboard, serverUrl: 'http://localhost:3020'})
 ```

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -37,7 +37,7 @@ const Dropbox = require('uppy/lib/plugins/Dropbox')
 const Transloadit = require('uppy/lib/plugins/Transloadit')
 
 uppy.use(Dropbox, {
-  host: Transloadit.UPPY_SERVER
+  serverUrl: Transloadit.UPPY_SERVER
 })
 ```
 
@@ -45,7 +45,7 @@ The value of this constant is `https://api2.transloadit.com/uppy-server`. If you
 
 ```js
 uppy.use(Dropbox, {
-  host: 'https://api2-us-east-1.transloadit.com/uppy-server'
+  serverUrl: 'https://api2-us-east-1.transloadit.com/uppy-server'
 })
 ```
 

--- a/website/src/docs/url.md
+++ b/website/src/docs/url.md
@@ -24,7 +24,7 @@ uppy.use(Url, {
 ```js
 uppy.use(Url, {
   target: Dashboard,
-  host: 'https://server.uppy.io/',
+  serverUrl: 'https://server.uppy.io/',
   locale: {}
 })
 ```
@@ -37,7 +37,7 @@ A unique identifier for this plugin. Defaults to `'Url'`.
 
 DOM element, CSS selector, or plugin to mount the Url provider into. This should normally be the Dashboard.
 
-### `host: null`
+### `serverUrl: null`
 
 URL to an Uppy Server instance.
 

--- a/website/src/examples/dashboard/app.es6
+++ b/website/src/examples/dashboard/app.es6
@@ -49,19 +49,19 @@ function uppyInit () {
   })
 
   if (opts.GoogleDrive) {
-    uppy.use(GoogleDrive, { target: Dashboard, host: UPPY_SERVER })
+    uppy.use(GoogleDrive, { target: Dashboard, serverUrl: UPPY_SERVER })
   }
 
   if (opts.Dropbox) {
-    uppy.use(Dropbox, { target: Dashboard, host: UPPY_SERVER })
+    uppy.use(Dropbox, { target: Dashboard, serverUrl: UPPY_SERVER })
   }
 
   if (opts.Instagram) {
-    uppy.use(Instagram, { target: Dashboard, host: UPPY_SERVER })
+    uppy.use(Instagram, { target: Dashboard, serverUrl: UPPY_SERVER })
   }
 
   if (opts.Url) {
-    uppy.use(Url, { target: Dashboard, host: UPPY_SERVER })
+    uppy.use(Url, { target: Dashboard, serverUrl: UPPY_SERVER })
   }
 
   if (opts.Webcam) {

--- a/website/src/examples/dashboard/index.ejs
+++ b/website/src/examples/dashboard/index.ejs
@@ -50,9 +50,9 @@ const uppy = Uppy({
     { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }
   ]
 })
-.use(GoogleDrive, { target: Dashboard, host: 'https://server.uppy.io' })
-.use(Dropbox, { target: Dashboard, host: 'https://server.uppy.io' })
-.use(Instagram, { target: Dashboard, host: 'https://server.uppy.io' })
+.use(GoogleDrive, { target: Dashboard, serverUrl: 'https://server.uppy.io' })
+.use(Dropbox, { target: Dashboard, serverUrl: 'https://server.uppy.io' })
+.use(Instagram, { target: Dashboard, serverUrl: 'https://server.uppy.io' })
 .use(Webcam, { target: Dashboard })
 .use(Tus, { endpoint: 'https://master.tus.io/files/' })
 

--- a/website/src/examples/transloadit/app.es6
+++ b/website/src/examples/transloadit/app.es6
@@ -57,7 +57,7 @@ function initUppy () {
       target: '#uppy-dashboard-container',
       note: 'Images only, 1–2 files, up to 1 MB'
     })
-    .use(Instagram, { target: Dashboard, host: 'https://api2.transloadit.com/uppy-server' })
+    .use(Instagram, { target: Dashboard, serverUrl: 'https://api2.transloadit.com/uppy-server' })
     .use(Webcam, { target: Dashboard })
 
   uppy

--- a/website/src/examples/transloadit/index.ejs
+++ b/website/src/examples/transloadit/index.ejs
@@ -125,7 +125,7 @@ uppy
     },
     waitForEncoding: true
   })
-  .use(Instagram, { target: Dashboard, host: 'https://api2.transloadit.com/uppy-server' })
+  .use(Instagram, { target: Dashboard, serverUrl: 'https://api2.transloadit.com/uppy-server' })
   .use(Dashboard, {
     inline: true,
     maxHeight: 400,


### PR DESCRIPTION
this PR renames the provider plugin `host` option to `serverUrl` and the `hostPattern` option to `serverPattern`.