### PR TITLE
build: Add size-limit that shows uppy bundle size and execution time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5056,10 +5056,38 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",
+      "integrity": "sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.1",
+        "run-parallel": "^1.1.9"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
+          "integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==",
+          "dev": true
+        }
+      }
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz",
+      "integrity": "sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.1",
+        "fastq": "^1.6.0"
+      }
     },
     "@octokit/endpoint": {
       "version": "5.3.0",
@@ -5260,6 +5288,132 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@size-limit/file": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-2.1.1.tgz",
+      "integrity": "sha512-zp0lZhyy+AhQqZ3g/nLPqFPRFbc6En2iA/ApiohRG7qQOMBbZhiZXvZeGX5GWUCDUU0ekH1NXz/SxhU/Cq6K2g==",
+      "dev": true,
+      "requires": {
+        "size-limit": "2.1.1"
+      }
+    },
+    "@size-limit/preset-big-lib": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-big-lib/-/preset-big-lib-2.1.1.tgz",
+      "integrity": "sha512-7oZBQyaSGotsR90EGckeb407wKR7eTfxmmfDga83Cww0d9Dd1vwmhJDmizQBg++R8rRrbIMHv2gw9lWaGzJpgQ==",
+      "dev": true,
+      "requires": {
+        "@size-limit/file": "2.1.1",
+        "@size-limit/time": "2.1.1",
+        "@size-limit/webpack": "2.1.1"
+      }
+    },
+    "@size-limit/time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@size-limit/time/-/time-2.1.1.tgz",
+      "integrity": "sha512-GpFfpSYMkLEvc7KVRJHCExKtk3sh7cnBRNjXWmawjheB3W57nNJmLfobmxa44xw8EOEmMkS2kw4py4HKnXuztw==",
+      "dev": true,
+      "requires": {
+        "estimo": "^1.1.5",
+        "react": "^16.9.0",
+        "size-limit": "2.1.1"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.9.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+          "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
+    "@size-limit/webpack": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@size-limit/webpack/-/webpack-2.1.1.tgz",
+      "integrity": "sha512-A00NV9q4znon1rXEuqLQp4eBVpH+avjdzA5Hk34Z6ddOpDNXDai5eXTDecryapSCb/Q5rs/iKHwDxZiMgHH2DA==",
+      "dev": true,
+      "requires": {
+        "css-loader": "^3.2.0",
+        "escape-string-regexp": "^2.0.0",
+        "file-loader": "^4.2.0",
+        "nanoid": "^2.0.3",
+        "optimize-css-assets-webpack-plugin": "^5.0.3",
+        "rimraf": "^3.0.0",
+        "size-limit": "2.1.1",
+        "style-loader": "^1.0.0",
+        "webpack": "^4.39.2",
+        "webpack-bundle-analyzer": "^3.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "webpack": {
+          "version": "4.39.2",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.2.tgz",
+          "integrity": "sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.8.5",
+            "@webassemblyjs/helper-module-context": "1.8.5",
+            "@webassemblyjs/wasm-edit": "1.8.5",
+            "@webassemblyjs/wasm-parser": "1.8.5",
+            "acorn": "^6.2.1",
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1",
+            "chrome-trace-event": "^1.0.2",
+            "enhanced-resolve": "^4.1.0",
+            "eslint-scope": "^4.0.3",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^2.4.0",
+            "loader-utils": "^1.2.3",
+            "memory-fs": "^0.4.1",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.1",
+            "neo-async": "^2.6.1",
+            "node-libs-browser": "^2.2.1",
+            "schema-utils": "^1.0.0",
+            "tapable": "^1.1.3",
+            "terser-webpack-plugin": "^1.4.1",
+            "watchpack": "^1.6.0",
+            "webpack-sources": "^1.4.1"
+          }
+        }
       }
     },
     "@types/aws-lambda": {
@@ -5539,6 +5693,12 @@
       "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
@@ -5735,8 +5895,7 @@
       "dependencies": {
         "es6-promise": {
           "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+          "bundled": true
         }
       }
     },
@@ -5778,8 +5937,7 @@
       "dependencies": {
         "@uppy/aws-s3": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3/-/aws-s3-0.30.5.tgz",
-          "integrity": "sha512-MNzu+WWi4HnohSXlDk1M/RRRF9EuZMWJNUIr6LmbO/hNtiznBwf/9/K+j22GSAhmbDA+46Tr3ViKdCHxeFuozQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -5789,8 +5947,7 @@
         },
         "@uppy/aws-s3-multipart": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3-multipart/-/aws-s3-multipart-0.30.5.tgz",
-          "integrity": "sha512-DalInROtn9rPXQ7p/SO87BuNT9drIK3REXR4odHnYscTbKaa2RgpsYqooAKZ4dHl0wkGcxVJ/jnXm5jc02kWoQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -5799,16 +5956,14 @@
         },
         "@uppy/companion-client": {
           "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-0.28.5.tgz",
-          "integrity": "sha512-oNutUB/dnHVgjKLwKi31kXjTQM1WTq/3XJy6euR5mLwYpxfWgx5FeO7M08HU4n98Dz3FxztIcAW5tNTKLq1/bQ==",
+          "bundled": true,
           "requires": {
             "namespace-emitter": "^2.0.1"
           }
         },
         "@uppy/core": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/core/-/core-0.30.5.tgz",
-          "integrity": "sha512-MekAgvE6MYX4PAW7ouCQEiUWXB4CpDZ0pD/Sbirfn0MbX7CqD2UyT9sEWt5jwZLgKz829G1nOt4TYw0GnzKHrQ==",
+          "bundled": true,
           "requires": {
             "@uppy/store-default": "0.28.3",
             "@uppy/utils": "0.30.5",
@@ -5822,8 +5977,7 @@
         },
         "@uppy/dashboard": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dashboard/-/dashboard-0.30.5.tgz",
-          "integrity": "sha512-G4220BPJcxB/EbvrHH8IUI0sHuRyWh/pchPWModqsE2RR9L/K2E1F2ad2LnWQP+v4H54R34FDmHtk/hjoTPzhA==",
+          "bundled": true,
           "requires": {
             "@uppy/informer": "0.30.5",
             "@uppy/provider-views": "0.30.5",
@@ -5842,8 +5996,7 @@
         },
         "@uppy/drag-drop": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/drag-drop/-/drag-drop-0.30.5.tgz",
-          "integrity": "sha512-78hu/Pk3OrSI+fEmC4zZaAZrcm4P6qaYx+YsGT1AeMHEzfV1uT1xsTUbyDj7UYmg2riy8OgUIK3VyP4i8uh0OA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "drag-drop": "2.13.3",
@@ -5852,8 +6005,7 @@
         },
         "@uppy/dropbox": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dropbox/-/dropbox-0.30.5.tgz",
-          "integrity": "sha512-rgbrJ+tWsaI63SFTlHJVyMEXSle88E31dWIl+EnCgQpfTFhG8j68A7HywcEVtD7eqsjf3DwDEO1ExcS1GYRNjQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -5863,8 +6015,7 @@
         },
         "@uppy/file-input": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/file-input/-/file-input-0.30.5.tgz",
-          "integrity": "sha512-DsPfR80am3dfj6kP9u6QOnrTT+ELOf5ET9xajhmPQsL0r+0TUB0Zq6WwhhkyvysIE8TeDzLz5AkzYRvK5EkCaA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -5872,8 +6023,7 @@
         },
         "@uppy/form": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/form/-/form-0.30.5.tgz",
-          "integrity": "sha512-Di2qAyhxdXCePOXbhRWfnmERbPXoWexif9sK+LDDoedwCrIXz48HbJc5JkEb/vjbvXhIv7aO7n7y0cLrCfRsmw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "get-form-data": "^2.0.0"
@@ -5881,8 +6031,7 @@
         },
         "@uppy/golden-retriever": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/golden-retriever/-/golden-retriever-0.30.5.tgz",
-          "integrity": "sha512-q4hKMoALSbiglEUncWUl2DwEDfaCP1P5t/iOe/PVMQwSVIQQbiHeGoPlZR0mZW91YKvECnurb5QXHoonzOxw8Q==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "prettier-bytes": "^1.0.4"
@@ -5890,8 +6039,7 @@
         },
         "@uppy/google-drive": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/google-drive/-/google-drive-0.30.5.tgz",
-          "integrity": "sha512-9BJUTe7B74IndINBoCBsj3nPndFhdA9W3KoPTIaY2BoMJFuno9zRXLA8j3LGJz4t7dUpVyu5t4RIMFA/JbWAMQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -5901,8 +6049,7 @@
         },
         "@uppy/informer": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/informer/-/informer-0.30.5.tgz",
-          "integrity": "sha512-4Ie19Hc03NYRjRA4fhrKebk0QHhgX3Z/ndq+G3Z0AcpbMr8SlNAzUxF52qunEqbOGJ+hFJqkTxas5v/o/uhUSw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -5910,8 +6057,7 @@
         },
         "@uppy/instagram": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/instagram/-/instagram-0.30.5.tgz",
-          "integrity": "sha512-yeQWZiKXLN4NcigoNpxijArhuX+FjupRWTsWipe7D1bOqJKHJh98eNSznjF8W4Mi/H5zJ223JCsQy7RCqx6eFA==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -5921,8 +6067,7 @@
         },
         "@uppy/progress-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/progress-bar/-/progress-bar-0.30.5.tgz",
-          "integrity": "sha512-SBXUaOfEJN8BCmGhL2SBcX81muV+9CcY3vK46mp/1oyFPjZf9XujKbVtX3WXrGW/D+o3KkyUHCp9zrYi7hedtQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -5930,8 +6075,7 @@
         },
         "@uppy/provider-views": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/provider-views/-/provider-views-0.30.5.tgz",
-          "integrity": "sha512-2P2/pzlRjG3TT7FY07jS5AEn2SUEb0yM6XteH4cv53kM9qdrOMdC3ORbZ2avOg2GFoZJgy2v3OeuFYIwat/jPw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -5940,13 +6084,11 @@
         },
         "@uppy/redux-dev-tools": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/redux-dev-tools/-/redux-dev-tools-0.30.5.tgz",
-          "integrity": "sha512-FP1UjXTR/cDw6kLOT2MvGAxKCDr1ioVGJrwasU6NajcNl9E8y63mwoFrOnhrg2R2LWKquV9XsKtWbRP+FaH1Sw=="
+          "bundled": true
         },
         "@uppy/status-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/status-bar/-/status-bar-0.30.5.tgz",
-          "integrity": "sha512-Yfrk4pDksnoEAuykiMiaPiE6JTZElRDuFIwgei/bRPcdNMtAyvF5/uYQ9zjOauivp5zWr8dJ8Y/CgfpxdhjSjw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -5957,29 +6099,25 @@
         },
         "@uppy/store-default": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-0.28.3.tgz",
-          "integrity": "sha512-H3dHvYnna1D3qGMeEW2Mc4BDe2+73IsshqyqyNawZcOG4EF053D5ZeeoB0DQoXaL290vsHMhYilZbp6O0v6Z8g=="
+          "bundled": true
         },
         "@uppy/store-redux": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-redux/-/store-redux-0.28.3.tgz",
-          "integrity": "sha512-VsEcwHotQF0lsaoQfvn7ErCdxthJfKfQpQNNBIZPoZI2SjC+AGjckEYyvih5U1mB9PT1yjbkTVoiSO/iMubRXA==",
+          "bundled": true,
           "requires": {
             "cuid": "^2.1.1"
           }
         },
         "@uppy/thumbnail-generator": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/thumbnail-generator/-/thumbnail-generator-0.30.5.tgz",
-          "integrity": "sha512-yD+AcjpFNJ9alNQ9B+C4KWv/9qj/GOvhhkU9dEDAcsls/ml6JiWlFf4pPaVdP84bpCFiUyKe5EzsLxPLK8MojQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5"
           }
         },
         "@uppy/transloadit": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/transloadit/-/transloadit-0.30.5.tgz",
-          "integrity": "sha512-6EQA3AUgPy2Zn9A6rv9XRYk0oJS+6XlxZPPyPzUxsxkBADx4bIG3HsBH0rZdL23XNSlAkNQcAX21yc0Xey4Qsg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -5991,8 +6129,7 @@
         },
         "@uppy/tus": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-0.30.5.tgz",
-          "integrity": "sha512-Vk1R/fMWqMOrwcc5r14Iit0/VWZCFVDde4yGIZSzF81YIIfC20nyCU2s7EjocNnU394tk6znXauDMT8FMdIC3g==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6001,8 +6138,7 @@
         },
         "@uppy/url": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/url/-/url-0.30.5.tgz",
-          "integrity": "sha512-l8tsCPzKQyxn4gaaI3JD42fEc6b/wdmgbwD6+tEJSe+4TNHaOyrFPZ+j/OYT9tiy7+/qEx3widzY9FN+2VaKHg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6011,16 +6147,14 @@
         },
         "@uppy/utils": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-0.30.5.tgz",
-          "integrity": "sha512-kdZK9qqbzduCIRsTUzEtQEv/Q4iTaEuwm75VlFAs+8mTMd0bFMRf/gYyGCAnANkfD2Ad/7cdjxy3FlwLO9gUBg==",
+          "bundled": true,
           "requires": {
             "lodash.throttle": "^4.1.1"
           }
         },
         "@uppy/webcam": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/webcam/-/webcam-0.30.5.tgz",
-          "integrity": "sha512-L96zDbXpAtzCHXpQuXztSJetQKYDrfU80Us83DvKmauwwV/fGWA85032v3mhvTt2DVFqbZiGl4DLRs5rYKYy1g==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6028,8 +6162,7 @@
         },
         "@uppy/xhr-upload": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-0.30.5.tgz",
-          "integrity": "sha512-i5xZ98ParlwZtcfaMAQwOTTJqiUe6WIxa9ctoBuMXOgg5jHZeXYk1/evUd3ToB93xqk6fsyTjO0kbKDBLjI9SQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6038,12 +6171,12 @@
         },
         "buffer-from": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+          "bundled": true
         },
         "tus-js-client": {
           "version": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
           "from": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
+          "bundled": true,
           "requires": {
             "buffer-from": "^0.1.1",
             "extend": "^3.0.0",
@@ -6055,8 +6188,7 @@
         },
         "uppy": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/uppy/-/uppy-0.30.5.tgz",
-          "integrity": "sha512-G/lE2+i/Oem1iqQ2zm4KUxMFCPNgDzDzFKhk2q8TVKxhOzsiFHrCtxnu8TYMnwoUVl+9HZf2r9Q8fsabmZk6NQ==",
+          "bundled": true,
           "requires": {
             "@uppy/aws-s3": "0.30.5",
             "@uppy/aws-s3-multipart": "0.30.5",
@@ -6104,8 +6236,7 @@
       "dependencies": {
         "@uppy/aws-s3": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3/-/aws-s3-0.30.5.tgz",
-          "integrity": "sha512-MNzu+WWi4HnohSXlDk1M/RRRF9EuZMWJNUIr6LmbO/hNtiznBwf/9/K+j22GSAhmbDA+46Tr3ViKdCHxeFuozQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6115,8 +6246,7 @@
         },
         "@uppy/aws-s3-multipart": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3-multipart/-/aws-s3-multipart-0.30.5.tgz",
-          "integrity": "sha512-DalInROtn9rPXQ7p/SO87BuNT9drIK3REXR4odHnYscTbKaa2RgpsYqooAKZ4dHl0wkGcxVJ/jnXm5jc02kWoQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6125,16 +6255,14 @@
         },
         "@uppy/companion-client": {
           "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-0.28.5.tgz",
-          "integrity": "sha512-oNutUB/dnHVgjKLwKi31kXjTQM1WTq/3XJy6euR5mLwYpxfWgx5FeO7M08HU4n98Dz3FxztIcAW5tNTKLq1/bQ==",
+          "bundled": true,
           "requires": {
             "namespace-emitter": "^2.0.1"
           }
         },
         "@uppy/core": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/core/-/core-0.30.5.tgz",
-          "integrity": "sha512-MekAgvE6MYX4PAW7ouCQEiUWXB4CpDZ0pD/Sbirfn0MbX7CqD2UyT9sEWt5jwZLgKz829G1nOt4TYw0GnzKHrQ==",
+          "bundled": true,
           "requires": {
             "@uppy/store-default": "0.28.3",
             "@uppy/utils": "0.30.5",
@@ -6148,8 +6276,7 @@
         },
         "@uppy/dashboard": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dashboard/-/dashboard-0.30.5.tgz",
-          "integrity": "sha512-G4220BPJcxB/EbvrHH8IUI0sHuRyWh/pchPWModqsE2RR9L/K2E1F2ad2LnWQP+v4H54R34FDmHtk/hjoTPzhA==",
+          "bundled": true,
           "requires": {
             "@uppy/informer": "0.30.5",
             "@uppy/provider-views": "0.30.5",
@@ -6168,8 +6295,7 @@
         },
         "@uppy/drag-drop": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/drag-drop/-/drag-drop-0.30.5.tgz",
-          "integrity": "sha512-78hu/Pk3OrSI+fEmC4zZaAZrcm4P6qaYx+YsGT1AeMHEzfV1uT1xsTUbyDj7UYmg2riy8OgUIK3VyP4i8uh0OA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "drag-drop": "2.13.3",
@@ -6178,8 +6304,7 @@
         },
         "@uppy/dropbox": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dropbox/-/dropbox-0.30.5.tgz",
-          "integrity": "sha512-rgbrJ+tWsaI63SFTlHJVyMEXSle88E31dWIl+EnCgQpfTFhG8j68A7HywcEVtD7eqsjf3DwDEO1ExcS1GYRNjQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6189,8 +6314,7 @@
         },
         "@uppy/file-input": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/file-input/-/file-input-0.30.5.tgz",
-          "integrity": "sha512-DsPfR80am3dfj6kP9u6QOnrTT+ELOf5ET9xajhmPQsL0r+0TUB0Zq6WwhhkyvysIE8TeDzLz5AkzYRvK5EkCaA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6198,8 +6322,7 @@
         },
         "@uppy/form": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/form/-/form-0.30.5.tgz",
-          "integrity": "sha512-Di2qAyhxdXCePOXbhRWfnmERbPXoWexif9sK+LDDoedwCrIXz48HbJc5JkEb/vjbvXhIv7aO7n7y0cLrCfRsmw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "get-form-data": "^2.0.0"
@@ -6207,8 +6330,7 @@
         },
         "@uppy/golden-retriever": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/golden-retriever/-/golden-retriever-0.30.5.tgz",
-          "integrity": "sha512-q4hKMoALSbiglEUncWUl2DwEDfaCP1P5t/iOe/PVMQwSVIQQbiHeGoPlZR0mZW91YKvECnurb5QXHoonzOxw8Q==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "prettier-bytes": "^1.0.4"
@@ -6216,8 +6338,7 @@
         },
         "@uppy/google-drive": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/google-drive/-/google-drive-0.30.5.tgz",
-          "integrity": "sha512-9BJUTe7B74IndINBoCBsj3nPndFhdA9W3KoPTIaY2BoMJFuno9zRXLA8j3LGJz4t7dUpVyu5t4RIMFA/JbWAMQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6227,8 +6348,7 @@
         },
         "@uppy/informer": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/informer/-/informer-0.30.5.tgz",
-          "integrity": "sha512-4Ie19Hc03NYRjRA4fhrKebk0QHhgX3Z/ndq+G3Z0AcpbMr8SlNAzUxF52qunEqbOGJ+hFJqkTxas5v/o/uhUSw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6236,8 +6356,7 @@
         },
         "@uppy/instagram": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/instagram/-/instagram-0.30.5.tgz",
-          "integrity": "sha512-yeQWZiKXLN4NcigoNpxijArhuX+FjupRWTsWipe7D1bOqJKHJh98eNSznjF8W4Mi/H5zJ223JCsQy7RCqx6eFA==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6247,8 +6366,7 @@
         },
         "@uppy/progress-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/progress-bar/-/progress-bar-0.30.5.tgz",
-          "integrity": "sha512-SBXUaOfEJN8BCmGhL2SBcX81muV+9CcY3vK46mp/1oyFPjZf9XujKbVtX3WXrGW/D+o3KkyUHCp9zrYi7hedtQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6256,8 +6374,7 @@
         },
         "@uppy/provider-views": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/provider-views/-/provider-views-0.30.5.tgz",
-          "integrity": "sha512-2P2/pzlRjG3TT7FY07jS5AEn2SUEb0yM6XteH4cv53kM9qdrOMdC3ORbZ2avOg2GFoZJgy2v3OeuFYIwat/jPw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -6266,13 +6383,11 @@
         },
         "@uppy/redux-dev-tools": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/redux-dev-tools/-/redux-dev-tools-0.30.5.tgz",
-          "integrity": "sha512-FP1UjXTR/cDw6kLOT2MvGAxKCDr1ioVGJrwasU6NajcNl9E8y63mwoFrOnhrg2R2LWKquV9XsKtWbRP+FaH1Sw=="
+          "bundled": true
         },
         "@uppy/status-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/status-bar/-/status-bar-0.30.5.tgz",
-          "integrity": "sha512-Yfrk4pDksnoEAuykiMiaPiE6JTZElRDuFIwgei/bRPcdNMtAyvF5/uYQ9zjOauivp5zWr8dJ8Y/CgfpxdhjSjw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -6283,29 +6398,25 @@
         },
         "@uppy/store-default": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-0.28.3.tgz",
-          "integrity": "sha512-H3dHvYnna1D3qGMeEW2Mc4BDe2+73IsshqyqyNawZcOG4EF053D5ZeeoB0DQoXaL290vsHMhYilZbp6O0v6Z8g=="
+          "bundled": true
         },
         "@uppy/store-redux": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-redux/-/store-redux-0.28.3.tgz",
-          "integrity": "sha512-VsEcwHotQF0lsaoQfvn7ErCdxthJfKfQpQNNBIZPoZI2SjC+AGjckEYyvih5U1mB9PT1yjbkTVoiSO/iMubRXA==",
+          "bundled": true,
           "requires": {
             "cuid": "^2.1.1"
           }
         },
         "@uppy/thumbnail-generator": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/thumbnail-generator/-/thumbnail-generator-0.30.5.tgz",
-          "integrity": "sha512-yD+AcjpFNJ9alNQ9B+C4KWv/9qj/GOvhhkU9dEDAcsls/ml6JiWlFf4pPaVdP84bpCFiUyKe5EzsLxPLK8MojQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5"
           }
         },
         "@uppy/transloadit": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/transloadit/-/transloadit-0.30.5.tgz",
-          "integrity": "sha512-6EQA3AUgPy2Zn9A6rv9XRYk0oJS+6XlxZPPyPzUxsxkBADx4bIG3HsBH0rZdL23XNSlAkNQcAX21yc0Xey4Qsg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6317,8 +6428,7 @@
         },
         "@uppy/tus": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-0.30.5.tgz",
-          "integrity": "sha512-Vk1R/fMWqMOrwcc5r14Iit0/VWZCFVDde4yGIZSzF81YIIfC20nyCU2s7EjocNnU394tk6znXauDMT8FMdIC3g==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6327,8 +6437,7 @@
         },
         "@uppy/url": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/url/-/url-0.30.5.tgz",
-          "integrity": "sha512-l8tsCPzKQyxn4gaaI3JD42fEc6b/wdmgbwD6+tEJSe+4TNHaOyrFPZ+j/OYT9tiy7+/qEx3widzY9FN+2VaKHg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6337,16 +6446,14 @@
         },
         "@uppy/utils": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-0.30.5.tgz",
-          "integrity": "sha512-kdZK9qqbzduCIRsTUzEtQEv/Q4iTaEuwm75VlFAs+8mTMd0bFMRf/gYyGCAnANkfD2Ad/7cdjxy3FlwLO9gUBg==",
+          "bundled": true,
           "requires": {
             "lodash.throttle": "^4.1.1"
           }
         },
         "@uppy/webcam": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/webcam/-/webcam-0.30.5.tgz",
-          "integrity": "sha512-L96zDbXpAtzCHXpQuXztSJetQKYDrfU80Us83DvKmauwwV/fGWA85032v3mhvTt2DVFqbZiGl4DLRs5rYKYy1g==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6354,8 +6461,7 @@
         },
         "@uppy/xhr-upload": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-0.30.5.tgz",
-          "integrity": "sha512-i5xZ98ParlwZtcfaMAQwOTTJqiUe6WIxa9ctoBuMXOgg5jHZeXYk1/evUd3ToB93xqk6fsyTjO0kbKDBLjI9SQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6364,12 +6470,12 @@
         },
         "buffer-from": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+          "bundled": true
         },
         "tus-js-client": {
           "version": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
           "from": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
+          "bundled": true,
           "requires": {
             "buffer-from": "^0.1.1",
             "extend": "^3.0.0",
@@ -6381,8 +6487,7 @@
         },
         "uppy": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/uppy/-/uppy-0.30.5.tgz",
-          "integrity": "sha512-G/lE2+i/Oem1iqQ2zm4KUxMFCPNgDzDzFKhk2q8TVKxhOzsiFHrCtxnu8TYMnwoUVl+9HZf2r9Q8fsabmZk6NQ==",
+          "bundled": true,
           "requires": {
             "@uppy/aws-s3": "0.30.5",
             "@uppy/aws-s3-multipart": "0.30.5",
@@ -6430,8 +6535,7 @@
       "dependencies": {
         "@uppy/aws-s3": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3/-/aws-s3-0.30.5.tgz",
-          "integrity": "sha512-MNzu+WWi4HnohSXlDk1M/RRRF9EuZMWJNUIr6LmbO/hNtiznBwf/9/K+j22GSAhmbDA+46Tr3ViKdCHxeFuozQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6441,8 +6545,7 @@
         },
         "@uppy/aws-s3-multipart": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/aws-s3-multipart/-/aws-s3-multipart-0.30.5.tgz",
-          "integrity": "sha512-DalInROtn9rPXQ7p/SO87BuNT9drIK3REXR4odHnYscTbKaa2RgpsYqooAKZ4dHl0wkGcxVJ/jnXm5jc02kWoQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6451,16 +6554,14 @@
         },
         "@uppy/companion-client": {
           "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-0.28.5.tgz",
-          "integrity": "sha512-oNutUB/dnHVgjKLwKi31kXjTQM1WTq/3XJy6euR5mLwYpxfWgx5FeO7M08HU4n98Dz3FxztIcAW5tNTKLq1/bQ==",
+          "bundled": true,
           "requires": {
             "namespace-emitter": "^2.0.1"
           }
         },
         "@uppy/core": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/core/-/core-0.30.5.tgz",
-          "integrity": "sha512-MekAgvE6MYX4PAW7ouCQEiUWXB4CpDZ0pD/Sbirfn0MbX7CqD2UyT9sEWt5jwZLgKz829G1nOt4TYw0GnzKHrQ==",
+          "bundled": true,
           "requires": {
             "@uppy/store-default": "0.28.3",
             "@uppy/utils": "0.30.5",
@@ -6474,8 +6575,7 @@
         },
         "@uppy/dashboard": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dashboard/-/dashboard-0.30.5.tgz",
-          "integrity": "sha512-G4220BPJcxB/EbvrHH8IUI0sHuRyWh/pchPWModqsE2RR9L/K2E1F2ad2LnWQP+v4H54R34FDmHtk/hjoTPzhA==",
+          "bundled": true,
           "requires": {
             "@uppy/informer": "0.30.5",
             "@uppy/provider-views": "0.30.5",
@@ -6494,8 +6594,7 @@
         },
         "@uppy/drag-drop": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/drag-drop/-/drag-drop-0.30.5.tgz",
-          "integrity": "sha512-78hu/Pk3OrSI+fEmC4zZaAZrcm4P6qaYx+YsGT1AeMHEzfV1uT1xsTUbyDj7UYmg2riy8OgUIK3VyP4i8uh0OA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "drag-drop": "2.13.3",
@@ -6504,8 +6603,7 @@
         },
         "@uppy/dropbox": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/dropbox/-/dropbox-0.30.5.tgz",
-          "integrity": "sha512-rgbrJ+tWsaI63SFTlHJVyMEXSle88E31dWIl+EnCgQpfTFhG8j68A7HywcEVtD7eqsjf3DwDEO1ExcS1GYRNjQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6515,8 +6613,7 @@
         },
         "@uppy/file-input": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/file-input/-/file-input-0.30.5.tgz",
-          "integrity": "sha512-DsPfR80am3dfj6kP9u6QOnrTT+ELOf5ET9xajhmPQsL0r+0TUB0Zq6WwhhkyvysIE8TeDzLz5AkzYRvK5EkCaA==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6524,8 +6621,7 @@
         },
         "@uppy/form": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/form/-/form-0.30.5.tgz",
-          "integrity": "sha512-Di2qAyhxdXCePOXbhRWfnmERbPXoWexif9sK+LDDoedwCrIXz48HbJc5JkEb/vjbvXhIv7aO7n7y0cLrCfRsmw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "get-form-data": "^2.0.0"
@@ -6533,8 +6629,7 @@
         },
         "@uppy/golden-retriever": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/golden-retriever/-/golden-retriever-0.30.5.tgz",
-          "integrity": "sha512-q4hKMoALSbiglEUncWUl2DwEDfaCP1P5t/iOe/PVMQwSVIQQbiHeGoPlZR0mZW91YKvECnurb5QXHoonzOxw8Q==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "prettier-bytes": "^1.0.4"
@@ -6542,8 +6637,7 @@
         },
         "@uppy/google-drive": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/google-drive/-/google-drive-0.30.5.tgz",
-          "integrity": "sha512-9BJUTe7B74IndINBoCBsj3nPndFhdA9W3KoPTIaY2BoMJFuno9zRXLA8j3LGJz4t7dUpVyu5t4RIMFA/JbWAMQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6553,8 +6647,7 @@
         },
         "@uppy/informer": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/informer/-/informer-0.30.5.tgz",
-          "integrity": "sha512-4Ie19Hc03NYRjRA4fhrKebk0QHhgX3Z/ndq+G3Z0AcpbMr8SlNAzUxF52qunEqbOGJ+hFJqkTxas5v/o/uhUSw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6562,8 +6655,7 @@
         },
         "@uppy/instagram": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/instagram/-/instagram-0.30.5.tgz",
-          "integrity": "sha512-yeQWZiKXLN4NcigoNpxijArhuX+FjupRWTsWipe7D1bOqJKHJh98eNSznjF8W4Mi/H5zJ223JCsQy7RCqx6eFA==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6573,8 +6665,7 @@
         },
         "@uppy/progress-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/progress-bar/-/progress-bar-0.30.5.tgz",
-          "integrity": "sha512-SBXUaOfEJN8BCmGhL2SBcX81muV+9CcY3vK46mp/1oyFPjZf9XujKbVtX3WXrGW/D+o3KkyUHCp9zrYi7hedtQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6582,8 +6673,7 @@
         },
         "@uppy/provider-views": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/provider-views/-/provider-views-0.30.5.tgz",
-          "integrity": "sha512-2P2/pzlRjG3TT7FY07jS5AEn2SUEb0yM6XteH4cv53kM9qdrOMdC3ORbZ2avOg2GFoZJgy2v3OeuFYIwat/jPw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -6592,13 +6682,11 @@
         },
         "@uppy/redux-dev-tools": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/redux-dev-tools/-/redux-dev-tools-0.30.5.tgz",
-          "integrity": "sha512-FP1UjXTR/cDw6kLOT2MvGAxKCDr1ioVGJrwasU6NajcNl9E8y63mwoFrOnhrg2R2LWKquV9XsKtWbRP+FaH1Sw=="
+          "bundled": true
         },
         "@uppy/status-bar": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/status-bar/-/status-bar-0.30.5.tgz",
-          "integrity": "sha512-Yfrk4pDksnoEAuykiMiaPiE6JTZElRDuFIwgei/bRPcdNMtAyvF5/uYQ9zjOauivp5zWr8dJ8Y/CgfpxdhjSjw==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "classnames": "^2.2.6",
@@ -6609,29 +6697,25 @@
         },
         "@uppy/store-default": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-0.28.3.tgz",
-          "integrity": "sha512-H3dHvYnna1D3qGMeEW2Mc4BDe2+73IsshqyqyNawZcOG4EF053D5ZeeoB0DQoXaL290vsHMhYilZbp6O0v6Z8g=="
+          "bundled": true
         },
         "@uppy/store-redux": {
           "version": "0.28.3",
-          "resolved": "https://registry.npmjs.org/@uppy/store-redux/-/store-redux-0.28.3.tgz",
-          "integrity": "sha512-VsEcwHotQF0lsaoQfvn7ErCdxthJfKfQpQNNBIZPoZI2SjC+AGjckEYyvih5U1mB9PT1yjbkTVoiSO/iMubRXA==",
+          "bundled": true,
           "requires": {
             "cuid": "^2.1.1"
           }
         },
         "@uppy/thumbnail-generator": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/thumbnail-generator/-/thumbnail-generator-0.30.5.tgz",
-          "integrity": "sha512-yD+AcjpFNJ9alNQ9B+C4KWv/9qj/GOvhhkU9dEDAcsls/ml6JiWlFf4pPaVdP84bpCFiUyKe5EzsLxPLK8MojQ==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5"
           }
         },
         "@uppy/transloadit": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/transloadit/-/transloadit-0.30.5.tgz",
-          "integrity": "sha512-6EQA3AUgPy2Zn9A6rv9XRYk0oJS+6XlxZPPyPzUxsxkBADx4bIG3HsBH0rZdL23XNSlAkNQcAX21yc0Xey4Qsg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/provider-views": "0.30.5",
@@ -6643,8 +6727,7 @@
         },
         "@uppy/tus": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-0.30.5.tgz",
-          "integrity": "sha512-Vk1R/fMWqMOrwcc5r14Iit0/VWZCFVDde4yGIZSzF81YIIfC20nyCU2s7EjocNnU394tk6znXauDMT8FMdIC3g==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6653,8 +6736,7 @@
         },
         "@uppy/url": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/url/-/url-0.30.5.tgz",
-          "integrity": "sha512-l8tsCPzKQyxn4gaaI3JD42fEc6b/wdmgbwD6+tEJSe+4TNHaOyrFPZ+j/OYT9tiy7+/qEx3widzY9FN+2VaKHg==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6663,16 +6745,14 @@
         },
         "@uppy/utils": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-0.30.5.tgz",
-          "integrity": "sha512-kdZK9qqbzduCIRsTUzEtQEv/Q4iTaEuwm75VlFAs+8mTMd0bFMRf/gYyGCAnANkfD2Ad/7cdjxy3FlwLO9gUBg==",
+          "bundled": true,
           "requires": {
             "lodash.throttle": "^4.1.1"
           }
         },
         "@uppy/webcam": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/webcam/-/webcam-0.30.5.tgz",
-          "integrity": "sha512-L96zDbXpAtzCHXpQuXztSJetQKYDrfU80Us83DvKmauwwV/fGWA85032v3mhvTt2DVFqbZiGl4DLRs5rYKYy1g==",
+          "bundled": true,
           "requires": {
             "@uppy/utils": "0.30.5",
             "preact": "^8.2.9"
@@ -6680,8 +6760,7 @@
         },
         "@uppy/xhr-upload": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-0.30.5.tgz",
-          "integrity": "sha512-i5xZ98ParlwZtcfaMAQwOTTJqiUe6WIxa9ctoBuMXOgg5jHZeXYk1/evUd3ToB93xqk6fsyTjO0kbKDBLjI9SQ==",
+          "bundled": true,
           "requires": {
             "@uppy/companion-client": "0.28.5",
             "@uppy/utils": "0.30.5",
@@ -6690,12 +6769,12 @@
         },
         "buffer-from": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+          "bundled": true
         },
         "tus-js-client": {
           "version": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
           "from": "github:ifedapoolarewaju/tus-js-client#d63fcf08ee43080a0e1cc968ad5986ace788c2d4",
+          "bundled": true,
           "requires": {
             "buffer-from": "^0.1.1",
             "extend": "^3.0.0",
@@ -6707,8 +6786,7 @@
         },
         "uppy": {
           "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/uppy/-/uppy-0.30.5.tgz",
-          "integrity": "sha512-G/lE2+i/Oem1iqQ2zm4KUxMFCPNgDzDzFKhk2q8TVKxhOzsiFHrCtxnu8TYMnwoUVl+9HZf2r9Q8fsabmZk6NQ==",
+          "bundled": true,
           "requires": {
             "@uppy/aws-s3": "0.30.5",
             "@uppy/aws-s3-multipart": "0.30.5",
@@ -6772,8 +6850,7 @@
       "dependencies": {
         "react": {
           "version": "16.5.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.5.0.tgz",
-          "integrity": "sha512-nw/yB/L51kA9PsAy17T1JrzzGRk+BlFCJwFF7p+pwVxgqwPjYNeZEkkH7LXn9dmflolrYMXLWMTkQ77suKPTNQ==",
+          "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -6817,8 +6894,7 @@
       "dependencies": {
         "drag-drop": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/drag-drop/-/drag-drop-4.2.0.tgz",
-          "integrity": "sha512-RA8jXrxOlOFzkM5+tapHeavt0PIlh4FReYx4Ct9ECBRMxixPKUehRs4OQSruAPhQScClt1JaZ3M882FQdcZWaw==",
+          "bundled": true,
           "requires": {
             "blob-to-buffer": "^1.0.2",
             "flatten": "^1.0.2",
@@ -6888,7 +6964,7 @@
         "helmet": "3.8.2",
         "isobject": "3.0.1",
         "jsonwebtoken": "8.3.0",
-        "lodash.merge": "4.6.1",
+        "lodash.merge": "4.6.2",
         "mime-types": "2.1.24",
         "morgan": "1.9.1",
         "ms": "2.1.1",
@@ -6908,8 +6984,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "bundled": true,
           "requires": {
             "co": "^4.6.0",
             "fast-deep-equal": "^1.0.0",
@@ -6919,13 +6994,11 @@
         },
         "atob": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-          "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
+          "bundled": true
         },
         "body-parser": {
           "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "bundled": true,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -6941,13 +7014,11 @@
         },
         "bytes": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+          "bundled": true
         },
         "cookie-parser": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-          "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+          "bundled": true,
           "requires": {
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6"
@@ -6955,23 +7026,20 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "bundled": true
             }
           }
         },
         "express-session": {
           "version": "1.15.6",
-          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
-          "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+          "bundled": true,
           "requires": {
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
@@ -6986,13 +7054,11 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+          "bundled": true
         },
         "har-validator": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "bundled": true,
           "requires": {
             "ajv": "^5.1.0",
             "har-schema": "^2.0.0"
@@ -7000,8 +7066,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "bundled": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -7011,38 +7076,31 @@
         },
         "iconv-lite": {
           "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+          "bundled": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+          "bundled": true
         },
         "lodash.merge": {
           "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-          "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+          "bundled": true
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+          "bundled": true
         },
         "qs": {
           "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "bundled": true
         },
         "raw-body": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "bundled": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.2",
@@ -7052,13 +7110,11 @@
           "dependencies": {
             "depd": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+              "bundled": true
             },
             "http-errors": {
               "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "bundled": true,
               "requires": {
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
@@ -7068,15 +7124,13 @@
             },
             "setprototypeof": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+              "bundled": true
             }
           }
         },
         "request": {
           "version": "2.85.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+          "bundled": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.6.0",
@@ -7104,33 +7158,28 @@
           "dependencies": {
             "uuid": {
               "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+              "bundled": true
             }
           }
         },
         "semver": {
           "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
+          "bundled": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+          "bundled": true
         },
         "tough-cookie": {
           "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "bundled": true,
           "requires": {
             "punycode": "^1.4.1"
           }
         },
         "uuid": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
+          "bundled": true
         }
       }
     },
@@ -7976,6 +8025,194 @@
         "@wdio/logger": "^5.11.0",
         "deepmerge": "^4.0.0"
       }
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "^0.0.3"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -9699,6 +9936,18 @@
         "callsite": "1.0.0"
       }
     },
+    "bfj": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
+      "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "check-types": "^8.0.3",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      }
+    },
     "big-integer": {
       "version": "1.6.44",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
@@ -11193,6 +11442,12 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "check-types": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
+      "integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
+      "dev": true
+    },
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -11263,10 +11518,25 @@
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
       "dev": true
     },
+    "chrome-trace-event": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "ci-job-number": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ci-job-number/-/ci-job-number-0.3.0.tgz",
+      "integrity": "sha1-NL3RFLDezhlgKHvUClcFEEGiqAA=",
       "dev": true
     },
     "cipher-base": {
@@ -12512,6 +12782,108 @@
         "timsort": "^0.3.0"
       }
     },
+    "css-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.0.tgz",
+      "integrity": "sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.17",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.0.0",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "postcss-modules-extract-imports": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+          "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+          "dev": true,
+          "requires": {
+            "postcss": "^7.0.5"
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+          "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^4.1.1",
+            "postcss": "^7.0.16",
+            "postcss-selector-parser": "^6.0.2",
+            "postcss-value-parser": "^4.0.0"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+          "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+          "dev": true,
+          "requires": {
+            "postcss": "^7.0.6",
+            "postcss-selector-parser": "^6.0.0"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+          "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^4.0.0",
+            "postcss": "^7.0.6"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
+          "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "css-modules-loader-core": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
@@ -13737,6 +14109,17 @@
         "has-binary2": "~1.0.2"
       }
     },
+    "enhanced-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+      "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
+      }
+    },
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -13888,6 +14271,15 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -14669,6 +15061,169 @@
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
+      }
+    },
+    "estimo": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/estimo/-/estimo-1.1.5.tgz",
+      "integrity": "sha512-UjORJIGwKLwfbejaM+rIQdeK0Ra8VaXyRwmETXQRk942RZyFy5K9hNlkFxaStIaTkB5Gu7xkar6URlOrfk9e1g==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^2.0.3",
+        "puppeteer-core": "^1.17.0",
+        "tracium": "^0.2.1",
+        "yargs": "^13.2.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "estraverse": {
@@ -15629,6 +16184,35 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -15713,6 +16297,15 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -15779,6 +16372,15 @@
         }
       }
     },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -15800,6 +16402,28 @@
       "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
+      }
+    },
+    "file-loader": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.2.0.tgz",
+      "integrity": "sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
+          "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "file-tree": {
@@ -18392,6 +19016,12 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -18648,6 +19278,15 @@
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -18772,6 +19411,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
       "integrity": "sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0="
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -21131,6 +21776,16 @@
         "stream-splicer": "^2.0.0"
       }
     },
+    "last-call-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5",
+        "webpack-sources": "^1.1.0"
+      }
+    },
     "last-commit-message": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/last-commit-message/-/last-commit-message-1.0.0.tgz",
@@ -21312,6 +21967,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
       "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg=="
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "lint-staged": {
       "version": "8.2.1",
@@ -21569,6 +22230,12 @@
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       }
+    },
+    "loader-runner": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "dev": true
     },
     "loader-utils": {
       "version": "1.2.3",
@@ -22287,6 +22954,12 @@
         "tmpl": "1.0.x"
       }
     },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -22447,6 +23120,16 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
       "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
     },
     "memorystream": {
       "version": "0.3.1",
@@ -23740,6 +24423,12 @@
         }
       }
     },
+    "nanoid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
+      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -24827,6 +25516,16 @@
         }
       }
     },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
+      "integrity": "sha512-q9fbvCRS6EYtUKKSwI87qm2IxlyJK5b4dygW1rKUBT6mMDhdG5e5bZT63v6tnJR9F9FB/H5a0HTmtw+laUBxKA==",
+      "dev": true,
+      "requires": {
+        "cssnano": "^4.1.10",
+        "last-call-webpack-plugin": "^3.0.0"
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -25612,6 +26311,12 @@
         "os-tmpdir": "^1.0.1",
         "which": "^1.3.1"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -26721,6 +27426,18 @@
         }
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -26787,6 +27504,39 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "puppeteer-core": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-1.19.0.tgz",
+      "integrity": "sha512-ZPbbjUymorIJomHBvdZX5+2gciUmQtAdepCrkweHH6rMJr96xd/dXzHgmYEOBMatH44SmJrcMtWkgsLHJqT89g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
     },
     "purest": {
       "version": "3.0.0",
@@ -27903,6 +28653,12 @@
         "through2": "^2.0.0"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -28595,6 +29351,12 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
+    "serialize-javascript": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
+      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
+      "dev": true
+    },
     "serialize-to-js": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
@@ -28837,6 +29599,241 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
       "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
       "dev": true
+    },
+    "size-limit": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-2.1.1.tgz",
+      "integrity": "sha512-OMODRoyU1ZeSAttafaOvVTnCG93z3pF6bw0ZIu8cxGEq8VZSnmhUC4/zgt/O9hUwDWEEE/INMR3ST5DYJlHvHA==",
+      "dev": true,
+      "requires": {
+        "bytes": "^3.1.0",
+        "chalk": "^2.4.2",
+        "ci-job-number": "^0.3.0",
+        "cosmiconfig": "^5.2.1",
+        "globby": "^10.0.1",
+        "read-pkg-up": "^6.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
+          "integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
+          "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.1",
+            "@nodelib/fs.walk": "^1.2.1",
+            "glob-parent": "^5.0.0",
+            "is-glob": "^4.0.1",
+            "merge2": "^1.2.3",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+          "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0",
+            "read-pkg": "^5.1.1",
+            "type-fest": "^0.5.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -29241,6 +30238,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
       "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "dev": true
     },
     "source-map": {
       "version": "0.5.7",
@@ -29859,6 +30862,28 @@
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
       "dev": true
     },
+    "style-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
+      "integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
+          "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -30112,6 +31137,12 @@
         }
       }
     },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true
+    },
     "tar": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
@@ -30277,6 +31308,86 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^1.7.0",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.0.tgz",
+          "integrity": "sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
         }
       }
     },
@@ -30641,6 +31752,15 @@
         }
       }
     },
+    "tracium": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tracium/-/tracium-0.2.1.tgz",
+      "integrity": "sha512-ERoaMqbl9h9qxXrHIh15ZMe2MuYKSN3lXoIrkvDnlQh09Ribn3fzrCQN774ewwS/DbX1wwuipyrhOFqrp5/1qg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
     "transform-ast": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/transform-ast/-/transform-ast-2.4.4.tgz",
@@ -30702,6 +31822,12 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
     },
     "tsconfig": {
       "version": "5.0.3",
@@ -31385,8 +32511,7 @@
       "dependencies": {
         "drag-drop": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/drag-drop/-/drag-drop-4.2.0.tgz",
-          "integrity": "sha512-RA8jXrxOlOFzkM5+tapHeavt0PIlh4FReYx4Ct9ECBRMxixPKUehRs4OQSruAPhQScClt1JaZ3M882FQdcZWaw==",
+          "bundled": true,
           "requires": {
             "blob-to-buffer": "^1.0.2",
             "flatten": "^1.0.2",
@@ -32144,6 +33269,17 @@
         "watchify": "^3.11.1"
       }
     },
+    "watchpack": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      }
+    },
     "wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -32217,6 +33353,117 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "webpack": {
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz",
+      "integrity": "sha512-/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.2.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.1",
+        "watchpack": "^1.6.0",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
+      "integrity": "sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-walk": "^6.1.1",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "dev": true,
+      "requires": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -32325,6 +33572,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "worker-farm": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.7"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -32820,6 +34076,15 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "lint-staged": {
     "*.js": "eslint"
   },
+  "size-limit": [
+    {
+      "path": "packages/uppy/index.js"
+    }
+  ],
   "pre-commit": "lint:staged",
   "license": "MIT",
   "dependencies": {
@@ -72,6 +77,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
     "@octokit/rest": "^16.25.0",
+    "@size-limit/preset-big-lib": "^2.1.1",
     "@types/aws-serverless-express": "^3.0.1",
     "@types/compression": "0.0.36",
     "@types/connect-redis": "0.0.7",
@@ -169,7 +175,8 @@
     "verdaccio": "^4.2.1",
     "watchify": "^3.11.1",
     "webdriverio": "^5.0.0",
-    "whatwg-fetch": "3.0.0"
+    "whatwg-fetch": "3.0.0",
+    "webpack": "4.39.1"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
@@ -206,6 +213,7 @@
     "test:type": "tsc -p .",
     "test:unit": "npm run build:lib && jest",
     "test:watch": "jest --watch",
+    "test:size": "size-limit",
     "test": "npm-run-all lint test:locale-packs test:unit test:type test:companion",
     "uploadcdn": "node ./bin/upload-to-cdn.js",
     "version": "node ./bin/after-version-bump.js",


### PR DESCRIPTION
- Add size-limit, `npm run test:size`, that shows uppy bundle size and execution time (with headless chromium)
- `npm run test:size -- --why` will show a webpack graph, like we have with disc, but more detailed:

<img width="1195" alt="Screen Shot 2019-08-14 at 20 21 56" src="https://user-images.githubusercontent.com/1199054/63052101-39536400-bee7-11e9-9c46-c4b37e075226.png">

We can also set a limit like `130kb` for the `uppy` package. Not sure if we should be adding this to individual modules? Seems like a hassle.

