### PR TITLE
[WIP] core: `autoProceed: false` by default

### DIFF
--- a/examples/aws-presigned-url/main.js
+++ b/examples/aws-presigned-url/main.js
@@ -3,8 +3,7 @@ const Dashboard = require('@uppy/dashboard')
 const AwsS3 = require('@uppy/aws-s3')
 
 const uppy = Uppy({
-  debug: true,
-  autoProceed: false
+  debug: true
 })
 
 uppy.use(Dashboard, {

--- a/examples/bundled-example/main.js
+++ b/examples/bundled-example/main.js
@@ -2,6 +2,7 @@ const Uppy = require('./../../packages/@uppy/core/src')
 const Dashboard = require('./../../packages/@uppy/dashboard/src')
 const Instagram = require('./../../packages/@uppy/instagram/src')
 const GoogleDrive = require('./../../packages/@uppy/google-drive/src')
+const Url = require('./../../packages/@uppy/url/src')
 const Webcam = require('./../../packages/@uppy/webcam/src')
 const Tus = require('./../../packages/@uppy/tus/src')
 const Form = require('./../../packages/@uppy/form/src')
@@ -10,7 +11,6 @@ const TUS_ENDPOINT = 'https://master.tus.io/files/'
 
 const uppy = Uppy({
   debug: true,
-  autoProceed: false,
   meta: {
     username: 'John',
     license: 'Creative Commons'
@@ -30,6 +30,7 @@ const uppy = Uppy({
   })
   .use(GoogleDrive, { target: Dashboard, serverUrl: 'http://localhost:3020' })
   .use(Instagram, { target: Dashboard, serverUrl: 'http://localhost:3020' })
+  .use(Url, { target: Dashboard, serverUrl: 'http://localhost:3020' })
   .use(Webcam, { target: Dashboard })
   .use(Tus, { endpoint: TUS_ENDPOINT })
   .use(Form, { target: '#upload-form' })

--- a/examples/custom-provider/client/main.js
+++ b/examples/custom-provider/client/main.js
@@ -5,8 +5,7 @@ const MyCustomProvider = require('./MyCustomProvider')
 const Dashboard = require('@uppy/dashboard')
 
 const uppy = Uppy({
-  debug: true,
-  autoProceed: false
+  debug: true
 })
 
 uppy.use(GoogleDrive, {

--- a/examples/digitalocean-spaces/main.js
+++ b/examples/digitalocean-spaces/main.js
@@ -3,8 +3,7 @@ const Dashboard = require('@uppy/dashboard')
 const AwsS3 = require('@uppy/aws-s3')
 
 const uppy = Uppy({
-  debug: true,
-  autoProceed: false
+  debug: true
 })
 
 uppy.use(Dashboard, {

--- a/examples/redux/main.js
+++ b/examples/redux/main.js
@@ -60,7 +60,6 @@ document.querySelector('#incrementAsync').onclick = () => {
 
 // Uppy using the same store
 const uppy = Uppy({
-  autoProceed: false,
   id: 'redux',
   store: uppyReduxStore({ store: store }),
   // If we had placed our `reducer` elsewhere in Redux, eg. under an `uppy` key in the state for a profile page,

--- a/examples/xhr-bundle/main.js
+++ b/examples/xhr-bundle/main.js
@@ -3,7 +3,6 @@ const Dashboard = require('@uppy/dashboard')
 const XHRUpload = require('@uppy/xhr-upload')
 
 const uppy = Uppy({
-  autoProceed: false,
   debug: true
 })
 

--- a/packages/@uppy/core/README.md
+++ b/packages/@uppy/core/README.md
@@ -20,7 +20,7 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 ```js
 const Uppy = require('@uppy/core')
 
-const uppy = Uppy({ autoProceed: false })
+const uppy = Uppy()
 uppy.use(SomePlugin)
 ```
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -53,7 +53,7 @@ class Uppy {
     // set default options
     const defaultOptions = {
       id: 'uppy',
-      autoProceed: true,
+      autoProceed: false,
       debug: false,
       restrictions: {
         maxFileSize: null,

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -688,7 +688,6 @@ describe('src/Core', () => {
 
     it('should not upload if onBeforeUpload returned false', () => {
       const core = new Core({
-        autoProceed: false,
         onBeforeUpload: (files) => {
           for (var fileId in files) {
             if (files[fileId].name === '123.foo') {
@@ -994,7 +993,6 @@ describe('src/Core', () => {
   describe('checkRestrictions', () => {
     it('should enforce the maxNumberOfFiles rule', () => {
       const core = new Core({
-        autoProceed: false,
         restrictions: {
           maxNumberOfFiles: 1
         }
@@ -1025,7 +1023,6 @@ describe('src/Core', () => {
 
     it('should enforce the allowedFileTypes rule', () => {
       const core = new Core({
-        autoProceed: false,
         restrictions: {
           allowedFileTypes: ['image/gif', 'image/png']
         }
@@ -1047,7 +1044,6 @@ describe('src/Core', () => {
 
     it('should enforce the allowedFileTypes rule with file extensions', () => {
       const core = new Core({
-        autoProceed: false,
         restrictions: {
           allowedFileTypes: ['.gif', '.jpg', '.jpeg']
         }
@@ -1069,7 +1065,6 @@ describe('src/Core', () => {
 
     it('should enforce the maxFileSize rule', () => {
       const core = new Core({
-        autoProceed: false,
         restrictions: {
           maxFileSize: 1234
         }

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -61,10 +61,10 @@ export interface UppyOptions {
   autoProceed: boolean;
   debug: boolean;
   restrictions: {
-    maxFileSize: false,
-    maxNumberOfFiles: false,
-    minNumberOfFiles: false,
-    allowedFileTypes: false
+    maxFileSize: number | null,
+    maxNumberOfFiles: number | null,
+    minNumberOfFiles: number | null,
+    allowedFileTypes: number | null
   };
   target: string | Plugin;
   meta: any;

--- a/packages/@uppy/transloadit/src/index.test.js
+++ b/packages/@uppy/transloadit/src/index.test.js
@@ -32,7 +32,7 @@ describe('Transloadit', () => {
   })
 
   it('Validates response from getAssemblyOptions()', () => {
-    const uppy = new Core({ autoProceed: false })
+    const uppy = new Core()
 
     uppy.use(Transloadit, {
       getAssemblyOptions: (file) => {
@@ -57,7 +57,7 @@ describe('Transloadit', () => {
   })
 
   it('Uses different assemblies for different params', () => {
-    const uppy = new Core({ autoProceed: false })
+    const uppy = new Core()
 
     uppy.use(Transloadit, {
       getAssemblyOptions: (file) => ({
@@ -96,7 +96,7 @@ describe('Transloadit', () => {
   })
 
   it('Should merge files with same parameters into one Assembly', () => {
-    const uppy = new Core({ autoProceed: false })
+    const uppy = new Core()
 
     uppy.use(Transloadit, {
       getAssemblyOptions: (file) => ({

--- a/packages/@uppy/xhr-upload/src/index.test.js
+++ b/packages/@uppy/xhr-upload/src/index.test.js
@@ -13,7 +13,7 @@ describe('XHRUpload', () => {
         .options('/').reply(200, {})
         .post('/').reply(200, {})
 
-      const core = new Core({ autoProceed: false })
+      const core = new Core()
       const getResponseData = jest.fn(function () {
         expect(this.some).toEqual('option')
         return {}

--- a/website/src/api-usage-example.js
+++ b/website/src/api-usage-example.js
@@ -2,7 +2,7 @@ import Uppy from '@uppy/core'
 import Dashboard from '@uppy/dashboard'
 import Tus from '@uppy/tus'
 
-Uppy({ autoProceed: false })
+Uppy()
   .use(Dashboard, { trigger: '#select-files' })
   .use(Tus, { endpoint: 'https://master.tus.io/files/' })
   .on('complete', (result) => {

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -20,7 +20,7 @@ const Uppy = require('@uppy/core')
 const Dashboard = require('@uppy/dashboard')
 const Tus = require('@uppy/tus')
  
-const uppy = Uppy({ autoProceed: false })
+const uppy = Uppy()
   .use(Dashboard, {
     trigger: '#select-files'
   })

--- a/website/src/docs/redux.md
+++ b/website/src/docs/redux.md
@@ -37,7 +37,6 @@ const ReduxDevTools = require('@uppy/redux-dev-tools')
 
 const uppy = Uppy({
   debug: true,
-  autoProceed: false,
   meta: {
     username: 'John',
     license: 'Creative Commons'

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -31,7 +31,7 @@ const Core = Uppy.Core
 ```js
 const uppy = Uppy({
   id: 'uppy',
-  autoProceed: true,
+  autoProceed: false,
   debug: false,
   restrictions: {
     maxFileSize: null,
@@ -61,9 +61,9 @@ const avatarUploader = Uppy({ id: 'avatar' })
 const photoUploader = Uppy({ id: 'post' })
 ```
 
-### `autoProceed: true`
+### `autoProceed: false`
 
-Uppy will start uploading automatically after the first file is selected.
+By default Uppy will wait for an upload button to be pressed in the UI, or an `.upload()` method to be called, before starting an upload. Setting this to `autoProceed: true` will start uploading automatically after the first file is selected.
 
 ### `restrictions: {}`
 

--- a/website/themes/uppy/layout/index.ejs
+++ b/website/themes/uppy/layout/index.ejs
@@ -85,8 +85,7 @@
 <script src="https://transloadit.edgly.net/releases/uppy/v0.26.0/dist/uppy.min.js"></script>
 
 <script>
-  var PROTOCOL = location.protocol === 'https:' ? 'https' : 'http'
-  var TUS_ENDPOINT = PROTOCOL + '://master.tus.io/files/'
+  var TUS_ENDPOINT = 'https://master.tus.io/files/'
 
   var uppy = Uppy.Core({ debug: true, autoProceed: false })
   .use(Uppy.Dashboard, {


### PR DESCRIPTION
Uppy used to be initialized with `autoProceed: true` by default, meaning that once a file has been selected, an upload would automatically begin right away. In most examples and demos however, we used to set `autoProceed: false`, because you want the user to be able to edit files, or select more than one, and control when the upload starts.

This PR sets `autoProceed: false` by default, so we can remove the boilerplate in many places.

- [x] check docs and examples
- [ ] fix end to end test (add .upload())