### PR TITLE
provider-views: Persist selected checkboxes when moving between folders

### DIFF
--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -323,7 +323,9 @@ module.exports = class ProviderView {
 
   isChecked (file) {
     const { currentSelection } = this.plugin.getPluginState()
-    return currentSelection.some((item) => item === file)
+    // comparing id instead of the file object, because the reference to the object
+    // changes when we switch folders, and the file list is updated
+    return currentSelection.some((item) => item.id === file.id)
   }
 
   /**
@@ -403,7 +405,7 @@ module.exports = class ProviderView {
     const { currentSelection } = this.plugin.getPluginState()
     if (this.isChecked(file)) {
       this.plugin.setPluginState({
-        currentSelection: currentSelection.filter((item) => item !== file)
+        currentSelection: currentSelection.filter((item) => item.id !== file.id)
       })
     } else {
       this.plugin.setPluginState({


### PR DESCRIPTION
Fixes #1423: before this PR, selected file/folder checkbox would appear unchecked after entering a folder:

![](https://user-images.githubusercontent.com/375537/55629191-420a8f80-57bb-11e9-8ae4-24f9d6dbfa41.gif)

This was because we were comparing `files` with a `file` object in `currentSelection` array, and `files` would change when moving between folders, so the reference to the file object would change, and `obj === obj` comparison failed, because that actually checks if the reference is the same.

@ifedapoolarewaju what do you think, can we rely on `id` being there for all providers?