### PR TITLE
Add metadata support for S3 MultiPart

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -96,7 +96,8 @@ module.exports = class AwsS3Multipart extends Plugin {
 
     return this.client.post('s3/multipart', {
       filename: file.name,
-      type: file.type
+      type: file.type,
+      metadata: file.meta
     }).then(assertServerError)
   }
 

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -122,8 +122,10 @@ module.exports = class AwsS3Multipart extends Plugin {
 
     const filename = encodeURIComponent(key)
     const uploadIdEnc = encodeURIComponent(uploadId)
-    return this.client.post(`s3/multipart/${uploadIdEnc}/complete?key=${filename}`, { parts })
-      .then(assertServerError)
+    return this.client.post(`s3/multipart/${uploadIdEnc}/complete?key=${filename}`, {
+      parts,
+      metadata: file.meta
+    }).then(assertServerError)
   }
 
   abortMultipartUpload (file, { key, uploadId }) {


### PR DESCRIPTION
Added metadata field to POST body params in `createMultipartUpload` method.

Closes #1291.