### PR TITLE
Improve addFile API

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -429,7 +429,7 @@ class Uppy {
    * and start an upload if `autoProceed === true`.
    *
    * @param {Object} file object to add
-   * @returns {String} id for the added file
+   * @returns {string} id for the added file
    */
   addFile (file) {
     const { files, allowNewUpload } = this.getState()
@@ -526,7 +526,7 @@ class Uppy {
       }, 4)
     }
 
-    return fileID;
+    return fileID
   }
 
   removeFile (fileID) {

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -524,6 +524,8 @@ class Uppy {
         })
       }, 4)
     }
+
+    return fileID;
   }
 
   removeFile (fileID) {

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -429,6 +429,7 @@ class Uppy {
    * and start an upload if `autoProceed === true`.
    *
    * @param {Object} file object to add
+   * @returns {String} id for the added file
    */
   addFile (file) {
     const { files, allowNewUpload } = this.getState()

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -598,14 +598,12 @@ describe('src/Core', () => {
       const core = new Core()
       core.on('file-added', fileAddedEventMock)
 
-      core.addFile({
+      const fileId = core.addFile({
         source: 'jest',
         name: 'foo.jpg',
         type: 'image/jpeg',
         data: fileData
       })
-
-      const fileId = Object.keys(core.getState().files)[0]
       const newFile = {
         extension: 'jpg',
         id: fileId,

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -341,6 +341,8 @@ uppy.addFile({
 
 If `uppy.opts.autoProceed === true`, Uppy will begin uploading automatically when files are added.
 
+This function will return the generated id for the file that was added.
+
 > Sometimes you might need to add a remote file to Uppy. This can be achieved by [fetching the file, then creating a Blob object, or using the Url plugin with Companion](https://github.com/transloadit/uppy/issues/1006#issuecomment-413495493).
 
 ### `uppy.removeFile(fileID)`


### PR DESCRIPTION
It is very strange that methods of the core module (for example: `removeFile`) expect the file id as an argument but we don't return it when we add a file. I think if the file id is returned when adding a file it will be much easier for clients to use the API.