### PR TITLE
Fix S3 plugin for browsers without support to responseURL

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -175,6 +175,11 @@ module.exports = class AwsS3 extends Plugin {
             return { location: null }
           }
 
+          // responseURL is not available in older browsers.
+          if (!xhr.responseURL) {
+            return { location: null }
+          }
+
           // Trim the query string because it's going to be a bunch of presign
           // parameters for a PUT request—doing a GET request with those will
           // always result in an error


### PR DESCRIPTION
Uppy [claims to support IE10+](https://uppy.io/docs/stats/).
At the same time, the S3 plugin relies on `responseURL` which is only available from Edge 14 on.

Right now, using the S3 plugin on browsers like Internet Explorer 11 (still 10% of Germany) breaks the execution just after the upload finishes.

For this fix, I'm assuming the `location` property is not useful.
An alternative would be to use the request URL but that would involve changing the signature of `getResponseData` and I don't think that's something we'd like.

I wrote a blog post about some strategies I thought of to solve this problem in case someone wants to dig deeper into the matter: https://webstuff.leods92.com/2018/07/07/xhr-response-url-polyfill.html.