### PR TITLE
provider-views: eliminate conflicting file list margin

### DIFF
--- a/packages/@uppy/provider-views/src/style.scss
+++ b/packages/@uppy/provider-views/src/style.scss
@@ -190,8 +190,8 @@
   @include reset-button();
   cursor: pointer;
 
-  &:hover { 
-    text-decoration: underline; 
+  &:hover {
+    text-decoration: underline;
   }
 }
 
@@ -237,6 +237,7 @@
   .uppy-ProviderBrowserItem {
     display: flex;
     padding: 10px 15px;
+    margin: 0;
   }
 
   .uppy-ProviderBrowserItem-checkbox {


### PR DESCRIPTION
maybe @arturi already has a WIP branch for addressing some of these but i noticed this simple fix too :)

in examples/dev, we have a `li { margin: 60px }` declaration that lols the provider view lists. this patch sets the provider view list entries to have 0 margin.

before:

![image](https://user-images.githubusercontent.com/1006268/54526975-c5814f80-4978-11e9-8219-9227aa034971.png)

after:

![image](https://user-images.githubusercontent.com/1006268/54526990-cd40f400-4978-11e9-85e8-02ff052b1354.png)
