### PR TITLE
Fix header bar css in ie11

### DIFF
--- a/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
+++ b/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
@@ -1,4 +1,5 @@
 const { h } = require('preact')
+const { iconPlus } = require('./icons')
 
 const uploadStates = {
   'STATE_ERROR': 'error',
@@ -77,26 +78,31 @@ function PanelTopBar (props) {
 
   return (
     <div class="uppy-DashboardContent-bar">
-      <div>
-        {!props.isAllComplete
-          ? <button class="uppy-DashboardContent-back"
-            type="button"
-            onclick={props.cancelAll}>{props.i18n('cancel')}</button>
-          : null
-        }
-      </div>
+      {
+        !props.isAllComplete &&
+        <button
+          class="uppy-DashboardContent-back"
+          type="button"
+          onclick={props.cancelAll}
+        >
+          {props.i18n('cancel')}
+        </button>
+      }
+
       <div class="uppy-DashboardContent-title" role="heading" aria-level="h1">
         <UploadStatus {...props} />
       </div>
-      { allowNewUpload &&
-        <button class="uppy-DashboardContent-addMore"
+
+      {
+        allowNewUpload &&
+        <button
+          class="uppy-DashboardContent-addMore"
           type="button"
           aria-label={props.i18n('addMoreFiles')}
           title={props.i18n('addMoreFiles')}
-          onclick={() => props.toggleAddFilesPanel(true)}>
-          <svg aria-hidden="true" focusable="false" class="UppyIcon" width="15" height="15" viewBox="0 0 15 15">
-            <path d="M8 6.5h6a.5.5 0 0 1 .5.5v.5a.5.5 0 0 1-.5.5H8v6a.5.5 0 0 1-.5.5H7a.5.5 0 0 1-.5-.5V8h-6a.5.5 0 0 1-.5-.5V7a.5.5 0 0 1 .5-.5h6v-6A.5.5 0 0 1 7 0h.5a.5.5 0 0 1 .5.5v6z" />
-          </svg>
+          onclick={() => props.toggleAddFilesPanel(true)}
+        >
+          {iconPlus()}
           <span class="uppy-DashboardContent-addMoreCaption">{props.i18n('addMore')}</span>
         </button>
       }

--- a/packages/@uppy/dashboard/src/components/icons.js
+++ b/packages/@uppy/dashboard/src/components/icons.js
@@ -104,6 +104,12 @@ function iconCross () {
   </svg>
 }
 
+function iconPlus () {
+  return <svg aria-hidden="true" focusable="false" class="UppyIcon" width="15" height="15" viewBox="0 0 15 15">
+    <path d="M8 6.5h6a.5.5 0 0 1 .5.5v.5a.5.5 0 0 1-.5.5H8v6a.5.5 0 0 1-.5.5H7a.5.5 0 0 1-.5-.5V8h-6a.5.5 0 0 1-.5-.5V7a.5.5 0 0 1 .5-.5h6v-6A.5.5 0 0 1 7 0h.5a.5.5 0 0 1 .5.5v6z" />
+  </svg>
+}
+
 module.exports = {
   defaultPickerIcon,
   iconCopy,
@@ -119,5 +125,6 @@ module.exports = {
   iconText,
   iconCopyLink,
   iconPencil,
-  iconCross
+  iconCross,
+  iconPlus
 }

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -413,83 +413,85 @@
   }
 }
 
-.uppy-DashboardContent-title {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  text-align: center;
-  font-size: 12px;
-  line-height: 40px;
-  font-weight: 500;
-  // MUST be present for title to be visible in IE11
-  width: 100%;
-  max-width: 170px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-x: hidden;
-  margin: auto;
-
-  .uppy-size--md & {
-    font-size: 14px;
-    line-height: 50px;
-    max-width: 300px;
-  }
-}
-
-.uppy-DashboardContent-back {
-  @include reset-button;
-  @include highlight-focus;
-  border-radius: 3px;
-  font-size: 12px;
-  font-weight: 400;
-  cursor: pointer;
-  color: $blue;
-  padding: 7px 6px;
-  margin-left: -6px;
-
-  .uppy-size--md & {
-    font-size: 14px;
-  }
-}
-
-.uppy-DashboardContent-addMore {
-  @include reset-button;
-  @include highlight-focus;
-  border-radius: 3px;
-  font-weight: 500;
-  cursor: pointer;
-  color: $blue;
-  width: 29px;
-  height: 29px;
-  padding: 7px 8px;
-  margin-right: -5px;
-
-  .uppy-size--md & {
-    font-size: 14px;
-    width: auto;
-    height: auto;
-    margin-right: -8px;
-  }
-}
-
-  .uppy-DashboardContent-addMore svg {
-    vertical-align: baseline;
-    margin-right: 4px;
+  .uppy-DashboardContent-title {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 12px;
+    line-height: 40px;
+    font-weight: 500;
+    // MUST be present for title to be visible in IE11
+    width: 100%;
+    max-width: 170px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: hidden;
+    margin: auto;
 
     .uppy-size--md & {
-      width: 11px;
-      height: 11px;
+      font-size: 14px;
+      line-height: 50px;
+      max-width: 300px;
     }
   }
 
-  .uppy-DashboardContent-addMoreCaption {
-    display: none;
+  .uppy-DashboardContent-back {
+    @include reset-button;
+    @include highlight-focus;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: 400;
+    cursor: pointer;
+    color: $blue;
+    padding: 7px 6px;
+    margin-left: -6px;
 
     .uppy-size--md & {
-      display: inline;
+      font-size: 14px;
     }
   }
+
+  .uppy-DashboardContent-addMore {
+    @include reset-button;
+    @include highlight-focus;
+    border-radius: 3px;
+    font-weight: 500;
+    cursor: pointer;
+    color: $blue;
+    width: 29px;
+    height: 29px;
+    padding: 7px 8px;
+    margin-right: -5px;
+
+    .uppy-size--md & {
+      font-size: 14px;
+      width: auto;
+      height: auto;
+      margin-right: -8px;
+    }
+  }
+
+    .uppy-DashboardContent-addMore svg {
+      vertical-align: baseline;
+      margin-right: 4px;
+
+      .uppy-size--md & {
+        width: 11px;
+        height: 11px;
+      }
+    }
+
+    .uppy-DashboardContent-addMoreCaption {
+      display: none;
+
+      .uppy-size--md & {
+        display: inline;
+      }
+    }
+  // ...uppy-DashboardContent-addMore|
+// ...uppy-DashboardContent-bar|
 
 .uppy-DashboardContent-panel {
   position: absolute;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -391,16 +391,21 @@
 }
 
 .uppy-DashboardContent-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   flex-shrink: 0;
   height: 40px;
   width: 100%;
-  border-bottom: 1px solid $gray-200;
-  z-index: $zIndex-4;
-  background-color: $gray-50;
   padding: 0 10px;
+  z-index: $zIndex-4;
+  // For when both 'Cancel' and '+ Add more' buttons are present
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  // For .uppy-DashboardContent-title's position: absolute
+  position: relative;
+
+  border-bottom: 1px solid $gray-200;
+  background-color: $gray-50;
 
   .uppy-size--md & {
     height: 50px;
@@ -417,6 +422,8 @@
   font-size: 12px;
   line-height: 40px;
   font-weight: 500;
+  // MUST be present for title to be visible in IE11
+  width: 100%;
   max-width: 170px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -434,7 +441,6 @@
   @include reset-button;
   @include highlight-focus;
   border-radius: 3px;
-  display: inline-block;
   font-size: 12px;
   font-weight: 400;
   cursor: pointer;
@@ -451,7 +457,6 @@
   @include reset-button;
   @include highlight-focus;
   border-radius: 3px;
-  display: inline-block;
   font-weight: 500;
   cursor: pointer;
   color: $blue;


### PR DESCRIPTION
1. Moved the Plus icon to './icons.js'.
2. Removed unneeded `<div>` in PickerPanelTopBar.js
3. Slightly changed the spacing in PickerPanelTopBar.js. What do you think, should we add this spacing as a rule (warning-level for now) to Eslint? If you prefer the way we do it in the rest of the codebase, - let's add the Eslint rule for that then.