### PR TITLE
[XHRUpload] Reject cancelled uploads

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -286,12 +286,14 @@ module.exports = class XHRUpload extends Plugin {
         if (removedFile.id === file.id) {
           timer.done()
           xhr.abort()
+          reject(new Error('File removed'))
         }
       })
 
       this.uppy.on('cancel-all', () => {
         timer.done()
         xhr.abort()
+        reject(new Error('Upload cancelled'))
       })
     })
   }


### PR DESCRIPTION
This allows for the 'complete' event to be properly triggered after uploads have succeeded, failed, or been cancelled.

fixes #1315