### PR TITLE
core: Log versions of Uppy plugins for debugging

### DIFF
--- a/packages/@uppy/core/src/Plugin.js
+++ b/packages/@uppy/core/src/Plugin.js
@@ -108,7 +108,7 @@ module.exports = class Plugin {
       }
       this._updateUI = debounce(this.rerender)
 
-      this.uppy.log(`Installing ${callerPluginName} to a DOM element`)
+      this.uppy.log(`Installing ${callerPluginName} to a DOM element '${target}'`)
 
       // clear everything inside the target container
       if (this.opts.replaceTargetContent) {

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -83,6 +83,8 @@ class Uppy {
     this.opts = Object.assign({}, defaultOptions, opts)
     this.opts.restrictions = Object.assign({}, defaultOptions.restrictions, this.opts.restrictions)
 
+    this.log(`Using Core v${this.constructor.VERSION}`)
+
     // i18n
     this.translator = new Translator([ this.defaultLocale, this.opts.locale ])
     this.locale = this.translator.locale
@@ -908,6 +910,8 @@ class Uppy {
         `Uppy plugins must have unique 'id' options. See https://uppy.io/docs/plugins/#id.`
       throw new Error(msg)
     }
+
+    this.log(`Using ${pluginId} v${Plugin.VERSION}`)
 
     this.plugins[plugin.type].push(plugin)
     plugin.install()

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -911,7 +911,9 @@ class Uppy {
       throw new Error(msg)
     }
 
-    this.log(`Using ${pluginId} v${Plugin.VERSION}`)
+    if (Plugin.VERSION) {
+      this.log(`Using ${pluginId} v${Plugin.VERSION}`)
+    }
 
     this.plugins[plugin.type].push(plugin)
     plugin.install()


### PR DESCRIPTION
After https://github.com/transloadit/uppy/pull/1600, we have `.VERSIONS` property on all plugins. 

With this PR, Uppy produces the following log:

```sh
[Uppy] [17:00:07] Using Core v1.1.0
[Uppy] [17:00:07] Using Dashboard v1.1.0
[Uppy] [17:00:07] Installing Dashboard to a DOM element
[Uppy] [17:00:07] Using Dashboard:StatusBar v1.1.0
[Uppy] [17:00:07] Installing Dashboard:StatusBar to Dashboard
[Uppy] [17:00:07] Using Dashboard:Informer v1.1.0
[Uppy] [17:00:07] Installing Dashboard:Informer to Dashboard
[Uppy] [17:00:07] Using Dashboard:ThumbnailGenerator v1.1.0
[Uppy] [17:00:07] Using GoogleDrive v1.1.0
[Uppy] [17:00:07] Installing GoogleDrive to Dashboard
[Uppy] [17:00:07] Using Instagram v1.1.0
[Uppy] [17:00:07] Installing Instagram to Dashboard
[Uppy] [17:00:07] Using Dropbox v1.1.0
[Uppy] [17:00:07] Installing Dropbox to Dashboard
[Uppy] [17:00:07] Using Url v1.1.0
[Uppy] [17:00:07] Installing Url to Dashboard
[Uppy] [17:00:07] Using Webcam v1.1.0
[Uppy] [17:00:07] Installing Webcam to Dashboard
[Uppy] [17:00:07] Using Tus v1.1.0
[Uppy] [17:00:07] Using Form v1.1.0
```