### PR TITLE
informer: Remove color-related code and docs

### DIFF
--- a/packages/@uppy/informer/src/index.js
+++ b/packages/@uppy/informer/src/index.js
@@ -16,26 +16,7 @@ module.exports = class Informer extends Plugin {
     this.title = 'Informer'
 
     // set default options
-    const defaultOptions = {
-      typeColors: {
-        info: {
-          text: '#fff',
-          bg: '#000'
-        },
-        warning: {
-          text: '#fff',
-          bg: '#F6A623'
-        },
-        error: {
-          text: '#fff',
-          bg: '#D32F2F'
-        },
-        success: {
-          text: '#fff',
-          bg: '#1BB240'
-        }
-      }
-    }
+    const defaultOptions = {}
 
     // merge default options with the ones set by user
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -45,10 +26,6 @@ module.exports = class Informer extends Plugin {
 
   render (state) {
     const { isHidden, message, details } = state.info
-    // const style = {
-    //   backgroundColor: this.opts.typeColors[type].bg,
-    //   color: this.opts.typeColors[type].text
-    // }
 
     return (
       <div class="uppy uppy-Informer"

--- a/website/src/docs/informer.md
+++ b/website/src/docs/informer.md
@@ -64,21 +64,6 @@ A unique identifier for this plugin. It defaults to `'Informer'`. Use this if yo
 
 DOM element, CSS selector, or plugin to mount the Informer into.
 
-### `typeColors: {}`
-
-Customize the background and foreground colors for different types of notifications. Supported types are `info`, `warning`, `error`, and `success`. To customize colors, pass an object containing `{ bg, text }` color pairs for each type of notification:
-
-```js
-uppy.use(Informer, {
-  typeColors: {
-    info:    { text: '#fff', bg: '#000000' },
-    warning: { text: '#fff', bg: '#f6a623' },
-    error:   { text: '#fff', bg: '#e74c3c' },
-    success: { text: '#fff', bg: '#7ac824' }
-  }
-})
-```
-
 ### `replaceTargetContent: false`
 
 Remove all children of the `target` element before mounting the Informer. By default, Uppy will append any UI to the `target` DOM element. This is the least dangerous option. However, you may have some fallback HTML inside the `target` element in case JavaScript or Uppy is not available. In that case, you can set `replaceTargetContent: true` to clear the `target` before appending.

--- a/website/src/docs/informer.md
+++ b/website/src/docs/informer.md
@@ -9,6 +9,8 @@ category: 'UI Elements'
 
 The `@uppy/informer` plugin is a pop-up bar for showing notifications. When plugins have some exciting news (or error) to share, they can show a notification here.
 
+Informer gets its data from `uppy.state.info`, which is updated by various plugins via [`uppy.info`](https://uppy.io/docs/uppy/#uppy-info) method.
+
 ```js
 const Informer = require('@uppy/informer')
 


### PR DESCRIPTION
Informer has adopted black and white lifestyle quite a while ago, this removes information about color options and related code.