### PR TITLE
xhr-upload: Set type and name from file.meta, re-create blob

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -21,6 +21,19 @@ function buildResponseError (xhr, error) {
   return error
 }
 
+/**
+ * Set `data.type` in the blob to `file.meta.type`,
+ * because we might have detected a more accurate file type in Uppy
+ * https://stackoverflow.com/a/50875615
+ *
+ * @param {Object} file File object with `data`, `size` and `meta` properties
+ * @return {Object} blob updated with the new `type` set from `file.meta.type`
+ */
+function setTypeInBlob (file) {
+  const dataWithUpdatedType = file.data.slice(0, file.data.size, file.meta.type)
+  return dataWithUpdatedType
+}
+
 module.exports = class XHRUpload extends Plugin {
   constructor (uppy, opts) {
     super(uppy, opts)
@@ -180,26 +193,18 @@ module.exports = class XHRUpload extends Plugin {
       formPost.append(item, file.meta[item])
     })
 
-    // Set `file.data.type` in the blob to `file.meta.type`,
-    // because we might have detected a more accurate file type in Uppy
-    // https://stackoverflow.com/a/50875615
-    file.data = file.data.slice(0, file.data.size, file.meta.type)
+    const dataWithUpdatedType = setTypeInBlob(file)
 
     if (file.name) {
-      formPost.append(opts.fieldName, file.data, file.meta.name)
+      formPost.append(opts.fieldName, dataWithUpdatedType, file.meta.name)
     } else {
-      formPost.append(opts.fieldName, file.data)
+      formPost.append(opts.fieldName, dataWithUpdatedType)
     }
 
     return formPost
   }
 
   createBareUpload (file, opts) {
-    // Set `file.data.type` in the blob to `file.meta.type`,
-    // because we might have detected a more accurate file type in Uppy
-    // https://stackoverflow.com/a/50875615
-    file.data = file.data.slice(0, file.data.size, file.meta.type)
-
     return file.data
   }
 
@@ -380,15 +385,12 @@ module.exports = class XHRUpload extends Plugin {
       files.forEach((file, i) => {
         const opts = this.getOptions(file)
 
-        // Set `file.data.type` in the blob to `file.meta.type`,
-        // because we might have detected a more accurate file type in Uppy
-        // https://stackoverflow.com/a/50875615
-        file.data = file.data.slice(0, file.data.size, file.meta.type)
+        const dataWithUpdatedType = setTypeInBlob(file)
 
         if (file.name) {
-          formData.append(opts.fieldName, file.data, file.meta.name)
+          formData.append(opts.fieldName, dataWithUpdatedType, file.meta.name)
         } else {
-          formData.append(opts.fieldName, file.data)
+          formData.append(opts.fieldName, dataWithUpdatedType)
         }
       })
 

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -180,8 +180,13 @@ module.exports = class XHRUpload extends Plugin {
       formPost.append(item, file.meta[item])
     })
 
+    // Set `file.data.type` in the blob to `file.meta.type`,
+    // because we might have detected a more accurate file type in Uppy
+    // https://stackoverflow.com/a/50875615
+    file.data = file.data.slice(0, file.data.size, file.meta.type)
+
     if (file.name) {
-      formPost.append(opts.fieldName, file.data, file.name)
+      formPost.append(opts.fieldName, file.data, file.meta.name)
     } else {
       formPost.append(opts.fieldName, file.data)
     }
@@ -190,6 +195,11 @@ module.exports = class XHRUpload extends Plugin {
   }
 
   createBareUpload (file, opts) {
+    // Set `file.data.type` in the blob to `file.meta.type`,
+    // because we might have detected a more accurate file type in Uppy
+    // https://stackoverflow.com/a/50875615
+    file.data = file.data.slice(0, file.data.size, file.meta.type)
+
     return file.data
   }
 
@@ -370,8 +380,13 @@ module.exports = class XHRUpload extends Plugin {
       files.forEach((file, i) => {
         const opts = this.getOptions(file)
 
+        // Set `file.data.type` in the blob to `file.meta.type`,
+        // because we might have detected a more accurate file type in Uppy
+        // https://stackoverflow.com/a/50875615
+        file.data = file.data.slice(0, file.data.size, file.meta.type)
+
         if (file.name) {
-          formData.append(opts.fieldName, file.data, file.name)
+          formData.append(opts.fieldName, file.data, file.meta.name)
         } else {
           formData.append(opts.fieldName, file.data)
         }


### PR DESCRIPTION
> To recap from the call: We'll merge https://github.com/transloadit/uppy/pull/1587 first, then change the xhr-upload client uploads to send metadata name and type instead, by putting `file.meta.name` in `formData.append` and by slicing the file data Blob + using the `contentType` option.

When uploading a file with `@uppy/xhr-upload`, a server receives the type that is set on the blob, `file.data.type`. This type is reported by the OS and might be incorrect or null, so in Uppy we try to detect the file type by extension sometimes. This PR re-creates the blob, setting `file.meta.type` as type, and uses `file.meta.name` for name, the one that can be updated by the user sometimes.

This should be consistent with how we send `name` and `type` with tus uploads and xhr-uploads on Companion.