### PR TITLE
ci: No need to web:install if we're not deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
 services:
   - docker
 script:
-- npm run web:install
 - npm run build
 - npm run test
 - '{ if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:acceptance; fi } || true'


### PR DESCRIPTION
And `web:deploy` already runs install. Speeds up builds :sparkles: 
