### PR TITLE
Add metadata support for S3 MultiPart

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -99,7 +99,7 @@ module.exports = class AwsS3Multipart extends Plugin {
     let metadata = {}
 
     Object.keys(file.meta).map(key => {
-      if (file.meta[key] !== null) {
+      if (file.meta[key] != null) {
         metadata[key] = file.meta[key].toString()
       }
     })

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -96,10 +96,18 @@ module.exports = class AwsS3Multipart extends Plugin {
   createMultipartUpload (file) {
     this.assertHost()
 
+    let metadata = {};
+
+    Object.keys(file.meta).map(key => {
+      if (file.meta[key] !== null) {
+        metadata[key] = file.meta[key].toString();
+      }
+    });
+
     return this.client.post('s3/multipart', {
       filename: file.name,
       type: file.type,
-      metadata: file.meta
+      metadata
     }).then(assertServerError)
   }
 

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -98,7 +98,8 @@ module.exports = class AwsS3Multipart extends Plugin {
 
     return this.client.post('s3/multipart', {
       filename: file.name,
-      type: file.type
+      type: file.type,
+      metadata: file.meta
     }).then(assertServerError)
   }
 

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -96,13 +96,13 @@ module.exports = class AwsS3Multipart extends Plugin {
   createMultipartUpload (file) {
     this.assertHost()
 
-    let metadata = {};
+    let metadata = {}
 
     Object.keys(file.meta).map(key => {
       if (file.meta[key] !== null) {
-        metadata[key] = file.meta[key].toString();
+        metadata[key] = file.meta[key].toString()
       }
-    });
+    })
 
     return this.client.post('s3/multipart', {
       filename: file.name,

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -71,7 +71,7 @@ module.exports = function s3 (config) {
     // @ts-ignore The `uppy` property is added by middleware before reaching here.
     const client = req.uppy.s3Client
     const key = config.getKey(req, req.body.filename)
-    const { type } = req.body
+    const { type, metadata } = req.body
     if (typeof key !== 'string') {
       return res.status(500).json({ error: 's3: filename returned from `getKey` must be a string' })
     }
@@ -84,6 +84,7 @@ module.exports = function s3 (config) {
       Key: key,
       ACL: config.acl,
       ContentType: type,
+      Metadata: metadata,
       Expires: ms('5 minutes') / 1000
     }, (err, data) => {
       if (err) {


### PR DESCRIPTION
Added metadata field to POST body params in createMultipartUpload method.

Fixes #1291 #1292.