### PR TITLE
Fix Restrictions parameter declaration

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -59,10 +59,10 @@ declare module Uppy {
   }
 
   interface Restrictions {
-    maxFileSize: number | null;
-    maxNumberOfFiles: number | null;
-    minNumberOfFiles: number | null;
-    allowedFileTypes: string[] | null;
+    maxFileSize?: number | null;
+    maxNumberOfFiles?: number | null;
+    minNumberOfFiles?: number | null;
+    allowedFileTypes?: string[] | null;
   }
 
   interface UppyOptions {


### PR DESCRIPTION
Restrictions interface requires all parameters to be passed, even though they can be safely omitted.

See: https://github.com/transloadit/uppy/blob/6b173d8c78689a3788ff770ee60de9a1ce8e6c82/packages/%40uppy/core/src/index.js#L84-L104