### PR TITLE
Progress fixes for unsized files

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -245,7 +245,7 @@ class Uploader {
    * @see emitProgress
    * @param {number=} bytesUploaded the bytes actually Uploaded so far
    */
-  emitIllusiveProgress (bytesUploaded) {
+  emitIllusiveProgress (bytesUploaded = 0) {
     if (this._paused) {
       return
     }
@@ -254,7 +254,6 @@ class Uploader {
     if (!this.streamsEnded) {
       bytesTotal = Math.max(bytesTotal, this.bytesWritten)
     }
-    bytesUploaded = bytesUploaded || 0
     // for a 10MB file, 10MB of download will account for 5MB upload progress
     // and 10MB of actual upload will account for the other 5MB upload progress.
     const illusiveBytesUploaded = (this.bytesWritten / 2) + (bytesUploaded / 2)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -649,7 +649,7 @@ class Uppy {
         percentage: canHavePercentage
           // TODO(goto-bus-stop) flooring this should probably be the choice of the UI?
           // we get more accurate calculations if we don't round this at all.
-          ? Math.floor(data.bytesUploaded / data.bytesTotal * 100)
+          ? Math.round(data.bytesUploaded / data.bytesTotal * 100)
           : 0
       })
     })
@@ -676,7 +676,7 @@ class Uppy {
     const unsizedFiles = inProgress.filter((file) => file.progress.bytesTotal == null)
 
     if (sizedFiles.length === 0) {
-      const progressMax = inProgress.length
+      const progressMax = inProgress.length * 100
       const currentProgress = unsizedFiles.reduce((acc, file) => {
         return acc + file.progress.percentage
       }, 0)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -696,7 +696,7 @@ class Uppy {
       uploadedSize += file.progress.bytesUploaded
     })
     unsizedFiles.forEach((file) => {
-      uploadedSize += averageSize * (file.progress.percentage || 0)
+      uploadedSize += averageSize * (file.progress.percentage || 0) / 100
     })
 
     let totalProgress = totalSize === 0

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -1073,7 +1073,7 @@ describe('src/Core', () => {
       core.close()
     })
 
-    it('should calculate the total progress', () => {
+    it('should estimate progress for unsized files', () => {
       const core = new Core()
 
       core.once('file-added', (file) => {

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -987,7 +987,7 @@ describe('src/Core', () => {
         bytesTotal: 17175
       })
       expect(core.getFile(fileId).progress).toEqual({
-        percentage: 71,
+        percentage: 72,
         bytesUploaded: 12345,
         bytesTotal: 17175,
         uploadComplete: false,
@@ -1052,8 +1052,10 @@ describe('src/Core', () => {
       expect(core.getFiles()[0].progress).toMatchObject({
         bytesUploaded: 1234,
         bytesTotal: 3456,
-        percentage: 35
+        percentage: 36
       })
+
+      expect(core.getState().totalProgress).toBe(36)
 
       finishUpload()
       // wait for success event
@@ -1067,6 +1069,47 @@ describe('src/Core', () => {
       })
 
       await uploadPromise
+
+      core.close()
+    })
+
+    it('should calculate the total progress', () => {
+      const core = new Core()
+
+      core.once('file-added', (file) => {
+        core.emit('upload-started', file)
+        core.emit('upload-progress', file, {
+          bytesTotal: 3456,
+          bytesUploaded: 1234
+        })
+      })
+      core.addFile({
+        source: 'instagram',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: {}
+      })
+
+      core.once('file-added', (file) => {
+        core.emit('upload-started', file)
+        core.emit('upload-progress', file, {
+          bytesTotal: null,
+          bytesUploaded: null
+        })
+      })
+      core.addFile({
+        source: 'instagram',
+        name: 'bar.jpg',
+        type: 'image/jpeg',
+        data: {}
+      })
+
+      core._calculateTotalProgress()
+
+      // foo.jpg at 35%, bar.jpg at 0%
+      expect(core.getState().totalProgress).toBe(18)
+
+      core.close()
     })
 
     it('should calculate the total progress of all file uploads', () => {


### PR DESCRIPTION
The 1203% issue was caused by some mixed up `/ 100` and `* 100`s.

The test is incomplete :hankey: 