### PR TITLE
Google Drive: Support Team Drives

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive.js
+++ b/packages/@uppy/companion/src/server/provider/drive.js
@@ -2,8 +2,9 @@ const request = require('request')
 // @ts-ignore
 const purest = require('purest')({ request })
 const logger = require('../logger')
-const DRIVE_FILE_FIELDS = 'kind,id,name,mimeType,ownedByMe,permissions(role,emailAddress),size,modifiedTime,iconLink,thumbnailLink'
+const DRIVE_FILE_FIELDS = 'kind,id,name,mimeType,ownedByMe,permissions(role,emailAddress),size,modifiedTime,iconLink,thumbnailLink,teamDriveId'
 const DRIVE_FILES_FIELDS = `kind,nextPageToken,incompleteSearch,files(${DRIVE_FILE_FIELDS})`
+const TEAM_DRIVE_FIELDS = 'teamDrives(kind,id,name,backgroundImageLink)'
 /**
  * @class
  * @implements {Provider}
@@ -24,23 +25,49 @@ class Drive {
   list (options, done) {
     const directory = options.directory || 'root'
     const trashed = options.trashed || false
+    const query = options.query || {}
+    const listTeamDrives = query.listTeamDrives || 'false'
+    const teamDriveId = query.teamDriveId || false
 
-    return this.client
-      .query()
-      .get('files')
-      .where({
+    if (listTeamDrives === 'true') {
+      // Just return a list of all Team Drives which the user can access.
+      return this.client
+        .query()
+        .get('teamdrives')
+        .where({ fields: TEAM_DRIVE_FIELDS })
+        .auth(options.token)
+        .request(done)
+    } else {
+      let where = {
         fields: DRIVE_FILES_FIELDS,
         q: `'${directory}' in parents and trashed=${trashed}`
-      })
-      .auth(options.token)
-      .request(done)
+      }
+      if (teamDriveId) {
+        // Team Drives require several extra parameters in order to work.
+        where.supportsTeamDrives = true
+        where.includeTeamDriveItems = true
+        where.teamDriveId = teamDriveId
+        where.corpora = 'teamDrive'
+        if (directory === 'root') {
+          // To list the top-level contents of a Team Drive, filter for the Team Drive id as a parent.
+          where.q = `'${teamDriveId}' in parents and trashed=${trashed}`
+        }
+      }
+
+      return this.client
+        .query()
+        .get('files')
+        .where(where)
+        .auth(options.token)
+        .request(done)
+    }
   }
 
   stats ({ id, token }, done) {
     return this.client
       .query()
       .get(`files/${id}`)
-      .where({fields: DRIVE_FILE_FIELDS})
+      .where({ fields: DRIVE_FILE_FIELDS, supportsTeamDrives: true })
       .auth(token)
       .request(done)
   }
@@ -49,7 +76,7 @@ class Drive {
     return this.client
       .query()
       .get(`files/${id}`)
-      .where({ alt: 'media' })
+      .where({ alt: 'media', supportsTeamDrives: true })
       .auth(token)
       .request()
       .on('data', onData)

--- a/packages/@uppy/google-drive/src/DriveProviderViews.js
+++ b/packages/@uppy/google-drive/src/DriveProviderViews.js
@@ -1,18 +1,13 @@
 const ProviderViews = require('@uppy/provider-views')
 
 module.exports = class DriveProviderViews extends ProviderViews {
-  constructor (plugin, opts) {
-    super(plugin, opts)
-    this.originalToggleCheckbox = this.toggleCheckbox
-    this.toggleCheckbox = this.toggleDriveCheckbox.bind(this)
-  }
-  toggleDriveCheckbox (e, file) {
+  toggleCheckbox (e, file) {
     e.stopPropagation()
     e.preventDefault()
 
     // Team Drives aren't selectable; for all else, defer to the base ProviderView.
     if (file.kind !== 'drive#teamDrive') {
-      this.originalToggleCheckbox(e, file)
+      super.toggleCheckbox(e, file)
     }
   }
 }

--- a/packages/@uppy/google-drive/src/DriveProviderViews.js
+++ b/packages/@uppy/google-drive/src/DriveProviderViews.js
@@ -1,0 +1,18 @@
+const ProviderViews = require('@uppy/provider-views')
+
+module.exports = class DriveProviderViews extends ProviderViews {
+  constructor (plugin, opts) {
+    super(plugin, opts)
+    this.originalToggleCheckbox = this.toggleCheckbox
+    this.toggleCheckbox = this.toggleDriveCheckbox.bind(this)
+  }
+  toggleDriveCheckbox (e, file) {
+    e.stopPropagation()
+    e.preventDefault()
+
+    // Team Drives aren't selectable; for all else, defer to the base ProviderView.
+    if (file.kind !== 'drive#teamDrive') {
+      this.originalToggleCheckbox(e, file)
+    }
+  }
+}

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -57,11 +57,11 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getUsername (data) {
-    for (const item of data.items) {
-      if (item.userPermission.role === 'owner') {
-        for (const owner of item.owners) {
-          if (owner.isAuthenticatedUser) {
-            return owner.emailAddress
+    for (const item of data.files) {
+      if (item.ownedByMe) {
+        for (const permission of item.permissions) {
+          if (permission.role === 'owner') {
+            return permission.emailAddress
           }
         }
       }
@@ -73,7 +73,7 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemData (item) {
-    return Object.assign({}, item, {size: parseFloat(item.fileSize)})
+    return Object.assign({}, item, {size: parseFloat(item.size)})
   }
 
   getItemIcon (item) {
@@ -81,13 +81,13 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemSubList (item) {
-    return item.items.filter((i) => {
+    return item.files.filter((i) => {
       return this.isFolder(i) || !i.mimeType.startsWith('application/vnd.google')
     })
   }
 
   getItemName (item) {
-    return item.title ? item.title : '/'
+    return item.name ? item.name : '/'
   }
 
   getMimeType (item) {
@@ -103,7 +103,7 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   getItemModifiedDate (item) {
-    return item.modifiedByMeDate
+    return item.modifiedTime
   }
 
   getItemThumbnailUrl (item) {


### PR DESCRIPTION
This PR builds on top of #977 to add support for Team Drives.  Although it appears to be fully functional (based on my limited testing), this is mostly a proof of concept and the starting point for a discussion on how Team Drive support should look.  I'm not wedded to the idea of bolting support into the existing Google Drive plugin; it might, for instance, be cleaner to create a separate Team Drive plugin which is restricted to only Team Drives (i.e. no access to the user's regular Google Drive).

Team Drives are currently displayed / handled very similarly to folders: they appear at the top of the root list, and when drilled into, they appear in the breadcrumb trail.
![image](https://user-images.githubusercontent.com/574359/43289834-47461da4-9180-11e8-84c1-8782d1365a0d.png)
![image](https://user-images.githubusercontent.com/574359/43289964-a9d04008-9180-11e8-8f81-21fb3932782a.png)

"Dev Nonsense" is a Team Drive; the icon is a small, cropped version of the Team Drive's "background image" and corresponds to what can be seen in the Drive web UI:
![image](https://user-images.githubusercontent.com/574359/43289877-6e51797a-9180-11e8-8d9c-bd4708aa1b0f.png)

The main behavioural difference between Team Drives and Folders in this implementation is that Team Drives can't be selected (using the checkbox).  In order to implement this, I've added a very slim subclass of `ProviderViews` within the Google Drive plugin, which overrides the `toggleCheckbox` method with one which simply ignores attempts to toggle Team Drive checkboxes, deferring to the `ProviderViews` implementation in all other cases.