### PR TITLE
Don’t show informer for an auth error

### DIFF
--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -453,7 +453,10 @@ module.exports = class ProviderView {
   handleError (error) {
     const uppy = this.plugin.uppy
     uppy.log(error.toString())
-    const message = uppy.i18n(error.isAuthError ? 'companionAuthError' : 'companionError')
+    if (error.isAuthError) {
+      return
+    }
+    const message = uppy.i18n('companionError')
     uppy.info({message: message, details: error.toString()}, 'error', 5000)
   }
 


### PR DESCRIPTION
I wondered if there’s a simple solution, and this seems to work! So maybe it’s less complex than we anticipated, or am I missing something @ifedapoolarewaju? Auth error informer is not shown, while other errors are.

https://github.com/transloadit/uppy/issues/1425