### PR TITLE
tus: fix cannot start more uploads after cancel

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -206,6 +206,7 @@ module.exports = class Tus extends Plugin {
 
       this.onCancelAll(file.id, () => {
         this.resetUploaderReferences(file.id)
+        resolve(`upload ${file.id} was canceled`)
       })
 
       this.onResumeAll(file.id, () => {


### PR DESCRIPTION
This fixes an issue that occurs when using tus and the limit option to limit the number of parallel uploads.
When you cancel the current uploads, you can't start new uploads after adding new files.

This is because the queue in limitPromises is not emptied on cancel,
due to the upload promise not being resolved or rejected on cancel.

This fixes the issue.