### PR TITLE
companion: set allowed http methods internally

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -62,6 +62,7 @@ module.exports.app = (options = {}) => {
   app.use(interceptGrantErrorResponse)
   app.use(new Grant(grantConfig))
   app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE')
     res.header(
       'Access-Control-Allow-Headers',
       [


### PR DESCRIPTION
to avoid issues like [this](https://github.com/transloadit/uppy/pull/1612#issuecomment-515117137) in the future, I am setting internally, the allowed http methods needed by companion. This way, non-standalone servers won't have to always keep track of what headers to set as regards to changes in companion.