### PR TITLE
Enable partial assignment of restrictions passed as options

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -51,17 +51,19 @@ declare module Uppy {
     pluralize?: (n: number) => number;
   }
 
+  interface Restrictions {
+    maxFileSize: number | null;
+    maxNumberOfFiles: number | null;
+    minNumberOfFiles: number | null;
+    allowedFileTypes: string[] | null;
+  }
+
   interface UppyOptions {
     id: string;
     autoProceed: boolean;
     allowMultipleUploads: boolean;
     debug: boolean;
-    restrictions: {
-      maxFileSize: number | null;
-      maxNumberOfFiles: number | null;
-      minNumberOfFiles: number | null;
-      allowedFileTypes: string[] | null;
-    };
+    restrictions: Partial<Restrictions>;
     target: string | Plugin;
     meta: any;
     onBeforeFileAdded: (currentFile: UppyFile, files: {[key: string]: UppyFile}) => UppyFile | boolean | undefined;


### PR DESCRIPTION
As described in #1653 this makes partial assignment of restrictions passed as options possible.

Closes #1653 