### PR TITLE
Fixing ResizeObserver is not a constructor, issue #1070

### DIFF
--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -8,7 +8,7 @@ const ThumbnailGenerator = require('@uppy/thumbnail-generator')
 const findAllDOMElements = require('@uppy/utils/lib/findAllDOMElements')
 const toArray = require('@uppy/utils/lib/toArray')
 const prettyBytes = require('prettier-bytes')
-const ResizeObserver = require('resize-observer-polyfill')
+const ResizeObserver = require('resize-observer-polyfill').default || require('resize-observer-polyfill')
 const { defaultTabIcon } = require('./components/icons')
 
 // Some code for managing focus was adopted from https://github.com/ghosh/micromodal


### PR DESCRIPTION
Follow up on https://github.com/transloadit/uppy/pull/1073, can’t wait — this needs an urgent fix and a patch release.

Fixes #1070.

@goto-bus-stop:
> I think we need to do: require('resize-observer-polyfill').default || require('resize-observer-polyfill'), to support both the transpiled version of its ES module format and its CommonJS format. A bit like we did here (although for a different related reason): https://github.com/transloadit/uppy/blob/4684a3e1f3bb43ed59c4ffcda73093cdbe1ddf0d/packages/%40uppy/form/src/index.js#L3-L5