### PR TITLE
Removed a `!` typo that caused the removal of delete buttons (for uploaded files)

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem.js
+++ b/packages/@uppy/dashboard/src/components/FileItem.js
@@ -174,7 +174,7 @@ module.exports = function fileItem (props) {
       </div>
     </div>
     <div class="uppy-DashboardItem-action">
-      {!isUploaded &&
+      {isUploaded &&
         <button class="uppy-DashboardItem-remove"
           type="button"
           aria-label={props.i18n('removeFile')}


### PR DESCRIPTION
Fixes #1216 #1301 #1319 (all unduly closed).