### PR TITLE
Change type on companion from configmap to secret

### DIFF
--- a/packages/@uppy/companion/infra/kube/companion/companion-kube.yaml
+++ b/packages/@uppy/companion/infra/kube/companion/companion-kube.yaml
@@ -50,7 +50,7 @@ spec:
         imagePullPolicy: Always
         name: companion
         envFrom:
-        - configMapRef:
+        - secretRef:
             name: uppy-companion-env
         ports:
         - containerPort: 3020


### PR DESCRIPTION
This PR changes the type of data we store on kubernetes from configmap to a secret which is more suitable. I already applied the change on our secrets repo and kept the configmap which can be deleted after this is merged. 