### PR TITLE
ci: tweak job run order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,16 @@ language: node_js
 
 matrix:
   include:
+    # Run e2e tests on branch builds, not PRs
+    # Start this first because it takes a while, so it doesn't only start running after
+    # other jobs have run
+    - node_js: 10
+      env: ENDTOEND=true
+      if: type = push
+      addons:
+        apt: *APT
+        hosts: *HOSTS
+        sauce_connect: *SAUCE
     - node_js: 'stable'
       env: UNIT=true
       addons:
@@ -44,14 +54,6 @@ matrix:
       if: branch = master AND type = push
       addons:
         apt: *APT
-    # Run e2e tests on branch builds, not PRs
-    - node_js: 10
-      env: ENDTOEND=true
-      if: type = push
-      addons:
-        apt: *APT
-        hosts: *HOSTS
-        sauce_connect: *SAUCE
 before_install:
 - nvm install-latest-npm
 install:


### PR DESCRIPTION
Right now our branch builds look like this:

![image](https://user-images.githubusercontent.com/1006268/61524542-ec2ec000-aa16-11e9-9dd4-8d0dc532dcfb.png)

We can run up to something like 5 jobs in parallel on travis. If we have 6 jobs, the ENDTOEND=true job will only start when one of the other jobs has finished. Then we have to wait for 3mins for the other job + 13 mins for the endtoend job. By starting ENDTOEND=true first, the other jobs can run in parallel next to it, and likely still be finished before the ENDTOEND job, saving 3 minutes before we can see the final results.