### PR TITLE
allow customized option to set upload status

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -75,6 +75,14 @@ module.exports = class XHRUpload extends Plugin {
        */
       getResponseError (responseText, response) {
         return new Error('Upload error')
+      },
+      /**
+       * @param {number} status the response status code
+       * @param {string} responseText the response body string
+       * @param {XMLHttpRequest | respObj} response the response object (XHR or similar)
+       */
+      validateStatus (status, responseText, response) {
+        return status >= 200 && status < 300
       }
     }
 
@@ -228,7 +236,7 @@ module.exports = class XHRUpload extends Plugin {
         this.uppy.log(`[XHRUpload] ${id} finished`)
         timer.done()
 
-        if (ev.target.status >= 200 && ev.target.status < 300) {
+        if (opts.validateStatus(ev.target.status, xhr.responseText, xhr)) {
           const body = opts.getResponseData(xhr.responseText, xhr)
           const uploadURL = body[opts.responseUrlFieldName]
 
@@ -403,7 +411,7 @@ module.exports = class XHRUpload extends Plugin {
       xhr.addEventListener('load', (ev) => {
         timer.done()
 
-        if (ev.target.status >= 200 && ev.target.status < 300) {
+        if (this.opts.validateStatus(ev.target.status, xhr.responseText, xhr)) {
           const body = this.opts.getResponseData(xhr.responseText, xhr)
           const uploadResp = {
             status: ev.target.status,

--- a/packages/@uppy/xhr-upload/src/index.test.js
+++ b/packages/@uppy/xhr-upload/src/index.test.js
@@ -34,4 +34,46 @@ describe('XHRUpload', () => {
       })
     })
   })
+
+  describe('validateStatus', () => {
+    it('emit upload error under status code 200', () => {
+      nock('https://fake-endpoint.uppy.io')
+      .defaultReplyHeaders({
+        'access-control-allow-method': 'POST',
+        'access-control-allow-origin': '*'
+      })
+      .options('/').reply(200, {})
+      .post('/').reply(200, {
+        code: 40000,
+        message: 'custom upload error'
+      })
+
+      const core = new Core()
+      const validateStatus = jest.fn(function (status, responseText, response) {
+        return JSON.parse(responseText).code !== 40000
+      })
+
+      core.use(XHRUpload, {
+        id: 'XHRUpload',
+        endpoint: 'https://fake-endpoint.uppy.io',
+        some: 'option',
+        validateStatus,
+        getResponseError (responseText, xhr) {
+          return JSON.parse(responseText).message
+        }
+      })
+      core.addFile({
+        name: 'test.jpg',
+        data: new Blob([Buffer.alloc(8192)])
+      })
+
+      return core.upload().then(result => {
+        expect(validateStatus).toHaveBeenCalled()
+        expect(result.failed.length).toBeGreaterThan(0)
+        result.failed.forEach(file => {
+          expect(file.error).toEqual('custom upload error')
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
I found that the code to determine the upload status is coupled and fixed.

Allowing user to customize the status of upload (still kept its default behavior) makes it more flexible (I actually need this feature badly)

And I also add the unit test, all seems well