### PR TITLE
s3: Use user provided filename / type for uploaded object, fixes #1238

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -70,8 +70,8 @@ module.exports = class AwsS3 extends Plugin {
       throw new Error('Expected a `serverUrl` option containing a Companion address.')
     }
 
-    const filename = encodeURIComponent(file.name)
-    const type = encodeURIComponent(file.type)
+    const filename = encodeURIComponent(file.meta.name)
+    const type = encodeURIComponent(file.meta.type)
     return this.client.get(`s3/params?filename=${filename}&type=${type}`)
       .then(assertServerError)
   }


### PR DESCRIPTION
Editing the `name` meta property in the Dashboard UI is reflected in the object name on S3.

Programmatically you can do:
```js
uppy.setFileMeta(fileID, {
  name: 'object/key/path.txt'
})
```