### PR TITLE
tests: start companion once

### DIFF
--- a/test/endtoend/providers/test.js
+++ b/test/endtoend/providers/test.js
@@ -1,48 +1,7 @@
 /* global browser, expect  */
-const path = require('path')
-const { spawn } = require('child_process')
 const testURL = 'http://localhost:4567/providers'
 
 describe('File upload with Providers', () => {
-  let companion
-  function prematureExit () {
-    throw new Error('Companion exited early')
-  }
-  before(() => {
-    companion = spawn('node', [
-      path.join(__dirname, '../../../packages/@uppy/companion/lib/standalone/start-server')
-    ], {
-      stdio: 'pipe',
-      env: Object.assign({}, process.env, {
-        UPPYSERVER_DATADIR: path.join(__dirname, '../../../output'),
-        UPPYSERVER_DOMAIN: 'localhost:3020',
-        UPPYSERVER_PROTOCOL: 'http',
-        UPPYSERVER_PORT: 3020,
-        UPPY_ENDPOINTS: '',
-        UPPYSERVER_SECRET: 'test'
-      })
-    })
-    return new Promise((resolve, reject) => {
-      companion.on('error', reject)
-      companion.stdout.on('data', (chunk) => {
-        if (`${chunk}`.includes('Listening on')) {
-          resolve()
-        }
-      })
-
-      companion.on('error', console.error)
-      companion.stderr.pipe(process.stderr)
-      companion.on('exit', prematureExit)
-    })
-  })
-  after(() => {
-    return new Promise((resolve) => {
-      companion.removeListener('exit', prematureExit)
-      companion.on('exit', () => resolve())
-      companion.kill('SIGINT')
-    })
-  })
-
   beforeEach(() => {
     browser.url(testURL)
   })

--- a/test/endtoend/utils.js
+++ b/test/endtoend/utils.js
@@ -1,4 +1,6 @@
 /* global window, capabilities */
+const path = require('path')
+const { spawn } = require('child_process')
 
 function selectFakeFile (uppyID) {
   var blob = new Blob(
@@ -20,7 +22,49 @@ function supportsChooseFile () {
          capabilities.platformName !== 'Android'
 }
 
+function prematureExit () {
+  throw new Error('Companion exited early')
+}
+
+class CompanionService {
+  onPrepare () {
+    this.companion = spawn('node', [
+      path.join(__dirname, '../../packages/@uppy/companion/lib/standalone/start-server')
+    ], {
+      stdio: 'pipe',
+      env: Object.assign({}, process.env, {
+        COMPANION_DATADIR: path.join(__dirname, '../../output'),
+        COMPANION_DOMAIN: 'localhost:3020',
+        COMPANION_PROTOCOL: 'http',
+        COMPANION_PORT: 3020,
+        COMPANION_SECRET: 'test'
+      })
+    })
+    return new Promise((resolve, reject) => {
+      this.companion.on('error', reject)
+      this.companion.stdout.on('data', (chunk) => {
+        if (`${chunk}`.includes('Listening on')) {
+          resolve()
+        }
+      })
+
+      this.companion.on('error', console.error)
+      this.companion.stderr.pipe(process.stderr)
+      this.companion.on('exit', prematureExit)
+    })
+  }
+
+  onComplete () {
+    return new Promise((resolve) => {
+      this.companion.removeListener('exit', prematureExit)
+      this.companion.on('exit', () => resolve())
+      this.companion.kill('SIGINT')
+    })
+  }
+}
+
 module.exports = {
   selectFakeFile,
-  supportsChooseFile
+  supportsChooseFile,
+  CompanionService
 }

--- a/test/endtoend/wdio.local.conf.js
+++ b/test/endtoend/wdio.local.conf.js
@@ -1,4 +1,5 @@
 const base = require('./wdio.base.conf')
+const { CompanionService } = require('./utils')
 
 exports.config = Object.assign(base.config, {
   capabilities: [
@@ -19,7 +20,7 @@ exports.config = Object.assign(base.config, {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  services: ['static-server'],
+  services: ['static-server', new CompanionService()],
 
   // Options to be passed to Mocha.
   // See the full list at http://mochajs.org/

--- a/test/endtoend/wdio.remote.conf.js
+++ b/test/endtoend/wdio.remote.conf.js
@@ -1,4 +1,5 @@
 const base = require('./wdio.base.conf')
+const { CompanionService } = require('./utils')
 
 function createCapability (capability) {
   return Object.assign({
@@ -30,7 +31,7 @@ exports.config = Object.assign(base.config, {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  services: ['static-server', 'sauce'],
+  services: ['static-server', 'sauce', new CompanionService()],
   user: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY
 })


### PR DESCRIPTION
currently when the test runs on travis, we are getting multiple occurrences of port conflicts. So it seems that we are starting companion multiple times as we run parallel browser sessions