### PR TITLE
transloadit: Only use socket.io's WebSocket transport.

### DIFF
--- a/packages/@uppy/transloadit/src/Assembly.js
+++ b/packages/@uppy/transloadit/src/Assembly.js
@@ -66,6 +66,7 @@ class TransloaditAssembly extends Emitter {
   _connectSocket () {
     const parsed = parseUrl(this.status.websocket_url)
     const socket = io().connect(parsed.origin, {
+      transports: ['websocket'],
       path: parsed.pathname
     })
 


### PR DESCRIPTION
There is not much benefit to this (except saving a few HTTP requests)
but if we do this we'll see if anyone's firewalls are blocking WS or
something. Then one day in the future we can switch to plain WebSockets
instead of socket.io to shed 20KB once the Transloadit backend supports
it. Or we can write a minimal socket.io-compatible alternative that only
uses websockets.

<strike>pls don't merge yet, wanna try it on netlify first</strike> works as intended!