### PR TITLE
core: use setFileState inside retryUpload

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -660,13 +660,9 @@ class Uppy {
   }
 
   retryUpload (fileID) {
-    const updatedFiles = Object.assign({}, this.getState().files)
-    const updatedFile = Object.assign({}, updatedFiles[fileID],
-      { error: null, isPaused: false }
-    )
-    updatedFiles[fileID] = updatedFile
-    this.setState({
-      files: updatedFiles
+    this.setFileState(fileID, {
+      error: null,
+      isPaused: false
     })
 
     this.emit('upload-retry', fileID)


### PR DESCRIPTION
Makes it a bit easier to follow. It also logs a warning now when you do
`.retryUpload(SomeNonsenseFileID)` instead of silently adding an invalid
object to the state, which is a less terrible failure.