### PR TITLE
@uppy/dashboard - made Add More always stick to the right

### DIFF
--- a/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
+++ b/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
@@ -78,33 +78,35 @@ function PanelTopBar (props) {
 
   return (
     <div class="uppy-DashboardContent-bar">
-      {
-        !props.isAllComplete &&
-        <button
-          class="uppy-DashboardContent-back"
-          type="button"
-          onclick={props.cancelAll}
-        >
-          {props.i18n('cancel')}
-        </button>
+      { // always on the left
+        !props.isAllComplete
+          ? <button
+            class="uppy-DashboardContent-back"
+            type="button"
+            onclick={props.cancelAll}
+          >
+            {props.i18n('cancel')}
+          </button>
+          : <div />
       }
 
       <div class="uppy-DashboardContent-title" role="heading" aria-level="h1">
         <UploadStatus {...props} />
       </div>
 
-      {
-        allowNewUpload &&
-        <button
-          class="uppy-DashboardContent-addMore"
-          type="button"
-          aria-label={props.i18n('addMoreFiles')}
-          title={props.i18n('addMoreFiles')}
-          onclick={() => props.toggleAddFilesPanel(true)}
-        >
-          {iconPlus()}
-          <span class="uppy-DashboardContent-addMoreCaption">{props.i18n('addMore')}</span>
-        </button>
+      { // always on the right
+        allowNewUpload
+          ? <button
+            class="uppy-DashboardContent-addMore"
+            type="button"
+            aria-label={props.i18n('addMoreFiles')}
+            title={props.i18n('addMoreFiles')}
+            onclick={() => props.toggleAddFilesPanel(true)}
+          >
+            {iconPlus()}
+            <span class="uppy-DashboardContent-addMoreCaption">{props.i18n('addMore')}</span>
+          </button>
+          : <div />
       }
     </div>
   )


### PR DESCRIPTION
I added the `// always on the left` comments to implicitly explain why we need two empty `<div>`.
(Second `<div>` is not needed, but I added it too, I think it reads better considering imaginary `justify-content: space-between;`)