### PR TITLE
website: Load all prism languages

### DIFF
--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -9,8 +9,8 @@ const path = require('path')
 // I think this is the way to add Prism components that it doesn't include
 // in the default build?
 global.Prism = Prism
-require('prismjs/components/prism-markup-templating')
-require('prismjs/components/prism-php')
+// the / is needed to force it to resolve to the directory
+require('prismjs/components/')()
 delete global.Prism
 
 const unhighlightedCodeRx = /<pre><code class="(.*)?">([\s\S]*?)<\/code><\/pre>/igm


### PR DESCRIPTION
This is server side so we don't need to worry about bundle size anyway.
It'll be best if every language is available to use, so we can't forget
about adding one.

In particular this fixes bash highlighting which is nice for the
Companion env variable list.