### PR TITLE
dashboard: Fix issues with multiple modals

### DIFF
--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -28,6 +28,7 @@
     "@uppy/thumbnail-generator": "0.29.1",
     "@uppy/utils": "0.29.1",
     "classnames": "^2.2.6",
+    "cuid": "^2.1.1",
     "drag-drop": "2.13.3",
     "lodash.throttle": "^4.1.1",
     "preact": "^8.2.9",

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -341,7 +341,8 @@ module.exports = class Dashboard extends Plugin {
       manualClose = true // Whether the modal is being closed by the user (`true`) or by other means (e.g. browser back button)
     } = opts
 
-    if (this.getPluginState().isClosing) {
+    const { isHidden, isClosing } = this.getPluginState()
+    if (isHidden || isClosing) {
       // short-circuit if animation is ongoing
       return
     }


### PR DESCRIPTION
- Allow multiple dashboard states in the history
- Check if a popstate() event could actually do anything to this modal,
  previously we could do `closeModal()` on a modal that was already
  closed
- fix modal entering broken state when `closeModal()` is called on a modal
  that was already closed (now is a noop)

Fixes #1239