### PR TITLE
companion-client: add asyn wrapper around token storage

### DIFF
--- a/packages/@uppy/companion-client/src/tokenStorage.js
+++ b/packages/@uppy/companion-client/src/tokenStorage.js
@@ -1,0 +1,21 @@
+'use strict'
+/**
+ * This module serves as an Async wrapper for LocalStorage
+ */
+module.exports.setItem = (key, value) => {
+  return new Promise((resolve) => {
+    localStorage.setItem(key, value)
+    resolve()
+  })
+}
+
+module.exports.getItem = (key) => {
+  return Promise.resolve(localStorage.getItem(key))
+}
+
+module.exports.removeItem = (key) => {
+  return new Promise((resolve) => {
+    localStorage.removeItem(key)
+    resolve()
+  })
+}


### PR DESCRIPTION
this PR Promisifies token storage, in order to support all kinds of storages (including React Native's Async Storage)