### PR TITLE
Add Robodog to CDN

### DIFF
--- a/bin/build-css.js
+++ b/bin/build-css.js
@@ -51,8 +51,16 @@ async function compileCSS () {
     })
 
     const outdir = path.join(path.dirname(file), '../dist')
-    // Save the `uppy` package's CSS as `uppy.css`, the rest as `style.css`.
-    const outfile = path.join(outdir, outdir.includes('packages/uppy/') ? 'uppy.css' : 'style.css')
+    // Save the `uppy` package's CSS as `uppy.css`,
+    // `@uppy/robodog` as `robodog.css`,
+    // the rest as `style.css`.
+    // const outfile = path.join(outdir, outdir.includes('packages/uppy/') ? 'uppy.css' : 'style.css')
+    let outfile = path.join(outdir, 'style.css')
+    if (outdir.includes('packages/uppy/')) {
+      outfile = path.join(outdir, 'uppy.css')
+    } else if (outdir.includes('packages/@uppy/robodog/')) {
+      outfile = path.join(outdir, 'robodog.css')
+    }
     await mkdirp(outdir)
     await writeFile(outfile, postcssResult.css)
     console.info(

--- a/bin/build-js.js
+++ b/bin/build-js.js
@@ -49,11 +49,11 @@ Promise.all([
   ),
   buildBundle(
     './packages/@uppy/robodog/bundle.js',
-    './packages/@uppy/robodog/dist/transloadit.js'
+    './packages/@uppy/robodog/dist/robodog.js'
   ),
   buildBundle(
     './packages/@uppy/robodog/bundle.js',
-    './packages/@uppy/robodog/dist/transloadit.min.js',
+    './packages/@uppy/robodog/dist/robodog.min.js',
     { minify: true }
   )
 ]).then(function () {

--- a/bin/upload-to-cdn.sh
+++ b/bin/upload-to-cdn.sh
@@ -34,7 +34,7 @@ __base="$(basename ${__file} .sh)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
 # copy robodog dist to uppy package dist, before publishing to cdn
-cp -r packages/@uppy/robodog/dist/ packages/uppy/dist/
+cp -vr packages/@uppy/robodog/dist/* packages/uppy/dist/
 
 function fatal () {
   echo "❌ ${*}";

--- a/bin/upload-to-cdn.sh
+++ b/bin/upload-to-cdn.sh
@@ -34,7 +34,7 @@ __base="$(basename ${__file} .sh)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
 # copy robodog dist to uppy package dist, before publishing to cdn
-cp -r packages/@uppy/robodog/dist packages/uppy/dist/robodog
+cp -r packages/@uppy/robodog/dist/ packages/uppy/dist/
 
 function fatal () {
   echo "❌ ${*}";

--- a/bin/upload-to-cdn.sh
+++ b/bin/upload-to-cdn.sh
@@ -33,6 +33,9 @@ __file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
 __base="$(basename ${__file} .sh)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
+# copy robodog dist to uppy package dist, before publishing to cdn
+cp -r packages/@uppy/robodog/dist packages/uppy/dist/robodog
+
 function fatal () {
   echo "❌ ${*}";
   exit 1


### PR DESCRIPTION
- In `@uppy/robodog/dist` call css and js files `robodog.js` and `robodog.css`, instead of `transloadit.js` and `style.css`
- Copy `@uppy/robodog/dist` to `uppy/dist/robodog` before uploading to CDN

So Robodog will be available from CDN as:

https://transloadit.edgly.net/releases/uppy/v0.30.0/dist/robodog/robodog.min.css
https://transloadit.edgly.net/releases/uppy/v0.30.0/dist/robodog/robodog.min.js