### PR TITLE
Fix wrong destination anchor link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,7 @@ npm run bootstrap
 
 We use lerna to manage the many plugin packages Uppy has. You should always do `npm run bootstrap` after an `npm install` to make sure lerna has installed the dependencies of each package and that the `package-lock.json` in the repository root is up to date.
 
-Our website’s examples section is also our playground, please read the [Local Previews](#Local-Previews) section to get up and running.
+Our website’s examples section is also our playground, please read the [Local Previews](#Local-previews) section to get up and running.
 
 ## Tests
 


### PR DESCRIPTION
URL: https://uppy.io/docs/contributing.html

The generated `id` for the `Local previews` `h3` element is `Local-previews`.

The anchor linking to that element was looking for `Local-Previews` (capital P), and thus wasn't scrolling to the element.