### PR TITLE
Change dashboard min-height to single row of file icons

### DIFF
--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -115,7 +115,7 @@
   max-width: 100%; /* no !important */
   max-height: 100%; /* no !important */
   min-width: 290px;
-  min-height: 400px;
+  min-height: 320px;
   outline: none;
   border: 1px solid rgba($color-gray, 0.2);
   border-radius: 5px;


### PR DESCRIPTION
I raised issue #1127 where the dashboard plugin cannot be vertically resized to less than 400px. This seems like an arbitrary limit so have updated the `min-height` of the `uppy-Dashboard-inner` to match the height of a single row of file icons.

