### PR TITLE
transloadit: Error tweaks

### DIFF
--- a/packages/@uppy/transloadit/src/AssemblyOptions.js
+++ b/packages/@uppy/transloadit/src/AssemblyOptions.js
@@ -19,7 +19,7 @@ function validateParams (params) {
 
   if (!params.auth || !params.auth.key) {
     throw new Error('Transloadit: The `params.auth.key` option is required. ' +
-      'You can find your Transloadit API key at https://transloadit.com/accounts/credentials.')
+      'You can find your Transloadit API key at https://transloadit.com/account/api-settings.')
   }
 }
 

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -67,7 +67,9 @@ module.exports = class Transloadit extends Plugin {
     this._onRestored = this._onRestored.bind(this)
     this._getPersistentData = this._getPersistentData.bind(this)
 
-    if (this.opts.params) {
+    if (this.opts.params ||
+        // No params _and_ no custom getAssemblyOptions is an early error.
+        this.opts.getAssemblyOptions === defaultOptions.getAssemblyOptions) {
       AssemblyOptions.validateParams(this.opts.params)
     }
 

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -67,10 +67,11 @@ module.exports = class Transloadit extends Plugin {
     this._onRestored = this._onRestored.bind(this)
     this._getPersistentData = this._getPersistentData.bind(this)
 
-    if (this.opts.params ||
-        // No params _and_ no custom getAssemblyOptions is an early error.
-        this.opts.getAssemblyOptions === defaultOptions.getAssemblyOptions) {
+    const hasCustomAssemblyOptions = this.opts.getAssemblyOptions !== defaultOptions.getAssemblyOptions
+    if (this.opts.params) {
       AssemblyOptions.validateParams(this.opts.params)
+    } else if (!hasCustomAssemblyOptions) {
+      AssemblyOptions.validateParams(null)
     }
 
     this.client = new Client({

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -71,6 +71,8 @@ module.exports = class Transloadit extends Plugin {
     if (this.opts.params) {
       AssemblyOptions.validateParams(this.opts.params)
     } else if (!hasCustomAssemblyOptions) {
+      // Throw the same error that we'd throw if the `params` returned from a
+      // `getAssemblyOptions()` function is null.
       AssemblyOptions.validateParams(null)
     }
 


### PR DESCRIPTION
- Update API key URL in the `auth.key` error message. The old URL still worked but not having to redirect is nice
- Error early if neither `params` nor `getAssemblyOptions` are given.