### PR TITLE
react: Allow Dashboard props width and height to accept a string for 100%

### DIFF
--- a/packages/@uppy/react/src/propTypes.js
+++ b/packages/@uppy/react/src/propTypes.js
@@ -21,16 +21,19 @@ const metaField = PropTypes.shape({
 })
 const metaFields = PropTypes.arrayOf(metaField)
 
+// A size in pixels (number) or with some other unit (string).
+const cssSize = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number
+])
+
 // Common props for dashboardy components (Dashboard and DashboardModal).
 const dashboard = {
   uppy,
   inline: PropTypes.bool,
   plugins,
-  width: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ]),
-  height: PropTypes.number,
+  width: cssSize,
+  height: cssSize,
   showProgressDetails: PropTypes.bool,
   hideUploadButton: PropTypes.bool,
   hideProgressAfterFinish: PropTypes.bool,

--- a/packages/@uppy/react/src/propTypes.js
+++ b/packages/@uppy/react/src/propTypes.js
@@ -26,7 +26,10 @@ const dashboard = {
   uppy,
   inline: PropTypes.bool,
   plugins,
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
   height: PropTypes.number,
   showProgressDetails: PropTypes.bool,
   hideUploadButton: PropTypes.bool,


### PR DESCRIPTION
Your prop type for width is restricted to numbers, although 100% works(I am using it), and is useful, also your Drag and Drop component allows strings, so allowing both is more consistent.