### PR TITLE
Don't pass removed file IDs to next upload step, fixes #1003

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1103,7 +1103,6 @@ class Uppy {
    */
   _runUpload (uploadID) {
     const uploadData = this.getState().currentUploads[uploadID]
-    const fileIDs = uploadData.fileIDs
     const restoreStep = uploadData.step
 
     const steps = [
@@ -1120,48 +1119,58 @@ class Uppy {
 
       lastStep = lastStep.then(() => {
         const { currentUploads } = this.getState()
-        const currentUpload = Object.assign({}, currentUploads[uploadID], {
+        const currentUpload = {
+          ...currentUploads[uploadID],
           step: step
-        })
+        }
         this.setState({
-          currentUploads: Object.assign({}, currentUploads, {
+          currentUploads: {
+            ...currentUploads,
             [uploadID]: currentUpload
-          })
+          }
         })
+
         // TODO give this the `currentUpload` object as its only parameter maybe?
         // Otherwise when more metadata may be added to the upload this would keep getting more parameters
-        return fn(fileIDs, uploadID)
+        return fn(currentUpload.fileIDs, uploadID)
       }).then((result) => {
         return null
       })
     })
 
-    // Not returning the `catch`ed promise, because we still want to return a rejected
-    // promise from this method if the upload failed.
-    lastStep.catch((err) => {
-      this.emit('error', err, uploadID)
-
-      this._removeUpload(uploadID)
-    })
-
     return lastStep.then(() => {
-      const files = fileIDs.map((fileID) => this.getFile(fileID))
-      const successful = files.filter((file) => file && !file.error)
-      const failed = files.filter((file) => file && file.error)
-      this.addResultData(uploadID, { successful, failed, uploadID })
-
+      // Set result data.
       const { currentUploads } = this.getState()
-      if (!currentUploads[uploadID]) {
+      const currentUpload = currentUploads[uploadID]
+      if (!currentUpload) {
         this.log(`Not setting result for an upload that has been removed: ${uploadID}`)
         return
       }
 
-      const result = currentUploads[uploadID].result
+      const files = currentUpload.fileIDs
+        .map((fileID) => this.getFile(fileID))
+      const successful = files.filter((file) => !file.error)
+      const failed = files.filter((file) => file.error)
+      this.addResultData(uploadID, { successful, failed, uploadID })
+    }).then(() => {
+      // Emit completion events.
+      // This is in a separate function so that the `currentUploads` variable
+      // always refers to the latest state. In the handler right above it refers
+      // to an outdated object without the `.result` property.
+      const { currentUploads } = this.getState()
+      const currentUpload = currentUploads[uploadID]
+      const result = currentUpload.result
       this.emit('complete', result)
 
       this._removeUpload(uploadID)
 
       return result
+    }, (err) => {
+      this.emit('error', err, uploadID)
+
+      this._removeUpload(uploadID)
+
+      throw err
     })
   }
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1138,6 +1138,13 @@ class Uppy {
       })
     })
 
+    // Not returning the `catch`ed promise, because we still want to return a rejected
+    // promise from this method if the upload failed.
+    lastStep.catch((err) => {
+      this.emit('error', err, uploadID)
+      this._removeUpload(uploadID)
+    })
+
     return lastStep.then(() => {
       // Set result data.
       const { currentUploads } = this.getState()
@@ -1165,12 +1172,6 @@ class Uppy {
       this._removeUpload(uploadID)
 
       return result
-    }, (err) => {
-      this.emit('error', err, uploadID)
-
-      this._removeUpload(uploadID)
-
-      throw err
     })
   }
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1119,15 +1119,13 @@ class Uppy {
 
       lastStep = lastStep.then(() => {
         const { currentUploads } = this.getState()
-        const currentUpload = {
-          ...currentUploads[uploadID],
+        const currentUpload = Object.assign({}, currentUploads[uploadID], {
           step: step
-        }
+        })
         this.setState({
-          currentUploads: {
-            ...currentUploads,
+          currentUploads: Object.assign({}, currentUploads, {
             [uploadID]: currentUpload
-          }
+          })
         })
 
         // TODO give this the `currentUpload` object as its only parameter maybe?

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -373,6 +373,34 @@ describe('src/Core', () => {
         })
     })
 
+    it('should not pass removed file IDs to next step', async () => {
+      const core = new Core()
+      const uploader = jest.fn()
+      core.addPreProcessor((fileIDs) => {
+        core.removeFile(fileIDs[0])
+      })
+      core.addUploader(uploader)
+
+      core.addFile({
+        source: 'jest',
+        name: 'rmd.jpg',
+        type: 'image/jpeg',
+        data: new File([sampleImage], { type: 'image/jpeg' })
+      })
+      core.addFile({
+        source: 'jest',
+        name: 'kept.jpg',
+        type: 'image/jpeg',
+        data: new File([sampleImage], { type: 'image/jpeg' })
+      })
+
+      await core.upload()
+
+      expect(uploader.mock.calls.length).toEqual(1)
+      expect(uploader.mock.calls[0][0].length).toEqual(1, 'Got 1 file ID')
+      expect(core.getFile(uploader.mock.calls[0][0][0]).name).toEqual('kept.jpg')
+    })
+
     it('should update the file progress state when preprocess-progress event is fired', () => {
       const core = new Core()
       core.addFile({


### PR DESCRIPTION
This fixes an error when files are removed during an upload, eg. by a plugin that does some filtering.

`uppy.removeFile()` already removes the fileID from the
`currentUploads[*].fileIDs` list, so all we need to do is to pass the
updated array instead of the original!

The code around the `.addResultData()` call had to be moved around a bit,
because we now need to use the `currentUpload.fileIDs` list to set the
`.successful` and `.failed` properties.