### PR TITLE
Issue a warning if an outdated `serverUrl` or `serverPattern` option is used

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -74,6 +74,10 @@ module.exports = class Provider extends RequestClient {
       plugin.opts = Object.assign({}, defaultOpts, opts)
     }
 
+    if (opts.serverUrl || opts.serverPattern) {
+      throw new Error('`serverUrl` and `serverPattern` have been renamed to `companionUrl` and `companionAllowedHosts` respectively in 0.30.5 release. Please consult the docs (for example, https://uppy.io/docs/instagram/ for Instagram plugin) and use the updated options.`')
+    }
+
     if (opts.companionAllowedHosts) {
       const pattern = opts.companionAllowedHosts
       // validate companionAllowedHosts param


### PR DESCRIPTION
<img width="1230" alt="Screen Shot 2019-04-18 at 15 02 13" src="https://user-images.githubusercontent.com/1199054/56359715-00320e00-61eb-11e9-972b-94bd57964773.png">
