### PR TITLE
website: fix highlighting again

### DIFF
--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -13,7 +13,7 @@ global.Prism = Prism
 require('prismjs/components/')()
 delete global.Prism
 
-const unhighlightedCodeRx = /<pre><code class="(.*)?">([\s\S]*?)<\/code><\/pre>/igm
+const unhighlightedCodeRx = /<pre><code class="([^"]*)?">([\s\S]*?)<\/code><\/pre>/igm
 
 function highlight (lang, code) {
   const startTag = `<figure class="highlight ${lang}"><table><tr><td class="code"><pre>`

--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -13,7 +13,15 @@ global.Prism = Prism
 require('prismjs/components/')()
 delete global.Prism
 
+const rawInlineCodeRx = /<code>([^\n]+?)<\/code>/ig
 const unhighlightedCodeRx = /<pre><code class="([^"]*)?">([\s\S]*?)<\/code><\/pre>/igm
+
+function escapeInlineCodeBlocks (data) {
+  data.content = data.content.replace(rawInlineCodeRx, (_, code) => {
+    return `<code>${entities.encode(code)}</code>`
+  })
+  return data
+}
 
 function highlight (lang, code) {
   const startTag = `<figure class="highlight ${lang}"><table><tr><td class="code"><pre>`
@@ -44,14 +52,15 @@ function code (args, content) {
   return highlight(lang, content)
 }
 
-function includeCode (args) {
+async function includeCode (args) {
   let lang = ''
   if (args[0].startsWith('lang:')) {
     lang = args.shift().replace(/^lang:/, '')
   }
 
   const file = path.join(hexo.source_dir, hexo.config.code_dir, args.join(' '))
-  return readFile(file, 'utf8').then((code) => highlight(lang, code.trim()))
+  const content = await readFile(file, 'utf8')
+  return highlight(lang, content.trim())
 }
 
 // Highlight as many things as we possibly can
@@ -60,6 +69,7 @@ hexo.extend.tag.register('codeblock', code, true)
 hexo.extend.tag.register('include_code', includeCode, { async: true })
 hexo.extend.tag.register('include-code', includeCode, { async: true })
 
+hexo.extend.filter.register('after_post_render', escapeInlineCodeBlocks)
 // Hexo includes its own code block handling by default which may
 // cause the above to miss some things, so do another pass when the page
 // is done rendering to pick up any code blocks we may have missed.


### PR DESCRIPTION
This should do it hopefully...

- The regex for detecting code blocks to highlight had a `.*` that was eating into the _contents_ of the block instead of stopping at the closing " for the class attribute.

- Inline code blocks are now escaped (not sure when that stopped happening...)

Sample: https://deploy-preview-1757--uppy.netlify.com/docs/