### PR TITLE
golden-retriever: Use this.opts instead of opts

### DIFF
--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -34,7 +34,7 @@ module.exports = class GoldenRetriever extends Plugin {
     }
     this.IndexedDBStore = new IndexedDBStore(Object.assign(
       { expires: this.opts.expires },
-      opts.indexedDB || {},
+      this.opts.indexedDB || {},
       { storeName: uppy.getID() }))
 
     this.saveFilesStateToLocalStorage = this.saveFilesStateToLocalStorage.bind(this)


### PR DESCRIPTION
Without this PR, `.use(GoldenRetriever)` without options was throwing an error.

How we never discovered this until now is a mystery to me.