### PR TITLE
website - add new version of hexo-filter-github-emojis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5536,7 +5536,8 @@
     "@types/node": {
       "version": "12.6.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -17921,6 +17922,24 @@
         "moment": "^2.10.6",
         "mv": "~2",
         "safe-json-stringify": "~1"
+      }
+    },
+    "hexo-filter-github-emojis": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hexo-filter-github-emojis/-/hexo-filter-github-emojis-2.1.0.tgz",
+      "integrity": "sha512-K3iw84E/ZpvvcH3iLM/uV+Ym16l65wGhAVUEYhKvpnJAI9Yi9jfoiAS90mGjXZOdjPlueroudlLDXdEl+b7yaQ==",
+      "requires": {
+        "jsdom": "^15.1.1",
+        "lodash": "^4.17.15",
+        "random-ua": "0.0.6",
+        "request": "^2.83.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "hexo-front-matter": {
@@ -31338,7 +31357,7 @@
         "he": "^1.1.1",
         "hexo": "3.8.0",
         "hexo-browsersync": "^0.3.0",
-        "hexo-filter-github-emojis": "2.0.0",
+        "hexo-filter-github-emojis": "^2.1.0",
         "hexo-generator-alias": "^0.1.3",
         "hexo-generator-archive": "^0.1.5",
         "hexo-generator-category": "^0.1.3",
@@ -31364,39 +31383,6 @@
         "watchify": "^3.11.0"
       },
       "dependencies": {
-        "cheerio": {
-          "version": "1.0.0-rc.3",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-          "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-          "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.1",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
-          }
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-          "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
-            "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
-          }
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
         "drag-drop": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/drag-drop/-/drag-drop-4.2.0.tgz",
@@ -31405,25 +31391,6 @@
             "blob-to-buffer": "^1.0.2",
             "flatten": "^1.0.2",
             "run-parallel": "^1.0.0"
-          }
-        },
-        "hexo-filter-github-emojis": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/hexo-filter-github-emojis/-/hexo-filter-github-emojis-2.0.0.tgz",
-          "integrity": "sha512-0ayu967Eebg8F/9gzvm0KWPWr61vYf/bJrJ2lgQ0ZaA+YMkdEaL3CaxfPjyvX5N5r34CdN+BTJlCYHCwjJCXzA==",
-          "requires": {
-            "cheerio": "^1.0.0-rc.2",
-            "lodash": "^4.17.4",
-            "random-ua": "0.0.6",
-            "request": "^2.83.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-          "requires": {
-            "@types/node": "*"
           }
         }
       }

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "he": "^1.1.1",
     "hexo": "3.8.0",
     "hexo-browsersync": "^0.3.0",
-    "hexo-filter-github-emojis": "2.0.0",
+    "hexo-filter-github-emojis": "^2.1.0",
     "hexo-generator-alias": "^0.1.3",
     "hexo-generator-archive": "^0.1.5",
     "hexo-generator-category": "^0.1.3",


### PR DESCRIPTION
Updated **hexo-filter-github-emojis** from v2.0.0 to v2.1.0.

Things to look for:
1. `<% include_code %>` rendering issue we used to have in v2.0.3  - https://uppy.io/examples/xhrupload/ (✅fixed)
2. Issue where emoticons in excerpts were not getting rendered in /blog (we have this issue now on the website with v2.0.0) - https://uppy.io/blog/  (✅fixed)