### PR TITLE
Dashboard: Auto close after finish using `closeAfterFinish: true` 

### DIFF
--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -659,7 +659,11 @@ module.exports = class Dashboard extends Plugin {
       targets: []
     })
 
-    const { closeAfterFinish } = this.opts
+    const { inline, closeAfterFinish } = this.opts
+    if (inline && closeAfterFinish) {
+      throw new Error('[Dashboard] `closeAfterFinish: true` cannot be used on an inline Dashboard, because an inline Dashboard cannot be closed at all. Either set `inline: false`, or disable the `closeAfterFinish` option.')
+    }
+
     const { allowMultipleUploads } = this.uppy.opts
     if (allowMultipleUploads && closeAfterFinish) {
       this.uppy.log('[Dashboard] When using `closeAfterFinish`, we recommended setting the `allowMultipleUploads` option to `false` in the Uppy constructor. See https://uppy.io/docs/uppy/#allowMultipleUploads-true', 'warning')

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -460,12 +460,8 @@ module.exports = class Dashboard extends Plugin {
     this.uppy.on('file-added', (ev) => {
       this.toggleAddFilesPanel(false)
     })
-    this.uppy.on('complete', ({ uploadID }) => {
-      const { currentUploads } = this.uppy.getState()
-      if (this.opts.closeAfterFinish &&
-          // This is the very last upload still in state
-          // (and will be removed by core after this handler is complete)
-          Object.keys(currentUploads).length === 1 && currentUploads[uploadID]) {
+    this.uppy.on('complete', ({ failed, uploadID }) => {
+      if (this.opts.closeAfterFinish && failed.length === 0) {
         // All uploads are done
         this.requestCloseModal()
       }
@@ -663,7 +659,13 @@ module.exports = class Dashboard extends Plugin {
       targets: []
     })
 
-    const target = this.opts.target
+    const { closeAfterFinish } = this.opts
+    const { allowMultipleUploads } = this.uppy.opts
+    if (allowMultipleUploads && closeAfterFinish) {
+      this.uppy.log('[Dashboard] When using `closeAfterFinish`, we recommended setting the `allowMultipleUploads` option to `false` in the Uppy constructor. See https://uppy.io/docs/uppy/#allowMultipleUploads-true', 'warning')
+    }
+
+    const { target } = this.opts
     if (target) {
       this.mount(target, this)
     }

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -117,6 +117,7 @@ module.exports = class Dashboard extends Plugin {
       hideProgressAfterFinish: false,
       note: null,
       closeModalOnClickOutside: false,
+      closeAfterFinish: false,
       disableStatusBar: false,
       disableInformer: false,
       disableThumbnailGenerator: false,
@@ -458,7 +459,16 @@ module.exports = class Dashboard extends Plugin {
     this.uppy.on('plugin-remove', this.removeTarget)
     this.uppy.on('file-added', (ev) => {
       this.toggleAddFilesPanel(false)
-      this.hideAllPanels()
+    })
+    this.uppy.on('complete', ({ uploadID }) => {
+      const { currentUploads } = this.uppy.getState()
+      if (this.opts.closeAfterFinish &&
+          // This is the very last upload still in state
+          // (and will be removed by core after this handler is complete)
+          Object.keys(currentUploads).length === 1 && currentUploads[uploadID]) {
+        // All uploads are done
+        this.requestCloseModal()
+      }
     })
   }
 

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -76,8 +76,7 @@ module.exports = (props) => {
   const width = typeof progressValue === 'number' ? progressValue : 100
   const isHidden = (uploadState === statusBarStates.STATE_WAITING && props.hideUploadButton) ||
     (uploadState === statusBarStates.STATE_WAITING && !props.newFiles > 0) ||
-    (uploadState === statusBarStates.STATE_COMPLETE && props.hideAfterFinish) ||
-    !props.allowNewUpload
+    (uploadState === statusBarStates.STATE_COMPLETE && props.hideAfterFinish)
 
   const progressClassNames = `uppy-StatusBar-progress
                            ${progressMode ? 'is-' + progressMode : ''}`

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -78,6 +78,12 @@ module.exports = (props) => {
     (uploadState === statusBarStates.STATE_WAITING && !props.newFiles > 0) ||
     (uploadState === statusBarStates.STATE_COMPLETE && props.hideAfterFinish)
 
+  const showUploadButton = props.newFiles && !props.hideUploadButton && props.allowNewUpload
+  const showRetryButton = props.error && !props.hideRetryButton
+  const showCancelButton = !props.hidePauseResumeCancelButtons &&
+    uploadState !== statusBarStates.STATE_WAITING &&
+    uploadState !== statusBarStates.STATE_COMPLETE
+
   const progressClassNames = `uppy-StatusBar-progress
                            ${progressMode ? 'is-' + progressMode : ''}`
 
@@ -98,12 +104,9 @@ module.exports = (props) => {
         aria-valuenow={progressValue} />
       {progressBarContent}
       <div class="uppy-StatusBar-actions">
-        { props.newFiles && !props.hideUploadButton ? <UploadBtn {...props} uploadState={uploadState} /> : null }
-        { props.error && !props.hideRetryButton ? <RetryBtn {...props} /> : null }
-        { !props.hidePauseResumeCancelButtons && uploadState !== statusBarStates.STATE_WAITING && uploadState !== statusBarStates.STATE_COMPLETE
-          ? <CancelBtn {...props} />
-          : null
-        }
+        { showUploadButton ? <UploadBtn {...props} uploadState={uploadState} /> : null }
+        { showRetryButton ? <RetryBtn {...props} /> : null }
+        { showCancelButton ? <CancelBtn {...props} /> : null }
       </div>
     </div>
   )

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -189,6 +189,8 @@ Set to true to automatically close the modal when the user clicks outside of it.
 
 Set to true to automatically close the modal when all current uploads are complete. You can use this together with the [`allowMultipleUploads: false`](/docs/uppy#allowMultipleUploads-true) option in Uppy Core to create a smooth experience when uploading a single (batch of) file(s).
 
+> Setting [`allowMultipleUploads: false`](/docs/uppy#allowMultipleUploads-true) is **strongly** recommended when using this option. With multiple upload batches, the auto-closing behavior can be very confusing for users.
+
 ### `disablePageScrollWhenModalOpen: true`
 
 Page scrolling is disabled by default when the Dashboard modal is open, so when you scroll a list of files in Uppy, the website in the background stays still. Set to false to override this behaviour and leave page scrolling intact.

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -71,6 +71,7 @@ uppy.use(Dashboard, {
   hideProgressAfterFinish: false,
   note: null,
   closeModalOnClickOutside: false,
+  closeAfterFinish: false,
   disableStatusBar: false,
   disableInformer: false,
   disableThumbnailGenerator: false,
@@ -183,6 +184,10 @@ Note that this metadata will only be set on a file object if it is entered by th
 ### `closeModalOnClickOutside: false`
 
 Set to true to automatically close the modal when the user clicks outside of it.
+
+### `closeAfterFinish: false`
+
+Set to true to automatically close the modal when all current uploads are complete. You can use this together with the [`allowMultipleUploads: false`](/docs/uppy#allowMultipleUploads-true) option in Uppy Core to create a smooth experience when uploading a single (batch of) file(s).
 
 ### `disablePageScrollWhenModalOpen: true`
 

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -189,6 +189,8 @@ Set to true to automatically close the modal when the user clicks outside of it.
 
 Set to true to automatically close the modal when all current uploads are complete. You can use this together with the [`allowMultipleUploads: false`](/docs/uppy#allowMultipleUploads-true) option in Uppy Core to create a smooth experience when uploading a single (batch of) file(s).
 
+With this option, the modal is only automatically closed when uploads are complete _and successful_. If some uploads failed, the modal stays open so the user can retry failed uploads or cancel the current batch and upload an entirely different set of files instead.
+
 > Setting [`allowMultipleUploads: false`](/docs/uppy#allowMultipleUploads-true) is **strongly** recommended when using this option. With multiple upload batches, the auto-closing behavior can be very confusing for users.
 
 ### `disablePageScrollWhenModalOpen: true`


### PR DESCRIPTION
This tries to prevent itself from being used in a way that would be confusing or unexpected.

 - When `allowMultipleUploads` is `true`, logs a warning to the console saying that that is probably not a good experience
 - When `inline` is `true`, throws an error because that just does not make sense
 - When some uploads failed, the auto-close behaviour is prevented, so the user can try to fix it or cancel.

The option is named after the `hideAfterFinish` options in Status Bar and Progress Bar.

Needs some more testing in funny situations with uploads failing, succeeding, processing etc