### PR TITLE
xhr-upload: Add `responseType` option

### DIFF
--- a/examples/aws-presigned-url/serve.js
+++ b/examples/aws-presigned-url/serve.js
@@ -26,20 +26,23 @@ b.transform(aliasify, {
 })
 
 function bundle () {
-  return b.bundle()
-    .pipe(createWriteStream(path.join(__dirname, './bundle.js')))
+  return b.bundle((err, data) => {
+    if (err) console.error(err.stack)
+    else console.log('bundle complete')
+  }).pipe(createWriteStream(path.join(__dirname, './bundle.js')))
 }
 
 b.on('log', console.log)
 b.on('update', bundle)
 b.on('error', console.error)
 
-bundle()
-
 fs.createReadStream(path.join(__dirname, '../../packages/uppy/dist/uppy.min.css'))
   .pipe(fs.createWriteStream(path.join(__dirname, './uppy.min.css')))
 
-// Start the PHP delevopment server.
-spawn('php', ['-S', `localhost:${port}`], {
-  stdio: 'inherit'
+console.log('bundling...')
+bundle().on('finish', () => {
+  // Start the PHP delevopment server.
+  spawn('php', ['-S', `localhost:${port}`], {
+    stdio: 'inherit'
+  })
 })

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -167,6 +167,7 @@ module.exports = class AwsS3 extends Plugin {
       responseUrlFieldName: 'location',
       timeout: this.opts.timeout,
       limit: this.opts.limit,
+      responseType: 'text',
       // Get the response data from a successful XMLHttpRequest instance.
       // `content` is the S3 response as a string.
       // `xhr` is the XMLHttpRequest instance.

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -10,6 +10,14 @@ function isXml (xhr) {
   return typeof contentType === 'string' && contentType.toLowerCase() === 'application/xml'
 }
 
+function getXmlValue (source, key) {
+  const start = source.indexOf(`<${key}>`)
+  const end = source.indexOf(`</${key}>`, start)
+  return start !== -1 && end !== -1
+    ? source.slice(start + key.length + 2, end)
+    : ''
+}
+
 function assertServerError (res) {
   if (res && res.error) {
     const error = new Error(res.message)
@@ -197,31 +205,13 @@ module.exports = class AwsS3 extends Plugin {
           return { location: xhr.responseURL.replace(/\?.*$/, '') }
         }
 
-        let getValue = () => ''
-        if (xhr.responseXML) {
-          getValue = (key) => {
-            const el = xhr.responseXML.querySelector(key)
-            return el ? el.textContent : ''
-          }
-        }
-
-        if (xhr.responseText) {
-          getValue = (key) => {
-            const start = xhr.responseText.indexOf(`<${key}>`)
-            const end = xhr.responseText.indexOf(`</${key}>`)
-            return start !== -1 && end !== -1
-              ? xhr.responseText.slice(start + key.length + 2, end)
-              : ''
-          }
-        }
-
         return {
           // Some S3 alternatives do not reply with an absolute URL.
           // Eg DigitalOcean Spaces uses /$bucketName/xyz
-          location: resolveUrl(xhr.responseURL, getValue('Location')),
-          bucket: getValue('Bucket'),
-          key: getValue('Key'),
-          etag: getValue('ETag')
+          location: resolveUrl(xhr.responseURL, getXmlValue(content, 'Location')),
+          bucket: getXmlValue(content, 'Bucket'),
+          key: getXmlValue(content, 'Key'),
+          etag: getXmlValue(content, 'ETag')
         }
       },
 
@@ -233,8 +223,8 @@ module.exports = class AwsS3 extends Plugin {
         if (!isXml(xhr)) {
           return
         }
-        const error = xhr.responseXML.querySelector('Error > Message')
-        return new Error(error.textContent)
+        const error = getXmlValue(content, 'Message')
+        return new Error(error)
       }
     })
   }

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -47,6 +47,7 @@ module.exports = class XHRUpload extends Plugin {
       timeout: 30 * 1000,
       limit: 0,
       withCredentials: false,
+      responseType: 'text',
       /**
        * @typedef respObj
        * @property {string} responseText
@@ -201,6 +202,9 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       const xhr = new XMLHttpRequest()
+      xhr.responseType = opts.responseType
+      xhr.withCredentials = opts.withCredentials
+
       const id = cuid()
 
       xhr.upload.addEventListener('loadstart', (ev) => {
@@ -271,8 +275,6 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       xhr.open(opts.method.toUpperCase(), opts.endpoint, true)
-
-      xhr.withCredentials = opts.withCredentials
 
       Object.keys(opts.headers).forEach((header) => {
         xhr.setRequestHeader(header, opts.headers[header])
@@ -358,6 +360,7 @@ module.exports = class XHRUpload extends Plugin {
 
       const xhr = new XMLHttpRequest()
 
+      xhr.responseType = this.opts.responseType
       xhr.withCredentials = this.opts.withCredentials
 
       const timer = this.createProgressTimeout(this.opts.timeout, (error) => {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -47,7 +47,7 @@ module.exports = class XHRUpload extends Plugin {
       timeout: 30 * 1000,
       limit: 0,
       withCredentials: false,
-      responseType: 'text',
+      responseType: '',
       /**
        * @typedef respObj
        * @property {string} responseText

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -203,7 +203,6 @@ module.exports = class XHRUpload extends Plugin {
 
       const xhr = new XMLHttpRequest()
       xhr.responseType = opts.responseType
-      xhr.withCredentials = opts.withCredentials
 
       const id = cuid()
 
@@ -275,6 +274,8 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       xhr.open(opts.method.toUpperCase(), opts.endpoint, true)
+      // IE10 does not allow setting `withCredentials` before `open()` is called.
+      xhr.withCredentials = opts.withCredentials
 
       Object.keys(opts.headers).forEach((header) => {
         xhr.setRequestHeader(header, opts.headers[header])
@@ -359,9 +360,7 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       const xhr = new XMLHttpRequest()
-
       xhr.responseType = this.opts.responseType
-      xhr.withCredentials = this.opts.withCredentials
 
       const timer = this.createProgressTimeout(this.opts.timeout, (error) => {
         xhr.abort()
@@ -425,7 +424,7 @@ module.exports = class XHRUpload extends Plugin {
       })
 
       xhr.open(method.toUpperCase(), endpoint, true)
-
+      // IE10 does not allow setting `withCredentials` before `open()` is called.
       xhr.withCredentials = this.opts.withCredentials
 
       Object.keys(this.opts.headers).forEach((header) => {

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -173,9 +173,9 @@ The default for the timeout is 30 seconds.
 
 Limit the amount of uploads going on at the same time. Setting this to `0` means there is no limit on concurrent uploads.
 
-### `responseType: 'text'`
+### `responseType: ''`
 
-The response type expected from the server, determining how the `xhr.response` property should be filled. The `xhr.response` property can be accessed in a custom [`getResponseData()`](#getResponseData-responseText-response) callback. This option sets the [`XMLHttpRequest.responseType][XHR.responseType] property. Only 'text', 'arraybuffer', 'blob' and 'document' are widely supported by browsers, so it's recommended to use one of those.
+The response type expected from the server, determining how the `xhr.response` property should be filled. The `xhr.response` property can be accessed in a custom [`getResponseData()`](#getResponseData-responseText-response) callback. This option sets the [`XMLHttpRequest.responseType][XHR.responseType] property. Only '', 'text', 'arraybuffer', 'blob' and 'document' are widely supported by browsers, so it's recommended to use one of those. The default is the empty string, which is equivalent to 'text' for the `xhr.response` property.
 
 ### `withCredentials: false`
 

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -173,6 +173,10 @@ The default for the timeout is 30 seconds.
 
 Limit the amount of uploads going on at the same time. Setting this to `0` means there is no limit on concurrent uploads.
 
+### `responseType: 'text'`
+
+The response type expected from the server, determining how the `xhr.response` property should be filled. The `xhr.response` property can be accessed in a custom [`getResponseData()`](#getResponseData-responseText-response) callback. This option sets the [`XMLHttpRequest.responseType][XHR.responseType] property. Only 'text', 'arraybuffer', 'blob' and 'document' are widely supported by browsers, so it's recommended to use one of those.
+
 ### `withCredentials: false`
 
 Indicates whether or not cross-site Access-Control requests should be made using credentials.
@@ -253,5 +257,6 @@ move_uploaded_file($file_path, './img/' . basename($file_name)); // save the fil
 
 [FormData]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
 [XHR.timeout]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
+[XHR.responseType]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
 [PHP.file-upload]: https://secure.php.net/manual/en/features.file-upload.php
 [PHP.multiple]: https://secure.php.net/manual/en/features.file-upload.multiple.php


### PR DESCRIPTION
This allows configuring the XMLHttpRequest `.responseType` value. Use cases for this are going to be quite rare I think, but it allows the S3 plugin to tell Firefox not to log XML errors when getting empty responses, so it finally fixes #518 :)

Because AwsS3 now sets `responseType: 'text'`, we can no longer use the `responseXML` property. We already did text based parsing for successful responses and now do the same for error responses.