### PR TITLE
Add object rest spread transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
     }]
   ],
   "plugins": [
+    "transform-object-rest-spread",
     "transform-object-assign",
     ["transform-react-jsx", { "pragma":"h" }]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1734,6 +1734,34 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "babel-plugin-transform-proto-to-assign": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^6.26.3",
     "babel-jest": "^22.4.4",
     "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-polyfill": "^6.26.0",

--- a/packages/@uppy/core/src/Plugin.js
+++ b/packages/@uppy/core/src/Plugin.js
@@ -49,11 +49,13 @@ module.exports = class Plugin {
   }
 
   setPluginState (update) {
-    const plugins = Object.assign({}, this.uppy.getState().plugins)
-    plugins[this.id] = Object.assign({}, plugins[this.id], update)
+    const { plugins } = this.uppy.getState()
 
     this.uppy.setState({
-      plugins: plugins
+      plugins: {
+        ...plugins,
+        [this.id]: update
+      }
     })
   }
 


### PR DESCRIPTION
Object rest spread was standardised this year so it's safe to use. It
has shipped in major browsers and Node. Because Uppy uses immutable
state we can make a lot of gains in terseness and readability by using
the new object syntaxes, I think.

I updated one place where we were using Object.assign; I think we can
merge it like this first and then update the other places when we are
changing stuff there anyway or when one of us needs a break from brain
intensive tasks.