### PR TITLE
Updated the callback URIs to reflect their correct location

### DIFF
--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -174,7 +174,7 @@ exports.buildHelpfulStartupMessage = (uppyOptions) => {
       providerName = 'drive'
     }
 
-    callbackURLs.push(buildURL(`/${providerName}/callback`, true))
+    callbackURLs.push(buildURL(`/connect/${providerName}/callback`, true))
   })
 
   return stripIndent`


### PR DESCRIPTION
While trying to setup the companion server, I noticed the callback URIs suggested on the main page are incorrect