### PR TITLE
Corrects path logging

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -248,7 +248,7 @@ module.exports = class XHRUpload extends Plugin {
           this.uppy.emit('upload-success', file, uploadResp)
 
           if (uploadURL) {
-            this.uppy.log(`Download ${file.name} from ${file.uploadURL}`)
+            this.uppy.log(`Download ${file.name} from ${uploadURL}`)
           }
 
           return resolve(file)


### PR DESCRIPTION
Pretty simple one, check is made for "uploadURL" and log is called with "file.uploadURL", which returns undefined. I've fixed it.