### PR TITLE
Companion errors

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -30,8 +30,10 @@ module.exports = class Provider extends RequestClient {
 
   onReceiveResponse (response) {
     response = super.onReceiveResponse(response)
-    const authenticated = response.status !== 401
-    this.uppy.getPlugin(this.pluginId).setPluginState({ authenticated })
+    const plugin = this.uppy.getPlugin(this.pluginId)
+    const oldAuthenticated = plugin.getPluginState().authenticated
+    const authenticated = oldAuthenticated ? response.status !== 401 : response.status < 400
+    plugin.setPluginState({ authenticated })
     return response
   }
 

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -60,8 +60,8 @@ class Drive {
         .where(where)
         .auth(options.token)
         .request((err, resp) => {
-          if (err) {
-            reject(err)
+          if (err || resp.statusCode !== 200) {
+            reject(this._error(err, resp))
             return
           }
           resolve(resp)
@@ -71,13 +71,6 @@ class Drive {
     Promise.all([teamDrivesPromise, filesPromise])
       .then(
         ([teamDrives, filesResponse]) => {
-          if (filesResponse.statusCode !== 200) {
-            const err = this._error(null, filesResponse)
-            logger.error(err, 'provider.drive.list.error')
-            done(err)
-            return
-          }
-
           const returnData = this.adaptData(
             filesResponse.body,
             teamDrives && teamDrives.body,


### PR DESCRIPTION
fixes [this issue](https://app.asana.com/0/707684331679643/1130022427298509/f) so that whenever an error is returned from companion:

1. the auth screen will be displayed if the user was never authenticated
2. if the user is authenticated, the last screen on display before the error will be displayed