### PR TITLE
Requires -g param

### DIFF
--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -30,7 +30,7 @@ As of now, Companion is integrated to work with:
 Install from NPM:
 
 ```bash
-npm install @uppy/companion
+sudo npm install -g @uppy/companion
 ```
 
 ## Usage


### PR DESCRIPTION
The `companion` command would not work if not install globally