### PR TITLE
robodog: use chooseFiles string like @uppy/file-input

### DIFF
--- a/packages/@uppy/file-input/src/index.js
+++ b/packages/@uppy/file-input/src/index.js
@@ -14,6 +14,9 @@ module.exports = class FileInput extends Plugin {
 
     this.defaultLocale = {
       strings: {
+        // The same key is used for the same purpose by @uppy/robodog's `form()` API, but our
+        // locale pack scripts can't access it in Robodog. If it is updated here, it should
+        // also be updated there!
         chooseFiles: 'Choose files'
       }
     }

--- a/packages/@uppy/robodog/src/form.js
+++ b/packages/@uppy/robodog/src/form.js
@@ -8,7 +8,26 @@ const addDashboardPlugin = require('./addDashboardPlugin')
 const addTransloaditPlugin = require('./addTransloaditPlugin')
 const addProviders = require('./addProviders')
 
+const defaultLocaleStrings = {
+  chooseFiles: 'Choose files'
+}
+
+function mergeDefaultLocale (defaults, userProvided = {}) {
+  const strings = userProvided.strings || {}
+  return {
+    ...userProvided,
+    strings: { ...defaults, ...strings }
+  }
+}
+
 function form (target, opts) {
+  if (!opts) throw new TypeError('robodog.form: must provide an options object')
+
+  opts = {
+    ...opts,
+    locale: mergeDefaultLocale(defaultLocaleStrings, opts.locale)
+  }
+
   const uppy = Uppy(opts)
   addTransloaditPlugin(uppy, opts)
 

--- a/packages/@uppy/robodog/src/form.js
+++ b/packages/@uppy/robodog/src/form.js
@@ -42,7 +42,7 @@ function form (target, opts) {
     if (opts.modal) {
       const trigger = 'input[type="file"]'
       const button = document.createElement('button')
-      button.textContent = 'Select files'
+      button.textContent = uppy.i18n('chooseFiles')
       button.type = 'button'
       const old = findDOMElement(trigger, findDOMElement(target))
       old.parentNode.replaceChild(button, old)

--- a/website/src/docs/robodog-form.md
+++ b/website/src/docs/robodog-form.md
@@ -37,6 +37,18 @@ Finally, we _really_ submit the form—without files, but with those Assembly st
 
 All the options to the [Transloadit][transloadit] plugin are supported.
 
+## Locale
+
+You can localize the “Choose files” button that is injected into the form, by setting the `locale.strings` option:
+
+```js
+locale: {
+  strings: {
+    chooseFiles: 'Choose files'
+  }
+}
+```
+
 ## Restrictions
 
 Set rules and conditions to limit the type and/or number of files that can be selected. Restrictions are configured by the `restrictions` option.


### PR DESCRIPTION
I think this is the only place that had a hardcoded string.

It now uses the `chooseFiles` localization so it'll already work with existing locale packs.

from `./examples/transloadit` in this repository:
![image](https://user-images.githubusercontent.com/1006268/59596444-0152bf00-90f8-11e9-970d-933534e33064.png)
