### PR TITLE
Add missing addMoreFiles string to locale

### DIFF
--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -222,6 +222,8 @@ The default English strings are:
 strings: {
   // When `inline: false`, used as the screen reader label for the button that closes the modal.
   closeModal: 'Close Modal',
+  // When `inline: false`, used as the screen reader label for the button that adds more files (+)
+  addMoreFiles: 'Add more files',
   // Used as the header for import panels, e.g., "Import from Google Drive".
   importFrom: 'Import from %{name}',
   // When `inline: false`, used as the screen reader label for the dashboard modal.


### PR DESCRIPTION
Just saw that addMoreFiles is not mentioned in the locale docs for Dashboard.

I am not sure about the `"When inline false"` part, just copied it from the other items.

Also, see #1109