### PR TITLE
[AWS-S3] Avoid throwing error when file has been removed

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -125,7 +125,7 @@ module.exports = class AwsS3 extends Plugin {
       const updatedFiles = {}
       fileIDs.forEach((id, index) => {
         const file = this.uppy.getFile(id)
-        if (file.error) {
+        if (!file || file.error) {
           return
         }
 


### PR DESCRIPTION
There is a case where a fileId no longer exists in uppy, namely if the
file is removed from uppy before `getUploadParameters` returns.

fixes #1317