### PR TITLE
tus: implement `metaFields`

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -179,10 +179,19 @@ module.exports = class Tus extends Plugin {
         }
       }
 
+      const meta = {}
+      const metaFields = Array.isArray(optsTus.metaFields)
+        ? optsTus.metaFields
+        // Send along all fields by default.
+        : Object.keys(file.meta)
+      metaFields.forEach((item) => {
+        meta[item] = file.meta[item]
+      })
+
       // tusd uses metadata fields 'filetype' and 'filename'
-      const meta = Object.assign({}, file.meta)
       copyProp(meta, 'type', 'filetype')
       copyProp(meta, 'name', 'filename')
+
       optsTus.metadata = meta
 
       const upload = new tus.Upload(file.data, optsTus)

--- a/website/src/docs/tus.md
+++ b/website/src/docs/tus.md
@@ -56,6 +56,14 @@ In most cases you should leave this option as is, relax, and enjoy resumable upl
 
 Destination URL for your uploads. This should be where your tus.io server is running.
 
+### `metaFields: null`
+
+Pass an array of field names to limit the metadata fields that will be added to uploads as [Tus Metadata](https://tus.io/protocols/resumable-upload.html#upload-metadata).
+
+* Set this to `['name']` to only send the `name` field.
+* Set this to `null` (the default) to send *all* metadata fields.
+* Set this to an empty array `[]` to not send any fields.
+
 ### `autoRetry: true`
 
 Configures whether or not to auto-retry the upload when the user's internet connection is back online after an outage.


### PR DESCRIPTION
A quick copy-paste hackjob from XHRUpload.

Tested manually on the `examples/transloadit/` `robodog.dashboard()` example, since the Transloadit plugin was already using this unsupported option. Without this patch, uploading a file sends along fields like `relativePath`, and after this patch, it only sends the `assembly_url`, `fieldname` and `filename` fields as intended.