### PR TITLE
Correct Uppy Companion rename version

### DIFF
--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -7,7 +7,7 @@ permalink: docs/companion/
 alias: docs/server/
 ---
 
-> Uppy Companion was previously known as Uppy Server. It was renamed in v0.14.0.
+> Uppy Companion was previously known as Uppy Server. It was renamed in v0.27.0.
 
 Drag and drop, webcam, basic file manipulation (adding metadata, for example) and uploading via tus-resumable uploads or XHR/Multipart are all possible using just the Uppy client module.
 


### PR DESCRIPTION
Uppy Server has been renamed to Uppy Companion only in the latest version, v0.27.0 (at least according to my knowledge and the Uppy blog posts).