### PR TITLE
Allow overriding of getResponseData()

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -171,7 +171,7 @@ module.exports = class AwsS3 extends Plugin {
     this.uppy.addPreProcessor(this.prepareUpload)
 
     let warnedSuccessActionStatus = false
-    this.uppy.use(XHRUpload, {
+    let xhrUploadOpts = {
       fieldName: 'file',
       responseUrlFieldName: 'location',
       timeout: this.opts.timeout,
@@ -227,7 +227,14 @@ module.exports = class AwsS3 extends Plugin {
         const error = getXmlValue(content, 'Message')
         return new Error(error)
       }
-    })
+    }
+
+    // Replace getResponseData() with overwritten version.
+    if (this.opts.getResponseData) {
+      xhrUploadOpts.getResponseData = this.opts.getResponseData
+    }
+
+    this.uppy.use(XHRUpload, xhrUploadOpts)
   }
 
   uninstall () {

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -96,6 +96,14 @@ The default is 30 seconds.
 Limit the amount of uploads going on at the same time. This is passed through to [XHRUpload](/docs/xhrupload#limit-0); see its documentation page for details.
 Set to `0` to disable limiting.
 
+### `getResponseData(responseText, response)`
+
+> This is an advanced option intended for use with _almost_ S3-compatible storage solutions.
+
+Customize response handling once an upload is completed. This passes the function through to @uppy/xhr-upload, see its [documentation](https://uppy.io/docs/xhr-upload/#getResponseData-responseText-response) for API details.
+
+This option is useful when uploading to an S3-like service that doesn't reply with an XML document, but with something else such as JSON.
+
 ### `locale: {}`
 
 Localize text that is shown to the user.


### PR DESCRIPTION
Since the AwsS3 plugin is capable of being used for more than just S3 uploads.  I found it beneficial to handle responses from my cloud provider differently than how it was being handled.  This change will allow anyone to overwrite the getResponseData() method returned by XHRUploader, but still use the default.  All tests were passing.