### PR TITLE
Add data attribute with source, hide the source icon with css

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.js
@@ -49,7 +49,7 @@ const renderFileSize = (props) => (
 
 module.exports = function FileInfo (props) {
   return (
-    <div class="uppy-DashboardItem-fileInfo">
+    <div class="uppy-DashboardItem-fileInfo" data-uppy-file-source={props.file.source}>
       {renderFileName(props)}
       <div class="uppy-DashboardItem-status">
         {renderFileSize(props)}

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
@@ -25,7 +25,8 @@
       text-transform: uppercase;
     }
     .uppy-DashboardItem-sourceIcon {
-      display: inline-block;
+      // display: inline-block;
+      display: none;
       vertical-align: bottom;
       color: $gray-400;
       &:not(:first-child) {


### PR DESCRIPTION
- Add `data` attribute with source (so maybe debugging is easier, or some customization, won’t hurt?).
- Hide the icon in CSS, reasons: fixes https://github.com/transloadit/uppy/issues/1412.

Rationale: some users might be unhappy with the icon missing in the minor update, if so, they’ll be able to override it with CSS.