### PR TITLE
Store Provider instances on `this.provider` instead of `this[this.id]`.

### DIFF
--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -17,7 +17,7 @@ module.exports = class Dropbox extends Plugin {
       </svg>
     )
 
-    this[this.id] = new Provider(uppy, {
+    this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
       provider: 'dropbox'
@@ -28,7 +28,9 @@ module.exports = class Dropbox extends Plugin {
   }
 
   install () {
-    this.view = new ProviderViews(this)
+    this.view = new ProviderViews(this, {
+      provider: this.provider
+    })
     // Set default state for Dropbox
     this.setPluginState({
       authenticated: false,

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -20,7 +20,7 @@ module.exports = class GoogleDrive extends Plugin {
       </svg>
     )
 
-    this[this.id] = new Provider(uppy, {
+    this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
       provider: 'drive',
@@ -32,7 +32,9 @@ module.exports = class GoogleDrive extends Plugin {
   }
 
   install () {
-    this.view = new DriveProviderViews(this)
+    this.view = new DriveProviderViews(this, {
+      provider: this.provider
+    })
     // Set default state for Google Drive
     this.setPluginState({
       authenticated: false,

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -17,7 +17,7 @@ module.exports = class Instagram extends Plugin {
       </svg>
     )
 
-    this[this.id] = new Provider(uppy, {
+    this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
       provider: 'instagram',
@@ -30,6 +30,7 @@ module.exports = class Instagram extends Plugin {
 
   install () {
     this.view = new ProviderViews(this, {
+      provider: this.provider,
       viewType: 'grid',
       showTitles: false,
       showFilter: false,


### PR DESCRIPTION
This was a bit weird and now it's not. Passing the Provider instance to `ProviderViews` as an option instead of having it look it up on the Plugin object.