### PR TITLE
Bring back locale packs

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -40,14 +40,11 @@ module.exports = class AwsS3 extends Plugin {
     }
 
     this.opts = { ...defaultOptions, ...opts }
-    this.locale = {
-      ...defaultLocale,
-      ...this.opts.locale,
-      strings: { ...defaultLocale.strings, ...this.opts.locale.strings }
-    }
 
-    this.translator = new Translator({ locale: this.locale })
+    // i18n
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
+    this.i18nArray = this.translator.translateArray.bind(this.translator)
 
     this.client = new RequestClient(uppy, opts)
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -73,11 +73,9 @@ class Uppy {
     this.opts = Object.assign({}, defaultOptions, opts)
     this.opts.restrictions = Object.assign({}, defaultOptions.restrictions, this.opts.restrictions)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
     // i18n
-    this.translator = new Translator({locale: this.locale})
+    this.translator = new Translator([ defaultLocale, this.opts.locale ])
+    this.locale = this.translator.locale
     this.i18n = this.translator.translate.bind(this.translator)
 
     // Container for different types of plugins

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -125,17 +125,15 @@ module.exports = class Dashboard extends Plugin {
       proudlyDisplayPoweredByUppy: true,
       onRequestCloseModal: () => this.closeModal(),
       showSelectedFiles: true,
-      locale: defaultLocale,
+      // locale: defaultLocale,
       browserBackButtonClose: false
     }
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
-    this.translator = new Translator({locale: this.locale})
+    // i18n
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
     this.i18nArray = this.translator.translateArray.bind(this.translator)
 

--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -38,11 +38,8 @@ module.exports = class DragDrop extends Plugin {
     // Check for browser dragDrop support
     this.isDragDropSupported = this.checkDragDropSupport()
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
     // i18n
-    this.translator = new Translator({locale: this.locale})
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
     this.i18nArray = this.translator.translateArray.bind(this.translator)
 

--- a/packages/@uppy/file-input/src/index.js
+++ b/packages/@uppy/file-input/src/index.js
@@ -27,12 +27,10 @@ module.exports = class FileInput extends Plugin {
     // Merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
     // i18n
-    this.translator = new Translator({locale: this.locale})
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
+    this.i18nArray = this.translator.translateArray.bind(this.translator)
 
     this.render = this.render.bind(this)
     this.handleInputChange = this.handleInputChange.bind(this)

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -64,10 +64,7 @@ module.exports = class StatusBar extends Plugin {
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
-    this.translator = new Translator({locale: this.locale})
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
 
     this.startUpload = this.startUpload.bind(this)

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -54,11 +54,10 @@ module.exports = class Transloadit extends Plugin {
 
     this.opts = Object.assign({}, defaultOptions, opts)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
-    this.translator = new Translator({ locale: this.locale })
+    // i18n
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
+    this.i18nArray = this.translator.translateArray.bind(this.translator)
 
     this._prepareUpload = this._prepareUpload.bind(this)
     this._afterUpload = this._afterUpload.bind(this)

--- a/packages/@uppy/utils/src/Translator.js
+++ b/packages/@uppy/utils/src/Translator.js
@@ -9,24 +9,37 @@
  *
  * Usage example: `translator.translate('files_chosen', {smart_count: 3})`
  *
- * @param {object} opts
+ * @param {object|Array<object>} locale Locale or list of locales.
  */
 module.exports = class Translator {
-  constructor (opts) {
-    const defaultOptions = {
-      locale: {
-        strings: {},
-        pluralize: function (n) {
-          if (n === 1) {
-            return 0
-          }
-          return 1
+  constructor (locales) {
+    this.locale = {
+      strings: {},
+      pluralize: function (n) {
+        if (n === 1) {
+          return 0
         }
+        return 1
       }
     }
 
-    this.opts = Object.assign({}, defaultOptions, opts)
-    this.locale = Object.assign({}, defaultOptions.locale, opts.locale)
+    if (Array.isArray(locales)) {
+      locales.forEach((locale) => this._apply(locale))
+    } else {
+      this._apply(locales)
+    }
+  }
+
+  _apply (locale) {
+    if (!locale || !locale.strings) {
+      return
+    }
+
+    const prevLocale = this.locale
+    this.locale = Object.assign({}, prevLocale, {
+      strings: Object.assign({}, prevLocale.strings, locale.strings)
+    })
+    this.locale.pluralize = locale.pluralize || prevLocale.pluralize
   }
 
   /**
@@ -102,9 +115,9 @@ module.exports = class Translator {
   translateArray (key, options) {
     if (options && typeof options.smart_count !== 'undefined') {
       var plural = this.locale.pluralize(options.smart_count)
-      return this.interpolate(this.opts.locale.strings[key][plural], options)
+      return this.interpolate(this.locale.strings[key][plural], options)
     }
 
-    return this.interpolate(this.opts.locale.strings[key], options)
+    return this.interpolate(this.locale.strings[key], options)
   }
 }

--- a/packages/@uppy/utils/src/Translator.test.js
+++ b/packages/@uppy/utils/src/Translator.test.js
@@ -6,17 +6,15 @@ const english = require('../../../../locales/en_US')
 describe('Translator', () => {
   describe('translate', () => {
     it('should translate a string', () => {
-      const translator = new Translator({ locale: russian })
+      const translator = new Translator(russian)
       expect(translator.translate('chooseFile')).toEqual('Выберите файл')
     })
 
     it('should translate a string with non-string elements', () => {
       const translator = new Translator({
-        locale: {
-          strings: {
-            test: 'Hello %{who}!',
-            test2: 'Hello %{who}'
-          }
+        strings: {
+          test: 'Hello %{who}!',
+          test2: 'Hello %{who}'
         }
       })
 
@@ -27,9 +25,37 @@ describe('Translator', () => {
     })
   })
 
+  describe('translation strings inheritance / overriding', () => {
+    const launguagePackLoadedInCore = english
+    const defaultStrings = {
+      strings: {
+        youHaveChosen: 'You have chosen 123: %{fileName}'
+      }
+    }
+    const userSuppliedStrings = {
+      strings: {
+        youHaveChosen: 'Beep boop: %{fileName}'
+      }
+    }
+
+    it('should prioritize language pack strings from Core over default', () => {
+      const translator = new Translator([ defaultStrings, launguagePackLoadedInCore ])
+      expect(
+        translator.translate('youHaveChosen', { fileName: 'img.jpg' })
+      ).toEqual('You have chosen: img.jpg')
+    })
+
+    it('should prioritize user-supplied strings over language pack from Core', () => {
+      const translator = new Translator([ defaultStrings, launguagePackLoadedInCore, userSuppliedStrings ])
+      expect(
+        translator.translate('youHaveChosen', { fileName: 'img.jpg' })
+      ).toEqual('Beep boop: img.jpg')
+    })
+  })
+
   describe('interpolation', () => {
     it('should interpolate a string', () => {
-      const translator = new Translator({ locale: english })
+      const translator = new Translator(english)
       expect(
         translator.translate('youHaveChosen', { fileName: 'img.jpg' })
       ).toEqual('You have chosen: img.jpg')
@@ -38,7 +64,7 @@ describe('Translator', () => {
 
   describe('pluralization', () => {
     it('should translate a string', () => {
-      const translator = new Translator({ locale: russian })
+      const translator = new Translator(russian)
       expect(
         translator.translate('filesChosen', { smart_count: 18 })
       ).toEqual('Выбрано 18 файлов')

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -72,12 +72,10 @@ module.exports = class Webcam extends Plugin {
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
 
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
-
     // i18n
-    this.translator = new Translator({locale: this.locale})
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
+    this.i18nArray = this.translator.translateArray.bind(this.translator)
 
     this.install = this.install.bind(this)
     this.setPluginState = this.setPluginState.bind(this)

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -79,12 +79,11 @@ module.exports = class XHRUpload extends Plugin {
 
     // Merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
-    this.locale = Object.assign({}, defaultLocale, this.opts.locale)
-    this.locale.strings = Object.assign({}, defaultLocale.strings, this.opts.locale.strings)
 
     // i18n
-    this.translator = new Translator({ locale: this.locale })
+    this.translator = new Translator([ defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
+    this.i18nArray = this.translator.translateArray.bind(this.translator)
 
     this.handleUpload = this.handleUpload.bind(this)
 


### PR DESCRIPTION
In the beginning we used to have unified locale packs that everything in Uppy used — English, Russian, Polish. Then we switched to per-plugin locales, and the ability to load one locale pack was lost for a while. This PR aims to bring this functionality back.

Goal: you have a language pack that you load `const uppy = Uppy({ locale: german})`, plugins have their own `defaultLocale`, which are used when locale pack is not used, or string is not included in that locale pack (it will include most common strings used by standard Uppy plugins maintained in this repo). Then when adding a plugin, you can also override one particular string to your liking, while keeping others from the pack:

```js
.use(Dashboard, {
  trigger: '#pick-files',
  locale: {
    strings: {
      dropPasteImport: 'Something else here, %{browse} or this'
    }
  }
})
```

@goto-bus-stop started this in https://github.com/transloadit/uppy/commit/4f51deaaf7eb528902dc65ced6a7f16e37564c0e#diff-989af75a364b65c408abe1fc3e7ac0f4R34:

> This patch allows locale keys passed to the main Uppy instance to override default keys in plugins. It's just one idea to kick things off, I'm not attached to this particular implementation.
> 
> If we do this we need to make sure that all keys have unique names and that things specific to eg. a single service are "namespaced" (`transloaditEncoding` instead of `encoding`).
> 
> The benefit to this is that there is a central point of configuration for languages, so there could be language packs with strings for eg Czech at `@uppy/lang-cz` (or `@uppy/langs/cz`) that would be very easy to use.