### PR TITLE
Fix for Cordova mangling new File instances

### DIFF
--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -286,7 +286,7 @@ module.exports = class Webcam extends Plugin {
       return {
         source: this.id,
         name: name,
-        data: new File([blob], name, { type: mimeType }),
+        data: new Blob([blob], { type: mimeType }),
         type: mimeType
       }
     })
@@ -305,7 +305,7 @@ module.exports = class Webcam extends Plugin {
     const file = {
       source: this.id,
       name: name,
-      data: new File([blob], name, { type: mimeType }),
+      data: new Blob([blob], { type: mimeType }),
       type: mimeType
     }
 

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -173,7 +173,12 @@ module.exports = class XHRUpload extends Plugin {
       formPost.append(item, file.meta[item])
     })
 
-    formPost.append(opts.fieldName, file.data)
+    if (file.name) {
+      formPost.append(opts.fieldName, file.data, file.name);
+    }
+    else {
+      formPost.append(opts.fieldName, file.data);
+    }
 
     return formPost
   }


### PR DESCRIPTION
Fix for issue https://github.com/transloadit/uppy/issues/1001.

Unfortunately, the Cordova File Plugin appears to mangle the new File() instance so it doesn't properly support the constructor used by Uppy.  This is causing a problem when capturing images via the Uppy webcam under Cordova.

This fix does two things...
- Replaces the new File() references with new Blob() references in the Webcam module
- Adds the file.name parameter when setting the FormData in the XhrUpload module
