### PR TITLE
companion: change oauth access token transport method

### DIFF
--- a/packages/@uppy/companion/src/config/grant.js
+++ b/packages/@uppy/companion/src/config/grant.js
@@ -2,17 +2,20 @@
 module.exports = () => {
   return {
     google: {
+      transport: 'session',
       scope: [
         'https://www.googleapis.com/auth/drive.readonly'
       ],
       callback: '/drive/callback'
     },
     dropbox: {
+      transport: 'session',
       authorize_url: 'https://www.dropbox.com/oauth2/authorize',
       access_url: 'https://api.dropbox.com/oauth2/token',
       callback: '/dropbox/callback'
     },
     instagram: {
+      transport: 'session',
       callback: '/instagram/callback'
     }
   }

--- a/packages/@uppy/companion/src/server/controllers/callback.js
+++ b/packages/@uppy/companion/src/server/controllers/callback.js
@@ -17,8 +17,7 @@ module.exports = function callback (req, res, next) {
     req.uppy.providerTokens = {}
   }
 
-  // TODO see if the access_token can be transported in a different way that url query params
-  req.uppy.providerTokens[providerName] = req.query.access_token
+  req.uppy.providerTokens[providerName] = req.session.grant.response.access_token
   logger.debug(`Generating auth token for provider ${providerName}.`)
   const uppyAuthToken = tokenService.generateToken(req.uppy.providerTokens, req.uppy.options.secret)
   return res.redirect(req.uppy.buildURL(`/${providerName}/send-token?uppyAuthToken=${uppyAuthToken}`, true))

--- a/packages/@uppy/companion/test/mockserver.js
+++ b/packages/@uppy/companion/test/mockserver.js
@@ -5,6 +5,12 @@ const session = require('express-session')
 var authServer = express()
 
 authServer.use(session({ secret: 'grant', resave: true, saveUninitialized: true }))
+authServer.all('*/callback', (req, res, next) => {
+  req.session.grant = {
+    response: { access_token: 'fake token' }
+  }
+  next()
+})
 authServer.all('/drive/send-token', (req, res, next) => {
   req.session.grant = {
     state: 'non-empty-value' }


### PR DESCRIPTION
this change prevents us from exposing the provider access_tokens in URLs which could be access in logs or browser history