### PR TITLE
form: try/catch parsing, set updatedResult to an empty array when not an array

### DIFF
--- a/packages/@uppy/form/src/index.js
+++ b/packages/@uppy/form/src/index.js
@@ -88,8 +88,19 @@ module.exports = class Form extends Plugin {
     let resultInput = this.form.querySelector(`[name="${this.opts.resultName}"]`)
     if (resultInput) {
       if (this.opts.multipleResults) {
-        // Append new result to the previous result array
-        const updatedResult = JSON.parse(resultInput.value)
+        // Append new result to the previous result array.
+        // If the previous result is empty, or not an array,
+        // set it to an empty array.
+        let updatedResult
+        try {
+          updatedResult = JSON.parse(resultInput.value)
+        } catch (err) {
+          // Nothing, since we check for array below anyway
+        }
+
+        if (!Array.isArray(updatedResult)) {
+          updatedResult = []
+        }
         updatedResult.push(result)
         resultInput.value = JSON.stringify(updatedResult)
       } else {


### PR DESCRIPTION
Fixes #1787

When an existing `input` is used for `@uppy/form` result, and it’s `value` is empty (or the value is otherwise invalid JSON, and finally when it’s not an array), the`@uppy/form` tries to `JSON.parse`, the error occurs — empty string is not valid JSON.

- Try/catch JSON.parse
- Check if the result is an array, if not, set it to an empty array