### PR TITLE
Fix @uppy/core window !== undefined check for React Native

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -785,7 +785,7 @@ class Uppy {
     })
 
     // show informer if offline
-    if (typeof document !== 'undefined') {
+    if (typeof window !== 'undefined' && window.addEventListener) {
       window.addEventListener('online', () => this.updateOnlineStatus())
       window.addEventListener('offline', () => this.updateOnlineStatus())
       setTimeout(() => this.updateOnlineStatus(), 3000)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -785,7 +785,7 @@ class Uppy {
     })
 
     // show informer if offline
-    if (typeof window !== 'undefined') {
+    if (typeof document !== 'undefined') {
       window.addEventListener('online', () => this.updateOnlineStatus())
       window.addEventListener('offline', () => this.updateOnlineStatus())
       setTimeout(() => this.updateOnlineStatus(), 3000)


### PR DESCRIPTION
Checking for both `typeof window !== 'undefined' && window.addEventListener` solves the problem 🎉

https://github.com/facebook/jest/issues/6643#issuecomment-410818740
https://stackoverflow.com/questions/49911424/what-does-the-variable-window-represent-in-react-native/49911697#49911697