### PR TITLE
docs: explicitly document supported tus-js-client options

### DIFF
--- a/website/src/docs/tus.md
+++ b/website/src/docs/tus.md
@@ -51,6 +51,10 @@ Note that this option is about resuming when you start an upload again with the 
 
 In most cases you should leave this option as is, relax, and enjoy resumable uploads.
 
+### `removeFingerprintOnSuccess: false`
+
+If the `resume` option is enabled, it will store some data in localStorage for each upload. With `removeFingerprintOnSuccess`, this data is removed once an upload has completed. The effect is that if the same file is uploaded again, it will create an entirely new upload.
+
 ### `endpoint: ''`
 
 Destination URL for your uploads. This should be where your tus.io server is running.

--- a/website/src/docs/tus.md
+++ b/website/src/docs/tus.md
@@ -39,8 +39,6 @@ const Tus = Uppy.Tus
 
 ## Options
 
-The `@uppy/tus` plugin supports all of [tus-js-client][]’s options. In addition to that, it has the following configurable options:
-
 ### `id: 'Tus'`
 
 A unique identifier for this plugin. It defaults to `'Tus'`.
@@ -57,6 +55,28 @@ In most cases you should leave this option as is, relax, and enjoy resumable upl
 
 Destination URL for your uploads. This should be where your tus.io server is running.
 
+### `headers: {}`
+
+Additional request headers to send to the Tus endpoint when making requests.
+
+### `chunkSize: Infinity`
+
+A number indicating the maximum size of a chunk in bytes which will be uploaded in a single request. This can be used when a server or proxy has a limit on how big request bodies may be. Note that if the server has hard limits (such as the minimum 5MB chunk size imposed by S3), specifying a chunk size which falls outside those hard limits will cause chunked uploads to fail.
+
+### `withCredentials: false`
+
+Configure XMLHttpRequests to send Cookies in requests using the [`xhr.withCredentials`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) property. The remote server must accept CORS and credentials.
+
+### `overridePatchMethod: false`
+
+Whether the POST method should be used instead of PATCH for transfering file chunks. This may be necessary if a browser or the server does not support latter one. In this case, a POST request will be made with the X-HTTP-Method-Override: PATCH header. The server must be able to detect it, and then handle the request as if PATCH would have been the method.
+
+### `retryDelays: [0, 1000, 3000, 5000]`
+
+When uploading a chunk fails, automatically try again after the millisecond intervals specified in this array. By default, we first retry instantly; if that fails, we retry after 1 second; if that fails, we retry after 3 seconds, etc.
+
+Set to `null` to disable automatic retries, and fail instantly if any chunk fails to upload.
+
 ### `metaFields: null`
 
 Pass an array of field names to limit the metadata fields that will be added to uploads as [Tus Metadata](https://tus.io/protocols/resumable-upload.html#upload-metadata).
@@ -68,6 +88,8 @@ Pass an array of field names to limit the metadata fields that will be added to 
 ### `autoRetry: true`
 
 Configures whether or not to auto-retry the upload when the user's internet connection is back online after an outage.
+
+Note that this is unrelated to the `retryDelays` option. The `retryDelays` option specifies how often to retry an upload that failed. The `autoRetry` option attempts to retry uploads that failed in the past, once the network has changed.
 
 ### `limit: 0`
 


### PR DESCRIPTION
We mentioned that we support all tus-js-client options, but the `on*` event options are not supported because we use them internally. This copies / adapts documentation from the tus-js-client readme, which also means you have to search less for available options because they're now all there on the page

Closes #1327