### PR TITLE
Use file sizes for progress calculations, closes #1132

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -645,6 +645,11 @@ class Uppy {
       return file.progress.uploadStarted
     })
 
+    if (inProgress.length === 0) {
+      this.setState({ totalProgress: 0 })
+      return
+    }
+
     const sizedFiles = inProgress.filter((file) => file.progress.bytesTotal != null)
     const unsizedFiles = inProgress.filter((file) => file.progress.bytesTotal == null)
 
@@ -653,7 +658,9 @@ class Uppy {
       const currentProgress = unsizedFiles.reduce((acc, file) => {
         return acc + file.progress.percentage
       }, 0)
-      return Math.round(currentProgress / progressMax * 100)
+      const totalProgress = Math.round(currentProgress / progressMax * 100)
+      this.setState({ totalProgress })
+      return
     }
 
     let totalSize = sizedFiles.reduce((acc, file) => {
@@ -674,9 +681,7 @@ class Uppy {
       ? 0
       : Math.round(uploadedSize / totalSize * 100)
 
-    this.setState({
-      totalProgress: totalProgress
-    })
+    this.setState({ totalProgress })
   }
 
   /**

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -1020,7 +1020,7 @@ describe('src/Core', () => {
       })
 
       core._calculateTotalProgress()
-      expect(core.getState().totalProgress).toEqual(65)
+      expect(core.getState().totalProgress).toEqual(66)
     })
 
     it('should reset the progress', () => {
@@ -1057,7 +1057,7 @@ describe('src/Core', () => {
 
       core._calculateTotalProgress()
 
-      expect(core.getState().totalProgress).toEqual(65)
+      expect(core.getState().totalProgress).toEqual(66)
 
       core.resetProgress()
 

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -1,6 +1,8 @@
 const throttle = require('lodash.throttle')
 const classNames = require('classnames')
 const statusBarStates = require('./StatusBarStates')
+const prettyBytes = require('prettier-bytes')
+const prettyETA = require('@uppy/utils/lib/prettyETA')
 const { h } = require('preact')
 
 function calculateProcessingProgress (files) {
@@ -204,8 +206,11 @@ const ProgressBarProcessing = (props) => {
 const ProgressDetails = (props) => {
   return <div class="uppy-StatusBar-statusSecondary">
     { props.numUploads > 1 && props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.numUploads }) + ' \u00B7 ' }
-    { props.i18n('dataUploadedOfTotal', { complete: props.totalUploadedSize, total: props.totalSize }) + ' \u00B7 ' }
-    { props.i18n('xTimeLeft', { time: props.totalETA }) }
+    { props.i18n('dataUploadedOfTotal', {
+      complete: prettyBytes(props.totalUploadedSize),
+      total: prettyBytes(props.totalSize)
+    }) + ' \u00B7 ' }
+    { props.i18n('xTimeLeft', { time: prettyETA(props.totalETA) }) }
   </div>
 }
 

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -4,8 +4,6 @@ const StatusBarUI = require('./StatusBar')
 const statusBarStates = require('./StatusBarStates')
 const getSpeed = require('@uppy/utils/lib/getSpeed')
 const getBytesRemaining = require('@uppy/utils/lib/getBytesRemaining')
-const prettyETA = require('@uppy/utils/lib/prettyETA')
-const prettyBytes = require('prettier-bytes')
 
 /**
  * StatusBar: renders a status bar with upload/pause/resume/cancel/retry buttons,
@@ -195,8 +193,7 @@ module.exports = class StatusBar extends Plugin {
       return files[file]
     })
 
-    const totalSpeed = prettyBytes(this.getTotalSpeed(inProgressNotPausedFilesArray))
-    const totalETA = prettyETA(this.getTotalETA(inProgressNotPausedFilesArray))
+    const totalETA = this.getTotalETA(inProgressNotPausedFilesArray)
 
     // total size and uploaded size
     let totalSize = 0
@@ -205,8 +202,6 @@ module.exports = class StatusBar extends Plugin {
       totalSize = totalSize + (file.progress.bytesTotal || 0)
       totalUploadedSize = totalUploadedSize + (file.progress.bytesUploaded || 0)
     })
-    totalSize = prettyBytes(totalSize)
-    totalUploadedSize = prettyBytes(totalUploadedSize)
 
     const isUploadStarted = uploadStartedFiles.length > 0
 
@@ -243,7 +238,6 @@ module.exports = class StatusBar extends Plugin {
       complete: completeFiles.length,
       newFiles: newFiles.length,
       numUploads: startedFiles.length,
-      totalSpeed,
       totalETA,
       files,
       i18n: this.i18n,


### PR DESCRIPTION
When possible, file sizes are used when calculating the `.totalProgress` value.

If there are files without sizes, the average size of all other files is assumed for the unsized files.

If there are no files with sizes, the percentage is just based on the percentages of the unsized files.

I think we could try in the future to remove the unsized files code or to assume 0% for them, because while testing this it seemed like files could only be unsized while they had not started uploading—eg. instagram don't have file sizes at the start, but once they've been downloaded on Companion, Companion starts emitting events with `bytesUploaded` and `bytesTotal` values. I'm not sure if there's any other case where we may have unsized files though so we could save that for a later time.