### PR TITLE
doc: Fix highlighting of PHP snippets

### DIFF
--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -5,6 +5,14 @@ const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const path = require('path')
 
+// oof
+// I think this is the way to add Prism components that it doesn't include
+// in the default build?
+global.Prism = Prism
+require('prismjs/components/prism-markup-templating')
+require('prismjs/components/prism-php')
+delete global.Prism
+
 const unhighlightedCodeRx = /<pre><code class="(.*)?">([\s\S]*?)<\/code><\/pre>/igm
 
 function highlight (lang, code) {

--- a/website/themes/uppy/source/css/_common.scss
+++ b/website/themes/uppy/source/css/_common.scss
@@ -111,7 +111,7 @@ a.button {
     margin: 0;
   }
 
-  &.html, &.js, &.bash, &.css {
+  &.html, &.js, &.bash, &.css, &.php {
     .code:after {
       position: absolute;
       top: 0;
@@ -130,6 +130,7 @@ a.button {
   &.js .code:after { content: 'JS'; }
   &.bash .code:after { content: 'Shell'; }
   &.css .code:after { content: 'CSS'; }
+  &.php .code:after { content: 'PHP'; }
 }
 
 .page {


### PR DESCRIPTION
The Prism language for this was not enabled.

Also added the "PHP" tag thing to the top right of PHP snippets.