### PR TITLE
Fix docs navigation

### DIFF
--- a/website/src/docs/plugin-common-options.md
+++ b/website/src/docs/plugin-common-options.md
@@ -1,7 +1,7 @@
 ---
 title: "Common Plugin Options"
 type: docs
-permalink: docs/plugins/
+permalink: docs/plugin-options/
 order: 4
 category: 'Docs'
 ---


### PR DESCRIPTION
There are two pages with /docs/plugins as their permalink (The other one is https://github.com/transloadit/uppy/blob/master/website/src/docs/plugins.md)