### PR TITLE
Fixing ResizeObserver is not a constructor, issue #1070

### DIFF
--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -8,7 +8,7 @@ const ThumbnailGenerator = require('@uppy/thumbnail-generator')
 const findAllDOMElements = require('@uppy/utils/lib/findAllDOMElements')
 const toArray = require('@uppy/utils/lib/toArray')
 const prettyBytes = require('prettier-bytes')
-const ResizeObserver = require('resize-observer-polyfill')
+const ResizeObserver = require('resize-observer-polyfill').default
 const { defaultTabIcon } = require('./components/icons')
 
 // Some code for managing focus was adopted from https://github.com/ghosh/micromodal


### PR DESCRIPTION
Uncaught TypeError: ResizeObserver is not a constructor, fixes #1070