### PR TITLE
transloadit: Add COMPANION_PATTERN constant.

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -129,7 +129,6 @@ module.exports = class Transloadit extends Plugin {
       remote = {
         ...file.remote,
         serverUrl: newHost,
-        serverPattern: ALLOWED_COMPANION_PATTERN,
         url: `${newHost}/${path}`
       }
     }
@@ -699,3 +698,4 @@ module.exports = class Transloadit extends Plugin {
 
 module.exports.COMPANION = COMPANION
 module.exports.UPPY_SERVER = COMPANION
+module.exports.COMPANION_PATTERN = ALLOWED_COMPANION_PATTERN

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -15,6 +15,8 @@ function defaultGetAssemblyOptions (file, options) {
 }
 
 const COMPANION = 'https://api2.transloadit.com/companion'
+// Regex matching acceptable postMessage() origins for authentication feedback from companion.
+const ALLOWED_COMPANION_PATTERN = /\.transloadit\.com$/
 // Regex used to check if a Companion address is run by Transloadit.
 const TL_COMPANION = /https?:\/\/api2(?:-\w+)?\.transloadit\.com\/companion/
 const TL_UPPY_SERVER = /https?:\/\/api2(?:-\w+)?\.transloadit\.com\/uppy-server/
@@ -116,16 +118,18 @@ module.exports = class Transloadit extends Plugin {
       this.uppy.log(err)
       throw err
     }
+
     if (file.remote && TL_COMPANION.test(file.remote.serverUrl)) {
-      let newHost = status.companion_url
+      const newHost = status.companion_url
         .replace(/\/$/, '')
-      let path = file.remote.url
+      const path = file.remote.url
         .replace(file.remote.serverUrl, '')
         .replace(/^\//, '')
 
       remote = {
         ...file.remote,
         serverUrl: newHost,
+        serverPattern: ALLOWED_COMPANION_PATTERN,
         url: `${newHost}/${path}`
       }
     }

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -55,6 +55,7 @@ const Transloadit = require('@uppy/transloadit')
 
 uppy.use(Dropbox, {
   serverUrl: Transloadit.COMPANION
+  serverPattern: Transloadit.COMPANION_PATTERN
 })
 ```
 
@@ -65,6 +66,24 @@ uppy.use(Dropbox, {
   serverUrl: 'https://api2-us-east-1.transloadit.com/companion'
 })
 ```
+
+### `Transloadit.COMPANION_PATTERN`
+
+A RegExp pattern matching Transloadit's hosted companion endpoints. The pattern is used in remote provider `serverPattern` options, to ensure that third party authentication messages cannot be faked by an attacker's page, but can only originate from Transloadit's servers.
+
+Use it whenever you use `serverUrl: Transloadit.COMPANION`, like so:
+
+```js
+const Dropbox = require('@uppy/dropbox')
+const Transloadit = require('@uppy/transloadit')
+
+uppy.use(Dropbox, {
+  serverUrl: Transloadit.COMPANION
+  serverPattern: Transloadit.COMPANION_PATTERN
+})
+```
+
+The value of this constant covers _all_ Transloadit's Companion servers, so it does not need to be changed if you are using a custom [`service`](#service) option. However, if you are not using the Transloadit Companion servers at `*.transloadit.com`, make sure to set the `serverPattern` option to something that matches what you do use.
 
 ## Options
 

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -59,6 +59,8 @@ uppy.use(Dropbox, {
 })
 ```
 
+When using `Transloadit.COMPANION`, you should also configure [`serverPattern: Transloadit.COMPANION_PATTERN`](#Transloadit-COMPANION-PATTERN).
+
 The value of this constant is `https://api2.transloadit.com/companion`. If you are using a custom [`service`](#service) option, you should also set a custom host option in your provider plugins, by taking a Transloadit API url and appending `/companion`:
 
 ```js

--- a/website/src/examples/transloadit/app.es6
+++ b/website/src/examples/transloadit/app.es6
@@ -57,7 +57,11 @@ function initUppy () {
       target: '#uppy-dashboard-container',
       note: 'Images only, 1–2 files, up to 1 MB'
     })
-    .use(Instagram, { target: Dashboard, serverUrl: 'https://api2.transloadit.com/companion', serverPattern: /\.transloadit\.com$/  })
+    .use(Instagram, {
+      target: Dashboard,
+      serverUrl: 'https://api2.transloadit.com/companion',
+      serverPattern: Transloadit.COMPANION_PATTERN
+    })
     .use(Webcam, { target: Dashboard })
 
   uppy


### PR DESCRIPTION
Simplify configuration of remote providers by having a `serverPattern` counterpart to `Transloadit.COMPANION`.

Initially, I wanted to auto configure this inside the Transloadit plugin, but the `serverPattern` option is passed through some constructors down to the `Provider` class, which is really internal to provider plugins. Instead of reaching through several private layers, this seems the nicer option…