### PR TITLE
golden retriever: add ghosts

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -231,8 +231,8 @@ module.exports = class AwsS3Multipart extends Plugin {
         upload.start()
       }
 
-      if (!file.isRestored) {
-        this.uppy.emit('upload-started', file, upload)
+      if (!file.progress.uploadStarted || !file.isRestored) {
+        this.uppy.emit('upload-started', file)
       }
     })
   }
@@ -247,7 +247,10 @@ module.exports = class AwsS3Multipart extends Plugin {
           .catch(reject)
       }
 
-      this.uppy.emit('upload-started', file)
+      // Don't double-emit upload-started for Golden Retriever-restored files that were already started
+      if (!file.progress.uploadStarted || !file.isRestored) {
+        this.uppy.emit('upload-started', file)
+      }
 
       const Client = file.remote.providerOptions.provider ? Provider : RequestClient
       const client = new Client(this.uppy, file.remote.providerOptions)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -492,12 +492,11 @@ class Uppy {
 
     // Remove this file from its `currentUpload`.
     const updatedUploads = Object.assign({}, currentUploads)
-    const removeUploads = []
     Object.keys(updatedUploads).forEach((uploadID) => {
       const newFileIDs = currentUploads[uploadID].fileIDs.filter((uploadFileID) => uploadFileID !== fileID)
       // Remove the upload if no files are associated with it anymore.
       if (newFileIDs.length === 0) {
-        removeUploads.push(uploadID)
+        delete updatedUploads[uploadID]
         return
       }
 
@@ -509,10 +508,6 @@ class Uppy {
     this.setState({
       currentUploads: updatedUploads,
       files: updatedFiles
-    })
-
-    removeUploads.forEach((uploadID) => {
-      this._removeUpload(uploadID)
     })
 
     this._calculateTotalProgress()
@@ -746,6 +741,7 @@ class Uppy {
         this.log(`Not setting progress for a file that has been removed: ${file.id}`)
         return
       }
+
       this.setFileState(file.id, {
         progress: {
           uploadStarted: Date.now(),

--- a/packages/@uppy/dashboard/src/components/FileItem.js
+++ b/packages/@uppy/dashboard/src/components/FileItem.js
@@ -54,6 +54,9 @@ module.exports = function FileItem (props) {
   const uploadInProgress = (file.progress.uploadStarted && !file.progress.uploadComplete) || isProcessing
   const isPaused = file.isPaused || false
   const error = file.error || false
+  // File that Golden Retriever was able to partly restore (only meta, not blob),
+  // users still need to re-add it, so it’s a ghost
+  const isGhost = file.isGhost
 
   const fileName = getFileNameAndExtension(file.meta.name).name
   const truncatedFileName = props.isWide ? truncateString(fileName, 30) : fileName
@@ -106,7 +109,8 @@ module.exports = function FileItem (props) {
     { 'is-paused': isPaused },
     { 'is-error': error },
     { 'is-resumable': props.resumableUploads },
-    { 'is-noIndividualCancellation': !props.individualCancellation }
+    { 'is-noIndividualCancellation': !props.individualCancellation },
+    { 'is-ghost': isGhost }
   )
 
   const showRemoveButton = props.individualCancellation
@@ -141,7 +145,7 @@ module.exports = function FileItem (props) {
         }
       </div>
       <div class="uppy-DashboardItem-status">
-        {file.data.size ? <div class="uppy-DashboardItem-statusSize">{prettyBytes(file.data.size)}</div> : null}
+        {file.size ? <div class="uppy-DashboardItem-statusSize">{prettyBytes(file.size)}</div> : null}
         {(file.source && file.source !== props.id) && (
           <div class="uppy-DashboardItem-sourceIcon">
             {acquirers.map(acquirer => {

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -697,6 +697,10 @@ a.uppy-Dashboard-poweredBy {
   }
 }
 
+.uppy-DashboardItem.is-ghost {
+  border: 1px solid purple;
+}
+
 .uppy-DashboardItem-preview {
   width: 50px;
   height: 50px;

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -149,7 +149,8 @@ const UploadBtn = (props) => {
   return <button type="button"
     class={uploadBtnClassNames}
     aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
-    onclick={props.startUpload}>
+    onclick={props.startUpload}
+    disabled={props.isSomeGhost}>
     {props.newFiles && props.isUploadStarted
       ? props.i18n('uploadXNewFiles', { smart_count: props.newFiles })
       : props.i18n('uploadXFiles', { smart_count: props.newFiles })

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -220,6 +220,8 @@ module.exports = class StatusBar extends Plugin {
     const resumableUploads = capabilities.resumableUploads || false
     const supportsUploadProgress = capabilities.uploadProgress !== false
 
+    const isSomeGhost = Object.keys(files).some((file) => files[file].isGhost)
+
     return StatusBarUI({
       error,
       uploadState: this.getUploadingState(isAllErrored, isAllComplete, state.files || {}),
@@ -232,6 +234,7 @@ module.exports = class StatusBar extends Plugin {
       isAllErrored,
       isUploadStarted,
       isUploadInProgress,
+      isSomeGhost,
       complete: completeFiles.length,
       newFiles: newFiles.length,
       numUploads: startedFiles.length,

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -240,7 +240,6 @@ module.exports = class Tus extends Plugin {
           .catch(reject)
       }
 
-      this.uppy.emit('upload-started', file)
       const Client = file.remote.providerOptions.provider ? Provider : RequestClient
       const client = new Client(this.uppy, file.remote.providerOptions)
       client.post(
@@ -419,10 +418,16 @@ module.exports = class Tus extends Plugin {
       } else if (file.isRemote) {
         // We emit upload-started here, so that it's also emitted for files
         // that have to wait due to the `limit` option.
-        this.uppy.emit('upload-started', file)
+        // Don't double-emit upload-started for Golden Retriever-restored files that were already started
+        if (!file.progress.uploadStarted || !file.isRestored) {
+          this.uppy.emit('upload-started', file)
+        }
         return this.uploadRemote.bind(this, file, current, total)
       } else {
-        this.uppy.emit('upload-started', file)
+        // Don't double-emit upload-started for Golden Retriever-restored files that were already started
+        if (!file.progress.uploadStarted || !file.isRestored) {
+          this.uppy.emit('upload-started', file)
+        }
         return this.upload.bind(this, file, current, total)
       }
     })


### PR DESCRIPTION
List of todos/comments:

1. Notification should include remote files and say “restore ghosts”
2. Check what uses `data.size` — we are setting `data` to `null`, so if something does `data.size` it will fail hard
3. Debounce saving `saveFilesStateToLocalStorage` — it saves on every state update now
4. Check to addFile: if the `file` exists, but `file.data` is null, only replace `file.data`, but also set `isGhost: false`
5. Don’t show error stack `[Uppy] [13:22:00] Error: File is too big to store, at IndexedDBStore.put (IndexedDBStore.js:165)`
6. We now have to events `restore-confirmed` and `restored` — `restore-confirmed` will be emitted by the UI, when all the ghost files have been re-selected and user clicks “restore”. Only then we’ll call `restore` in Core
7. Add `hasGhostFiles` prop to `FileList` and don’t show pause/resume/cancel in the progress of individual files until `restore-confirmed`

---

Renée:
there's an issue ATM where you can do:
- add 3 files, one too big for IndexedDB
- refresh; all 3 files restored from ServiceWorker
- quit; serviceWorker stops
- load it up again; serviceworker doesn't have anything, indexedDB has two small files, you see  1 ghost file

- add the ghost file again, adding it to the SW cache
- refresh
- now the serviceworker doesn't load the files, because it wants 3, and sees 1
- indexeddb has the two small files, so the big one isnt loaded from SW

fix: loading from IDB and SW, concatenate, _then_ put it into onblobsloaded