### PR TITLE
companion: return 401 for invalid access token

### DIFF
--- a/packages/@uppy/companion-client/src/AuthError.js
+++ b/packages/@uppy/companion-client/src/AuthError.js
@@ -1,0 +1,11 @@
+'use strict'
+
+class AuthError extends Error {
+  constructor () {
+    super('Authorization required')
+    this.name = 'AuthError'
+    this.isAuthError = true
+  }
+}
+
+module.exports = AuthError

--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -28,19 +28,20 @@ module.exports = class Provider extends RequestClient {
     })
   }
 
+  onReceiveResponse (response) {
+    response = super.onReceiveResponse(response)
+    const authenticated = response.status !== 401
+    this.uppy.getPlugin(this.pluginId).setPluginState({ authenticated })
+    return response
+  }
+
+  // @todo(i.olarewaju) consider whether or not this method should be exposed
   setAuthToken (token) {
     return this.uppy.getPlugin(this.pluginId).storage.setItem(this.tokenKey, token)
   }
 
   getAuthToken () {
     return this.uppy.getPlugin(this.pluginId).storage.getItem(this.tokenKey)
-  }
-
-  checkAuth () {
-    return this.get(`${this.id}/authorized`)
-      .then((payload) => {
-        return payload.authenticated
-      })
   }
 
   authUrl () {

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const AuthError = require('./AuthError')
+
 // Remove the trailing slash so we can always safely append /xyz.
 function stripSlash (url) {
   return url.replace(/\/$/, '')
@@ -64,7 +66,7 @@ module.exports = class RequestClient {
 
   _json(res) {
     if (res.status === 401) {
-      throw new Error('Auth required')
+      throw new AuthError()
     }
 
     if (res.status < 200 || res.status > 300) {
@@ -84,7 +86,8 @@ module.exports = class RequestClient {
           .then(this._getPostResponseFunc(skipPostResponse))
           .then((res) => this._json(res).then(resolve))
           .catch((err) => {
-            reject(new Error(`Could not get ${this._getUrl(path)}. ${err}`))
+            err = err.isAuthError ? err : new Error(`Could not get ${this._getUrl(path)}. ${err}`)
+            reject(err)
           })
       })
     })
@@ -102,7 +105,8 @@ module.exports = class RequestClient {
           .then(this._getPostResponseFunc(skipPostResponse))
           .then((res) => this._json(res).then(resolve))
           .catch((err) => {
-            reject(new Error(`Could not post ${this._getUrl(path)}. ${err}`))
+            err = err.isAuthError ? err : new Error(`Could not post ${this._getUrl(path)}. ${err}`)
+            reject(err)
           })
       })
     })
@@ -120,7 +124,8 @@ module.exports = class RequestClient {
           .then(this._getPostResponseFunc(skipPostResponse))
           .then((res) => this._json(res).then(resolve))
           .catch((err) => {
-            reject(new Error(`Could not delete ${this._getUrl(path)}. ${err}`))
+            err = err.isAuthError ? err : new Error(`Could not delete ${this._getUrl(path)}. ${err}`)
+            reject(err)
           })
       })
     })

--- a/packages/@uppy/companion/src/server/controllers/get.js
+++ b/packages/@uppy/companion/src/server/controllers/get.js
@@ -2,7 +2,7 @@ const Uploader = require('../Uploader')
 const redis = require('../redis')
 const logger = require('../logger')
 
-function get (req, res) {
+function get (req, res, next) {
   const providerName = req.params.providerName
   const id = req.params.id
   const body = req.body
@@ -11,7 +11,11 @@ function get (req, res) {
   const { providerOptions } = req.uppy.options
 
   // get the file size before proceeding
-  provider.size({ id, token }, (size) => {
+  provider.size({ id, token }, (err, size) => {
+    if (err) {
+      return err.isAuthError ? res.sendStatus(401) : next(err)
+    }
+
     if (!size) {
       logger.error('unable to determine file size', 'controller.get.provider.size')
       return res.status(400).json({error: 'unable to determine file size'})

--- a/packages/@uppy/companion/src/server/controllers/list.js
+++ b/packages/@uppy/companion/src/server/controllers/list.js
@@ -3,7 +3,10 @@ function list ({ query, params, uppy }, res, next) {
   const token = uppy.providerTokens[providerName]
 
   uppy.provider.list({ uppy, token, directory: params.id, query }, (err, data) => {
-    return err ? next(err) : res.json(data)
+    if (err) {
+      return err.isAuthError ? res.sendStatus(401) : next(err)
+    }
+    return res.json(data)
   })
 }
 

--- a/packages/@uppy/companion/src/server/controllers/thumbnail.js
+++ b/packages/@uppy/companion/src/server/controllers/thumbnail.js
@@ -3,13 +3,18 @@
  * @param {object} req
  * @param {object} res
  */
-function thumbnail (req, res) {
+function thumbnail (req, res, next) {
   const providerName = req.params.providerName
   const id = req.params.id
   const token = req.uppy.providerTokens[providerName]
   const provider = req.uppy.provider
 
-  provider.thumbnail({ id, token }, (response) => response ? response.pipe(res) : res.sendStatus(404))
+  provider.thumbnail({ id, token }, (err, response) => {
+    if (err) {
+      err.isAuthError ? res.sendStatus(401) : next(err)
+    }
+    response ? response.pipe(res) : res.sendStatus(404)
+  })
 }
 
 module.exports = thumbnail

--- a/packages/@uppy/companion/src/server/logger.js
+++ b/packages/@uppy/companion/src/server/logger.js
@@ -45,5 +45,7 @@ exports.debug = (msg, tag) => {
 const log = (msg, tag, level) => {
   // @TODO add some colors based on log level
   const time = new Date().toISOString()
-  console.log(`uppy: ${time} [${level}] ${tag || ''} ${msg}`)
+  // exclude msg from template string so values such as error objects
+  // can be well formatted
+  console.log(`uppy: ${time} [${level}] ${tag || ''}`, msg)
 }

--- a/packages/@uppy/companion/src/server/provider/error.js
+++ b/packages/@uppy/companion/src/server/provider/error.js
@@ -1,0 +1,13 @@
+/**
+ * AuthError is error returned when an adapter encounters
+ * an authorization error while communication with its corresponding provider
+ */
+class AuthError extends Error {
+  constructor () {
+    super('invalid access token detected by Provider')
+    this.name = 'AuthError'
+    this.isAuthError = true
+  }
+}
+
+module.exports = AuthError

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -36,6 +36,7 @@ class Uppy {
         exceedsSize: 'This file exceeds maximum allowed size of',
         youCanOnlyUploadFileTypes: 'You can only upload: %{types}',
         companionError: 'Connection with Companion failed',
+        companionAuthError: 'Authorization required',
         failedToUpload: 'Failed to upload %{file}',
         noInternetConnection: 'No Internet connection',
         connectedToInternet: 'Connected to the Internet',

--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -25,7 +25,7 @@ module.exports = class Dropbox extends Plugin {
       pluginId: this.id
     })
 
-    this.onAuth = this.onAuth.bind(this)
+    this.onFirstRender = this.onFirstRender.bind(this)
     this.render = this.render.bind(this)
   }
 
@@ -55,11 +55,8 @@ module.exports = class Dropbox extends Plugin {
     this.unmount()
   }
 
-  onAuth (authenticated) {
-    this.setPluginState({ authenticated })
-    if (authenticated) {
-      this.view.getFolder()
-    }
+  onFirstRender () {
+    return this.view.getFolder()
   }
 
   render (state) {

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -29,7 +29,7 @@ module.exports = class GoogleDrive extends Plugin {
       pluginId: this.id
     })
 
-    this.onAuth = this.onAuth.bind(this)
+    this.onFirstRender = this.onFirstRender.bind(this)
     this.render = this.render.bind(this)
   }
 
@@ -62,11 +62,8 @@ module.exports = class GoogleDrive extends Plugin {
     this.unmount()
   }
 
-  onAuth (authenticated) {
-    this.setPluginState({ authenticated })
-    if (authenticated) {
-      this.view.getFolder('root', '/')
-    }
+  onFirstRender () {
+    return this.view.getFolder('root', '/')
   }
 
   render (state) {

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -26,7 +26,7 @@ module.exports = class Instagram extends Plugin {
       pluginId: this.id
     })
 
-    this.onAuth = this.onAuth.bind(this)
+    this.onFirstRender = this.onFirstRender.bind(this)
     this.render = this.render.bind(this)
   }
 
@@ -60,11 +60,8 @@ module.exports = class Instagram extends Plugin {
     this.unmount()
   }
 
-  onAuth (authenticated) {
-    this.setPluginState({ authenticated })
-    if (authenticated) {
-      this.view.getFolder('recent')
-    }
+  onFirstRender () {
+    this.view.getFolder('recent')
   }
 
   render (state) {

--- a/packages/@uppy/provider-views/src/AuthView.js
+++ b/packages/@uppy/provider-views/src/AuthView.js
@@ -1,4 +1,3 @@
-const LoaderView = require('./Loader')
 const { h, Component } = require('preact')
 
 class AuthBlock extends Component {
@@ -29,14 +28,7 @@ class AuthBlock extends Component {
 }
 
 class AuthView extends Component {
-  componentDidMount () {
-    this.props.checkAuth()
-  }
-
   render () {
-    if (this.props.checkAuthInProgress) {
-      return <LoaderView />
-    }
     return <AuthBlock {...this.props} />
   }
 }

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -452,8 +452,8 @@ module.exports = class ProviderView {
 
   handleError (error) {
     const uppy = this.plugin.uppy
-    const message = uppy.i18n('companionError')
     uppy.log(error.toString())
+    const message = uppy.i18n(error.isAuthError ? 'companionAuthError' : 'companionError')
     uppy.info({message: message, details: error.toString()}, 'error', 5000)
   }
 

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -56,7 +56,7 @@ module.exports = class ProviderView {
     this.getFolder = this.getFolder.bind(this)
     this.getNextFolder = this.getNextFolder.bind(this)
     this.logout = this.logout.bind(this)
-    this.checkAuth = this.checkAuth.bind(this)
+    this.preFirstRender = this.preFirstRender.bind(this)
     this.handleAuth = this.handleAuth.bind(this)
     this.handleDemoAuth = this.handleDemoAuth.bind(this)
     this.sortByTitle = this.sortByTitle.bind(this)
@@ -93,17 +93,13 @@ module.exports = class ProviderView {
     this.plugin.setPluginState({ folders, files })
   }
 
-  checkAuth () {
-    this.plugin.setPluginState({ checkAuthInProgress: true })
-    this.provider.checkAuth()
-      .then((authenticated) => {
-        this.plugin.setPluginState({ checkAuthInProgress: false })
-        this.plugin.onAuth(authenticated)
-      })
-      .catch((err) => {
-        this.plugin.setPluginState({ checkAuthInProgress: false })
-        this.handleError(err)
-      })
+  /**
+   * Called only the first time the provider view is rendered.
+   * Kind of like an init function.
+   */
+  preFirstRender () {
+    this.plugin.setPluginState({ didFirstRender: true })
+    this.plugin.onFirstRender()
   }
 
   /**
@@ -434,7 +430,7 @@ module.exports = class ProviderView {
       authWindow.close()
       window.removeEventListener('message', handleToken)
       this.provider.setAuthToken(e.data.token)
-      this._loaderWrapper(this.provider.checkAuth(), this.plugin.onAuth, this.handleError)
+      this.preFirstRender()
     }
     window.addEventListener('message', handleToken)
   }
@@ -517,9 +513,14 @@ module.exports = class ProviderView {
   }
 
   render (state) {
-    const { authenticated, checkAuthInProgress, loading } = this.plugin.getPluginState()
+    const { authenticated, didFirstRender } = this.plugin.getPluginState()
+    if (!didFirstRender) {
+      this.preFirstRender()
+    }
 
-    if (loading) {
+    // reload pluginState for "loading" attribute because it might
+    // have changed above.
+    if (this.plugin.getPluginState().loading) {
       return (
         <CloseWrapper onUnmount={this.clearSelection}>
           <LoaderView />
@@ -534,10 +535,8 @@ module.exports = class ProviderView {
             pluginName={this.plugin.title}
             pluginIcon={this.plugin.icon}
             demo={this.plugin.opts.demo}
-            checkAuth={this.checkAuth}
             handleAuth={this.handleAuth}
-            handleDemoAuth={this.handleDemoAuth}
-            checkAuthInProgress={checkAuthInProgress} />
+            handleDemoAuth={this.handleDemoAuth} />
         </CloseWrapper>
       )
     }


### PR DESCRIPTION
return 401 for invalid access token so that the `/authorized` endpoint can be deprecated