### PR TITLE
dashboard: add modal open and close events

### DIFF
--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -350,3 +350,19 @@ if ( dashboard.isModalOpen() ) {
   dashboard.closeModal()
 }
 ```
+
+## Events
+
+### `dashboard:modal-open`
+
+Fired when the Dashboard modal is open.
+
+```js
+uppy.on('dashboard:modal-open', () => {
+  console.log('Modal is open')
+})
+```
+
+### `dashboard:modal-closed`
+
+Fired when the Dashboard modal is closed.


### PR DESCRIPTION
This PR:

- Adds `dashboard:modal-open` and `dashboard:modal-closed` events
- Calls `hideAllPanels()` in the Dashboard when modal is closed — solves the issue where Webcam would continue to be active after the modal is closed (reported in  https://github.com/transloadit/uppy/issues/1568)
- Minor refactor: sorted Dashboard methods logically, grouped event handlers together. This makes the PR harder to review, unfortunately, didn’t think about that, I’m sorry. The only real changes are with the aforementioned events.

Closes https://github.com/transloadit/uppy/issues/1568