### PR TITLE
[wip] Add allowDuplicateFiles option to @uppy/core

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -57,6 +57,7 @@ class Uppy {
       id: 'uppy',
       autoProceed: false,
       allowMultipleUploads: true,
+      allowDuplicateFiles: true,
       debug: false,
       restrictions: {
         maxFileSize: null,
@@ -421,7 +422,16 @@ class Uppy {
     const fileExtension = getFileNameAndExtension(fileName).extension
     const isRemote = file.isRemote || false
 
-    const fileID = generateFileID(file)
+    let fileID = generateFileID(file)
+
+    if (this.state.files[fileID]) {
+      if (!this.opts.allowDuplicateFiles) {
+        onError(new Error('This file has already been added'))
+        return
+      }
+
+      fileID = `${fileID}/${cuid()}`
+    }
 
     const meta = file.meta || {}
     meta.name = fileName


### PR DESCRIPTION
If the `fileId` exists, we either throw an error, or generate a new unique file id, so that a copy of the file can be added:

<img width="1230" alt="screen shot 2019-03-08 at 15 18 09" src="https://user-images.githubusercontent.com/1199054/54028262-8b17f580-41b5-11e9-845f-bc475aa852a5.png">

<img width="796" alt="screen shot 2019-03-08 at 15 17 33" src="https://user-images.githubusercontent.com/1199054/54028269-92d79a00-41b5-11e9-9c5c-5d35a5c431ca.png">

Fixes #843 #1179 #754

Does this break something for Golden Retriever and Tus?

todo:

- [ ] tests
- [ ] docs
- [ ] figure out the default, and whether we want to add an “overwrite” option — current behavior  