### PR TITLE
Dashboard Plugin: made list items even out

### DIFF
--- a/packages/@uppy/dashboard/src/components/Dashboard.js
+++ b/packages/@uppy/dashboard/src/components/Dashboard.js
@@ -35,6 +35,7 @@ module.exports = function Dashboard (props) {
     { 'uppy-Dashboard--modal': !props.inline },
     { 'uppy-size--md': props.containerWidth > 576 },
     { 'uppy-size--lg': props.containerWidth > 700 },
+    { 'uppy-size--xl': props.containerWidth > 900 },
     { 'uppy-Dashboard--isAddFilesPanelVisible': props.showAddFilesPanel },
     { 'uppy-Dashboard--isInnerWrapVisible': props.areInsidesReadyToBeVisible }
   )

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -620,17 +620,29 @@ a.uppy-Dashboard-poweredBy {
   padding-bottom: 10px;
   padding-left: 10px;
 
+  $rl-margin: 15px;
   .uppy-size--md & {
-    flex-direction: column;
     float: left;
-    width: 140px;
+    margin: 5px $rl-margin;
+    width: calc(33.333% - #{$rl-margin} - #{$rl-margin});
     height: 170px;
-    margin: 5px 15px;
-    border: 0;
+
+    flex-direction: column;
     background-color: initial;
+    border: 0;
     border-bottom: none;
     padding-bottom: 0;
     padding-left: 0;
+  }
+
+  .uppy-size--lg & {
+    width: calc(25% - #{$rl-margin} - #{$rl-margin});
+    height: 190px;
+  }
+
+  .uppy-size--xl & {
+    width: calc(20% - #{$rl-margin} - #{$rl-margin});
+    height: 210px;
   }
 }
 
@@ -647,6 +659,14 @@ a.uppy-Dashboard-poweredBy {
     width: 100%;
     height: 100px;
     border: 0;
+  }
+
+  .uppy-size--lg & {
+    height: 120px;
+  }
+
+  .uppy-size--xl & {
+    height: 140px;
   }
 }
 


### PR DESCRIPTION
___Why not just use `justify-content: space-between`?
Because making the last row items flock to the left side tends to be a trouble, solutions would be either not very browser-compatible, or would include some Js.