### PR TITLE
companion: do not use Uploader instance if options validation failed

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -74,6 +74,10 @@ class Uploader {
     })
   }
 
+  hasError () {
+    return this._errRespMessage != null
+  }
+
   /**
    * returns a substring of the token
    */

--- a/packages/@uppy/companion/src/server/controllers/get.js
+++ b/packages/@uppy/companion/src/server/controllers/get.js
@@ -35,6 +35,12 @@ function get (req, res) {
       headers: body.headers
     })
 
+    if (uploader.hasError()) {
+      const response = uploader.getResponse()
+      res.status(response.status).json(response.body)
+      return
+    }
+
     // wait till the client has connected to the socket, before starting
     // the download, so that the client can receive all download/upload progress.
     logger.debug('Waiting for socket connection before beginning remote download.')

--- a/packages/@uppy/companion/src/server/controllers/url.js
+++ b/packages/@uppy/companion/src/server/controllers/url.js
@@ -61,6 +61,12 @@ const get = (req, res) => {
         headers: req.body.headers
       })
 
+      if (uploader.hasError()) {
+        const response = uploader.getResponse()
+        res.status(response.status).json(response.body)
+        return
+      }
+
       logger.debug('Waiting for socket connection before beginning remote download.')
       uploader.onSocketReady(() => {
         logger.debug('Socket connection received. Starting remote download.')


### PR DESCRIPTION
noticed in #1350, if the validation fails we still try to use the Uploader instance, but it will be in an invalid state (none of the members are populated).

instead, after instantiating an Uploader we need to check if it's valid and respond with the error immediately if it's not.