### PR TITLE
[Dashboard] add showSelectedFiles option

### DIFF
--- a/packages/@uppy/dashboard/src/components/Dashboard.js
+++ b/packages/@uppy/dashboard/src/components/Dashboard.js
@@ -18,6 +18,7 @@ module.exports = function Dashboard (props) {
   // }
 
   const noFiles = props.totalFileCount === 0
+
   const dashboardClassName = classNames(
     { 'uppy-Root': props.isTargetDOMEl },
     'uppy-Dashboard',
@@ -25,7 +26,6 @@ module.exports = function Dashboard (props) {
     { 'uppy-Dashboard--animateOpenClose': props.animateOpenClose },
     { 'uppy-Dashboard--isClosing': props.isClosing },
     { 'uppy-Dashboard--modal': !props.inline },
-    // { 'uppy-Dashboard--wide': props.isWide },
     { 'uppy-size--md': props.containerWidth > 576 },
     { 'uppy-size--lg': props.containerWidth > 700 },
     { 'uppy-Dashboard--isAddFilesPanelVisible': props.showAddFilesPanel }
@@ -55,9 +55,13 @@ module.exports = function Dashboard (props) {
         </button>
 
         <div class="uppy-Dashboard-innerWrap">
-          { !noFiles && <PanelTopBar {...props} /> }
+          { (!noFiles && props.showSelectedFiles) && <PanelTopBar {...props} /> }
 
-          { noFiles ? <AddFiles {...props} /> : <FileList {...props} /> }
+          { props.showSelectedFiles ? (
+            noFiles ? <AddFiles {...props} /> : <FileList {...props} />
+          ) : (
+            <AddFiles {...props} />
+          )}
 
           <PreactCSSTransitionGroup
             transitionName="uppy-transition-slideDownUp"

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -123,6 +123,7 @@ module.exports = class Dashboard extends Plugin {
       animateOpenClose: true,
       proudlyDisplayPoweredByUppy: true,
       onRequestCloseModal: () => this.closeModal(),
+      showSelectedFiles: true,
       locale: defaultLocale,
       browserBackButtonClose: false
     }
@@ -625,7 +626,8 @@ module.exports = class Dashboard extends Plugin {
       containerWidth: pluginState.containerWidth,
       isTargetDOMEl: this.isTargetDOMEl,
       allowedFileTypes: this.uppy.opts.restrictions.allowedFileTypes,
-      maxNumberOfFiles: this.uppy.opts.restrictions.maxNumberOfFiles
+      maxNumberOfFiles: this.uppy.opts.restrictions.maxNumberOfFiles,
+      showSelectedFiles: this.opts.showSelectedFiles
     })
   }
 

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -66,6 +66,8 @@ uppy.use(Dashboard, {
   showLinkToFileUploadResult: true,
   showProgressDetails: false,
   hideUploadButton: false,
+  hideRetryButton: false,
+  hidePauseResumeCancelButtons: false,
   hideProgressAfterFinish: false,
   note: null,
   closeModalOnClickOutside: false,
@@ -73,9 +75,12 @@ uppy.use(Dashboard, {
   disableInformer: false,
   disableThumbnailGenerator: false,
   disablePageScrollWhenModalOpen: true,
+  animateOpenClose: true,
   proudlyDisplayPoweredByUppy: true,
   onRequestCloseModal: () => this.closeModal(),
-  locale: {}
+  showSelectedFiles: true,
+  locale: defaultLocale,
+  browserBackButtonClose: false
 })
 ```
 
@@ -143,6 +148,12 @@ Hide the cancel or pause/resume buttons (for resumable uploads, via [tus](http:/
 ### `hideProgressAfterFinish: false`
 
 Hide StatusBar after the upload has finished.
+
+### `showSelectedFiles: true`
+
+Show the list (grid) of selected files with preview and file name. In case you are showing selected files in your own app’s UI and want the Uppy Dashboard to just be a picker, the list can be hidden with this option.
+
+See also `disableStatusBar` option, which can hide the progress and upload button.
 
 ### `note: null`
 


### PR DESCRIPTION
Requested in #717 (and closes #717 if merged):

> I'd like to use the Dashboard component, but not show the list of added files, because I display them elsewhere on the page. it would be handy to have an option to disable the file list.

This adds `showSelectedFiles: true` option, when `false` the `FileList` and `PanelTopBar` (that displays number of selected files, cancel button and a plus button) are never shown, you add files and keep seeing the “drop files here” prompt.

Docs explanation:

> Show the list (grid) of selected files with preview and file name. In case you are showing selected files in your own app’s UI and want the Uppy Dashboard to just be a picker, the list can be hidden with this option.
> 
> See also `disableStatusBar` option, which can hide the progress and upload button.

Up for discussion, maybe this is not very necessary, but it’s something that’s hard to do with CSS only, since `AddFiles` component is hidden altogether is JS when files are selected.

<img width="865" alt="screen shot 2018-09-13 at 4 33 05 pm" src="https://user-images.githubusercontent.com/1199054/45514193-b83d9b00-b772-11e8-9c8e-4e8b694cc518.png">

(StatusBar or just the upload button can already be disabled via options).