### PR TITLE
Fix border colors

### DIFF
--- a/packages/@uppy/core/src/_variables.scss
+++ b/packages/@uppy/core/src/_variables.scss
@@ -14,8 +14,9 @@ $blue: #2275d7 !default;
 
 $gray-50: #fafafa !default;
 $gray-100: #f4f4f4 !default;
-$gray-100--highlighted: #f1f3f6;
+$gray-100--highlighted: #f1f3f6 !default;
 $gray-200: #eaeaea !default;
+$gray-250: #dfdfdf !default;
 $gray-300: #cfcfcf !default;
 $gray-400: #bbb !default;
 $gray-500: #939393 !default;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -119,7 +119,7 @@
   // min-height: 450px is required for everything to fit on mobile
   min-height: 450px;
   outline: none;
-  border: 1px solid $gray-100;
+  border: 1px solid $gray-250;
   border-radius: 5px;
 
   .uppy-size--md & {
@@ -192,12 +192,16 @@
   position: relative;
   text-align: center;
   flex: 1;
-  margin: 8px;
-  border: 1px dashed $gray-300;
+  margin: 7px;
+  border: 1px dashed $gray-250;
   border-radius: 3px;
 
   .uppy-Dashboard-AddFilesPanel & {
     border: none;
+  }
+
+  .uppy-Dashboard--modal & {
+    border-color: $gray-300;
   }
 }
 
@@ -572,13 +576,13 @@
   justify-content: center;
   visibility: hidden;
   position: absolute;
-  top: 3px;
-  right: 3px;
-  bottom: 3px;
-  left: 3px;
+  top: 7px;
+  right: 7px;
+  bottom: 7px;
+  left: 7px;
   padding-top: 90px;
-  border: 2px dashed rgb(34, 117, 215);
-  border-radius: 4px;
+  border: 1px dashed $blue;
+  border-radius: 3px;
   z-index: 2000;
   text-align: center;
   background-image: url("data:image/svg+xml,%3Csvg width='48' height='48' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24 1v1C11.85 2 2 11.85 2 24s9.85 22 22 22 22-9.85 22-22S36.15 2 24 2V1zm0 0V0c13.254 0 24 10.746 24 24S37.254 48 24 48 0 37.254 0 24 10.746 0 24 0v1zm7.707 19.293a.999.999 0 1 1-1.414 1.414L25 16.414V34a1 1 0 1 1-2 0V16.414l-5.293 5.293a.999.999 0 1 1-1.414-1.414l7-7a.999.999 0 0 1 1.414 0l7 7z' fill='%232275D7' fill-rule='nonzero'/%3E%3C/svg%3E");
@@ -595,7 +599,7 @@
   .uppy-DashboardContent-bar,
   .uppy-Dashboard-files,
   .uppy-Dashboard-progressindicators {
-    opacity: 0.2;
+    opacity: 0.15;
   }
   .uppy-DashboardAddFiles {
     opacity: 0.03;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -119,7 +119,7 @@
   // min-height: 450px is required for everything to fit on mobile
   min-height: 450px;
   outline: none;
-  border: 1px solid $gray-250;
+  border: 1px solid $gray-200;
   border-radius: 5px;
 
   .uppy-size--md & {


### PR DESCRIPTION
## Changes

1. Fixed a problem when the outer border color was too bright:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/375537/56364793-1f836800-61f8-11e9-8372-120b5a53cacd.png">

2. Harmonized the dashed borders: that we have by default and that we have when dragging some file(s).

## Preview

<img width="828" alt="Screen Shot 2019-04-18 at 16 38 53" src="https://user-images.githubusercontent.com/375537/56365029-a46e8180-61f8-11e9-889a-38ba2b008ce9.png">

<img width="839" alt="Screen Shot 2019-04-18 at 16 39 02" src="https://user-images.githubusercontent.com/375537/56365033-a7697200-61f8-11e9-8e7f-40e33a3c8a2f.png">

<img width="771" alt="Screen Shot 2019-04-18 at 16 39 46" src="https://user-images.githubusercontent.com/375537/56365043-a9333580-61f8-11e9-96a2-54c1256a0234.png">
