### PR TITLE
Call `removeFile` on each file when doing `cancelAll`

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -505,8 +505,6 @@ class Uppy {
     if (removedFile.preview && isObjectURL(removedFile.preview)) {
       URL.revokeObjectURL(removedFile.preview)
     }
-
-    this.log(`Removed file: ${fileID}`)
   }
 
   pauseResume (fileID) {
@@ -588,16 +586,18 @@ class Uppy {
   cancelAll () {
     this.emit('cancel-all')
 
-    // TODO Or should we just call removeFile on all files?
     const { currentUploads } = this.getState()
     const uploadIDs = Object.keys(currentUploads)
-
     uploadIDs.forEach((id) => {
       this._removeUpload(id)
     })
 
+    const files = Object.keys(this.getState().files)
+    files.forEach((fileID) => {
+      this.removeFile(fileID)
+    })
+
     this.setState({
-      files: {},
       totalProgress: 0,
       error: null
     })

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -586,12 +586,6 @@ class Uppy {
   cancelAll () {
     this.emit('cancel-all')
 
-    const { currentUploads } = this.getState()
-    const uploadIDs = Object.keys(currentUploads)
-    uploadIDs.forEach((id) => {
-      this._removeUpload(id)
-    })
-
     const files = Object.keys(this.getState().files)
     files.forEach((fileID) => {
       this.removeFile(fileID)

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -240,15 +240,33 @@ describe('src/Core', () => {
     })
   })
 
-  it('should clear all uploads on cancelAll()', () => {
+  it('should clear all uploads and files on cancelAll()', () => {
     const core = new Core()
-    const id = core._createUpload([ 'a', 'b' ])
+
+    core.addFile({
+      source: 'jest',
+      name: 'foo1.jpg',
+      type: 'image/jpeg',
+      data: new File([sampleImage], { type: 'image/jpeg' })
+    })
+
+    core.addFile({
+      source: 'jest',
+      name: 'foo2.jpg',
+      type: 'image/jpeg',
+      data: new File([sampleImage], { type: 'image/jpeg' })
+    })
+
+    const fileIDs = Object.keys(core.getState().files)
+    const id = core._createUpload(fileIDs)
 
     expect(core.getState().currentUploads[id]).toBeDefined()
+    expect(Object.keys(core.getState().files).length).toEqual(2)
 
     core.cancelAll()
 
     expect(core.getState().currentUploads[id]).toBeUndefined()
+    expect(Object.keys(core.getState().files).length).toEqual(0)
   })
 
   it('should close, reset and uninstall when the close method is called', () => {


### PR DESCRIPTION
We have an `uppy.cancelAll` in `@uppy/core`. It used to just set `files` object in `uppy.state` to an empty object `{}`. This PR changes this to instead call `uppy.removeFile` on each file in state, because:

> When I click Cancel in the top bar of the dashboard, the state of the dashboard resets and all the already-uploaded files go away, but corresponding file-removed events are not triggered for each uploaded file, which I need so I can properly clean up app state.

> Yeah, the Cancel button uses a different event, cancel-all. We work around this in Uppy's own source code by listening for both file-removed and cancel-all. It's come up before that making the cancel-all action emit file-removed for each file would be easier and less surprising but we never acted on it yet, so thanks for opening an issue for it 😄

I wonder if this makes things unnecessarily slow when dealing with, for instance, 1000 files.

Fixes #1049