### PR TITLE
utils: Add fallback to getFileType

### DIFF
--- a/packages/@uppy/utils/src/getFileType.js
+++ b/packages/@uppy/utils/src/getFileType.js
@@ -19,6 +19,6 @@ module.exports = function getFileType (file) {
     return mimeTypes[fileExtension]
   }
 
-  // if all fails, well, return empty
-  return null
+  // if all fails, fall back to a generic byte stream type
+  return 'application/octet-stream'
 }

--- a/packages/@uppy/utils/src/getFileType.test.js
+++ b/packages/@uppy/utils/src/getFileType.test.js
@@ -42,6 +42,6 @@ describe('getFileType', () => {
       name: 'foobar',
       data: 'sdfsfhfh329fhwihs'
     }
-    expect(getFileType(file)).toEqual(null)
+    expect(getFileType(file)).toEqual('application/octet-stream')
   })
 })


### PR DESCRIPTION
If we can't determine the file type, use the generic
'application/octet-stream' type. This way `file.type` will always be
defined and uploaders don't have to worry about it being `null` or
whatever.