### PR TITLE
feature: add support for custom headers sent to uppy-server

### DIFF
--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -22,6 +22,7 @@ module.exports = class Dropbox extends Plugin {
     // the provider instance must be equal to this.id.
     this[this.id] = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
+      serverHeaders: this.opts.serverHeaders,
       provider: 'dropbox'
     })
 

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -16,6 +16,7 @@ module.exports = class GoogleDrive extends Plugin {
 
     this[this.id] = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
+      serverHeaders: this.opts.serverHeaders,
       provider: 'drive',
       authProvider: 'google'
     })

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -19,6 +19,7 @@ module.exports = class Instagram extends Plugin {
 
     this[this.id] = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
+      serverHeaders: this.opts.serverHeaders,
       provider: 'instagram',
       authProvider: 'instagram'
     })

--- a/packages/@uppy/server-utils/src/RequestClient.js
+++ b/packages/@uppy/server-utils/src/RequestClient.js
@@ -25,6 +25,10 @@ module.exports = class RequestClient {
     }
   }
 
+  get headers () {
+    return Object.assign({}, this.defaultHeaders, this.opts.serverHeaders || {})
+  }
+
   onReceiveResponse (response) {
     const state = this.uppy.getState()
     const uppyServer = state.uppyServer || {}
@@ -51,7 +55,7 @@ module.exports = class RequestClient {
   get (path) {
     return fetch(this._getUrl(path), {
       method: 'get',
-      headers: this.defaultHeaders
+      headers: this.headers
     })
       // @todo validate response status before calling json
       .then(this.onReceiveResponse)
@@ -64,7 +68,7 @@ module.exports = class RequestClient {
   post (path, data) {
     return fetch(this._getUrl(path), {
       method: 'post',
-      headers: this.defaultHeaders,
+      headers: this.headers,
       body: JSON.stringify(data)
     })
       .then(this.onReceiveResponse)
@@ -82,11 +86,7 @@ module.exports = class RequestClient {
   delete (path, data) {
     return fetch(`${this.hostname}/${path}`, {
       method: 'delete',
-      credentials: 'include',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
+      headers: this.headers,
       body: data ? JSON.stringify(data) : null
     })
       .then(this.onReceiveResponse)

--- a/packages/@uppy/server-utils/types/index.d.ts
+++ b/packages/@uppy/server-utils/types/index.d.ts
@@ -2,6 +2,7 @@ import { Uppy } from '@uppy/core';
 
 export interface RequestClientOptions {
   serverUrl: string;
+  serverHeaders?: object;
 }
 
 export class RequestClient {
@@ -11,8 +12,7 @@ export class RequestClient {
   delete (path: string, data: object): Promise<any>;
 }
 
-export interface ProviderOptions {
-  serverUrl: string;
+export interface ProviderOptions extends RequestClientOptions {
   provider: string;
   authProvider?: string;
   name?: string;

--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -60,7 +60,10 @@ module.exports = class Url extends Plugin {
 
     this.handlePaste = this.handlePaste.bind(this)
 
-    this.client = new RequestClient(uppy, { serverUrl: this.opts.serverUrl })
+    this.client = new RequestClient(uppy, {
+      serverUrl: this.opts.serverUrl,
+      serverHeaders: this.opts.serverHeaders
+    })
   }
 
   getFileNameFromUrl (url) {


### PR DESCRIPTION
Since developers are allowed to make uppy-server as custom as they want, it's useful if the client can set custom headers depending on the requirement of their uppy-server.
