### PR TITLE
correct info on blog post about older Uppy server version

### DIFF
--- a/website/src/_posts/2017-10-0.21.md
+++ b/website/src/_posts/2017-10-0.21.md
@@ -60,7 +60,7 @@ We’ve refactored end to end tests to use [Webdriver.io](http://webdriver.io), 
 
 ## More secure Uppy Server
 
-We made sure access tokens from third-party providers, such as Google Drive or Instagram, are not stored on the server with Uppy Server, and kept in your browser instead. Then, when you want to pick a file from your Instagram, the token is used to make a request. Even though they live on the browser, these tokens are encrypted with JWT on the server side, before they are being sent to the client. So they can only be decrypted and understood on the server side.
+We made sure access tokens from third-party providers, such as Google Drive or Instagram, are not stored on the server with Uppy Server, and kept in your browser instead. Then, when you want to pick a file from your Instagram, the token is used to make a request to Uppy Server, which is in turn used by Uppy Server to communicate with Instagram.
 
 Data validation is also now done during intiation of an upload, to prevent corrupt data from triggering funny behaviours on the server. :)
 


### PR DESCRIPTION
At the time of this release, the tokens were not being encrypted. This information was falsely added because I thought JWT encrypts its tokens before it was eventually brought to my attention by @goto-bus-stop that this was not the case. It is in subsequent versions that an actual encryption was implemented.
