### PR TITLE
Export Plugin class from @uppy/core.

### DIFF
--- a/examples/custom-provider/client/MyCustomProvider.js
+++ b/examples/custom-provider/client/MyCustomProvider.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { Provider } = require('@uppy/server-utils')
 const ProviderViews = require('@uppy/provider-views')
 const { h } = require('preact')

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { Socket, RequestClient } = require('@uppy/server-utils')
 const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')
 const getSocketHost = require('@uppy/utils/lib/getSocketHost')

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -1,5 +1,5 @@
 const resolveUrl = require('resolve-url')
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const limitPromises = require('@uppy/utils/lib/limitPromises')
 const XHRUpload = require('@uppy/xhr-upload')

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -10,6 +10,7 @@ const getFileNameAndExtension = require('@uppy/utils/lib/getFileNameAndExtension
 const generateFileID = require('@uppy/utils/lib/generateFileID')
 const isObjectURL = require('@uppy/utils/lib/isObjectURL')
 const getTimeStamp = require('@uppy/utils/lib/getTimeStamp')
+const Plugin = require('./Plugin') // Exported from here.
 
 /**
  * Uppy Core module.
@@ -1220,3 +1221,4 @@ module.exports = function (opts) {
 
 // Expose class constructor.
 module.exports.Uppy = Uppy
+module.exports.Plugin = Plugin

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const dragDrop = require('drag-drop')
 const DashboardUI = require('./Dashboard')

--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const toArray = require('@uppy/utils/lib/toArray')
 const dragDrop = require('drag-drop')

--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { Provider } = require('@uppy/server-utils')
 const ProviderViews = require('@uppy/provider-views')
 const icons = require('./icons')

--- a/packages/@uppy/file-input/src/index.js
+++ b/packages/@uppy/file-input/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const toArray = require('@uppy/utils/lib/toArray')
 const Translator = require('@uppy/utils/lib/Translator')
 const { h } = require('preact')

--- a/packages/@uppy/form/src/index.js
+++ b/packages/@uppy/form/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const findDOMElement = require('@uppy/utils/lib/findDOMElement')
 // Rollup uses get-form-data's ES modules build, and rollup-plugin-commonjs automatically resolves `.default`.
 // So, if we are being built using rollup, this require() won't have a `.default` property.

--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const ServiceWorkerStore = require('./ServiceWorkerStore')
 const IndexedDBStore = require('./IndexedDBStore')
 const MetaDataStore = require('./MetaDataStore')

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { Provider } = require('@uppy/server-utils')
 const ProviderViews = require('@uppy/provider-views')
 const { h } = require('preact')

--- a/packages/@uppy/informer/src/index.js
+++ b/packages/@uppy/informer/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { h } = require('preact')
 
 /**

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { Provider } = require('@uppy/server-utils')
 const ProviderViews = require('@uppy/provider-views')
 const { h } = require('preact')

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { h } = require('preact')
 
 /**

--- a/packages/@uppy/react/src/__mocks__/DashboardPlugin.js
+++ b/packages/@uppy/react/src/__mocks__/DashboardPlugin.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 
 module.exports = class Dashboard extends Plugin {
   constructor (uppy, opts) {

--- a/packages/@uppy/react/src/__mocks__/DragDropPlugin.js
+++ b/packages/@uppy/react/src/__mocks__/DragDropPlugin.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 
 module.exports = class DragDrop extends Plugin {
   constructor (uppy, opts) {

--- a/packages/@uppy/react/src/__mocks__/ProgressBarPlugin.js
+++ b/packages/@uppy/react/src/__mocks__/ProgressBarPlugin.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 
 module.exports = class ProgressBar extends Plugin {
   constructor (uppy, opts) {

--- a/packages/@uppy/react/src/__mocks__/StatusBarPlugin.js
+++ b/packages/@uppy/react/src/__mocks__/StatusBarPlugin.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 
 module.exports = class StatusBar extends Plugin {
   constructor (uppy, opts) {

--- a/packages/@uppy/redux-dev-tools/src/index.js
+++ b/packages/@uppy/redux-dev-tools/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 
 /**
  * Add Redux DevTools support to Uppy

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const StatusBarUI = require('./StatusBar')
 const statusBarStates = require('./StatusBarStates')

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const dataURItoBlob = require('@uppy/utils/lib/dataURItoBlob')
 const isPreviewSupported = require('@uppy/utils/lib/isPreviewSupported')
 

--- a/packages/@uppy/thumbnail-generator/src/index.test.js
+++ b/packages/@uppy/thumbnail-generator/src/index.test.js
@@ -1,5 +1,5 @@
 const ThumbnailGeneratorPlugin = require('./index')
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const emitter = require('namespace-emitter')
 
 const delay = duration => new Promise(resolve => setTimeout(resolve, duration))

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -1,5 +1,5 @@
 const Translator = require('@uppy/utils/lib/Translator')
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Tus = require('@uppy/tus')
 const Client = require('./Client')
 const StatusSocket = require('./Socket')

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const tus = require('tus-js-client')
 const { Provider, RequestClient, Socket } = require('@uppy/server-utils')
 const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')

--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const { h } = require('preact')
 const { RequestClient } = require('@uppy/server-utils')

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -1,5 +1,5 @@
 const { h } = require('preact')
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const getFileTypeExtension = require('@uppy/utils/lib/getFileTypeExtension')
 const canvasToBlob = require('@uppy/utils/lib/canvasToBlob')

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const cuid = require('cuid')
 const Translator = require('@uppy/utils/lib/Translator')
 const { Provider, Socket } = require('@uppy/server-utils')

--- a/test/mocks/acquirerPlugin1.js
+++ b/test/mocks/acquirerPlugin1.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../packages/@uppy/core/lib/Plugin')
+const { Plugin } = require('../../packages/@uppy/core')
 
 module.exports = class TestSelector1 extends Plugin {
   constructor (uppy, opts) {

--- a/test/mocks/acquirerPlugin2.js
+++ b/test/mocks/acquirerPlugin2.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../packages/@uppy/core/lib/Plugin')
+const { Plugin } = require('../../packages/@uppy/core')
 
 module.exports = class TestSelector2 extends Plugin {
   constructor (uppy, opts) {

--- a/test/mocks/invalidPluginWithoutId.js
+++ b/test/mocks/invalidPluginWithoutId.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../packages/@uppy/core/lib/Plugin')
+const { Plugin } = require('../../packages/@uppy/core')
 
 module.exports = class InvalidPluginWithoutName extends Plugin {
   constructor (uppy, opts) {

--- a/test/mocks/invalidPluginWithoutType.js
+++ b/test/mocks/invalidPluginWithoutType.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../packages/@uppy/core/lib/Plugin')
+const { Plugin } = require('../../packages/@uppy/core')
 
 module.exports = class InvalidPluginWithoutType extends Plugin {
   constructor (uppy, opts) {

--- a/website/src/docs/writing-plugins.md
+++ b/website/src/docs/writing-plugins.md
@@ -18,7 +18,7 @@ Plugins are classes that extend from Uppy's `Plugin` class. Each plugin has an `
 The plugin constructor receives the Uppy instance in the first parameter, and any options passed to `uppy.use()` in the second parameter.
 
 ```js
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 module.exports = class MyPlugin extends Plugin {
   constructor (uppy, opts) {
     super(uppy, opts)
@@ -175,7 +175,7 @@ See the Preact [Getting Started Guide](https://preactjs.com/guide/getting-starte
 
 ```js
 /** @jsx h */
-const Plugin = require('@uppy/core/lib/Plugin')
+const { Plugin } = require('@uppy/core')
 const { h } = require('preact')
 
 class NumFiles extends Plugin {


### PR DESCRIPTION
Instead of

```js
const Plugin = require('@uppy/core/lib/Plugin')
```

do

```js
const { Plugin } = require('@uppy/core')
```

This way nobody gets to rely on the file system layout anymore :)