### PR TITLE
pin preact to 8.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,9 +1651,9 @@
       }
     },
     "@types/cors": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.4.tgz",
-      "integrity": "sha512-ipZjBVsm2tF/n8qFGOuGBkUij9X9ZswVi9G3bx/6dz7POpVa6gVHcj1wsX/LVEn9MMF41fxK/PnZPPoTD1UFPw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-GmK8AKu8i+s+EChK/uZ5IbrXPcPaQKWaNSGevDT/7o3gFObwSUQwqb1jMqxuo+YPvj0ckGzINI+EO7EHcmJjKg==",
       "requires": {
         "@types/express": "*"
       }
@@ -1669,9 +1669,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.3.tgz",
-      "integrity": "sha512-HFgBmRDTvdnrRFXqBr2NM2NUCu6fIpzJsUTlRVENF8lxvstof7cl9Fxfwq5S0kJbO/FsPVcjlxpOM3ZxIkn7Rw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.4.tgz",
+      "integrity": "sha512-x/8h6FHm14rPWnW2HP5likD/rsqJ3t/77OWx2PLxym0hXbeBWQmcPyHmwX+CtCQpjIfgrUdEoDFcLPwPZWiqzQ==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -9017,7 +9017,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9038,12 +9039,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9058,17 +9061,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9185,7 +9191,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9197,6 +9204,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9211,6 +9219,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9218,12 +9227,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9242,6 +9253,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9322,7 +9334,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9334,6 +9347,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9419,7 +9433,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9455,6 +9470,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9474,6 +9490,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9517,12 +9534,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -14329,9 +14348,9 @@
       }
     },
     "nodemon": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.11.tgz",
-      "integrity": "sha512-KdN3tm1zkarlqNo4+W9raU3ihM4H15MVMSE/f9rYDZmFgDHAfAJsomYrHhApAkuUemYjFyEeXlpCOQ2v5gtBEw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.0.tgz",
+      "integrity": "sha512-NHKpb/Je0Urmwi3QPDHlYuFY9m1vaVfTsRZG5X73rY46xPj0JpNe8WhUGQdkDXQDOxrBNIU3JrcflE9Y44EcuA==",
       "requires": {
         "chokidar": "^2.1.5",
         "debug": "^3.1.0",
@@ -18202,9 +18221,9 @@
       }
     },
     "preact": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.4.2.tgz",
-      "integrity": "sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A=="
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA=="
     },
     "preact-css-transition-group": {
       "version": "1.3.0",
@@ -22225,11 +22244,11 @@
       }
     },
     "url-parse": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
-      "integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -26,7 +26,7 @@
     "lodash.throttle": "^4.1.1",
     "mime-match": "^1.0.2",
     "namespace-emitter": "^2.0.1",
-    "preact": "^8.2.9",
+    "preact": "8.2.9",
     "prettier-bytes": "^1.0.4"
   }
 }

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -31,7 +31,7 @@
     "cuid": "^2.1.1",
     "drag-drop": "2.13.3",
     "lodash.throttle": "^4.1.1",
-    "preact": "^8.2.9",
+    "preact": "8.2.9",
     "preact-css-transition-group": "^1.3.0",
     "prettier-bytes": "^1.0.4",
     "resize-observer-polyfill": "^1.5.0"

--- a/packages/@uppy/drag-drop/package.json
+++ b/packages/@uppy/drag-drop/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@uppy/utils": "0.30.5",
     "drag-drop": "2.13.3",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/dropbox/package.json
+++ b/packages/@uppy/dropbox/package.json
@@ -23,7 +23,7 @@
     "@uppy/companion-client": "1.0.0",
     "@uppy/provider-views": "1.0.0",
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/file-input/package.json
+++ b/packages/@uppy/file-input/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/google-drive/package.json
+++ b/packages/@uppy/google-drive/package.json
@@ -24,7 +24,7 @@
     "@uppy/companion-client": "1.0.0",
     "@uppy/provider-views": "1.0.0",
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/informer/package.json
+++ b/packages/@uppy/informer/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/instagram/package.json
+++ b/packages/@uppy/instagram/package.json
@@ -26,7 +26,7 @@
     "@uppy/companion-client": "1.0.0",
     "@uppy/provider-views": "1.0.0",
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/progress-bar/package.json
+++ b/packages/@uppy/progress-bar/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/provider-views/package.json
+++ b/packages/@uppy/provider-views/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@uppy/utils": "0.30.5",
     "classnames": "^2.2.6",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/status-bar/package.json
+++ b/packages/@uppy/status-bar/package.json
@@ -29,7 +29,7 @@
     "@uppy/utils": "0.30.5",
     "classnames": "^2.2.6",
     "lodash.throttle": "^4.1.1",
-    "preact": "^8.2.9",
+    "preact": "8.2.9",
     "prettier-bytes": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/@uppy/url/package.json
+++ b/packages/@uppy/url/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@uppy/companion-client": "1.0.0",
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"

--- a/packages/@uppy/webcam/package.json
+++ b/packages/@uppy/webcam/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@uppy/utils": "0.30.5",
-    "preact": "^8.2.9"
+    "preact": "8.2.9"
   },
   "devDependencies": {
     "@uppy/core": "1.0.0"


### PR DESCRIPTION
Webpack likes to pick the ES module versions of modules over CJS
versions. So, if we do `require('preact')`, we can get the ES module
version of it. preact in version 8.3.0 switched its file extension
from `.esm.js` to `.mjs`, which in webpack's default configuration meant
the module implementation became much stricter. The result is that we
get a different value in `require('preact')`.

This older version of preact doesn't use `.mjs` yet so we can safely
`require('preact')` it in webpack. It still picks the ESM version, but
now it uses the looser implementation which is interchangeable for our
purposes.