### PR TITLE
ci: cache ~/.npm and use latest npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ addons:
 cache:
   apt: true
   directories:
-  - node_modules
-  - website/node_modules
+  - ~/.npm
+before_install:
+- nvm install-latest-npm
 script:
 - npm run web:install
 - npm run build


### PR DESCRIPTION
Cache the npm cache folder instead of node_modules. If my intuition is right this should be a little faster but it is definitely more correct ever since npm v5 :)

We MAY be able to switch to `npm ci` too which would be even faster, and force us to keep lockfiles up to date. Can check that once this PR is green