### PR TITLE
@uppy/dashboard - made added-files previews look more proportional

### DIFF
--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -675,7 +675,7 @@ a.uppy-Dashboard-poweredBy {
     float: left;
     margin: 5px $rl-margin;
     width: calc(33.333% - #{$rl-margin} - #{$rl-margin});
-    height: 190px;
+    height: 200px;
 
     flex-direction: column;
     background-color: initial;
@@ -686,6 +686,7 @@ a.uppy-Dashboard-poweredBy {
   }
 
   .uppy-size--lg & {
+    margin: 5px $rl-margin;
     width: calc(25% - #{$rl-margin} - #{$rl-margin});
     height: 190px;
   }
@@ -707,7 +708,7 @@ a.uppy-Dashboard-poweredBy {
 
   .uppy-size--md & {
     width: 100%;
-    height: 129px;
+    height: 139px;
     border: 0;
   }
 

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -675,7 +675,7 @@ a.uppy-Dashboard-poweredBy {
     float: left;
     margin: 5px $rl-margin;
     width: calc(33.333% - #{$rl-margin} - #{$rl-margin});
-    height: 216px;
+    height: 215px;
 
     flex-direction: column;
     background-color: initial;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -675,7 +675,7 @@ a.uppy-Dashboard-poweredBy {
     float: left;
     margin: 5px $rl-margin;
     width: calc(33.333% - #{$rl-margin} - #{$rl-margin});
-    height: 170px;
+    height: 190px;
 
     flex-direction: column;
     background-color: initial;
@@ -707,7 +707,7 @@ a.uppy-Dashboard-poweredBy {
 
   .uppy-size--md & {
     width: 100%;
-    height: 100px;
+    height: 129px;
     border: 0;
   }
 

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -709,7 +709,7 @@ a.uppy-Dashboard-poweredBy {
 
   .uppy-size--md & {
     width: 100%;
-    height: 152px;
+    height: 140px;
     border: 0;
   }
 

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -675,7 +675,7 @@ a.uppy-Dashboard-poweredBy {
     float: left;
     margin: 5px $rl-margin;
     width: calc(33.333% - #{$rl-margin} - #{$rl-margin});
-    height: 200px;
+    height: 216px;
 
     flex-direction: column;
     background-color: initial;
@@ -702,13 +702,14 @@ a.uppy-Dashboard-poweredBy {
   height: 50px;
   border-bottom: 0;
   position: relative;
+  flex-shrink: 0;
   display: flex;
   justify-content: center;
   align-items: center;
 
   .uppy-size--md & {
     width: 100%;
-    height: 139px;
+    height: 152px;
     border: 0;
   }
 


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/7578559/58216148-8d9add80-7d16-11e9-956c-bd5373f12412.png)

Now:
![image](https://user-images.githubusercontent.com/7578559/58216155-a0151700-7d16-11e9-91ae-f32c879e4447.png)