### PR TITLE
contributing.md - improved #Local previews section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -122,28 +122,17 @@ Even though bundled in this repo, the website is regarded as a separate project.
 
 ### Local previews
 
-It is recommended to exclude `./website/public/` from your editor if you want efficient searches.
-
-To install the required node modules, type:
-
-```bash
-npm install && cd website && npm install && cd ..
-```
-
-For local previews on http://localhost:4000, type:
-
-```bash
-npm run web:start # that gets you just the website. if you need companion, etc. you can use `npm start` instead
-```
-
-This will watch the website, as well as Uppy, as the examples, and rebuild everything and refresh your browser as files change.
+1. `npm install`
+2. `cd website && npm install && cd ..` (even if you ran `npm run bootstrap` before)
+3. `npm start`
+4. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
 
 Then, to work on, for instance, the XHRUpload example, you would edit the following files:
 
 ```bash
-${EDITOR} src/core/Core.js \
-  src/plugins/XHRUpload.js \
-  src/plugins/Plugin.js \
+${EDITOR} packages/@uppy/core/src/index.js \
+  packages/@uppy/core/src/Plugin.js \
+  packages/@uppy/xhr-upload/src/index.js \
   website/src/examples/xhrupload/app.es6
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -123,9 +123,10 @@ Even though bundled in this repo, the website is regarded as a separate project.
 ### Local previews
 
 1. `npm install`
-2. `cd website && npm install && cd ..` (even if you ran `npm run bootstrap` before)
-3. `npm start`
-4. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
+2. `npm run bootstrap`
+3. `cd website && npm install && cd ..`
+4. `npm start`
+5. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
 
 Then, to work on, for instance, the XHRUpload example, you would edit the following files:
 

--- a/website/src/_template/contributing.md
+++ b/website/src/_template/contributing.md
@@ -124,28 +124,17 @@ Even though bundled in this repo, the website is regarded as a separate project.
 
 ### Local previews
 
-It is recommended to exclude `./website/public/` from your editor if you want efficient searches.
-
-To install the required node modules, type:
-
-```bash
-npm install && cd website && npm install && cd ..
-```
-
-For local previews on http://localhost:4000, type:
-
-```bash
-npm run web:start # that gets you just the website. if you need companion, etc. you can use `npm start` instead
-```
-
-This will watch the website, as well as Uppy, as the examples, and rebuild everything and refresh your browser as files change.
+1. `npm install`
+2. `cd website && npm install && cd ..` (even if you ran `npm run bootstrap` before)
+3. `npm start`
+4. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
 
 Then, to work on, for instance, the XHRUpload example, you would edit the following files:
 
 ```bash
-${EDITOR} src/core/Core.js \
-  src/plugins/XHRUpload.js \
-  src/plugins/Plugin.js \
+${EDITOR} packages/@uppy/core/src/index.js \
+  packages/@uppy/core/src/Plugin.js \
+  packages/@uppy/xhr-upload/src/index.js \
   website/src/examples/xhrupload/app.es6
 ```
 

--- a/website/src/_template/contributing.md
+++ b/website/src/_template/contributing.md
@@ -125,9 +125,10 @@ Even though bundled in this repo, the website is regarded as a separate project.
 ### Local previews
 
 1. `npm install`
-2. `cd website && npm install && cd ..` (even if you ran `npm run bootstrap` before)
-3. `npm start`
-4. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
+2. `npm run bootstrap`
+3. `cd website && npm install && cd ..`
+4. `npm start`
+5. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
 
 Then, to work on, for instance, the XHRUpload example, you would edit the following files:
 


### PR DESCRIPTION
Maybe questionable removals, tell me if we should readd those:
1. I removed the part about `npm run web:start` - because why not fire up companion too, I think that's what most people would want. It doesn't require more installs.
2. And I removed the recommendation to exclude `./website/public/` from the editor, I think people are accustomed to removing things from their editors? We don't advise to be removing `output` folders for example.