### PR TITLE
Typescript: Make DashboardModal.target prop optional

### DIFF
--- a/packages/@uppy/react/src/DashboardModal.d.ts
+++ b/packages/@uppy/react/src/DashboardModal.d.ts
@@ -1,7 +1,7 @@
 import { DashboardProps } from './Dashboard';
 
 export interface DashboardModalProps extends DashboardProps {
-  target: string | HTMLElement;
+  target?: string | HTMLElement;
   open?: boolean;
   onRequestClose?: VoidFunction;
   closeModalOnClickOutside?: boolean;


### PR DESCRIPTION
This prop was not marked as optional so that the Typescript compiler complains if it is not present. Fixed.