### PR TITLE
Update AWS S3 Multipart documentation wrt CORS settings

### DIFF
--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -126,14 +126,16 @@ S3 buckets do not allow public uploads by default.  In order to allow Uppy to up
 
 This process is described in the [AwsS3 documentation](/docs/aws-s3/#S3-Bucket-configuration).
 
-On top of the configuration mentioned there, the `ETag` header must also be whitelisted:
+While the Uppy AWS S3 plugin uses `POST` requests while uploading files to an S3 bucket, the AWS S3 Multipart plugin uses `PUT` requests when uploading file parts. Additionally, the `ETag` header must also be whitelisted:
 
 ```xml
 <CORSRule>
+  <!-- Change from POST to PUT if you followed the docs for the AWS S3 plugin ... -->
   <AllowedMethod>PUT</AllowedMethod>
-  <!-- ... all your existingCORS config goes here ... -->
+  
+  <!-- ... keep the existing MaxAgeSeconds and AllowedHeader lines and your other stuff ... -->
 
-  <!-- The magic: -->
+  <!-- ... and don't forget to add this tag. -->
   <ExposeHeader>ETag</ExposeHeader>
 </CORSRule>
 ```


### PR DESCRIPTION
Blame it on me, but because the documentation only talked about the additional `ExposeHeader` tag for the `ETag` header, I honestly believed that the `<AllowedMethod>PUT</AllowedMethod>` was a mistake and that the allowed method must be `POST`, as with the "normal" S3 upload. I'm thus proposing to change the documentation to make it crystal clear.