### PR TITLE
companion: return nextPagePath for drive/dropbox

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -1,3 +1,5 @@
+const querystring = require('querystring')
+
 exports.getUsername = (data) => {
   for (const item of data.files) {
     if (item.ownedByMe) {
@@ -20,7 +22,11 @@ exports.getItemSize = (item) => {
 
 exports.getItemIcon = (item) => {
   if (item.kind === 'drive#teamDrive') {
-    return item.backgroundImageLink + '=w16-h16-n'
+    const size = '=w16-h16-n'
+    const sizeParamRegex = /=[-whncsp0-9]*$/
+    return item.backgroundImageLink.match(sizeParamRegex)
+      ? item.backgroundImageLink.replace(sizeParamRegex, size)
+      : `${item.backgroundImageLink}${size}`
   }
 
   if (item.thumbnailLink) {
@@ -50,8 +56,12 @@ exports.getItemId = (item) => {
 }
 
 exports.getItemRequestPath = (item) => {
-  // If it's from a Team Drive, add the Team Drive ID as a query param.
+  // If it's from/is a Team Drive, add the Team Drive ID as a query param.
   // The server needs the Team Drive ID to list files in a Team Drive folder.
+  if (exports.isTeamDrive(item)) {
+    return `${item.id}?teamDriveId=${item.id}`
+  }
+
   if (item.teamDriveId) {
     return item.id + `?teamDriveId=${item.teamDriveId}`
   }
@@ -69,4 +79,15 @@ exports.getItemThumbnailUrl = (item) => {
 
 exports.isTeamDrive = (item) => {
   return item.kind === 'drive#teamDrive'
+}
+
+exports.getNextPagePath = (data, currentQuery, currentPath) => {
+  if (!data.nextPageToken) {
+    return null
+  }
+  const query = {
+    ...currentQuery,
+    nextPageToken: data.nextPageToken
+  }
+  return `${currentPath}?${querystring.stringify(query)}`
 }

--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -77,7 +77,7 @@ exports.getNextPagePath = (data, currentQuery, currentPath) => {
   }
   const query = {
     ...currentQuery,
-    nextPageToken: data.nextPageToken
+    cursor: data.nextPageToken
   }
   return `${currentPath}?${querystring.stringify(query)}`
 }

--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -56,16 +56,6 @@ exports.getItemId = (item) => {
 }
 
 exports.getItemRequestPath = (item) => {
-  // If it's from/is a Team Drive, add the Team Drive ID as a query param.
-  // The server needs the Team Drive ID to list files in a Team Drive folder.
-  if (exports.isTeamDrive(item)) {
-    return `${item.id}?teamDriveId=${item.id}`
-  }
-
-  if (item.teamDriveId) {
-    return item.id + `?teamDriveId=${item.teamDriveId}`
-  }
-
   return item.id
 }
 

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -27,7 +27,7 @@ class Drive {
 
     let teamDrivesPromise = Promise.resolve(undefined)
 
-    const shouldListTeamDrives = directory === 'root' && !query.nextPageToken
+    const shouldListTeamDrives = directory === 'root' && !query.cursor
     if (shouldListTeamDrives) {
       teamDrivesPromise = new Promise((resolve) => {
         this.client
@@ -47,7 +47,7 @@ class Drive {
 
     let where = {
       fields: DRIVE_FILES_FIELDS,
-      pageToken: query.nextPageToken,
+      pageToken: query.cursor,
       q: `'${directory}' in parents and trashed=false`,
       includeItemsFromAllDrives: true,
       supportsAllDrives: true

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -24,11 +24,10 @@ class Drive {
   list (options, done) {
     const directory = options.directory || 'root'
     const query = options.query || {}
-    const teamDriveId = query.teamDriveId
 
     let teamDrivesPromise = Promise.resolve(undefined)
 
-    const shouldListTeamDrives = directory === 'root' && !teamDriveId && !query.nextPageToken
+    const shouldListTeamDrives = directory === 'root' && !query.nextPageToken
     if (shouldListTeamDrives) {
       teamDrivesPromise = new Promise((resolve) => {
         this.client
@@ -49,14 +48,9 @@ class Drive {
     let where = {
       fields: DRIVE_FILES_FIELDS,
       pageToken: query.nextPageToken,
-      q: `'${directory}' in parents and trashed=false`
-    }
-    if (teamDriveId) {
-      // Team Drives require several extra parameters in order to work.
-      where.supportsAllDrives = true
-      where.includeItemsFromAllDrives = true
-      where.driveId = teamDriveId
-      where.corpora = 'drive'
+      q: `'${directory}' in parents and trashed=false`,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true
     }
 
     const filesPromise = new Promise((resolve, reject) => {

--- a/packages/@uppy/companion/src/server/provider/dropbox/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/adapter.js
@@ -1,4 +1,5 @@
 const mime = require('mime-types')
+const querystring = require('querystring')
 
 exports.getUsername = (data) => {
   return data.user_email
@@ -42,4 +43,12 @@ exports.getItemModifiedDate = (item) => {
 
 exports.getItemThumbnailUrl = (item) => {
   return `/dropbox/thumbnail/${exports.getItemRequestPath(item)}`
+}
+
+exports.getNextPagePath = (data) => {
+  if (!data.has_more) {
+    return null
+  }
+  const query = { cursor: data.cursor }
+  return `?${querystring.stringify(query)}`
 }

--- a/packages/@uppy/companion/src/server/provider/dropbox/index.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/index.js
@@ -79,6 +79,18 @@ class DropBox {
   }
 
   stats ({ directory, query, token }, done) {
+    if (query.cursor) {
+      this.client
+        .post('files/list_folder/continue')
+        .options({ version: '2' })
+        .auth(token)
+        .json({
+          cursor: query.cursor
+        })
+        .request(done)
+      return
+    }
+
     this.client
       .post('files/list_folder')
       .options({ version: '2' })
@@ -169,7 +181,7 @@ class DropBox {
       })
     })
 
-    data.nextPagePath = null
+    data.nextPagePath = adapter.getNextPagePath(res)
 
     return data
   }

--- a/packages/@uppy/companion/src/server/provider/instagram/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/adapter.js
@@ -74,7 +74,8 @@ exports.getItemThumbnailUrl = (item) => {
   return item.images ? item.images.thumbnail.url : null
 }
 
-exports.getNextPagePath = (items) => {
+exports.getNextPagePath = (data) => {
+  const items = exports.getItemSubList(data)
   if (items.length) {
     return `recent?max_id=${exports.getItemId(items[items.length - 1])}`
   }

--- a/packages/@uppy/companion/src/server/provider/instagram/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/adapter.js
@@ -77,6 +77,6 @@ exports.getItemThumbnailUrl = (item) => {
 exports.getNextPagePath = (data) => {
   const items = exports.getItemSubList(data)
   if (items.length) {
-    return `recent?max_id=${exports.getItemId(items[items.length - 1])}`
+    return `recent?cursor=${exports.getItemId(items[items.length - 1])}`
   }
 }

--- a/packages/@uppy/companion/src/server/provider/instagram/index.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/index.js
@@ -125,7 +125,7 @@ class Instagram {
       })
     })
 
-    data.nextPagePath = adapter.getNextPagePath(items)
+    data.nextPagePath = adapter.getNextPagePath(res)
     return data
   }
 

--- a/packages/@uppy/companion/src/server/provider/instagram/index.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/index.js
@@ -16,7 +16,8 @@ class Instagram {
   }
 
   list ({ directory = 'recent', token, query = {} }, done) {
-    const qs = query.max_id ? { max_id: query.max_id } : {}
+    const cursor = query.cursor || query.max_id
+    const qs = cursor ? { max_id: cursor } : {}
     this.client
       .select(`users/self/media/${directory}`)
       .qs(qs)


### PR DESCRIPTION
See #1611 - this is only the backend changes, the frontend will need an update for the issue to be completely resolved

Was the idea for all the `adapter.js` files to have the same interface? Drive/dropbox required different parameters, I updated the instagram `getNextPagePath` to match.

Team drive support appeared to be broken, so I made a few changes to get it working. Also, the current team drive API being used is deprecated and I think its usage can be simplified some, I didn't want too make to many changes re that in this PR though