### PR TITLE
dashboard: Log error if `trigger` is not found.

### DIFF
--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -441,7 +441,7 @@ module.exports = class Dashboard extends Plugin {
     }
 
     if (!this.opts.inline && !showModalTrigger) {
-      this.uppy.log('Dashboard modal trigger not found. Make sure `trigger` is set in Dashboard options unless you are planning to call openModal() method yourself')
+      this.uppy.log('Dashboard modal trigger not found. Make sure `trigger` is set in Dashboard options unless you are planning to call openModal() method yourself', 'error')
     }
 
     // Drag Drop


### PR DESCRIPTION
This message looked just like other debug messages for Uppy so I didn't notice it for a while! I think we can safely assume that it's an error if somenoe tries to set a nonexistent element as the modal trigger. If they don't want a trigger they shouldn't pass the option.