### PR TITLE
Added focus styles for all elements

### DIFF
--- a/packages/@uppy/core/src/_utils.scss
+++ b/packages/@uppy/core/src/_utils.scss
@@ -25,26 +25,29 @@
 }
 
 @mixin highlight-focus() {
+  @include clear-focus();
+
   &:hover {
     color: darken($blue, 10%);
   }
 
   &:focus {
-    outline: none;
     background-color: $highlight;
-  }
-
-  &::-moz-focus-inner {
-    border: 0;
   }
 }
 
 @mixin blue-border-focus() {
+  @include clear-focus();
+
   &:focus {
-    outline: none;
     box-shadow: 0 0 0 3px rgba($blue, 0.5);
   }
+}
 
+@mixin clear-focus() {
+  &:focus {
+    outline: none;
+  }
   &::-moz-focus-inner {
     border: 0;
   }

--- a/packages/@uppy/dashboard/src/components/AddFiles.js
+++ b/packages/@uppy/dashboard/src/components/AddFiles.js
@@ -66,7 +66,7 @@ class AddFiles extends Component {
   renderDropPasteBrowseTagline () {
     const browse =
       <button type="button"
-        class="uppy-Dashboard-browse"
+        class="uppy-u-reset uppy-Dashboard-browse"
         onclick={this.triggerFileInputClick}>
         {this.props.i18n('browse')}
       </button>

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.scss
@@ -11,13 +11,13 @@
   transition: all .35 ease;
 }
   .uppy-DashboardItem-progressIndicator {
+    @include clear-focus;
     display: inline-block;
     width: 38px;
     height: 38px;
     opacity: 0.9;
     cursor: pointer;
     &:focus{
-      outline: none;
       svg.UppyIcon-progressCircle .bg,
       svg.retry{
         fill: lighten($blue, 20%);

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -170,6 +170,7 @@
 }
 
 .uppy-Dashboard-close {
+  @include clear-focus;
   display: block;
   position: absolute;
   top: -33px;
@@ -179,6 +180,9 @@
   font-size: 27px;
   z-index: $zIndex-5;
 
+  &:focus{
+    color: lighten($blue, 25%);
+  }
   @media #{$screen-medium} {
     font-size: 35px;
     top: -10px;
@@ -252,19 +256,14 @@
 }
 
 .uppy-Dashboard-browse {
-  @include reset-button;
+  @include clear-focus;
   cursor: pointer;
   color: rgba($blue, 0.9);
 
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
-  .uppy-Dashboard-browse:focus {
-    outline: none;
+  &:hover, &:focus {
     border-bottom: 2px solid $blue;
   }
+}
 
 .uppy-DashboardTabs-list {
   display: flex;

--- a/packages/@uppy/provider-views/src/Breadcrumbs.js
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.js
@@ -1,16 +1,13 @@
 const { h } = require('preact')
 
-const Breadcrumb = (props) => {
-  return (
-    <span>
-      <button
-        type="button"
-        class="uppy-u-reset"
-        onclick={props.getFolder}>{props.title}</button>
-      {!props.isLast ? ' / ' : ''}
-    </span>
-  )
-}
+const Breadcrumb = (props) => [
+  <button
+    type="button"
+    class="uppy-u-reset"
+    onclick={props.getFolder}>{props.title}
+  </button>,
+  !props.isLast ? ' / ' : ''
+]
 
 module.exports = (props) => {
   return (

--- a/packages/@uppy/provider-views/src/style.scss
+++ b/packages/@uppy/provider-views/src/style.scss
@@ -60,31 +60,32 @@
     margin-bottom: 0;
   }
 }
-
-.uppy-Provider-breadcrumbsIcon {
-  display: inline-block;
-  color: $gray-700;
-  vertical-align: bottom;
-  margin-right: 8px;
-  line-height: 1;
-}
-
-  .uppy-Provider-breadcrumbsIcon svg {
-    width: 13px;
-    height: 13px;
-    fill: $gray-700;
+  .uppy-Provider-breadcrumbsIcon {
+    display: inline-block;
+    color: $gray-700;
+    vertical-align: middle;
+    margin-right: 4px;
+    line-height: 1;
   }
+    .uppy-Provider-breadcrumbsIcon svg {
+      width: 13px;
+      height: 13px;
+      fill: $gray-700;
+    }
 
-.uppy-Provider-breadcrumbs button {
-  display: inline-block;
-  line-height: inherit;
-  // font-size: 14px;
-}
-
-.uppy-Provider-breadcrumbs button:hover {
-  text-decoration: underline;
-  cursor: pointer;
-}
+  .uppy-Provider-breadcrumbs button {
+    @include highlight-focus;
+    display: inline-block;
+    line-height: inherit;
+    // for focus
+    padding: 4px;
+    border-radius: 3px;
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+// ...uppy-Provider-breadcrumbs|
 
 .uppy-ProviderBrowser {
   display: flex;
@@ -116,7 +117,7 @@
 }
 
 .uppy-ProviderBrowser-headerBar {
-  padding: 12px 15px;
+  padding: 7px 15px;
   background-color: $gray-50;
   z-index: $zIndex-2;
   color: $gray-600;
@@ -126,9 +127,6 @@
   .uppy-size--md & {
     display: flex;
     align-items: center;
-    // height: 40px;
-    // line-height: 40px;
-    padding: 12px 15px;
   }
 }
 
@@ -210,9 +208,13 @@
 }
 
 .uppy-ProviderBrowser-userLogout {
+  @include highlight-focus;
   cursor: pointer;
   line-height: inherit;
   color: $blue;
+  // for focus
+  padding: 4px;
+  border-radius: 3px;
 
   &:hover {
     text-decoration: underline;

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -232,24 +232,36 @@ const ProgressBarProcessing = (props) => {
   </div>
 }
 
+const renderDot = () =>
+  ' \u00B7 '
+
 const ProgressDetails = (props) => {
+  const ifShowFilesUploadedOfTotal = props.numUploads > 1
+
   return <div class="uppy-StatusBar-statusSecondary">
     {
-      props.numUploads > 1 &&
+      ifShowFilesUploadedOfTotal &&
       props.i18n('filesUploadedOfTotal', {
         complete: props.complete,
         smart_count: props.numUploads
-      }) + ' \u00B7 '
+      })
     }
-    <span class="uppy-StatusBar--onlyForDesktop">
+    <span class="uppy-StatusBar-additionalInfo">
+      {/* When should we render this dot?
+        1. .-additionalInfo is shown (happens only on desktops)
+        2. AND 'filesUploadedOfTotal' was shown
+      */}
+      {ifShowFilesUploadedOfTotal && renderDot()}
+
       {
         props.i18n('dataUploadedOfTotal', {
           complete: prettyBytes(props.totalUploadedSize),
           total: prettyBytes(props.totalSize)
-        }) + ' \u00B7 '
+        })
       }
-    </span>
-    <span class="uppy-StatusBar--onlyForDesktop">
+
+      {renderDot()}
+
       {
         props.i18n('xTimeLeft', {
           time: prettyETA(props.totalETA)

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -234,12 +234,28 @@ const ProgressBarProcessing = (props) => {
 
 const ProgressDetails = (props) => {
   return <div class="uppy-StatusBar-statusSecondary">
-    { props.numUploads > 1 && props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.numUploads }) + ' \u00B7 ' }
-    { props.i18n('dataUploadedOfTotal', {
-      complete: prettyBytes(props.totalUploadedSize),
-      total: prettyBytes(props.totalSize)
-    }) + ' \u00B7 ' }
-    { props.i18n('xTimeLeft', { time: prettyETA(props.totalETA) }) }
+    {
+      props.numUploads > 1 &&
+      props.i18n('filesUploadedOfTotal', {
+        complete: props.complete,
+        smart_count: props.numUploads
+      }) + ' \u00B7 '
+    }
+    <span class="uppy-StatusBar--onlyForDesktop">
+      {
+        props.i18n('dataUploadedOfTotal', {
+          complete: prettyBytes(props.totalUploadedSize),
+          total: prettyBytes(props.totalSize)
+        }) + ' \u00B7 '
+      }
+    </span>
+    <span class="uppy-StatusBar--onlyForDesktop">
+      {
+        props.i18n('xTimeLeft', {
+          time: prettyETA(props.totalETA)
+        })
+      }
+    </span>
   </div>
 }
 
@@ -253,7 +269,8 @@ const UploadNewlyAddedFiles = (props) => {
   const uploadBtnClassNames = classNames(
     'uppy-u-reset',
     'uppy-c-btn',
-    'uppy-StatusBar-actionBtn'
+    'uppy-StatusBar-actionBtn',
+    'uppy-StatusBar-actionBtn--uploadNewlyAdded'
   )
 
   return <div class="uppy-StatusBar-statusSecondary">

--- a/packages/@uppy/status-bar/src/style.scss
+++ b/packages/@uppy/status-bar/src/style.scss
@@ -109,13 +109,12 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: 170px;
-  overflow-x: hidden;
   padding-right: 0.3em;
+}
 
-  .uppy-size--md & {
-    max-width: 400px;
-  }
+// Don't display elements with class .--onlyForDesktop if we're not at least on .md
+.uppy-Root:not(.uppy-size--md) .uppy-StatusBar--onlyForDesktop {
+  display: none;
 }
 
 .uppy-StatusBar-statusPrimary {
@@ -128,10 +127,7 @@
   line-height: 1.2;
   display: inline-block;
   color: $gray-600;
-  text-overflow: ellipsis;
   white-space: nowrap;
-  overflow-x: hidden;
-  // max-width: 170px;
 }
 
   .uppy-StatusBar-statusSecondaryHint {
@@ -178,37 +174,21 @@
 }
 
 .uppy-StatusBar-actionCircleBtn {
+  @include blue-border-focus;
   line-height: 1;
   cursor: pointer;
-  padding: 3px;
+  margin: 3px;
   opacity: 0.9;
-  // display: flex;
-  // align-items: center;
-  // justify-content: center;
-  // width: 20px;
-  // height: 20px;
-  // border-radius: 50%;
-  // color: rgba($black, 0.6);
-  // background-color: rgba($gray-500, 0.3);
-  // text-align: center;
 
   &:hover {
     opacity: 1;
   }
+  &:focus {
+    border-radius: 50%;
+  }
 }
 
-  // .uppy-StatusBar-actionCircleBtn:not(:last-child) {
-  //   margin-right: 2px;
-  // }
-
-  // .uppy-size--md .uppy-StatusBar-actionCircleBtn {
-  //   padding: 1px 4px;
-  // }
-
   .uppy-StatusBar-actionCircleBtn svg {
-    // width: 12px;
-    // height: 12px;
-    // fill: currentColor;
     vertical-align: bottom;
   }
 
@@ -229,6 +209,7 @@
   // }
 
   .uppy-StatusBar-actionBtn--retry {
+    @include blue-border-focus();
     height: 16px;
     border-radius: 8px;
     margin-right: 6px;
@@ -271,6 +252,15 @@
     background-color: transparent;
     // border: 1px solid $white;
     color: $blue;
+  }
+
+  .uppy-StatusBar-actionBtn--uploadNewlyAdded {
+    // for focus
+    @include blue-border-focus;
+    padding-right: 3px;
+    padding-left: 3px;
+    padding-bottom: 1px;
+    border-radius: 3px;
   }
 
 .uppy-StatusBar-details {

--- a/packages/@uppy/status-bar/src/style.scss
+++ b/packages/@uppy/status-bar/src/style.scss
@@ -112,8 +112,8 @@
   padding-right: 0.3em;
 }
 
-// Don't display elements with class .--onlyForDesktop if we're not at least on .md
-.uppy-Root:not(.uppy-size--md) .uppy-StatusBar--onlyForDesktop {
+// Don't display elements with class .-additionalInfo if we're not at least on .md
+.uppy-Root:not(.uppy-size--md) .uppy-StatusBar-additionalInfo {
   display: none;
 }
 


### PR DESCRIPTION
1. Added :focus() styles for focusable elements (hopefully I caught all of them).
2. Removed an excessive `<span>`.
3. I made it so that on mobiles some status is not displayed at all (1st - before, 2nd - after):
<img width="455" alt="Screenshot 2019-06-29 at 08 25 57" src="https://user-images.githubusercontent.com/7578559/60379516-82da1380-9a4d-11e9-992b-cd31866104c3.png">
<img width="404" alt="Screenshot 2019-06-29 at 08 54 24" src="https://user-images.githubusercontent.com/7578559/60379518-82da1380-9a4d-11e9-9512-c30f1ae1c83a.png">

Before it was always getting cut off, and we were not getting any useful information anyway.
I did this to avoid having `overflow-x: hidden` that was hiding outline of the `'Upload'` button.