### PR TITLE
[@uppy/core] Add onMount and this.parent to Plugin

### DIFF
--- a/packages/@uppy/core/src/Plugin.js
+++ b/packages/@uppy/core/src/Plugin.js
@@ -73,6 +73,16 @@ module.exports = class Plugin {
   }
 
   /**
+  * Called when plugin is mounted, whether in DOM or into another plugin.
+  * Needed because sometimes plugins are mounted separately/after `install`,
+  * so this.el and this.parent might not be available in `install`.
+  * This is the case with @uppy/react plugins, for example.
+  */
+  onMount () {
+
+  }
+
+  /**
    * Check if supplied `target` is a DOM element or an `object`.
    * If it’s an object — target is a plugin, and we search `plugins`
    * for a plugin with same name and return its target.
@@ -107,6 +117,7 @@ module.exports = class Plugin {
 
       this.el = preact.render(this.render(this.uppy.getState()), targetElement)
 
+      this.onMount()
       return this.el
     }
 
@@ -127,9 +138,11 @@ module.exports = class Plugin {
     }
 
     if (targetPlugin) {
-      const targetPluginName = targetPlugin.id
-      this.uppy.log(`Installing ${callerPluginName} to ${targetPluginName}`)
+      this.uppy.log(`Installing ${callerPluginName} to ${targetPlugin.id}`)
+      this.parent = targetPlugin.id
       this.el = targetPlugin.addTarget(plugin)
+
+      this.onMount()
       return this.el
     }
 

--- a/packages/@uppy/core/src/Plugin.js
+++ b/packages/@uppy/core/src/Plugin.js
@@ -139,7 +139,7 @@ module.exports = class Plugin {
 
     if (targetPlugin) {
       this.uppy.log(`Installing ${callerPluginName} to ${targetPlugin.id}`)
-      this.parent = targetPlugin.id
+      this.parent = targetPlugin
       this.el = targetPlugin.addTarget(plugin)
 
       this.onMount()

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -456,7 +456,10 @@ module.exports = class Dashboard extends Plugin {
     this.ro.observe(this.el.querySelector('.uppy-Dashboard-inner'))
 
     this.uppy.on('plugin-remove', this.removeTarget)
-    this.uppy.on('file-added', (ev) => this.toggleAddFilesPanel(false))
+    this.uppy.on('file-added', (ev) => {
+      this.toggleAddFilesPanel(false)
+      this.hideAllPanels()
+    })
   }
 
   removeEvents () {
@@ -658,7 +661,9 @@ module.exports = class Dashboard extends Plugin {
     const plugins = this.opts.plugins || []
     plugins.forEach((pluginID) => {
       const plugin = this.uppy.getPlugin(pluginID)
-      if (plugin) plugin.mount(this, plugin)
+      if (plugin) {
+        plugin.mount(this, plugin)
+      }
     })
 
     if (!this.opts.disableStatusBar) {

--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -143,9 +143,8 @@ module.exports = class Url extends Plugin {
       .then(() => {
         // Close the Dashboard panel if plugin is installed
         // into Dashboard (could be other parent UI plugin)
-        // const parent = this.uppy.getPlugin(this.parent)
-        // if (parent && parent.hideAllPanels) {
-        //   parent.hideAllPanels()
+        // if (this.parent && this.parent.hideAllPanels) {
+        //   this.parent.hideAllPanels()
         // }
       })
       .catch((err) => {

--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -141,8 +141,12 @@ module.exports = class Url extends Plugin {
         }
       })
       .then(() => {
-        const dashboard = this.uppy.getPlugin('Dashboard')
-        if (dashboard) dashboard.hideAllPanels()
+        // Close the Dashboard panel if plugin is installed
+        // into Dashboard (could be other parent UI plugin)
+        // const parent = this.uppy.getPlugin(this.parent)
+        // if (parent && parent.hideAllPanels) {
+        //   parent.hideAllPanels()
+        // }
       })
       .catch((err) => {
         this.uppy.log(err)
@@ -206,23 +210,29 @@ module.exports = class Url extends Plugin {
       addFile={this.addFile} />
   }
 
+  onMount () {
+    if (this.el) {
+      this.el.addEventListener('drop', this.handleDrop)
+      this.el.addEventListener('dragover', this.handleDragOver)
+      this.el.addEventListener('dragleave', this.handleDragLeave)
+      this.el.addEventListener('paste', this.handlePaste)
+    }
+  }
+
   install () {
     const target = this.opts.target
     if (target) {
       this.mount(target, this)
     }
-
-    this.el.addEventListener('drop', this.handleDrop)
-    this.el.addEventListener('dragover', this.handleDragOver)
-    this.el.addEventListener('dragleave', this.handleDragLeave)
-    this.el.addEventListener('paste', this.handlePaste)
   }
 
   uninstall () {
-    this.el.removeEventListener('drop', this.handleDrop)
-    this.el.removeEventListener('dragover', this.handleDragOver)
-    this.el.removeEventListener('dragleave', this.handleDragLeave)
-    this.el.removeEventListener('paste', this.handlePaste)
+    if (this.el) {
+      this.el.removeEventListener('drop', this.handleDrop)
+      this.el.removeEventListener('dragover', this.handleDragOver)
+      this.el.removeEventListener('dragleave', this.handleDragLeave)
+      this.el.removeEventListener('paste', this.handlePaste)
+    }
 
     this.unmount()
   }

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -183,8 +183,13 @@ module.exports = class Webcam extends Plugin {
     .then(() => {
       this.recordingChunks = null
       this.recorder = null
-      const dashboard = this.uppy.getPlugin('Dashboard')
-      if (dashboard) dashboard.hideAllPanels()
+
+      // Close the Dashboard panel if plugin is installed
+      // into Dashboard (could be other parent UI plugin)
+      // const parent = this.uppy.getPlugin(this.parent)
+      // if (parent && parent.hideAllPanels) {
+      //   parent.hideAllPanels()
+      // }
     }, (error) => {
       this.recordingChunks = null
       this.recorder = null
@@ -242,8 +247,12 @@ module.exports = class Webcam extends Plugin {
       return this.getImage()
     }).then((tagFile) => {
       this.captureInProgress = false
-      const dashboard = this.uppy.getPlugin('Dashboard')
-      if (dashboard) dashboard.hideAllPanels()
+      // Close the Dashboard panel if plugin is installed
+      // into Dashboard (could be other parent UI plugin)
+      // const parent = this.uppy.getPlugin(this.parent)
+      // if (parent && parent.hideAllPanels) {
+      //   parent.hideAllPanels()
+      // }
       try {
         this.uppy.addFile(tagFile)
       } catch (err) {

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -186,9 +186,8 @@ module.exports = class Webcam extends Plugin {
 
       // Close the Dashboard panel if plugin is installed
       // into Dashboard (could be other parent UI plugin)
-      // const parent = this.uppy.getPlugin(this.parent)
-      // if (parent && parent.hideAllPanels) {
-      //   parent.hideAllPanels()
+      // if (this.parent && this.parent.hideAllPanels) {
+      //   this.parent.hideAllPanels()
       // }
     }, (error) => {
       this.recordingChunks = null
@@ -249,9 +248,8 @@ module.exports = class Webcam extends Plugin {
       this.captureInProgress = false
       // Close the Dashboard panel if plugin is installed
       // into Dashboard (could be other parent UI plugin)
-      // const parent = this.uppy.getPlugin(this.parent)
-      // if (parent && parent.hideAllPanels) {
-      //   parent.hideAllPanels()
+      // if (this.parent && this.parent.hideAllPanels) {
+      //   this.parent.hideAllPanels()
       // }
       try {
         this.uppy.addFile(tagFile)


### PR DESCRIPTION
Fixes https://github.com/transloadit/uppy/issues/1057 (hopefully ;-)

- Add `onMount` to Plugin which can be used when access to`this.el` is needed
- Add `this.parent` to Plugin, which can be used to access parent plugin like `this.parent.hideAllPanels()` — no need to fish the plugin by id
- Automatically hide panels in Dashboard when a file is added (up until now Providers manually called `hideAllPanels`, which is not ideal — Providers shouldn’t be concerned about Dashboard)