### PR TITLE
robodog: fix `form({ modal: true })` not enabling modal options

### DIFF
--- a/packages/@uppy/robodog/src/addDashboardPlugin.js
+++ b/packages/@uppy/robodog/src/addDashboardPlugin.js
@@ -36,7 +36,7 @@ function addDashboardPlugin (uppy, opts, overrideOpts) {
   })
 
   const inline = overrideOpts.inline == null ? dashboardOpts.inline : overrideOpts.inline
-  if (inline === false) {
+  if (!inline) {
     modalDashboardOptionNames.forEach((key) => {
       if (opts.hasOwnProperty(key)) {
         dashboardOpts[key] = opts[key]

--- a/packages/@uppy/robodog/src/form.js
+++ b/packages/@uppy/robodog/src/form.js
@@ -65,6 +65,7 @@ function form (target, opts) {
       button.type = 'button'
       const old = findDOMElement(trigger, findDOMElement(target))
       old.parentNode.replaceChild(button, old)
+      dashboardOpts.inline = false
       dashboardOpts.trigger = button
     } else {
       dashboardOpts.inline = true


### PR DESCRIPTION
Previously, dashboard modal options like `closeAfterFinish` were not
available to robodog.form even if the `modal: true` option was set. this
was because the `addDashboardPlugin` function checks that `opts.inline
=== false`, and we were keeping it null/undefined.

Fixes #1638