### PR TITLE
Fix `setPluginState`

### DIFF
--- a/packages/@uppy/core/src/Plugin.js
+++ b/packages/@uppy/core/src/Plugin.js
@@ -45,7 +45,7 @@ module.exports = class Plugin {
 
   getPluginState () {
     const { plugins } = this.uppy.getState()
-    return plugins[this.id]
+    return plugins[this.id] || {}
   }
 
   setPluginState (update) {
@@ -54,7 +54,10 @@ module.exports = class Plugin {
     this.uppy.setState({
       plugins: {
         ...plugins,
-        [this.id]: update
+        [this.id]: {
+          ...plugins[this.id],
+          ...update
+        }
       }
     })
   }

--- a/packages/@uppy/core/src/Plugin.test.js
+++ b/packages/@uppy/core/src/Plugin.test.js
@@ -1,0 +1,25 @@
+const Plugin = require('./Plugin')
+const Core = require('./index')
+
+describe('Plugin', () => {
+  describe('getPluginState', () => {
+    it('returns an empty object if no state is available', () => {
+      class Example extends Plugin {}
+      const inst = new Example(new Core(), {})
+
+      expect(inst.getPluginState()).toEqual({})
+    })
+  })
+
+  describe('setPluginState', () => {
+    it('applies patches', () => {
+      class Example extends Plugin {}
+      const inst = new Example(new Core(), {})
+
+      inst.setPluginState({ a: 1 })
+      expect(inst.getPluginState()).toEqual({ a: 1 })
+      inst.setPluginState({ b: 2 })
+      expect(inst.getPluginState()).toEqual({ a: 1, b: 2 })
+    })
+  })
+})

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -34,7 +34,8 @@
     "prettier-bytes": "^1.0.4"
   },
   "devDependencies": {
-    "@uppy/core": "0.26.0"
+    "@uppy/core": "0.26.0",
+    "@uppy/google-drive": "0.26.0"
   },
   "peerDependencies": {
     "@uppy/core": "^0.26.0"

--- a/packages/@uppy/dashboard/src/index.test.js
+++ b/packages/@uppy/dashboard/src/index.test.js
@@ -1,6 +1,7 @@
 const Core = require('@uppy/core')
 const DashboardPlugin = require('./index')
 const StatusBarPlugin = require('@uppy/status-bar')
+const GoogleDrivePlugin = require('@uppy/google-drive')
 
 describe('Dashboard', () => {
   it('can safely be added together with the StatusBar without id conflicts', () => {
@@ -10,5 +11,48 @@ describe('Dashboard', () => {
     expect(() => {
       core.use(DashboardPlugin, { inline: false })
     }).not.toThrow()
+
+    core.close()
+  })
+
+  it('works without any remote provider plugins', () => {
+    const core = new Core()
+
+    expect(() => {
+      core.use(DashboardPlugin, {
+        inline: true,
+        target: 'body'
+      })
+    }).not.toThrow()
+
+    core.close()
+  })
+
+  it('works when targeting remote provider plugins using `target`', () => {
+    const core = new Core()
+    expect(() => {
+      core.use(DashboardPlugin, {
+        inline: true,
+        target: 'body'
+      })
+      core.use(GoogleDrivePlugin, { target: DashboardPlugin, serverUrl: 'https://fake.uppy.io/' })
+    }).not.toThrow()
+
+    core.close()
+  })
+
+  it('works when passing plugins in `plugins` array', () => {
+    const core = new Core()
+    core.use(GoogleDrivePlugin, { serverUrl: 'https://fake.uppy.io/' })
+
+    expect(() => {
+      core.use(DashboardPlugin, {
+        inline: true,
+        target: 'body',
+        plugins: ['GoogleDrive']
+      })
+    }).not.toThrow()
+
+    core.close()
   })
 })


### PR DESCRIPTION
I broke this in the object rest spread PR. I noticed the Dashboard was
throwing errors when trying to access `pluginState.target.filter()`.
Added a bunch of tests + fixed that method!
