### PR TITLE
Fix(1607): Add remote-url to emit-success

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -480,7 +480,8 @@ class Uploader {
       if (error) {
         this.emitError(error)
       } else {
-        this.emitSuccess(null, {
+        const url = data && data.Location ? data.Location : null;
+        this.emitSuccess(url, {
           response: {
             responseText: JSON.stringify(data),
             headers: {

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -480,7 +480,7 @@ class Uploader {
       if (error) {
         this.emitError(error)
       } else {
-        const url = data && data.Location ? data.Location : null;
+        const url = data && data.Location ? data.Location : null
         this.emitSuccess(url, {
           response: {
             responseText: JSON.stringify(data),


### PR DESCRIPTION
S3 stores the remote-url of the newly stored file in the `Location`-property of the response. Use it as remote-url-param.

Fixes https://github.com/transloadit/uppy/issues/1607