### PR TITLE
Google Drive: move to v3 API

### DIFF
--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -57,11 +57,11 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getUsername (data) {
-    for (const item of data.items) {
-      if (item.userPermission.role === 'owner') {
-        for (const owner of item.owners) {
-          if (owner.isAuthenticatedUser) {
-            return owner.emailAddress
+    for (const item of data.files) {
+      if (item.ownedByMe) {
+        for (const permission of item.permissions) {
+          if (permission.role === 'owner') {
+            return permission.emailAddress
           }
         }
       }
@@ -73,7 +73,7 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemData (item) {
-    return Object.assign({}, item, {size: parseFloat(item.fileSize)})
+    return Object.assign({}, item, {size: parseFloat(item.size)})
   }
 
   getItemIcon (item) {
@@ -81,13 +81,13 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemSubList (item) {
-    return item.items.filter((i) => {
+    return item.files.filter((i) => {
       return this.isFolder(i) || !i.mimeType.startsWith('application/vnd.google')
     })
   }
 
   getItemName (item) {
-    return item.title ? item.title : '/'
+    return item.name ? item.name : '/'
   }
 
   getMimeType (item) {
@@ -103,7 +103,7 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemModifiedDate (item) {
-    return item.modifiedByMeDate
+    return item.modifiedTime
   }
 
   getItemThumbnailUrl (item) {


### PR DESCRIPTION
As the first step towards supporting Team Drives (#972), this PR moves from v2 to v3 of the Drive API.

The main difference (other than some changed field names) between v2 and v3 is that the responses don't contain much information about each file by default.  As a result, it's now necessary to specify the `fields` param with a list of fields which we want to retrieve; I've added a couple of consts to `provider/drive` with a reasonably minimal set of fields for individual file or file list requests, which seem to cover all current needs.

This PR includes the corresponding changes to both the Uppy `google-drive` plugin and the Companion `provider/drive` plugin.  If changes to Companion (uppy-server) should still be submitted to the uppy-server repo either instead of (or as well as) here, please let me know and I can whip up a PR over there.