### PR TITLE
[@uppy/dashboard] Only show the plus button if selected file count !== maxNumberOfFiles

### DIFF
--- a/packages/@uppy/dashboard/src/components/PanelTopBar.js
+++ b/packages/@uppy/dashboard/src/components/PanelTopBar.js
@@ -7,6 +7,8 @@ function DashboardContentTitle (props) {
 }
 
 function PanelTopBar (props) {
+  const notOverFileLimit = props.maxNumberOfFiles !== props.totalFileCount
+
   return (
     <div class="uppy-DashboardContent-bar">
       <button class="uppy-DashboardContent-back"
@@ -15,15 +17,18 @@ function PanelTopBar (props) {
       <div class="uppy-DashboardContent-title" role="heading" aria-level="h1">
         <DashboardContentTitle {...props} />
       </div>
-      <button class="uppy-DashboardContent-addMore"
-        type="button"
-        aria-label={props.i18n('addMoreFiles')}
-        title={props.i18n('addMoreFiles')}
-        onclick={() => props.toggleAddFilesPanel(true)}>
-        <svg class="UppyIcon" width="15" height="15" viewBox="0 0 13 13" version="1.1" xmlns="http://www.w3.org/2000/svg">
-          <path d="M7,6 L13,6 L13,7 L7,7 L7,13 L6,13 L6,7 L0,7 L0,6 L6,6 L6,0 L7,0 L7,6 Z" />
-        </svg>
-      </button>
+      { notOverFileLimit &&
+        <button class="uppy-DashboardContent-addMore"
+          type="button"
+          aria-label={props.i18n('addMoreFiles')}
+          title={props.i18n('addMoreFiles')}
+          onclick={() => props.toggleAddFilesPanel(true)}>
+          <svg class="UppyIcon" width="15" height="15" viewBox="0 0 13 13" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7,6 L13,6 L13,7 L7,7 L7,13 L6,13 L6,7 L0,7 L0,6 L6,6 L6,0 L7,0 L7,6 Z" />
+          </svg>
+        </button>
+      }
+
     </div>
   )
 }

--- a/packages/@uppy/dashboard/src/components/PanelTopBar.js
+++ b/packages/@uppy/dashboard/src/components/PanelTopBar.js
@@ -7,7 +7,9 @@ function DashboardContentTitle (props) {
 }
 
 function PanelTopBar (props) {
-  const notOverFileLimit = props.maxNumberOfFiles !== props.totalFileCount
+  const notOverFileLimit = props.maxNumberOfFiles
+    ? props.totalFileCount < props.maxNumberOfFiles
+    : true
 
   return (
     <div class="uppy-DashboardContent-bar">


### PR DESCRIPTION
When you can only select 2 files and 2 are already selected, it makes no sense to show a plus button in the Dashboard. This PR fixes that.

> Hi, I have to handle each image separately in the application by assigning each image several properties, such as date, credit, photographer and so on. It doesn't make sense to support multiple files for that particular interface. I can set the max number of files to 1, however the Dashboard interface could be confusing to users since they present the add (+) button when a file has already been picked while I'd prefer to tell Dashboard to not display that button by either enabling some single-selection mode or by having it behaving differently by not showing that button when the number of files has already reached its limit.

Fixes https://github.com/transloadit/uppy/issues/1061