### PR TITLE
Only rebuild changed files with `npm run build:lib`

### DIFF
--- a/bin/build-lib.js
+++ b/bin/build-lib.js
@@ -40,6 +40,7 @@ async function buildLib () {
     if (!process.env.FRESH) {
       const srcMtime = await lastModified(file)
       const libMtime = await lastModified(libFile)
+        .catch(() => 0) // probably doesn't exist
       // Skip files that haven't changed
       if (srcMtime < libMtime && metaMtime < libMtime) {
         continue

--- a/bin/release
+++ b/bin/release
@@ -59,7 +59,7 @@ git add README.md
 cp README.md packages/uppy/README.md
 
 npm run clean
-npm run build
+FRESH=1 npm run build
 
 git commit -m "Release"
 lerna version --amend --no-push --exact

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "test:prepare-ci": "npm-run-all --parallel --race test:registry test:build-ci",
     "test:acceptance": "npm run test:prepare-ci && wdio test/endtoend/wdio.remote.conf.js",
     "test:acceptance:local": "npm run test:build && wdio test/endtoend/wdio.local.conf.js",
-    "test:unit": "jest",
+    "test:unit": "npm run build:lib && jest",
     "test:companion": "cd ./packages/@uppy/companion && npm run test",
     "test:type": "tsc -p .",
     "test": "npm run lint && npm run test:unit && npm run test:type && npm run test:companion",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "build:gzip": "node ./bin/gzip.js",
     "size": "echo 'JS Bundle mingz:' && cat ./packages/uppy/dist/uppy.min.js | gzip | wc -c && echo 'CSS Bundle mingz:' && cat ./packages/uppy/dist/uppy.min.css | gzip | wc -c",
     "build:js": "npm-run-all build:lib build:bundle",
-    "build:lib": "babel --version && node ./bin/build-lib.js",
+    "build:lib": "node ./bin/build-lib.js",
     "build": "npm-run-all --parallel build:js build:css build:companion --serial build:gzip size",
     "clean": "rm -rf packages/*/lib packages/@uppy/*/lib && rm -rf packages/uppy/dist",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
This makes it faster in most cases, so we have to wait less.

The FRESH=1 environment variable forces recompiling all source files,
and is used in the release script to be doubly sure that everything
we publish is up to date.

```bash
FRESH=1 npm run build:lib
```