### PR TITLE
companion: don't log uppyAuthToken

### DIFF
--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -31,13 +31,20 @@ if (app.get('env') !== 'test') {
 // log server requests.
 app.use(morgan('combined'))
 morgan.token('url', (req, res) => {
-  // don't log access_tokens in urls
-  if (req.query && req.query.access_token) {
+  const mask = (key) => {
+    // don't log access_tokens in urls
     const query = Object.assign({}, req.query)
     // replace logged access token with xxxx character
-    query.access_token = 'x'.repeat(req.query.access_token.length)
+    query[key] = 'x'.repeat(req.query[key].length)
     return `${req.path}?${qs.stringify(query)}`
   }
+
+  if (req.query && req.query['access_token']) {
+    return mask('access_token')
+  } else if (req.query && req.query['uppyAuthToken']) {
+    return mask('uppyAuthToken')
+  }
+
   return req.originalUrl || req.url
 })
 


### PR DESCRIPTION
request logs containing uppyAuthToken will look something like this:

```
::1 - - [13/Jun/2019:13:14:01 +0000] "GET /instagram/send-token?uppyAuthToken=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```