### PR TITLE
Add getUploadHeaders options to AwsS3 provider

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -26,7 +26,8 @@ module.exports = class AwsS3 extends Plugin {
       timeout: 30 * 1000,
       limit: 0,
       getUploadParameters: this.getUploadParameters.bind(this),
-      locale: defaultLocale
+      locale: defaultLocale,
+      getUploadHeaders: () => ({})
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -54,7 +55,10 @@ module.exports = class AwsS3 extends Plugin {
     const type = encodeURIComponent(file.type)
     return fetch(`${this.opts.serverUrl}/s3/params?filename=${filename}&type=${type}`, {
       method: 'get',
-      headers: { accept: 'application/json' }
+      headers: {
+        accept: 'application/json',
+        ...this.opts.getUploadHeaders()
+      }
     }).then((response) => response.json())
   }
 

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -102,6 +102,49 @@ strings: {
 }
 ```
 
+### `getUploadHeaders()`
+
+Set the default headers for the request to be sent to the server.
+A common use case is adding the `Authorization` header with your JWT token.
+```js
+getUploadHeaders: () => {
+  return {
+    Authorization: localStorage.getItem('token')
+  }
+}
+```
+
+This can be used in your server as follows:
+```js
+const options = {
+  secret: process.env.COMPANION_SECRET,
+  server: {
+    host: process.env.COMPANION_DOMAIN,
+    protocol: process.env.COMPANION_PROTOCOL,
+  },
+  filePath: process.env.DATA_DIR,
+  debug: true,
+  providerOptions: {
+    s3: {
+      // Example use case, generating a folder in the bucket
+      // for each user
+      getKey: (req, filename) => {
+        const userId = jwt.decode(req.headers.authorization)
+        const key = `${userId}/${filename}`
+        return key
+      },
+      key: process.env.COMPANION_AWS_KEY,
+      secret: process.env.COMPANION_AWS_SECRET,
+      bucket: process.env.COMPANION_AWS_BUCKET,
+      region: process.env.COMPANION_AWS_REGION,
+    },
+  },
+}
+
+// Adding to your express server later on
+app.use(companion(options))
+```
+
 ## S3 Bucket configuration
 
 S3 buckets do not allow public uploads by default.


### PR DESCRIPTION
Allow passing a function to get default headers to be sent to the server as part of the request. Examples and documentation were added showing a use case. 

The `getUploadParams` function is expecting a `url` by default, but in some cases I don't want to pass a custom url, I just want some custom headers so I can perform validations in my middlewares before reaching the `companion` middleware`.

I saw a few issues here related to this problem, and I think it suppose to be easier to pass this headers to the request. Perhaps a better solution for this would be passing an `axios` client instead of using `fetch` internally by default.

And by the way, this `getUploadHeaders` option suppose to be available on all providers. I will let you guys decide if this is a good idea an I can continue on this implementation if it makes sense.