### PR TITLE
Send cookies with fetch requests

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -55,7 +55,8 @@ module.exports = class RequestClient {
   get (path) {
     return fetch(this._getUrl(path), {
       method: 'get',
-      headers: this.headers
+      headers: this.headers,
+      credentials: 'same-origin'
     })
       // @todo validate response status before calling json
       .then(this.onReceiveResponse)
@@ -69,6 +70,7 @@ module.exports = class RequestClient {
     return fetch(this._getUrl(path), {
       method: 'post',
       headers: this.headers,
+      credentials: 'same-origin',
       body: JSON.stringify(data)
     })
       .then(this.onReceiveResponse)
@@ -87,6 +89,7 @@ module.exports = class RequestClient {
     return fetch(`${this.hostname}/${path}`, {
       method: 'delete',
       headers: this.headers,
+      credentials: 'same-origin',
       body: data ? JSON.stringify(data) : null
     })
       .then(this.onReceiveResponse)


### PR DESCRIPTION
Firstly, thanks for an amazing project.

I am using Uppy with the `aws-s3-multipart` plugin and my own implementation of the S3 related server endpoints on my existing website (I don't need the other integrations like Dropbox etc). However my website uses cookies for authentication and on many browsers the requests to the server fail because the authentication cookies are not sent with the fetch requests. (eg on Chrome as recent as 67, Safari 11.1)

See https://github.com/github/fetch for more information.

> The current default value for credentials is "same-origin", however some browsers implement an older version of the specification where the default was "omit".

I know I could use the events in the plugin (eg `createMultipartUpload`, `prepareUploadPart` etc) to make these requests to my server endpoints, but this small change fixes the problem with no other client side changes required.

