### PR TITLE
Catch and handle errors in prepareUploadPart of S3 multipart upload

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -150,6 +150,8 @@ class MultipartUploader {
       return result
     }).then(({ url }) => {
       this._uploadPartBytes(index, url)
+    }, (err) => {
+      this._onError(err)
     })
   }
 


### PR DESCRIPTION
Currently when a request to prepare upload URL for chunks fails, an uncought promise error is reported in the console (`Uncaught (in promise)` and e.g. `TypeError: Failed to fetch`), and the upload is stuck without reporting any errors.

With this change, the request error is thrown in the uppy's upload method promise.