### PR TITLE
transloadit: add limit option, warn about using limit when it’s set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,11 @@ PRs are welcome! Please do open an issue to discuss first if it's a big feature,
 - [ ] docs: Completely drop soft IE10 (and IE11?) support
 - [ ] dashboard: showing links to files should be turned off by default (it's great for devs, they can opt-in, but for end-user UI it's weird and can even lead to problems though)
 - [ ] xhr: change default name depending on wether `bundle` is set `files[]` (`true`) vs `file` (default) (#782)
+- [ ] xhr: set the `limit` option to a sensible default, like 10
 - [ ] core: remove `debug`, we have `logger` and `logger: Uppy.debugLogger` for that now
 - [ ] form: make the `multipleResults` option `true` by default
 - [ ] core: pass full file object to `onBeforeFileAdded`. Maybe also check restrictions before calling the callbacks: https://github.com/transloadit/uppy/pull/1594
+- [ ] tus: set the `limit` option to a sensible default, like 10
 
 ## 1.5
 

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -51,7 +51,8 @@ module.exports = class Transloadit extends Plugin {
       signature: null,
       params: null,
       fields: {},
-      getAssemblyOptions: defaultGetAssemblyOptions
+      getAssemblyOptions: defaultGetAssemblyOptions,
+      limit: 0
     }
 
     this.opts = {
@@ -717,7 +718,9 @@ module.exports = class Transloadit extends Plugin {
         // so it can't just reuse the same tus.Upload instance server-side.
         useFastRemoteRetry: false,
         // Only send Assembly metadata to the tus endpoint.
-        metaFields: ['assembly_url', 'filename', 'fieldname']
+        metaFields: ['assembly_url', 'filename', 'fieldname'],
+        // Pass the limit option to @uppy/tus
+        limit: this.opts.limit
       })
     }
 

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -448,11 +448,18 @@ module.exports = class Tus extends Plugin {
 
   handleUpload (fileIDs) {
     if (fileIDs.length === 0) {
-      this.uppy.log('Tus: no files to upload!')
+      this.uppy.log('[Tus] No files to upload')
       return Promise.resolve()
     }
 
-    this.uppy.log('Tus is uploading...')
+    if (fileIDs.length > 10 && this.opts.limit === 0) {
+      this.uppy.log(
+        '[Tus] When uploading multiple files at once, consider setting the `limit` option (to `10` for example), to limit the number of concurrent uploads, which helps prevent memory and network issues: https://uppy.io/docs/tus/#limit-0',
+        'warning'
+      )
+    }
+
+    this.uppy.log('[Tus] Uploading...')
     const filesToUpload = fileIDs.map((fileID) => this.uppy.getFile(fileID))
 
     return this.uploadFiles(filesToUpload)

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -452,7 +452,7 @@ module.exports = class Tus extends Plugin {
       return Promise.resolve()
     }
 
-    if (fileIDs.length > 10 && this.opts.limit === 0) {
+    if (this.opts.limit === 0) {
       this.uppy.log(
         '[Tus] When uploading multiple files at once, consider setting the `limit` option (to `10` for example), to limit the number of concurrent uploads, which helps prevent memory and network issues: https://uppy.io/docs/tus/#limit-0',
         'warning'

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -533,6 +533,13 @@ module.exports = class XHRUpload extends Plugin {
       return Promise.resolve()
     }
 
+    if (fileIDs.length > 10 && this.opts.limit === 0) {
+      this.uppy.log(
+        '[XHRUpload] When uploading multiple files at once, consider setting the `limit` option (to `10` for example), to limit the number of concurrent uploads, which helps prevent memory and network issues: https://uppy.io/docs/xhr-upload/#limit-0',
+        'warning'
+      )
+    }
+
     this.uppy.log('[XHRUpload] Uploading...')
     const files = fileIDs.map((fileID) => this.uppy.getFile(fileID))
 

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -533,7 +533,7 @@ module.exports = class XHRUpload extends Plugin {
       return Promise.resolve()
     }
 
-    if (fileIDs.length > 10 && this.opts.limit === 0) {
+    if (this.opts.limit === 0) {
       this.uppy.log(
         '[XHRUpload] When uploading multiple files at once, consider setting the `limit` option (to `10` for example), to limit the number of concurrent uploads, which helps prevent memory and network issues: https://uppy.io/docs/xhr-upload/#limit-0',
         'warning'

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -27,7 +27,8 @@ uppy.use(Transloadit, {
   importFromUploadURLs: false,
   alwaysRunAssembly: false,
   signature: null,
-  fields: {}
+  fields: {},
+  limit: 0
 })
 ```
 
@@ -256,6 +257,10 @@ uppy.use(Transloadit, {
   }
 })
 ```
+
+### `limit: 0`
+
+Limit the amount of uploads going on at the same time. Setting this to `0` means there is no limit on concurrent uploads. This option is passed through to the [`@uppy/tus`](/docs/tus) plugin that Transloadit plugin uses internally.
 
 ### `locale: {}`
 


### PR DESCRIPTION
- Add `limit` option to `@uppy/transloadit`, it will be passed down to `@uppy/tus`
- Warn in `@uppy/xhr-upload` and `@uppy/tus` when trying to upload > 10 files with `limit: 0` (default)
- Update docs