### PR TITLE
companion: remove default upload protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ PRs are welcome! Please do open an issue to discuss first if it's a big feature,
 - [x] @uppy/companion: investigate 423 and 500 issues with React Native + Url plugin when pause/resuming an upload
 - [x] dashboard: Bring back "Drop Here" screen for dragged URLs without introducing flickering (tricky! see PR #1400)
 - [x] companion: remove deprecated "authorized" endpoint
+- [x] companion: remove default upload protocol
 
 ## 1.0 Goals
 

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -157,8 +157,7 @@ class Uploader {
    * @param {Buffer | Buffer[]} chunk
    */
   handleChunk (chunk) {
-    // @todo a default protocol should not be set. We should ensure that the user specifies her protocol.
-    const protocol = this.options.protocol || PROTOCOLS.multipart
+    const protocol = this.options.protocol
 
     // The download has completed; close the file and start an upload if necessary.
     if (chunk === null) {

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -93,6 +93,11 @@ class Uploader {
    * @returns {boolean}
    */
   validateOptions (options) {
+    if (!Object.keys(PROTOCOLS).some((key) => PROTOCOLS[key] === options.protocol)) {
+      this._errRespMessage = 'Invalid upload protocol'
+      return false
+    }
+
     // s3 uploads don't require upload destination
     // validation, because the destination is determined
     // by the server's s3 config

--- a/packages/@uppy/companion/test/__tests__/companion.js
+++ b/packages/@uppy/companion/test/__tests__/companion.js
@@ -63,6 +63,17 @@ describe('download provdier file', () => {
       .expect(200)
       .then((res) => expect(res.body.token).toBeTruthy())
   })
+
+  test('download should fail if protocol is not specified', () => {
+    return request(authServer)
+      .post('/drive/get/README.md')
+      .set('uppy-auth-token', token)
+      .set('Content-Type', 'application/json')
+      .send({
+        endpoint: 'http://master.tus.com/files'
+      })
+      .expect(400)
+  })
 })
 
 describe('test authentication', () => {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -324,6 +324,7 @@ module.exports = class XHRUpload extends Plugin {
         file.remote.url,
         Object.assign({}, file.remote.body, {
           endpoint: opts.endpoint,
+          protocol: 'multipart',
           size: file.data.size,
           fieldname: opts.fieldName,
           metadata: fields,


### PR DESCRIPTION
submitting this as a PR in case there is an uploader on Uppy client which relies on the default protocol to be set on companion's end. cc @arturi @goto-bus-stop 