### PR TITLE
build: Update readme contributors list before publish

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -19,6 +19,11 @@ fi
 
 set -o xtrace
 
+# Update README before publishing `uppy`
+# So up-to-date contributors are shown on the npm page.
+npm run contributors:save
+git commit -m "Update contributors" README.md
+
 # Add readme file to the main `uppy` package.
 cp README.md packages/uppy/README.md
 


### PR DESCRIPTION
Auto update on every release so we don't have to remember to do it
manually. Update it _before_ doing the release so that the Uppy readme on npm is always up to date.