### PR TITLE
Support mime types with additional data, fixes #1074

### DIFF
--- a/packages/@uppy/utils/src/getFileTypeExtension.js
+++ b/packages/@uppy/utils/src/getFileTypeExtension.js
@@ -7,10 +7,13 @@ const mimeToExtensions = {
   'audio/ogg': 'ogg',
   'video/webm': 'webm',
   'audio/webm': 'webm',
+  'video/x-matroska': 'mkv',
   'video/mp4': 'mp4',
   'audio/mp3': 'mp3'
 }
 
 module.exports = function getFileTypeExtension (mimeType) {
+  // Remove the ; bit in 'video/x-matroska;codecs=avc1'
+  mimeType = mimeType.replace(/;.*$/, '')
   return mimeToExtensions[mimeType] || null
 }

--- a/packages/@uppy/utils/src/getFileTypeExtension.test.js
+++ b/packages/@uppy/utils/src/getFileTypeExtension.test.js
@@ -5,6 +5,9 @@ describe('getFileTypeExtension', () => {
     expect(getFileTypeExtension('video/ogg')).toEqual('ogv')
     expect(getFileTypeExtension('audio/ogg')).toEqual('ogg')
     expect(getFileTypeExtension('video/webm')).toEqual('webm')
+    // Supports mime types with additional data
+    expect(getFileTypeExtension('video/webm;codecs=vp8,opus')).toEqual('webm')
+    expect(getFileTypeExtension('video/x-matroska;codecs=avc1')).toEqual('mkv')
     expect(getFileTypeExtension('audio/webm')).toEqual('webm')
     expect(getFileTypeExtension('video/mp4')).toEqual('mp4')
     expect(getFileTypeExtension('audio/mp3')).toEqual('mp3')


### PR DESCRIPTION
Chrome's MediaRecorder mime types include metadata about the codecs used in container formats like webm and mkv. This patch discards it when determining the file extension to use.