### PR TITLE
Remove resources requirements for companion

### DIFF
--- a/packages/@uppy/companion/infra/kube/companion/companion-kube.yaml
+++ b/packages/@uppy/companion/infra/kube/companion/companion-kube.yaml
@@ -48,12 +48,7 @@ spec:
       containers:
       - image: docker.io/transloadit/companion:latest
         imagePullPolicy: Always
-        name: companion        
-        resources:
-          limits:
-            memory: 2Gi
-          requests:
-            memory: 2Gi
+        name: companion
         envFrom:
         - configMapRef:
             name: uppy-companion-env


### PR DESCRIPTION
This will enable pods to use all resource available by the node without setting hard limits on requirements. Makes part of moving to smaller nodes.