### PR TITLE
Don’t emit a complete event if an upload has been canceled

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1197,6 +1197,10 @@ class Uppy {
       // always refers to the latest state. In the handler right above it refers
       // to an outdated object without the `.result` property.
       const { currentUploads } = this.getState()
+      if (!currentUploads[uploadID]) {
+        this.log(`Not setting result for an upload that has been canceled: ${uploadID}`)
+        return
+      }
       const currentUpload = currentUploads[uploadID]
       const result = currentUpload.result
       this.emit('complete', result)


### PR DESCRIPTION
Fixes #1186