### PR TITLE
Show thumbnails instead of a generic icon in Google Drive

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -22,6 +22,12 @@ exports.getItemIcon = (item) => {
   if (item.kind === 'drive#teamDrive') {
     return item.backgroundImageLink + '=w16-h16-n'
   }
+
+  if (item.thumbnailLink) {
+    const smallerThumbnailLink = item.thumbnailLink.replace('s220', 's40')
+    return smallerThumbnailLink
+  }
+
   return item.iconLink
 }
 

--- a/packages/@uppy/provider-views/src/style.scss
+++ b/packages/@uppy/provider-views/src/style.scss
@@ -394,7 +394,6 @@
 .uppy-ProviderBrowserItem-checkbox {
   position: relative;
   display: inline-block;
-  // top: -3px;
   margin-right: 15px;
 }
 

--- a/packages/@uppy/provider-views/src/style.scss
+++ b/packages/@uppy/provider-views/src/style.scss
@@ -262,8 +262,10 @@
 
   .uppy-ProviderBrowserItem-inner img,
   .uppy-ProviderBrowserItem-inner svg {
-    vertical-align: top;
+    vertical-align: middle;
     margin-right: 8px;
+    max-width: 20px;
+    max-height: 20px;
   }
 }
 
@@ -392,7 +394,7 @@
 .uppy-ProviderBrowserItem-checkbox {
   position: relative;
   display: inline-block;
-  top: -3px;
+  // top: -3px;
   margin-right: 15px;
 }
 


### PR DESCRIPTION
Fixes #1162 

Before:

<img width="747" alt="Screen Shot 2019-03-21 at 20 10 43" src="https://user-images.githubusercontent.com/1199054/54771000-70ae3500-4c15-11e9-87cb-e7f243eda7b9.png">

After:

<img width="746" alt="Screen Shot 2019-03-21 at 20 03 17" src="https://user-images.githubusercontent.com/1199054/54770773-fb426480-4c14-11e9-874b-d8fda7e04e30.png">


