### PR TITLE
Set response in Core rather than in upload plugins

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -171,7 +171,11 @@ module.exports = class AwsS3Multipart extends Plugin {
           reject(err)
         },
         onSuccess: (result) => {
-          this.uppy.emit('upload-success', file, upload, result.location)
+          const uploadResp = {
+            uploadURL: result.location
+          }
+
+          this.uppy.emit('upload-success', file, uploadResp)
 
           if (result.location) {
             this.uppy.log('Download ' + upload.file.name + ' from ' + result.location)
@@ -328,7 +332,11 @@ module.exports = class AwsS3Multipart extends Plugin {
       })
 
       socket.on('success', (data) => {
-        this.uppy.emit('upload-success', file, data, data.url)
+        const uploadResp = {
+          uploadURL: data.url
+        }
+
+        this.uppy.emit('upload-success', file, uploadResp)
         resolve()
       })
     })

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -713,6 +713,7 @@ class Uppy {
           percentage: 100,
           bytesUploaded: currentProgress.bytesTotal
         }),
+        response: uploadResp,
         uploadURL: uploadURL,
         isPaused: false
       })

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -666,8 +666,12 @@ class Uppy {
       this.setState({ error: error.message })
     })
 
-    this.on('upload-error', (file, error) => {
-      this.setFileState(file.id, { error: error.message })
+    this.on('upload-error', (file, error, response) => {
+      this.setFileState(file.id, {
+        error: error.message,
+        response
+      })
+
       this.setState({ error: error.message })
 
       let message = this.i18n('failedToUpload', { file: file.name })

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -705,7 +705,7 @@ class Uppy {
 
     this.on('upload-progress', this._calculateProgress)
 
-    this.on('upload-success', (file, uploadResp, uploadURL) => {
+    this.on('upload-success', (file, uploadResp) => {
       const currentProgress = this.getFile(file.id).progress
       this.setFileState(file.id, {
         progress: Object.assign({}, currentProgress, {
@@ -714,7 +714,7 @@ class Uppy {
           bytesUploaded: currentProgress.bytesTotal
         }),
         response: uploadResp,
-        uploadURL: uploadURL,
+        uploadURL: uploadResp.uploadURL,
         isPaused: false
       })
 

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -154,7 +154,11 @@ module.exports = class Tus extends Plugin {
       }
 
       optsTus.onSuccess = () => {
-        this.uppy.emit('upload-success', file, null, upload.url)
+        const uploadResp = {
+          uploadURL: upload.url
+        }
+
+        this.uppy.emit('upload-success', file, uploadResp)
 
         if (upload.url) {
           this.uppy.log('Download ' + upload.file.name + ' from ' + upload.url)
@@ -327,7 +331,11 @@ module.exports = class Tus extends Plugin {
       })
 
       socket.on('success', (data) => {
-        this.uppy.emit('upload-success', file, null, data.url)
+        const uploadResp = {
+          uploadURL: data.url
+        }
+
+        this.uppy.emit('upload-success', file, uploadResp)
         this.resetUploaderReferences(file.id)
         resolve()
       })

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -154,7 +154,7 @@ module.exports = class Tus extends Plugin {
       }
 
       optsTus.onSuccess = () => {
-        this.uppy.emit('upload-success', file, upload, upload.url)
+        this.uppy.emit('upload-success', file, null, upload.url)
 
         if (upload.url) {
           this.uppy.log('Download ' + upload.file.name + ' from ' + upload.url)
@@ -327,7 +327,7 @@ module.exports = class Tus extends Plugin {
       })
 
       socket.on('success', (data) => {
-        this.uppy.emit('upload-success', file, data, data.url)
+        this.uppy.emit('upload-success', file, null, data.url)
         this.resetUploaderReferences(file.id)
         resolve()
       })

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -244,10 +244,15 @@ module.exports = class XHRUpload extends Plugin {
 
           return resolve(file)
         } else {
-          // const body = opts.getResponseData(xhr.responseText, xhr)
+          const body = opts.getResponseData(xhr.responseText, xhr)
           const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
 
-          this.uppy.emit('upload-error', file, error)
+          const response = {
+            status: ev.target.status,
+            body
+          }
+
+          this.uppy.emit('upload-error', file, error, response)
           return reject(error)
         }
       })

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -230,15 +230,13 @@ module.exports = class XHRUpload extends Plugin {
           const body = opts.getResponseData(xhr.responseText, xhr)
           const uploadURL = body[opts.responseUrlFieldName]
 
-          const response = {
+          const uploadResp = {
             status: ev.target.status,
             body,
             uploadURL
           }
 
-          // this.uppy.setFileState(file.id, { response })
-
-          this.uppy.emit('upload-success', file, response)
+          this.uppy.emit('upload-success', file, uploadResp)
 
           if (uploadURL) {
             this.uppy.log(`Download ${file.name} from ${file.uploadURL}`)
@@ -246,17 +244,10 @@ module.exports = class XHRUpload extends Plugin {
 
           return resolve(file)
         } else {
-          const body = opts.getResponseData(xhr.responseText, xhr)
+          // const body = opts.getResponseData(xhr.responseText, xhr)
           const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
 
-          const response = {
-            status: ev.target.status,
-            body
-          }
-
-          // this.uppy.setFileState(file.id, { response })
-
-          this.uppy.emit('upload-error', file, response, error)
+          this.uppy.emit('upload-error', file, error)
           return reject(error)
         }
       })
@@ -329,13 +320,13 @@ module.exports = class XHRUpload extends Plugin {
           const body = opts.getResponseData(data.response.responseText, data.response)
           const uploadURL = body[opts.responseUrlFieldName]
 
-          const response = {
+          const uploadResp = {
             status: data.response.status,
             body,
             uploadURL
           }
 
-          this.uppy.emit('upload-success', file, response)
+          this.uppy.emit('upload-success', file, uploadResp)
           socket.close()
           return resolve()
         })
@@ -402,9 +393,13 @@ module.exports = class XHRUpload extends Plugin {
         timer.done()
 
         if (ev.target.status >= 200 && ev.target.status < 300) {
-          const resp = this.opts.getResponseData(xhr.responseText, xhr)
+          const body = this.opts.getResponseData(xhr.responseText, xhr)
+          const uploadResp = {
+            status: ev.target.status,
+            body
+          }
           files.forEach((file) => {
-            this.uppy.emit('upload-success', file, resp)
+            this.uppy.emit('upload-success', file, uploadResp)
           })
           return resolve()
         }

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -236,9 +236,9 @@ module.exports = class XHRUpload extends Plugin {
             uploadURL
           }
 
-          this.uppy.setFileState(file.id, { response })
+          // this.uppy.setFileState(file.id, { response })
 
-          this.uppy.emit('upload-success', file, body, uploadURL)
+          this.uppy.emit('upload-success', file, response)
 
           if (uploadURL) {
             this.uppy.log(`Download ${file.name} from ${file.uploadURL}`)
@@ -254,9 +254,9 @@ module.exports = class XHRUpload extends Plugin {
             body
           }
 
-          this.uppy.setFileState(file.id, { response })
+          // this.uppy.setFileState(file.id, { response })
 
-          this.uppy.emit('upload-error', file, error)
+          this.uppy.emit('upload-error', file, response, error)
           return reject(error)
         }
       })
@@ -326,9 +326,16 @@ module.exports = class XHRUpload extends Plugin {
         socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
 
         socket.on('success', (data) => {
-          const resp = opts.getResponseData(data.response.responseText, data.response)
-          const uploadURL = resp[opts.responseUrlFieldName]
-          this.uppy.emit('upload-success', file, resp, uploadURL)
+          const body = opts.getResponseData(data.response.responseText, data.response)
+          const uploadURL = body[opts.responseUrlFieldName]
+
+          const response = {
+            status: data.response.status,
+            body,
+            uploadURL
+          }
+
+          this.uppy.emit('upload-success', file, response)
           socket.close()
           return resolve()
         })

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -549,13 +549,23 @@ uppy.on('upload-progress', (file, progress) => {
 
 Fired each time a single upload is completed.
 
+`response` object (depending on the uploader plugin used, it might contain less info, the example is for `@uppy/xhr-upload`):
+
+```js
+{
+  status, // HTTP status code (0, 200, 300)
+  body, // response body
+  uploadURL // the file url, if it was returned
+}
+```
+
 ``` javascript
-uppy.on('upload-success', (file, resp, uploadURL) => {
-  console.log(file.name, uploadURL)
+uppy.on('upload-success', (file, response) => {
+  console.log(file.name, response.uploadURL)
   var img = new Image()
   img.width = 300
-  img.alt = fileId
-  img.src = uploadURL
+  img.alt = file.id
+  img.src = response.uploadURL
   document.body.appendChild(img)
 })
 ```
@@ -579,10 +589,19 @@ Fired when Uppy fails to upload/encode the entire upload. That error is then set
 
 ### `upload-error`
 
-Fired when an error occurs with a specific file:
+Fired each time a single upload has errored.
+
+`response` object (depending on the uploader plugin used, it might contain less info, the example is for `@uppy/xhr-upload`):
+
+```js
+{
+  status, // HTTP status code (0, 200, 300)
+  body // response body
+}
+```
 
 ``` javascript
-uppy.on('upload-error', (file, error) => {
+uppy.on('upload-error', (file, error, response) => {
   console.log('error with file:', file.id)
   console.log('error message:', error)
 })


### PR DESCRIPTION
Change all `upload-success` events to emit:

```js
const body = opts.getResponseData(xhr.responseText, xhr)
const uploadURL = body[opts.responseUrlFieldName]

const uploadResp = {
  status: ev.target.status,
  body,
  uploadURL
}

this.uppy.emit('upload-success', file, uploadResp)
```

Core then sets response and uploadURL on the file object:

```js
{
  ...
  response: uploadResp,
  uploadURL: uploadResp.uploadURL
}
```

`uploadURL` will not be passed as a separate parameter anymore, but instead inside the `uploadResp` object.

Hopefully this solves https://github.com/transloadit/uppy/pull/871 and https://github.com/transloadit/uppy/pull/1065.

todo:

- [x] update docs