### PR TITLE
Fix version numbers used for website build

### DIFF
--- a/bin/endtoend-build-ci
+++ b/bin/endtoend-build-ci
@@ -12,12 +12,13 @@ __base="$(basename ${__file} .sh)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
 VERDACCIO_REGISTRY=http://localhost:4002
+CURRENT_COMMIT="$(git rev-parse HEAD)"
 
 cleanup() {
   rm -rf "${__root}/test/endtoend/node_modules"
   rm -rf "${__root}/test/endtoend/tmp"
   git reset
-  git checkout -- .
+  git checkout $CURRENT_COMMIT
 }
 function on_exit() {
   # revert to public registry
@@ -57,9 +58,6 @@ ENDTOEND=1 lerna publish from-git --yes \
   --registry="$VERDACCIO_REGISTRY" \
   --no-verify-access \
   --npm-client=npm
-
-# revert version changes
-git checkout -- packages/*/package.json packages/@uppy/*/package.json
 
 # install all packages to the endtoend folder
 # (Don't use the npm cache, don't generate a package-lock, don't save dependencies to any package.json)


### PR DESCRIPTION
Needed some fiddling but the solution is quite simple. After building integration tests, we revert to the commit we were on _before_ building integration tests. That removes the changes lerna makes during the publish to the local registry.

Current output (v0.28.1-alpha.0): https://github.com/transloadit/uppy/blob/91c891db00965628686c00be61171a197e93c4b1/examples/dashboard/index.html#L325-L331

New output (v0.28.0): https://github.com/transloadit/uppy/blob/test-deploy-numberfix/examples/dashboard/index.html#L325-L331