### PR TITLE
Fix mime types on CDN

### DIFF
--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -100,6 +100,11 @@ async function main (packageName, version) {
     process.exit(1)
   }
 
+  // version should only be a positional arg and semver string
+  // this deals with usage like `npm run uploadcdn uppy -- --force`
+  // where we force push a local build
+  if (version.startsWith('-')) version = undefined
+
   const s3 = new AWS.S3({
     credentials: new AWS.Credentials({
       accessKeyId: process.env.EDGLY_KEY,

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -31,8 +31,8 @@ function delay (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-const AWS_REGION = 'eu-west-2'
-const AWS_BUCKET = 'uppy-test'
+const AWS_REGION = 'us-east-1'
+const AWS_BUCKET = 'crates.edgly.net'
 const AWS_DIRECTORY = '756b8efaed084669b02cb99d4540d81f/default'
 
 /**

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -22,6 +22,7 @@ const packlist = require('npm-packlist')
 const tar = require('tar')
 const pacote = require('pacote')
 const concat = require('concat-stream')
+const mime = require('mime-types')
 const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const finished = promisify(require('stream').finished)
@@ -30,8 +31,8 @@ function delay (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-const AWS_REGION = 'us-east-1'
-const AWS_BUCKET = 'crates.edgly.net'
+const AWS_REGION = 'eu-west-2'
+const AWS_BUCKET = 'uppy-test'
 const AWS_DIRECTORY = '756b8efaed084669b02cb99d4540d81f/default'
 
 /**
@@ -152,6 +153,7 @@ async function main (packageName, version) {
     await s3.putObject({
       Bucket: AWS_BUCKET,
       Key: key,
+      ContentType: mime.lookup(filename),
       Body: buffer
     }).promise()
   }

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -139,8 +139,12 @@ async function main (packageName, version) {
     Prefix: `${AWS_DIRECTORY}/${outputPath}/`
   }).promise()
   if (existing.length > 0) {
-    console.error(`Release files for ${dirName} v${version} already exist, exiting...`)
-    process.exit(1)
+    if (process.argv.includes('--force')) {
+      console.warn(`WARN Release files for ${dirName} v${version} already exist, overwriting...`)
+    } else {
+      console.error(`Release files for ${dirName} v${version} already exist, exiting...`)
+      process.exit(1)
+    }
   }
 
   const files = remote

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "last-commit-message": "^1.0.0",
     "lerna": "^3.14.1",
     "lint-staged": "^8.1.7",
+    "mime-types": "2.1.24",
     "minify-stream": "^1.2.0",
     "mkdirp": "0.5.1",
     "multi-glob": "^1.0.2",


### PR DESCRIPTION
The mime-types library is already in use by companion, hence no lockfile
update

Tested with my personal bucket