### PR TITLE
Do not extract keys from empty `fields`.

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -138,7 +138,7 @@ module.exports = class AwsS3 extends Plugin {
           method,
           formData: method.toLowerCase() === 'post',
           endpoint: url,
-          metaFields: Object.keys(fields)
+          metaFields: fields ? Object.keys(fields) : []
         }
 
         if (headers) {


### PR DESCRIPTION
Per documentation at https://uppy.io/docs/aws-s3/, `fields` can be empty. 
"For presigned PUT uploads, this should be left empty."

Adding a safety check before attempting to extract keys.