### PR TITLE
Docs > Custom Stores > Fix store source link

### DIFF
--- a/website/src/docs/stores.md
+++ b/website/src/docs/stores.md
@@ -142,4 +142,4 @@ function defaultStore () {
 
 A pattern like this, where users can pass options via a function call if necessary, is recommended.
 
-See the [./src/store](https://github.com/transloadit/uppy/tree/master/src/store) folder in the repository for more inspiration.
+See the [./src/store](https://github.com/transloadit/uppy/tree/master/packages/%40uppy/store-default) folder in the repository for more inspiration.

--- a/website/src/docs/stores.md
+++ b/website/src/docs/stores.md
@@ -142,4 +142,4 @@ function defaultStore () {
 
 A pattern like this, where users can pass options via a function call if necessary, is recommended.
 
-See the [./src/store](https://github.com/transloadit/uppy/tree/master/packages/%40uppy/store-default) folder in the repository for more inspiration.
+See the [@uppy/store-default](https://github.com/transloadit/uppy/tree/master/packages/%40uppy/store-default) package for more inspiration.


### PR DESCRIPTION
Docs > Custom Stores > Implementing Stores
link to store-default at the bottom of the page was outdated/broken.
Update to new store-default location in packages/@uppy/src/store-default.