### PR TITLE
Account for MS Edge's missing progress updates, fixes #945

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -9,6 +9,7 @@ const getFileType = require('@uppy/utils/lib/getFileType')
 const getFileNameAndExtension = require('@uppy/utils/lib/getFileNameAndExtension')
 const generateFileID = require('@uppy/utils/lib/generateFileID')
 const getTimeStamp = require('@uppy/utils/lib/getTimeStamp')
+const supportsUploadProgress = require('./supportsUploadProgress')
 const Plugin = require('./Plugin') // Exported from here.
 
 /**
@@ -118,6 +119,7 @@ class Uppy {
       currentUploads: {},
       allowNewUpload: true,
       capabilities: {
+        uploadProgress: supportsUploadProgress(),
         resumableUploads: false
       },
       totalProgress: 0,

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -149,7 +149,7 @@ describe('src/Core', () => {
 
       const newState = {
         bee: 'boo',
-        capabilities: { resumableUploads: false },
+        capabilities: { uploadProgress: true, resumableUploads: false },
         files: {},
         currentUploads: {},
         allowNewUpload: true,
@@ -173,7 +173,7 @@ describe('src/Core', () => {
       // current state
       expect(stateUpdateEventMock.mock.calls[1][0]).toEqual({
         bee: 'boo',
-        capabilities: { resumableUploads: false },
+        capabilities: { uploadProgress: true, resumableUploads: false },
         files: {},
         currentUploads: {},
         allowNewUpload: true,
@@ -186,7 +186,7 @@ describe('src/Core', () => {
       // new state
       expect(stateUpdateEventMock.mock.calls[1][1]).toEqual({
         bee: 'boo',
-        capabilities: { resumableUploads: false },
+        capabilities: { uploadProgress: true, resumableUploads: false },
         files: {},
         currentUploads: {},
         allowNewUpload: true,
@@ -204,7 +204,7 @@ describe('src/Core', () => {
       core.setState({ foo: 'bar' })
 
       expect(core.getState()).toEqual({
-        capabilities: { resumableUploads: false },
+        capabilities: { uploadProgress: true, resumableUploads: false },
         files: {},
         currentUploads: {},
         allowNewUpload: true,
@@ -232,7 +232,7 @@ describe('src/Core', () => {
     expect(coreCancelEventMock.mock.calls.length).toEqual(1)
     expect(coreStateUpdateEventMock.mock.calls.length).toEqual(2)
     expect(coreStateUpdateEventMock.mock.calls[1][1]).toEqual({
-      capabilities: { resumableUploads: false },
+      capabilities: { uploadProgress: true, resumableUploads: false },
       files: {},
       currentUploads: {},
       allowNewUpload: true,
@@ -291,7 +291,7 @@ describe('src/Core', () => {
     expect(coreCancelEventMock.mock.calls.length).toEqual(1)
     expect(coreStateUpdateEventMock.mock.calls.length).toEqual(1)
     expect(coreStateUpdateEventMock.mock.calls[0][1]).toEqual({
-      capabilities: { resumableUploads: false },
+      capabilities: { uploadProgress: true, resumableUploads: false },
       files: {},
       currentUploads: {},
       allowNewUpload: true,

--- a/packages/@uppy/core/src/supportsUploadProgress.js
+++ b/packages/@uppy/core/src/supportsUploadProgress.js
@@ -1,0 +1,30 @@
+// Edge 15.x does not fire 'progress' events on uploads.
+// See https://github.com/transloadit/uppy/issues/945
+// And https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12224510/
+module.exports = function supportsUploadProgress () {
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : null
+  // Assume it works because basically everything supports progress events.
+  if (!userAgent) return true
+
+  const m = /Edge\/(\d+\.\d+)/.exec(userAgent)
+  if (!m) return true
+
+  const edgeVersion = m[1]
+  const [major, minor] = edgeVersion.split('.')
+
+  // Worked before:
+  // Edge 40.15063.0.0
+  // Microsoft EdgeHTML 15.15063
+  if (major < 15 || (major === 15 && minor < 15063)) {
+    return true
+  }
+
+  // Fixed in:
+  // Microsoft EdgeHTML 18.18218
+  if (major > 18 || (major === 18 && minor > 18218)) {
+    return true
+  }
+
+  // other versions don't work.
+  return false
+}

--- a/packages/@uppy/core/src/supportsUploadProgress.js
+++ b/packages/@uppy/core/src/supportsUploadProgress.js
@@ -1,8 +1,11 @@
 // Edge 15.x does not fire 'progress' events on uploads.
 // See https://github.com/transloadit/uppy/issues/945
 // And https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12224510/
-module.exports = function supportsUploadProgress () {
-  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : null
+module.exports = function supportsUploadProgress (userAgent) {
+  // Allow passing in userAgent for tests
+  if (userAgent == null) {
+    userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : null
+  }
   // Assume it works because basically everything supports progress events.
   if (!userAgent) return true
 
@@ -10,7 +13,9 @@ module.exports = function supportsUploadProgress () {
   if (!m) return true
 
   const edgeVersion = m[1]
-  const [major, minor] = edgeVersion.split('.')
+  let [major, minor] = edgeVersion.split('.')
+  major = parseInt(major, 10)
+  minor = parseInt(minor, 10)
 
   // Worked before:
   // Edge 40.15063.0.0
@@ -21,7 +26,7 @@ module.exports = function supportsUploadProgress () {
 
   // Fixed in:
   // Microsoft EdgeHTML 18.18218
-  if (major > 18 || (major === 18 && minor > 18218)) {
+  if (major > 18 || (major === 18 && minor >= 18218)) {
     return true
   }
 

--- a/packages/@uppy/core/src/supportsUploadProgress.test.js
+++ b/packages/@uppy/core/src/supportsUploadProgress.test.js
@@ -1,0 +1,28 @@
+const supportsUploadProgress = require('./supportsUploadProgress')
+
+describe('supportsUploadProgress', () => {
+  it('returns true in working browsers', () => {
+    // Firefox 64 (dev edition)
+    expect(supportsUploadProgress('Mozilla/5.0 (X11; Linux x86_64; rv:64.0) Gecko/20100101 Firefox/64.0')).toBe(true)
+
+    // Chromium 70
+    expect(supportsUploadProgress('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36')).toBe(true)
+
+    // IE 11
+    expect(supportsUploadProgress('Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko')).toBe(true)
+
+    // MS Edge 14
+    expect(supportsUploadProgress('Chrome (AppleWebKit/537.1; Chrome50.0; Windows NT 6.3) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393')).toBe(true)
+
+    // MS Edge 18, supposedly fixed
+    expect(supportsUploadProgress('Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/18.18218')).toBe(true)
+  })
+
+  it('returns false in broken browsers', () => {
+    // MS Edge 15, first broken version
+    expect(supportsUploadProgress('Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063')).toBe(false)
+
+    // MS Edge 17
+    expect(supportsUploadProgress('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134')).toBe(false)
+  })
+})

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -248,7 +248,6 @@ const ProgressBarUploading = (props) => {
     return null
   }
 
-  const supportsUploadProgress = props.capabilities.uploadProgress
   const title = props.isAllPaused ? props.i18n('paused') : props.i18n('uploading')
   const showUploadNewlyAddedFiles = props.newFiles && props.isUploadStarted
 
@@ -257,10 +256,10 @@ const ProgressBarUploading = (props) => {
       { !props.isAllPaused ? <LoadingSpinner {...props} /> : null }
       <div class="uppy-StatusBar-status">
         <div class="uppy-StatusBar-statusPrimary">
-          {supportsUploadProgress ? `${title}: ${props.totalProgress}%` : title}
+          {props.supportsUploadProgress ? `${title}: ${props.totalProgress}%` : title}
         </div>
         { !props.isAllPaused && !showUploadNewlyAddedFiles && props.showProgressDetails
-          ? (supportsUploadProgress ? <ThrottledProgressDetails {...props} /> : <UnknownProgressDetails />)
+          ? (props.supportsUploadProgress ? <ThrottledProgressDetails {...props} /> : <UnknownProgressDetails {...props} />)
           : null
         }
         { showUploadNewlyAddedFiles ? <UploadNewlyAddedFiles {...props} /> : null }

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -214,6 +214,13 @@ const ProgressDetails = (props) => {
   </div>
 }
 
+const UnknownProgressDetails = (props) => {
+  return <div class="uppy-StatusBar-statusSecondary">
+    { props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.numUploads }) + ' \u00B7 ' }
+    { props.i18n('progressUnavailable') }
+  </div>
+}
+
 const UploadNewlyAddedFiles = (props) => {
   const uploadBtnClassNames = classNames(
     'uppy-u-reset',
@@ -241,6 +248,7 @@ const ProgressBarUploading = (props) => {
     return null
   }
 
+  const supportsUploadProgress = props.capabilities.uploadProgress
   const title = props.isAllPaused ? props.i18n('paused') : props.i18n('uploading')
   const showUploadNewlyAddedFiles = props.newFiles && props.isUploadStarted
 
@@ -248,9 +256,11 @@ const ProgressBarUploading = (props) => {
     <div class="uppy-StatusBar-content" aria-label={title} title={title}>
       { !props.isAllPaused ? <LoadingSpinner {...props} /> : null }
       <div class="uppy-StatusBar-status">
-        <div class="uppy-StatusBar-statusPrimary">{title}: {props.totalProgress}%</div>
+        <div class="uppy-StatusBar-statusPrimary">
+          {supportsUploadProgress ? `${title}: ${props.totalProgress}%` : title}
+        </div>
         { !props.isAllPaused && !showUploadNewlyAddedFiles && props.showProgressDetails
-          ? <ThrottledProgressDetails {...props} />
+          ? (supportsUploadProgress ? <ThrottledProgressDetails {...props} /> : <UnknownProgressDetails />)
           : null
         }
         { showUploadNewlyAddedFiles ? <UploadNewlyAddedFiles {...props} /> : null }

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -223,6 +223,7 @@ module.exports = class StatusBar extends Plugin {
     const isUploadInProgress = inProgressFiles.length > 0
 
     const resumableUploads = capabilities.resumableUploads || false
+    const supportsUploadProgress = capabilities.uploadProgress !== false
 
     return StatusBarUI({
       error,
@@ -247,7 +248,8 @@ module.exports = class StatusBar extends Plugin {
       retryAll: this.uppy.retryAll,
       cancelAll: this.uppy.cancelAll,
       startUpload: this.startUpload,
-      resumableUploads: resumableUploads,
+      resumableUploads,
+      supportsUploadProgress,
       showProgressDetails: this.opts.showProgressDetails,
       hideUploadButton: this.opts.hideUploadButton,
       hideRetryButton: this.opts.hideRetryButton,

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -40,6 +40,7 @@ module.exports = class StatusBar extends Plugin {
         },
         dataUploadedOfTotal: '%{complete} of %{total}',
         xTimeLeft: '%{time} left',
+        progressUnavailable: 'Unknown time left',
         uploadXFiles: {
           0: 'Upload %{smart_count} file',
           1: 'Upload %{smart_count} files'


### PR DESCRIPTION
Previously, upload progress would be stuck at 0% until everything is finished.

With this patch, in the affected MS Edge versions, the status bar looks like:

![image](https://user-images.githubusercontent.com/1006268/49377230-e4c9d900-f709-11e8-87af-c8aed7a88a3d.png)
(The "Unknown time left" probably needs a wording tweak, like "Progress information unavailable", or we could just omit it…)

This changes the `.is-determinate` class to use a transparent black stripe colour instead of a computed darker version of the Encoding progress colour. Now the indeterminate progress animation can be shown on any type of progress bar. It works correctly because the progress gradient is an image, which in CSS is shown on top of the background colour.

`uploadProgress` is added as a new capability flag. it's determined based on the `navigator.userAgent` value, according to the versions mentioned in this bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12224510/
