### PR TITLE
Use src/ files in website examples.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,9 +2580,9 @@
       "dev": true
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
         "resolve": "1.1.7"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
     "babelify": "^8.0.0",
+    "browser-resolve": "^1.11.3",
     "browser-sync": "^2.24.5",
     "browserify": "^16.2.2",
     "chai": "^4.1.2",


### PR DESCRIPTION
Now you can make changes to the Uppy source code and the examples on the
website will update without having to run `build:lib` first.

Uses a custom Browserify plugin that turns resolved
`@uppy/xyz/lib/index.js` paths into `@uppy/xyz/src/index.js`. We can
move that plugin to a different file and use it in other places later.
It's a bit of a hack but this is easier than maintaining an aliasify
config for every package, I think.

(Also took this opportunity to ES6ify the examples build script using
`const` / arrows / Set.)