### PR TITLE
aws-s3-multipart: Proper cleanup on cancellation, fixes #992

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -254,6 +254,7 @@ class MultipartUploader {
       key: this.key,
       uploadId: this.uploadId
     })
+    this.uploading = []
   }
 
   _onError (err) {


### PR DESCRIPTION
Previously, cancelling an upload would not reset all upload-related
objects used by the S3 Multipart plugin. With this patch, cancellation
behaves similarly to files being removed (they are conceptually similar).