### PR TITLE
website: Add support for arguments in website’s console.log hack

### DIFF
--- a/website/themes/uppy/layout/example.ejs
+++ b/website/themes/uppy/layout/example.ejs
@@ -30,10 +30,14 @@
     console.log = (function (log, container) {
       return function () {
         var text = [];
+        // loop through `arguments`, because console.log accepts multiple
         var args = Array.prototype.slice.call(arguments);
         args.forEach(function (arg) {
           if (arg !== (arg + '')) {
-            arg = JSON.stringify(arg);
+            // try/catch to prevent TypeError: cyclic object value
+            try {
+              arg = JSON.stringify(arg);
+            } catch (err) {}
           }
           text.push(arg);
         })

--- a/website/themes/uppy/layout/example.ejs
+++ b/website/themes/uppy/layout/example.ejs
@@ -28,12 +28,19 @@
   <textarea id="console-log" class="Console"></textarea>
   <script>
     console.log = (function (log, container) {
-      return function (text) {
-        log(text);
+      return function () {
+        var text = [];
+        var args = Array.prototype.slice.call(arguments);
+        args.forEach(function (arg) {
+          if (arg !== (arg + '')) {
+            arg = JSON.stringify(arg);
+          }
+          text.push(arg);
+        })
 
-        if (text !== (text + '')) {
-          text = JSON.stringify(text);
-        }
+        text = text.join(' ');
+
+        log(text);
 
         container.value += text + '\n';
         container.scrollTop = container.scrollHeight;

--- a/website/themes/uppy/layout/example.ejs
+++ b/website/themes/uppy/layout/example.ejs
@@ -27,7 +27,7 @@
 
   <textarea id="console-log" class="Console"></textarea>
   <script>
-    console.log = (function (log, container) {
+    function customLog (log, container) {
       return function () {
         var text = [];
         // loop through `arguments`, because console.log accepts multiple
@@ -49,7 +49,11 @@
         container.value += text + '\n';
         container.scrollTop = container.scrollHeight;
       };
-    }(console.log.bind(console), document.getElementById("console-log")));
+    }
+
+    console.log = customLog(console.log.bind(console), document.getElementById("console-log"));
+    console.warn = customLog(console.warn.bind(console), document.getElementById("console-log"));
+    console.error = customLog(console.error.bind(console), document.getElementById("console-log"));
   </script>
 
   <script>


### PR DESCRIPTION
Website log before this PR:

<img width="642" alt="Screen Shot 2019-06-06 at 17 58 32" src="https://user-images.githubusercontent.com/1199054/59043462-ef198b00-8884-11e9-8a17-13bba4feda06.png">

After this PR:

<img width="634" alt="Screen Shot 2019-06-06 at 17 58 44" src="https://user-images.githubusercontent.com/1199054/59043489-fb9de380-8884-11e9-9f9a-fab35c571dfd.png">

Reason being, in https://github.com/transloadit/uppy/pull/1451 we started logging things with 2 arguments:

```js
console.log(prefix, message)
```

So with this PR, I’m concatenating [arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments) and logging the resulting string.