### PR TITLE
xhr-upload: Throw an error when trying to upload a remote file with `bundle: true`

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1316,6 +1316,7 @@ class Uppy {
           this.emit('restriction-failed', null, err)
           this.log(`${message} ${details}`, 'info')
           this.info({ message: message, details: details }, 'info', 5000)
+          return Promise.reject(typeof err === 'object' ? err : new Error(err))
         } else {
           this.log(`${message} ${details}`, 'error')
           this.info({ message: message, details: details }, 'error', 5000)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1316,12 +1316,12 @@ class Uppy {
           this.emit('restriction-failed', null, err)
           this.log(`${message} ${details}`, 'info')
           this.info({ message: message, details: details }, 'info', 5000)
-          return Promise.reject(typeof err === 'object' ? err : new Error(err))
         } else {
           this.log(`${message} ${details}`, 'error')
           this.info({ message: message, details: details }, 'error', 5000)
-          throw (typeof err === 'object' ? err : new Error(err))
         }
+
+        throw (typeof err === 'object' ? err : new Error(err))
       })
   }
 }

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1273,11 +1273,11 @@ class Uppy {
    * @returns {Promise}
    */
   upload () {
-    const onError = (err) => {
+    const onError = (err, type = 'info') => {
       const message = typeof err === 'object' ? err.message : err
       const details = (typeof err === 'object' && err.details) ? err.details : ''
-      this.log(`${message} ${details}`)
-      this.info({ message: message, details: details }, 'error', 5000)
+      this.log(`${message} ${details}`, type)
+      this.info({ message: message, details: details }, type, 5000)
       throw (typeof err === 'object' ? err : new Error(err))
     }
 
@@ -1286,6 +1286,7 @@ class Uppy {
     }
 
     let files = this.getState().files
+
     const onBeforeUploadResult = this.opts.onBeforeUpload(files)
 
     if (onBeforeUploadResult === false) {
@@ -1318,8 +1319,9 @@ class Uppy {
       .catch((err) => {
         if (err.isRestriction) {
           this.emit('restriction-failed', null, err)
+          return onError(err)
         }
-        onError(err)
+        onError(err, 'error')
       })
   }
 }

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -120,7 +120,7 @@ class Uppy {
     }
 
     // i18n
-    this.translator = new Translator([ this.defaultLocale, this.opts.locale ])
+    this.translator = new Translator([this.defaultLocale, this.opts.locale])
     this.locale = this.translator.locale
     this.i18n = this.translator.translate.bind(this.translator)
     this.i18nArray = this.translator.translateArray.bind(this.translator)
@@ -667,7 +667,7 @@ class Uppy {
 
     this.emit('upload-retry', fileID)
 
-    const uploadID = this._createUpload([ fileID ])
+    const uploadID = this._createUpload([fileID])
     return this._runUpload(uploadID)
   }
 
@@ -916,7 +916,7 @@ class Uppy {
    */
   use (Plugin, opts) {
     if (typeof Plugin !== 'function') {
-      let msg = `Expected a plugin class, but got ${Plugin === null ? 'null' : typeof Plugin}.` +
+      const msg = `Expected a plugin class, but got ${Plugin === null ? 'null' : typeof Plugin}.` +
         ' Please verify that the plugin was imported and spelled correctly.'
       throw new TypeError(msg)
     }
@@ -934,9 +934,9 @@ class Uppy {
       throw new Error('Your plugin must have a type')
     }
 
-    let existsPluginAlready = this.getPlugin(pluginId)
+    const existsPluginAlready = this.getPlugin(pluginId)
     if (existsPluginAlready) {
-      let msg = `Already found a plugin named '${existsPluginAlready.id}'. ` +
+      const msg = `Already found a plugin named '${existsPluginAlready.id}'. ` +
         `Tried to use: '${pluginId}'.\n` +
         `Uppy plugins must have unique 'id' options. See https://uppy.io/docs/plugins/#id.`
       throw new Error(msg)
@@ -1273,14 +1273,6 @@ class Uppy {
    * @returns {Promise}
    */
   upload () {
-    const onError = (err, type = 'info') => {
-      const message = typeof err === 'object' ? err.message : err
-      const details = (typeof err === 'object' && err.details) ? err.details : ''
-      this.log(`${message} ${details}`, type)
-      this.info({ message: message, details: details }, type, 5000)
-      throw (typeof err === 'object' ? err : new Error(err))
-    }
-
     if (!this.plugins.uploader) {
       this.log('No uploader type plugins are used', 'warning')
     }
@@ -1317,11 +1309,18 @@ class Uppy {
         return this._runUpload(uploadID)
       })
       .catch((err) => {
+        const message = typeof err === 'object' ? err.message : err
+        const details = (typeof err === 'object' && err.details) ? err.details : ''
+
         if (err.isRestriction) {
           this.emit('restriction-failed', null, err)
-          return onError(err)
+          this.log(`${message} ${details}`, 'info')
+          this.info({ message: message, details: details }, 'info', 5000)
+        } else {
+          this.log(`${message} ${details}`, 'error')
+          this.info({ message: message, details: details }, 'error', 5000)
+          throw (typeof err === 'object' ? err : new Error(err))
         }
-        onError(err, 'error')
       })
   }
 }

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -104,7 +104,7 @@ module.exports = class XHRUpload extends Plugin {
     this.opts = Object.assign({}, defaultOptions, opts)
 
     // i18n
-    this.translator = new Translator([ this.defaultLocale, this.uppy.locale, this.opts.locale ])
+    this.translator = new Translator([this.defaultLocale, this.uppy.locale, this.opts.locale])
     this.i18n = this.translator.translate.bind(this.translator)
     this.i18nArray = this.translator.translateArray.bind(this.translator)
 
@@ -540,7 +540,7 @@ module.exports = class XHRUpload extends Plugin {
       // if bundle: true, we don’t support remote uploads
       const isSomeFileRemote = files.some(file => file.isRemote)
       if (isSomeFileRemote) {
-        throw new Error('Can’t bundle remote files when bundle: true is set')
+        throw new Error('Can’t upload remote files when bundle: true option is set')
       }
 
       return this.uploadBundle(files)

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -537,6 +537,12 @@ module.exports = class XHRUpload extends Plugin {
     const files = fileIDs.map((fileID) => this.uppy.getFile(fileID))
 
     if (this.opts.bundle) {
+      // if bundle: true, we don’t support remote uploads
+      const isSomeFileRemote = files.some(file => file.isRemote)
+      if (isSomeFileRemote) {
+        throw new Error('Can’t bundle remote files when bundle: true is set')
+      }
+
       return this.uploadBundle(files)
     }
 

--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -90,7 +90,9 @@ headers: {
 
 Send all files in a single multipart request. When `bundle` is set to `true`, `formData` must also be set to `true`.
 
-> Note: When `bundle` is set to `true`, file metadata is **not** sent to the endpoint. This is because it is not obvious how metadata should be sent when there are multiple files in a single request. If you need this, please open an issue and we will try to figure it out together.
+⚠️ Only use `bundle: true` with local uploads (drag-drop, browse, webcam), Uppy won’t be able to bundle remote files (from Google Drive or Instagram), and will throw an error in this case.
+
+> Note: When `bundle` is set to `true`, [global uppy metadata](https://uppy.io/docs/uppy/#meta), the one set via `meta` options property, is sent to the endpoint. Individual per-file metadata is ignored.
 
 All files will be appended to the provided `fieldName` field in the request. To upload files on different fields, use [`uppy.setFileState()`](/docs/uppy#uppy-setFileState-fileID-state) to set the `xhrUpload.fieldName` property on the file:
 


### PR DESCRIPTION
- Throw an error when trying to upload a remote file with `bundle: true` in `xhr-upload` — we can’t bundle remote files.
- Allow for `uppy.log` type `error` when `catching` errors in `uppy.upload()`.

Fixes #866