### PR TITLE
typescript: fix uppy package use with allowSyntheticImports: false

### DIFF
--- a/packages/@uppy/aws-s3-multipart/types/aws-s3-multipart-tests.ts
+++ b/packages/@uppy/aws-s3-multipart/types/aws-s3-multipart-tests.ts
@@ -1,34 +1,34 @@
-import Uppy, { UppyFile } from '@uppy/core';
-import AwsS3Multipart, { AwsS3Part } from '../';
+import Uppy = require('@uppy/core');
+import AwsS3Multipart = require('../');
 
 {
   const uppy = Uppy();
   uppy.use(AwsS3Multipart, {
     createMultipartUpload(file) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
     },
     listParts(file, opts) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
       opts.uploadId // $ExpectType string
       opts.key // $ExpectType string
     },
     prepareUploadPart(file, part) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
       part.uploadId // $ExpectType string
       part.key // $ExpectType string
       part.body // $ExpectType Blob
       part.number // $ExpectType number
     },
     abortMultipartUpload(file, opts) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
       opts.uploadId // $ExpectType string
       opts.key // $ExpectType string
     },
     completeMultipartUpload(file, opts) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
       opts.uploadId // $ExpectType string
       opts.key // $ExpectType string
-      opts.parts[0] // $ExpectType AwsS3Part
+      opts.parts[0] // $ExpectType AwsS3Multipart.AwsS3Part
     },
   });
 }

--- a/packages/@uppy/aws-s3/types/aws-s3-tests.ts
+++ b/packages/@uppy/aws-s3/types/aws-s3-tests.ts
@@ -1,11 +1,11 @@
-import Uppy, { UppyFile } from '@uppy/core';
-import AwsS3 from '../';
+import Uppy = require('@uppy/core');
+import AwsS3 = require('../');
 
 {
   const uppy = Uppy();
   uppy.use(AwsS3, {
     getUploadParameters(file) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
     }
   });
 }

--- a/packages/@uppy/dashboard/types/dashboard-tests.ts
+++ b/packages/@uppy/dashboard/types/dashboard-tests.ts
@@ -1,5 +1,5 @@
-import Uppy from '@uppy/core';
-import Dashboard from '../';
+import Uppy = require('@uppy/core')
+import Dashboard = require('../')
 
 {
   const uppy = Uppy()
@@ -7,7 +7,7 @@ import Dashboard from '../';
     target: 'body'
   })
 
-  const plugin = <Dashboard>uppy.getPlugin('Dashboard')
+  const plugin = uppy.getPlugin('Dashboard') as Dashboard
   plugin.openModal()
   plugin.isModalOpen() // $ExpectType boolean
   plugin.closeModal()

--- a/packages/@uppy/transloadit/types/transloadit-tests.ts
+++ b/packages/@uppy/transloadit/types/transloadit-tests.ts
@@ -1,11 +1,11 @@
-import Uppy, { UppyFile } from '@uppy/core';
-import Transloadit  from '../';
+import Uppy = require('@uppy/core')
+import Transloadit = require('../')
 
 {
-  const uppy = Uppy();
+  const uppy = Uppy()
   uppy.use(Transloadit, {
     getAssemblyOptions(file) {
-      file // $ExpectType UppyFile
+      file // $ExpectType Uppy.UppyFile
     },
     waitForEncoding: false,
     waitForMetadata: true,
@@ -14,40 +14,40 @@ import Transloadit  from '../';
       auth: { key: 'abc' },
       steps: {}
     }
-  });
+  })
 }
 
 {
-  const uppy = Uppy();
+  const uppy = Uppy()
   // $ExpectError
-  uppy.use(Transloadit, { waitForEncoding: null });
+  uppy.use(Transloadit, { waitForEncoding: null })
   // $ExpectError
-  uppy.use(Transloadit, { waitForMetadata: null });
+  uppy.use(Transloadit, { waitForMetadata: null })
 }
 
 {
-  const uppy = Uppy();
+  const uppy = Uppy()
   // $ExpectError
-  uppy.use(Transloadit, { params: {} });
+  uppy.use(Transloadit, { params: {} })
   // $ExpectError
-  uppy.use(Transloadit, { params: { auth: {} } });
+  uppy.use(Transloadit, { params: { auth: {} } })
   // $ExpectError
   uppy.use(Transloadit, {
     params: {
       auth: { key: null }
     }
-  });
+  })
   // $ExpectError
   uppy.use(Transloadit, {
     params: {
       auth: { key: 'abc' },
       steps: 'test'
     }
-  });
+  })
   uppy.use(Transloadit, {
     params: {
       auth: { key: 'abc' },
       steps: { name: {} }
     }
-  });
+  })
 }

--- a/packages/uppy/types/index.d.ts
+++ b/packages/uppy/types/index.d.ts
@@ -1,40 +1,61 @@
-// Type definitions for uppy 0.25.5
+// Type definitions for uppy
 // Project: https://uppy.io
 // Definitions by: taoqf <https://github.com/taoqf>
 
 // Core
-export { default as Core } from '@uppy/core';
+import Core = require('@uppy/core');
+export { Core };
 
 // Stores
 import DefaultStore = require('@uppy/store-default');
-export { DefaultStore };  // this is weird: exporting a function as something that sounds like a class name!
-// do we really mean what the line above says?
-export { default as ReduxStore } from '@uppy/store-redux';
+export { DefaultStore };
+import ReduxStore = require('@uppy/store-redux');
+export { ReduxStore };
 
 // UI plugins
-export { default as Dashboard } from '@uppy/dashboard';
-export { default as DragDrop } from '@uppy/drag-drop';
-export { default as FileInput } from '@uppy/file-input';
-export { default as Informer } from '@uppy/informer';
-export { default as ProgressBar } from '@uppy/progress-bar';
-export { default as StatusBar } from '@uppy/status-bar';
+import Dashboard = require('@uppy/dashboard');
+export { Dashboard };
+import DragDrop = require('@uppy/drag-drop');
+export { DragDrop };
+import FileInput = require('@uppy/file-input');
+export { FileInput };
+import Informer = require('@uppy/informer');
+export { Informer };
+import ProgressBar = require('@uppy/progress-bar');
+export { ProgressBar };
+import StatusBar = require('@uppy/status-bar');
+export { StatusBar };
 
 // Acquirers
-export { default as Dropbox } from '@uppy/dropbox';
-export { default as GoogleDrive } from '@uppy/google-drive';
-export { default as Instagram } from '@uppy/instagram';
-export { default as Url } from '@uppy/url';
-export { default as Webcam } from '@uppy/webcam';
+import Dropbox = require('@uppy/dropbox');
+export { Dropbox };
+import GoogleDrive = require('@uppy/google-drive');
+export { GoogleDrive };
+import Instagram = require('@uppy/instagram');
+export { Instagram };
+import Url = require('@uppy/url');
+export { Url };
+import Webcam = require('@uppy/webcam');
+export { Webcam };
 
 // Uploaders
-export { default as AwsS3 } from '@uppy/aws-s3';
-export { default as AwsS3Multipart } from '@uppy/aws-s3-multipart';
-export { default as Transloadit } from '@uppy/transloadit';
-export { default as Tus } from '@uppy/tus';
-export { default as XHRUpload } from '@uppy/xhr-upload';
+import AwsS3 = require('@uppy/aws-s3');
+export { AwsS3 };
+import AwsS3Multipart = require('@uppy/aws-s3-multipart');
+export { AwsS3Multipart };
+import Transloadit = require('@uppy/transloadit');
+export { Transloadit };
+import Tus = require('@uppy/tus');
+export { Tus };
+import XHRUpload = require('@uppy/xhr-upload');
+export { XHRUpload };
 
 // Miscellaneous
-export { default as Form } from '@uppy/form';
-export { default as GoldenRetriever } from '@uppy/golden-retriever';
-export { default as ReduxDevTools } from '@uppy/redux-dev-tools';
-export { default as ThumbnailGenerator } from '@uppy/thumbnail-generator';
+import Form = require('@uppy/form');
+export { Form };
+import GoldenRetriever = require('@uppy/golden-retriever');
+export { GoldenRetriever };
+import ReduxDevTools = require('@uppy/redux-dev-tools');
+export { ReduxDevTools };
+import ThumbnailGenerator = require('@uppy/thumbnail-generator');
+export { ThumbnailGenerator };

--- a/test/endtoend/typescript/main.ts
+++ b/test/endtoend/typescript/main.ts
@@ -1,18 +1,20 @@
 import 'es6-promise/auto'
 import 'whatwg-fetch'
-import Uppy = require('@uppy/core')
-import Dashboard = require('@uppy/dashboard')
-import Instagram = require('@uppy/instagram')
-import Dropbox = require('@uppy/dropbox')
-import GoogleDrive = require('@uppy/google-drive')
-import Url = require('@uppy/url')
-import Webcam = require('@uppy/webcam')
-import Tus = require('@uppy/tus')
-import Form = require('@uppy/form')
+import {
+  Core,
+  Dashboard,
+  Instagram,
+  Dropbox,
+  GoogleDrive,
+  Url,
+  Webcam,
+  Tus,
+  Form
+} from 'uppy'
 
 const TUS_ENDPOINT = 'https://master.tus.io/files/'
 
-const uppy = Uppy({
+const uppy = Core({
   debug: true,
   meta: {
     username: 'John',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "types": [],
     "noEmit": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
Synthetic default imports allow you to `import X from 'x'` if `'x'` is a
CommonJS module. Our `uppy` package relied on that (probably forgot to
update it in a previous patch). If users had set
`allowSyntheticDefaultImports: false`, they would not be able to use the
`uppy` package.

We should at some point go through the typings again and set everything to
the tightest options, because that'll work with the widest array of users,
but for now let's just unbreak this particular case.

Fixes #1395