### PR TITLE
Fix registry once integration test is over

### DIFF
--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -17,6 +17,12 @@ cleanup() {
   rm -rf "${__root}/test/endtoend/node_modules"
   rm -rf "${__root}/test/endtoend/tmp"
 }
+function on_exit() {
+  # revert to public registry
+  npm set registry https://registry.npmjs.org
+  cleanup
+}
+trap on_exit EXIT
 
 echo "Preparing for end to end test: copying static HTML and CSS, building JS"
 rm -rf "${__root}/test/endtoend/node_modules"
@@ -56,9 +62,6 @@ pushd "${__root}/test/endtoend"
     --no-save \
     uppy $PACKAGES
 popd
-
-# revert to public registry
-npm set registry https://registry.npmjs.org
 
 bash "${__dir}/endtoend-build-tests"
 

--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -26,7 +26,7 @@ PACKAGES="$(for pkg in packages/@uppy/*; do echo "${pkg#packages/}"; done)"
 
 cleanup
 # Initialise verdaccio storage path.
-mkir -p "${__root}/test/endtoend/tmp/verdaccio"
+mkdir -p "${__root}/test/endtoend/tmp/verdaccio"
 
 npm run build
 

--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -25,6 +25,9 @@ rm -rf "${__root}/test/endtoend/node_modules"
 PACKAGES="$(for pkg in packages/@uppy/*; do echo "${pkg#packages/}"; done)"
 
 cleanup
+# Initialise verdaccio storage path.
+mkir -p "${__root}/test/endtoend/tmp/verdaccio"
+
 npm run build
 
 # https://github.com/facebook/create-react-app/pull/4626

--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -58,7 +58,7 @@ pushd "${__root}/test/endtoend"
 popd
 
 # revert to public registry
-npm set registry https://registry.npmjs.com
+npm set registry https://registry.npmjs.org
 
 bash "${__dir}/endtoend-build-tests"
 

--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -21,6 +21,7 @@ cleanup() {
 echo "Preparing for end to end test: copying static HTML and CSS, building JS"
 rm -rf "${__root}/test/endtoend/node_modules"
 
+# list of @uppy/* packages
 PACKAGES="$(for pkg in packages/@uppy/*; do echo "${pkg#packages/}"; done)"
 
 cleanup
@@ -44,7 +45,14 @@ git checkout -- packages/*/package.json packages/@uppy/*/package.json
 
 # install all packages to the endtoend folder
 # (Don't use the npm cache, don't generate a package-lock, don't save dependencies to any package.json)
-(cd "${__root}/test/endtoend" && npm install --prefer-online --registry "$VERDACCIO_REGISTRY" --no-package-lock --no-save uppy $PACKAGES)
+pushd "${__root}/test/endtoend"
+  npm install \
+    --prefer-online \
+    --registry "$VERDACCIO_REGISTRY" \
+    --no-package-lock \
+    --no-save \
+    uppy $PACKAGES
+popd
 
 # revert to public registry
 npm set registry https://registry.npmjs.com


### PR DESCRIPTION
The integration tests are currently failing pending #1013, and those failures are causing website deploys to fail as well. The website deploy does `npm install`, but the integration test uses a local proxy registry and didn't get a chance to revert back to the global registry if the test failed. With this patch, the registry reset code is moved to an `EXIT` trap, so it's always run when the bash script ends, even if the test fails.