### PR TITLE
Set StatusBar in is-error state when all files have errors

### DIFF
--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -209,8 +209,8 @@ module.exports = class StatusBar extends Plugin {
       completeFiles.length === Object.keys(files).length &&
       processingFiles.length === 0
 
-    const isAllErrored = isUploadStarted &&
-      erroredFiles.length === uploadStartedFiles.length
+    const isAllErrored = Object.keys(files).length > 0 &&
+      erroredFiles.length === Object.keys(files).length
 
     const isAllPaused = inProgressFiles.length !== 0 &&
       pausedFiles.length === inProgressFiles.length


### PR DESCRIPTION
**Problem: clicking retry doesn’t retry the assembly.**

This is not a working solution, but at least it sets the StatusBar in correct `is-error` state when Transloadit assembly fails to start:

<img width="745" alt="Screen Shot 2019-03-05 at 19 06 32" src="https://user-images.githubusercontent.com/1199054/54997956-0400b500-4fde-11e9-9276-4fd21c355ae1.png">

<img width="1069" alt="Screen Shot 2019-03-26 at 15 17 54" src="https://user-images.githubusercontent.com/1199054/54997893-dca9e800-4fdd-11e9-9599-7596d1f041b8.png">

After this PR it will look like this (which can be adjusted ui-wise):

<img width="802" alt="Screen Shot 2019-03-26 at 15 44 46" src="https://user-images.githubusercontent.com/1199054/54998001-22ff4700-4fde-11e9-92f7-de80f7d61c85.png">

