### PR TITLE
core: Restrictions improvements

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1311,7 +1311,7 @@ class Uppy {
         return this._runUpload(uploadID)
       })
       .catch((err) => {
-        if (!err.isRestriction) {
+        if (err.isRestriction) {
           this.emit('restriction-failed', null, err)
         }
         onError(err)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -107,6 +107,12 @@ class Uppy {
 
     this.log(`Using Core v${this.constructor.VERSION}`)
 
+    if (this.opts.restrictions.allowedFileTypes &&
+        this.opts.restrictions.allowedFileTypes !== null &&
+        !Array.isArray(this.opts.restrictions.allowedFileTypes)) {
+      throw new Error(`'restrictions.allowedFileTypes' must be an array`)
+    }
+
     // i18n
     this.translator = new Translator([ this.defaultLocale, this.opts.locale ])
     this.locale = this.translator.locale

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -1261,6 +1261,19 @@ describe('src/Core', () => {
       }
     })
 
+    it('should throw if allowedFileTypes is not an array', () => {
+      try {
+        const core = Core({
+          restrictions: {
+            allowedFileTypes: 'image/gif'
+          }
+        })
+        core.log('hi')
+      } catch (err) {
+        expect(err).toMatchObject(new Error(`'restrictions.allowedFileTypes' must be an array`))
+      }
+    })
+
     it('should enforce the allowedFileTypes rule with file extensions', () => {
       const core = new Core({
         restrictions: {

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -660,13 +660,6 @@ module.exports = class Dashboard extends Plugin {
     this.superFocusOnEachUpdate()
   }
 
-  startUpload = (ev) => {
-    this.uppy.upload().catch((err) => {
-      // Log error.
-      this.uppy.log(err.stack || err.message || err)
-    })
-  }
-
   cancelUpload = (fileID) => {
     this.uppy.removeFile(fileID)
   }
@@ -803,7 +796,6 @@ module.exports = class Dashboard extends Plugin {
       metaFields: pluginState.metaFields,
       resumableUploads: capabilities.resumableUploads || false,
       individualCancellation: capabilities.individualCancellation,
-      startUpload: this.startUpload,
       pauseUpload: this.uppy.pauseResume,
       retryUpload: this.uppy.retryUpload,
       cancelUpload: this.cancelUpload,

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -71,7 +71,6 @@ module.exports = class StatusBar extends Plugin {
     this.translator = new Translator([ this.defaultLocale, this.uppy.locale, this.opts.locale ])
     this.i18n = this.translator.translate.bind(this.translator)
 
-    this.startUpload = this.startUpload.bind(this)
     this.render = this.render.bind(this)
     this.install = this.install.bind(this)
   }
@@ -97,10 +96,11 @@ module.exports = class StatusBar extends Plugin {
     return Math.round(totalBytesRemaining / totalSpeed * 10) / 10
   }
 
-  startUpload () {
+  startUpload = () => {
     return this.uppy.upload().catch((err) => {
-      this.uppy.log(err.stack || err.message || err)
-      // Ignore
+      if (!err.isRestriction) {
+        this.uppy.log(err.stack || err.message || err)
+      }
     })
   }
 


### PR DESCRIPTION
This PR:

- Sets file.type to the one detected by Uppy, before calling `onBeforeFileAdded` callback. This way you’ll get a meaningful type in the callback, instead of an empty string or an incorrect one.
- Emits `restriction-failed` for `minNumberOfFiles`, too (so in `uppy.upload()`). Not sure about the signature in this case, it is `(file, err)` for when a file restriction fails, and I made it `(null, err)` for when it’s `minNumberOfFiles`.
- Only logs non-restriction errors when “Upload” is pressed in StatusBar. For that, `return Promise.reject()` had to be changed to `throw` — `Promise.reject` wasn’t caught in `.catch()`. Without this it throws an error in console.
- Checks and throws early if `restrictions.allowedFileTypes` is not an array.

This PR supersedes https://github.com/transloadit/uppy/pull/1594, since we’ve decided it has breaking changes.

Closes #1594