### PR TITLE
thumbnail-generator: add waitForThumbnailsBeforeUpload option, false by default

### DIFF
--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -101,6 +101,7 @@ module.exports = class Dashboard extends Plugin {
       width: 750,
       height: 550,
       thumbnailWidth: 280,
+      waitForThumbnailsBeforeUpload: false,
       defaultPickerIcon,
       showLinkToFileUploadResult: true,
       showProgressDetails: false,
@@ -900,7 +901,8 @@ module.exports = class Dashboard extends Plugin {
     if (!this.opts.disableThumbnailGenerator) {
       this.uppy.use(ThumbnailGenerator, {
         id: `${this.id}:ThumbnailGenerator`,
-        thumbnailWidth: this.opts.thumbnailWidth
+        thumbnailWidth: this.opts.thumbnailWidth,
+        waitForThumbnailsBeforeUpload: this.opts.waitForThumbnailsBeforeUpload
       })
     }
 

--- a/packages/@uppy/locales/src/en_US.js
+++ b/packages/@uppy/locales/src/en_US.js
@@ -54,6 +54,7 @@ en_US.strings = {
     '1': 'Added %{smart_count} files from %{folder}',
     '2': 'Added %{smart_count} files from %{folder}'
   },
+  generatingThumbnails: 'Generating thumbnails...',
   import: 'Import',
   importFrom: 'Import from %{name}',
   link: 'Link',

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -332,7 +332,13 @@ module.exports = class ThumbnailGenerator extends Plugin {
     })
 
     return new Promise((resolve, reject) => {
-      this.uppy.on('thumbnail:all-generated', resolve)
+      if (this.queueProcessing) {
+        this.uppy.on('thumbnail:all-generated', () => {
+          resolve()
+        })
+      } else {
+        resolve()
+      }
     })
   }
 

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -114,7 +114,11 @@ module.exports = class ThumbnailGenerator extends Plugin {
 
   getOrientation (file) {
     return new Promise((resolve) => {
+      const uppy = this.uppy
       Exif.getData(file.data, function callback () {
+        uppy.setFileMeta(file.id, {
+          exifdata: Exif.getAllTags(this)
+        })
         const orientation = Exif.getTag(this, 'Orientation') || 1
         resolve(ORIENTATIONS[orientation])
       })
@@ -333,7 +337,7 @@ module.exports = class ThumbnailGenerator extends Plugin {
 
     return new Promise((resolve, reject) => {
       if (this.queueProcessing) {
-        this.uppy.on('thumbnail:all-generated', () => {
+        this.uppy.once('thumbnail:all-generated', () => {
           resolve()
         })
       } else {

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -115,10 +115,12 @@ module.exports = class ThumbnailGenerator extends Plugin {
   getOrientation (file) {
     return new Promise((resolve) => {
       const uppy = this.uppy
-      Exif.getData(file.data, function callback () {
-        uppy.setFileMeta(file.id, {
-          exifdata: Exif.getAllTags(this)
-        })
+      Exif.getData(file.data, function exifGetDataCallback () {
+        const exifdata = Exif.getAllTags(this)
+        // delete the thumbnail from exif metadata, because it contains a blob
+        // and we don’t blobs in meta — it might lead to unexpected issues on the server
+        delete exifdata.thumbnail
+        uppy.setFileMeta(file.id, { exifdata })
         const orientation = Exif.getTag(this, 'Orientation') || 1
         resolve(ORIENTATIONS[orientation])
       })

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -134,6 +134,12 @@ Width of the Dashboard in pixels. Used when `inline: true`.
 
 Height of the Dashboard in pixels. Used when `inline: true`.
 
+### `waitForThumbnailsBeforeUpload: false`
+
+Whether to wait for all thumbnails from `@uppy/thumbnail-generator` to be ready before starting the upload. If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing stage, displaying “Generating thumbnails...” message, and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
+
+This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be avilable on the server after the upload.
+
 ### `showLinkToFileUploadResult: true`
 
 By default, when a file upload has completed, the file icon in the Dashboard turns into a link to the uploaded file. If your app does not publicly store uploaded files or if it's otherwise unwanted, pass `showLinkToFileUploadResult: false`.

--- a/website/src/docs/thumbnail-generator.md
+++ b/website/src/docs/thumbnail-generator.md
@@ -17,7 +17,8 @@ const ThumbnailGenerator = require('@uppy/thumbnail-generator')
 
 uppy.use(ThumbnailGenerator, {
   thumbnailWidth: 200,
-  // thumbnailHeight: 200 // optional, use either width or height
+  // thumbnailHeight: 200 // optional, use either width or height,
+  waitForThumbnailsBeforeUpload: false
 })
 ```
 
@@ -47,7 +48,8 @@ The `@uppy/thumbnail-generator` plugin has the following configurable options:
 uppy.use(ThumbnailGenerator, {
   id: 'ThumbnailGenerator',
   thumbnailWidth: 200,
-  thumbnailHeight: 200
+  thumbnailHeight: 200,
+  waitForThumbnailsBeforeUpload: false
 })
 ```
 
@@ -74,6 +76,12 @@ If both width and height are given, only width is taken into account.
 > uppy.use(ThumbnailGenerator, { thumbnailWidth: 300, thumbnailHeight: 300 }) will produce a 300px width thumbnail with calculated height to match ratio (and ignore the given height).
 >
 > See https://github.com/transloadit/uppy/issues/979 and https://github.com/transloadit/uppy/pull/1096 for details on this feature.
+
+### `waitForThumbnailsBeforeUpload: false`
+
+Whether to wait for all thumbnails to be ready before starting the upload. If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing stage and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
+
+This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be avilable on the server after the upload.
 
 ## Event
 


### PR DESCRIPTION
This PR adds `waitForThumbnailsBeforeUpload: false` option, when enabled Thumbnail Generator will enter a `preprocess` stage until all thumbnails are generated and all EXIF data is added.

Reason: fixes https://github.com/transloadit/uppy/issues/1775, which asks for “Disable upload button in dashboard until exif data is resolved”.

The option can be passed in from the Dashboard.

Concerns:

1. Is EXIF data available on the `file.data` object by sheer magic (side effect)? It seems that we are not explicitly setting this EXIF data anywhere, and `exif-js` just mutates `file.data`. Should we set it explicitly? Should we add EXIF to `file.meta`?
2. Do we need this functionality at all? @lakesare expressed an opinion that we don’t actually need to worry about this, since EXIF data can be obtained on the server. 