### PR TITLE
Fix Uppy Companion Running on Serverless on AWS Lambda

### DIFF
--- a/packages/@uppy/companion/examples/serverless/index.js
+++ b/packages/@uppy/companion/examples/serverless/index.js
@@ -3,14 +3,12 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-const compression = require('compression')
 const awsServerlessExpress = require('aws-serverless-express')
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
 const uppy = require('@uppy/companion')
 
 const app = express()
 
-app.use(compression())
 app.use(cors())
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))

--- a/packages/@uppy/companion/examples/serverless/serverless.yml
+++ b/packages/@uppy/companion/examples/serverless/serverless.yml
@@ -2,7 +2,7 @@ service: uppyloader
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
   environment:
     # NOTE: Make sure you set this to the url of your service endpoint
@@ -25,7 +25,7 @@ provider:
 
 functions:
   uppy:
-    handler: handler.uppy
+    handler: index.uppy
 
     events:
       - http: ANY /


### PR DESCRIPTION
This should fix these two issues.
#1306
#1192 

Disabling compression should fix #1192 - Doesn't seem worth it to enable it, you can do it using binary mime types.  See [lambda.js](https://github.com/awslabs/aws-serverless-express/blob/master/examples/basic-starter/lambda.js) and [simple-proxy-api.yaml](https://github.com/awslabs/aws-serverless-express/blob/master/examples/basic-starter/simple-proxy-api.yaml).

And #1306 appears to be a naming issue with the target of the [handler function](https://serverless.com/framework/docs/providers/aws/guide/functions/).  It should be
```
functions:
  uppy:
    handler: index.uppy
```
handler: filename.module