### PR TITLE
Make providers support react native

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -13,18 +13,22 @@ module.exports = class Provider extends RequestClient {
     this.id = this.provider
     this.authProvider = opts.authProvider || this.provider
     this.name = this.opts.name || _getName(this.id)
-    this.tokenKey = `companion-${this.id}-auth-token`
-    this.storage = opts.storage || localStorage
+    this.pluginId = this.opts.pluginId
+    this.tokenKey = `companion-${this.pluginId}-auth-token`
   }
 
   get defaultHeaders () {
-    return Object.assign({}, super.defaultHeaders, {'uppy-auth-token': this.storage.getItem(this.tokenKey)})
+    return Object.assign({}, super.defaultHeaders, {'uppy-auth-token': this.getAuthToken()})
   }
 
   // @todo(i.olarewaju) consider whether or not this method should be exposed
   setAuthToken (token) {
     // @todo(i.olarewaju) add fallback for OOM storage
-    this.storage.setItem(this.tokenKey, token)
+    this.uppy.getPlugin(this.pluginId).storage.setItem(this.tokenKey, token)
+  }
+
+  getAuthToken () {
+    return this.uppy.getPlugin(this.pluginId).storage.getItem(this.tokenKey)
   }
 
   checkAuth () {
@@ -60,6 +64,7 @@ module.exports = class Provider extends RequestClient {
     if (defaultOpts) {
       plugin.opts = Object.assign({}, defaultOpts, opts)
     }
+
     if (opts.serverPattern) {
       const pattern = opts.serverPattern
       // validate serverPattern param
@@ -75,5 +80,7 @@ module.exports = class Provider extends RequestClient {
         plugin.opts.serverPattern = opts.serverUrl
       }
     }
+
+    plugin.storage = plugin.opts.storage || localStorage
   }
 }

--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -14,16 +14,17 @@ module.exports = class Provider extends RequestClient {
     this.authProvider = opts.authProvider || this.provider
     this.name = this.opts.name || _getName(this.id)
     this.tokenKey = `companion-${this.id}-auth-token`
+    this.storage = opts.storage || localStorage
   }
 
   get defaultHeaders () {
-    return Object.assign({}, super.defaultHeaders, {'uppy-auth-token': localStorage.getItem(this.tokenKey)})
+    return Object.assign({}, super.defaultHeaders, {'uppy-auth-token': this.storage.getItem(this.tokenKey)})
   }
 
   // @todo(i.olarewaju) consider whether or not this method should be exposed
   setAuthToken (token) {
     // @todo(i.olarewaju) add fallback for OOM storage
-    localStorage.setItem(this.tokenKey, token)
+    this.storage.setItem(this.tokenKey, token)
   }
 
   checkAuth () {
@@ -48,7 +49,7 @@ module.exports = class Provider extends RequestClient {
   logout (redirect = location.href) {
     return this.get(`${this.id}/logout?redirect=${redirect}`)
       .then((res) => {
-        localStorage.removeItem(this.tokenKey)
+        this.storage.removeItem(this.tokenKey)
         return res
       })
   }

--- a/packages/@uppy/companion/src/server/controllers/callback.js
+++ b/packages/@uppy/companion/src/server/controllers/callback.js
@@ -1,11 +1,7 @@
 /**
  * oAuth callback.  Encrypts the access token and sends the new token with the response,
- * and redirects to redirect url.
  */
 const tokenService = require('../helpers/jwt')
-const parseUrl = require('url').parse
-const { hasMatch, sanitizeHtml } = require('../helpers/utils')
-const oAuthState = require('../helpers/oauth-state')
 const logger = require('../logger')
 
 /**
@@ -25,43 +21,5 @@ module.exports = function callback (req, res, next) {
   req.uppy.providerTokens[providerName] = req.query.access_token
   logger.debug(`Generating auth token for provider ${providerName}.`)
   const uppyAuthToken = tokenService.generateToken(req.uppy.providerTokens, req.uppy.options.secret)
-  // add the token to cookies for thumbnail/image requests
-  tokenService.addToCookies(res, uppyAuthToken, req.uppy.options)
-
-  const state = (req.session.grant || {}).state
-  if (state) {
-    const origin = oAuthState.getFromState(state, 'origin', req.uppy.options.secret)
-    const allowedClients = req.uppy.options.clients
-    // if no preset clients then allow any client
-    if (!allowedClients || hasMatch(origin, allowedClients) || hasMatch(parseUrl(origin).host, allowedClients)) {
-      const redirect = oAuthState.getFromState(state, 'redirect', req.uppy.options.secret)
-      if (redirect) {
-        // if a redirect value is specified from the client, then redirect there instead
-        const query = (parseUrl(redirect).query ? `&` : `?`) + `uppyAuthToken=${uppyAuthToken}`
-        return res.redirect(`${redirect}${query}`)
-      }
-      return res.send(htmlContent(uppyAuthToken, origin))
-    }
-  }
-  next()
-}
-
-/**
- *
- * @param {string} token uppy auth token
- * @param {string} origin url string
- */
-const htmlContent = (token, origin) => {
-  return `
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8" />
-        <script>
-          window.opener.postMessage({token: "${token}"}, "${sanitizeHtml(origin)}")
-          window.close()
-        </script>
-    </head>
-    <body></body>
-    </html>`
+  return res.redirect(req.uppy.buildURL(`/${providerName}/send-token?uppyAuthToken=${uppyAuthToken}`, true))
 }

--- a/packages/@uppy/companion/src/server/controllers/index.js
+++ b/packages/@uppy/companion/src/server/controllers/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   authorized: require('./authorized'),
   callback: require('./callback'),
+  sendToken: require('./send-token'),
   get: require('./get'),
   thumbnail: require('./thumbnail'),
   list: require('./list'),

--- a/packages/@uppy/companion/src/server/controllers/send-token.js
+++ b/packages/@uppy/companion/src/server/controllers/send-token.js
@@ -1,0 +1,51 @@
+/**
+ *
+ * sends auth token to uppy client
+ */
+const tokenService = require('../helpers/jwt')
+const parseUrl = require('url').parse
+const { hasMatch, sanitizeHtml } = require('../helpers/utils')
+const oAuthState = require('../helpers/oauth-state')
+
+/**
+ *
+ * @param {object} req
+ * @param {object} res
+ * @param {function} next
+ */
+module.exports = function sendToken (req, res, next) {
+  const uppyAuthToken = req.uppy.authToken
+  // add the token to cookies for thumbnail/image requests
+  tokenService.addToCookies(res, uppyAuthToken, req.uppy.options)
+
+  const state = (req.session.grant || {}).state
+  if (state) {
+    const origin = oAuthState.getFromState(state, 'origin', req.uppy.options.secret)
+    const allowedClients = req.uppy.options.clients
+    // if no preset clients then allow any client
+    if (!allowedClients || hasMatch(origin, allowedClients) || hasMatch(parseUrl(origin).host, allowedClients)) {
+      return res.send(htmlContent(uppyAuthToken, origin))
+    }
+  }
+  next()
+}
+
+/**
+ *
+ * @param {string} token uppy auth token
+ * @param {string} origin url string
+ */
+const htmlContent = (token, origin) => {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8" />
+        <script>
+          window.opener.postMessage({token: "${token}"}, "${sanitizeHtml(origin)}")
+          window.close()
+        </script>
+    </head>
+    <body></body>
+    </html>`
+}

--- a/packages/@uppy/companion/src/uppy.js
+++ b/packages/@uppy/companion/src/uppy.js
@@ -87,6 +87,7 @@ module.exports.app = (options = {}) => {
   app.get('/:providerName/redirect', middlewares.hasSessionAndProvider, controllers.redirect)
   app.get('/:providerName/logout', middlewares.hasSessionAndProvider, middlewares.gentleVerifyToken, controllers.logout)
   app.get('/:providerName/authorized', middlewares.hasSessionAndProvider, middlewares.gentleVerifyToken, controllers.authorized)
+  app.get('/:providerName/send-token', middlewares.hasSessionAndProvider, middlewares.verifyToken, controllers.sendToken)
   app.get('/:providerName/list/:id?', middlewares.hasSessionAndProvider, middlewares.verifyToken, controllers.list)
   app.post('/:providerName/get/:id', middlewares.hasSessionAndProvider, middlewares.verifyToken, controllers.get)
   app.get('/:providerName/thumbnail/:id', middlewares.hasSessionAndProvider, middlewares.cookieAuthToken, middlewares.verifyToken, controllers.thumbnail)
@@ -217,7 +218,7 @@ const getOptionsMiddleware = (options) => {
     req.uppy = {
       options,
       s3Client,
-      authToken: req.header('uppy-auth-token'),
+      authToken: req.header('uppy-auth-token') || req.query.uppyAuthToken,
       buildURL: getURLBuilder(options)
     }
     next()

--- a/packages/@uppy/companion/test/mockserver.js
+++ b/packages/@uppy/companion/test/mockserver.js
@@ -5,7 +5,7 @@ const session = require('express-session')
 var authServer = express()
 
 authServer.use(session({ secret: 'grant', resave: true, saveUninitialized: true }))
-authServer.all('/drive/callback', (req, res, next) => {
+authServer.all('/drive/send-token', (req, res, next) => {
   req.session.grant = {
     state: 'non-empty-value' }
   next()

--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -21,7 +21,8 @@ module.exports = class Dropbox extends Plugin {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
       storage: this.opts.storage,
-      provider: 'dropbox'
+      provider: 'dropbox',
+      pluginId: this.id
     })
 
     this.onAuth = this.onAuth.bind(this)

--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -20,6 +20,7 @@ module.exports = class Dropbox extends Plugin {
     this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
+      storage: this.opts.storage,
       provider: 'dropbox'
     })
 

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -23,6 +23,7 @@ module.exports = class GoogleDrive extends Plugin {
     this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
+      storage: this.opts.storage,
       provider: 'drive',
       authProvider: 'google'
     })

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -25,7 +25,8 @@ module.exports = class GoogleDrive extends Plugin {
       serverHeaders: this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'drive',
-      authProvider: 'google'
+      authProvider: 'google',
+      pluginId: this.id
     })
 
     this.onAuth = this.onAuth.bind(this)

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -20,6 +20,7 @@ module.exports = class Instagram extends Plugin {
     this.provider = new Provider(uppy, {
       serverUrl: this.opts.serverUrl,
       serverHeaders: this.opts.serverHeaders,
+      storage: this.opts.storage,
       provider: 'instagram',
       authProvider: 'instagram'
     })

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -22,7 +22,8 @@ module.exports = class Instagram extends Plugin {
       serverHeaders: this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'instagram',
-      authProvider: 'instagram'
+      authProvider: 'instagram',
+      pluginId: this.id
     })
 
     this.onAuth = this.onAuth.bind(this)

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -422,7 +422,7 @@ module.exports = class ProviderView {
   }
 
   handleAuth () {
-    const authState = btoa(JSON.stringify({ origin: location.origin, redirect: 'http://localhost:3' }))
+    const authState = btoa(JSON.stringify({ origin: location.origin }))
     const link = `${this.provider.authUrl()}?state=${authState}`
 
     const authWindow = window.open(link, '_blank')

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -422,7 +422,7 @@ module.exports = class ProviderView {
   }
 
   handleAuth () {
-    const authState = btoa(JSON.stringify({ origin: location.origin }))
+    const authState = btoa(JSON.stringify({ origin: location.origin, redirect: 'http://localhost:3' }))
     const link = `${this.provider.authUrl()}?state=${authState}`
 
     const authWindow = window.open(link, '_blank')


### PR DESCRIPTION
Providers can be instantiated with a `storage` module that behaves similarly to `localStorage` [here](https://github.com/transloadit/uppy/blob/7a4219ee989e15373c8d92cd941c061539a9deb7/examples/bundled-example/main.js#L32-L34)

The auth URL can also be called similarly as done [here](https://github.com/transloadit/uppy/blob/7a4219ee98/packages/%40uppy/provider-views/src/index.js#L452-L453), but with an additional `redirect` option specified. Like so:

```js
const authState = btoa(JSON.stringify({ origin: location.origin, redirect: location.href }))
const link = `${this.Provider.authUrl()}?state=${authState}`
```

If this is done on react-native (on the same window, not a new one), Companion will redirect to the redirect value set after the OAuth dance is done with a `uppyAuthToken` query param passed.
