### PR TITLE
aws-s3: Use RequestClient, fixes #1088

### DIFF
--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@uppy/utils": "0.27.1",
     "@uppy/xhr-upload": "0.27.4",
+    "@uppy/companion-client": "0.27.2",
     "resolve-url": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -2,11 +2,21 @@ const resolveUrl = require('resolve-url')
 const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const limitPromises = require('@uppy/utils/lib/limitPromises')
+const { RequestClient } = require('@uppy/companion-client')
 const XHRUpload = require('@uppy/xhr-upload')
 
 function isXml (xhr) {
   const contentType = xhr.headers ? xhr.headers['content-type'] : xhr.getResponseHeader('Content-Type')
   return typeof contentType === 'string' && contentType.toLowerCase() === 'application/xml'
+}
+
+function assertServerError (res) {
+  if (res && res.error) {
+    const error = new Error(res.message)
+    Object.assign(error, res.error)
+    throw error
+  }
+  return res
 }
 
 module.exports = class AwsS3 extends Plugin {
@@ -36,6 +46,8 @@ module.exports = class AwsS3 extends Plugin {
     this.translator = new Translator({ locale: this.locale })
     this.i18n = this.translator.translate.bind(this.translator)
 
+    this.client = new RequestClient(uppy, opts)
+
     this.prepareUpload = this.prepareUpload.bind(this)
 
     if (typeof this.opts.limit === 'number' && this.opts.limit !== 0) {
@@ -52,10 +64,8 @@ module.exports = class AwsS3 extends Plugin {
 
     const filename = encodeURIComponent(file.name)
     const type = encodeURIComponent(file.type)
-    return fetch(`${this.opts.serverUrl}/s3/params?filename=${filename}&type=${type}`, {
-      method: 'get',
-      headers: { accept: 'application/json' }
-    }).then((response) => response.json())
+    return this.client.get(`s3/params?filename=${filename}&type=${type}`)
+      .then(assertServerError)
   }
 
   validateParameters (file, params) {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -39,9 +39,12 @@ module.exports = class AwsS3 extends Plugin {
       locale: defaultLocale
     }
 
-    this.opts = Object.assign({}, defaultOptions, opts)
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
+    this.opts = { ...defaultOptions, ...opts }
+    this.locale = {
+      ...defaultLocale,
+      ...this.opts.locale,
+      strings: { ...defaultLocale.strings, ...this.opts.locale.strings }
+    }
 
     this.translator = new Translator({ locale: this.locale })
     this.i18n = this.translator.translate.bind(this.translator)

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -58,6 +58,12 @@ uppy.use(AwsS3, {
 })
 ```
 
+### `serverHeaders: {}`
+
+> Note: This only applies when using [Companion][companion docs] to sign S3 uploads.
+
+Custom headers that should be sent along to [Companion][companion docs] on every request.
+
 ### `getUploadParameters(file)`
 
 > Note: When using [Companion][companion docs] to sign S3 uploads, do not define this option.


### PR DESCRIPTION
RequestClient contains the Uppy Companion specific stuff, so we don't have to think about that when working on the S3 plugin.

This fixes an issue where AwsS3 did not use `credentials: 'same-origin'` by default for Companion requests, where the other plugins do.

This also adds support for the RequestClient's `serverHeaders` option.

Finally, when we change the `server*` option names again, we only have to do it in RequestClient and it'll apply here too :)