### PR TITLE
 react: Allow changing instance in `uppy` prop 

### DIFF
--- a/packages/@uppy/react/src/Dashboard.js
+++ b/packages/@uppy/react/src/Dashboard.js
@@ -21,6 +21,10 @@ class Dashboard extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(

--- a/packages/@uppy/react/src/Dashboard.js
+++ b/packages/@uppy/react/src/Dashboard.js
@@ -11,6 +11,17 @@ const h = React.createElement
 
 class Dashboard extends React.Component {
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(
       { id: 'react:Dashboard' },
@@ -23,8 +34,8 @@ class Dashboard extends React.Component {
     this.plugin = uppy.getPlugin(options.id)
   }
 
-  componentWillUnmount () {
-    const uppy = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const uppy = props.uppy
 
     uppy.removePlugin(this.plugin)
   }

--- a/packages/@uppy/react/src/DashboardModal.js
+++ b/packages/@uppy/react/src/DashboardModal.js
@@ -22,6 +22,10 @@ class DashboardModal extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(

--- a/packages/@uppy/react/src/DashboardModal.js
+++ b/packages/@uppy/react/src/DashboardModal.js
@@ -12,6 +12,17 @@ const h = React.createElement
 
 class DashboardModal extends React.Component {
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(
       { id: 'react:DashboardModal' },
@@ -34,8 +45,8 @@ class DashboardModal extends React.Component {
     }
   }
 
-  componentWillUnmount () {
-    const uppy = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const uppy = props.uppy
 
     uppy.removePlugin(this.plugin)
   }

--- a/packages/@uppy/react/src/DragDrop.js
+++ b/packages/@uppy/react/src/DragDrop.js
@@ -11,6 +11,17 @@ const h = React.createElement
 
 class DragDrop extends React.Component {
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(
       { id: 'react:DragDrop' },
@@ -24,8 +35,8 @@ class DragDrop extends React.Component {
     this.plugin = uppy.getPlugin(options.id)
   }
 
-  componentWillUnmount () {
-    const uppy = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const uppy = props.uppy
 
     uppy.removePlugin(this.plugin)
   }

--- a/packages/@uppy/react/src/DragDrop.js
+++ b/packages/@uppy/react/src/DragDrop.js
@@ -21,6 +21,10 @@ class DragDrop extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(

--- a/packages/@uppy/react/src/ProgressBar.js
+++ b/packages/@uppy/react/src/ProgressBar.js
@@ -21,6 +21,10 @@ class ProgressBar extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(

--- a/packages/@uppy/react/src/ProgressBar.js
+++ b/packages/@uppy/react/src/ProgressBar.js
@@ -11,6 +11,17 @@ const h = React.createElement
 
 class ProgressBar extends React.Component {
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(
       { id: 'react:ProgressBar' },
@@ -24,8 +35,8 @@ class ProgressBar extends React.Component {
     this.plugin = uppy.getPlugin(options.id)
   }
 
-  componentWillUnmount () {
-    const uppy = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const uppy = props.uppy
 
     uppy.removePlugin(this.plugin)
   }

--- a/packages/@uppy/react/src/StatusBar.js
+++ b/packages/@uppy/react/src/StatusBar.js
@@ -22,6 +22,10 @@ class StatusBar extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(

--- a/packages/@uppy/react/src/StatusBar.js
+++ b/packages/@uppy/react/src/StatusBar.js
@@ -12,6 +12,17 @@ const h = React.createElement
 
 class StatusBar extends React.Component {
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const uppy = this.props.uppy
     const options = Object.assign(
       { id: 'react:StatusBar' },
@@ -25,8 +36,8 @@ class StatusBar extends React.Component {
     this.plugin = uppy.getPlugin(options.id)
   }
 
-  componentWillUnmount () {
-    const uppy = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const uppy = props.uppy
 
     uppy.removePlugin(this.plugin)
   }

--- a/packages/@uppy/react/src/Wrapper.js
+++ b/packages/@uppy/react/src/Wrapper.js
@@ -22,6 +22,10 @@ class UppyWrapper extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.uninstallPlugin()
+  }
+
   installPlugin () {
     const plugin = this.props.uppy
       .getPlugin(this.props.plugin)

--- a/packages/@uppy/react/src/Wrapper.js
+++ b/packages/@uppy/react/src/Wrapper.js
@@ -12,14 +12,25 @@ class UppyWrapper extends React.Component {
   }
 
   componentDidMount () {
+    this.installPlugin()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.uppy !== this.props.uppy) {
+      this.uninstallPlugin(prevProps)
+      this.installPlugin()
+    }
+  }
+
+  installPlugin () {
     const plugin = this.props.uppy
       .getPlugin(this.props.plugin)
 
     plugin.mount(this.container, plugin)
   }
 
-  componentWillUnmount () {
-    const plugin = this.props.uppy
+  uninstallPlugin (props = this.props) {
+    const plugin = props.uppy
       .getPlugin(this.props.plugin)
 
     plugin.unmount()


### PR DESCRIPTION
When changing the Uppy instance, the components will uninstall the UI plugin from the old instance, and install it to the new instance.

One other thing that I wanted to do is warn when you create the Uppy instance in the render() method. that becomes harder when this use case is supported. If we didn't support changing instances, we could simply throw an error if the `uppy` prop ever changes. If we support changing instances, I'm not sure how we'd detect Uppy instances being created in render().