### PR TITLE
companion: update request to v2.88.0

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -56,7 +56,7 @@
     "prom-client": "10.2.3",
     "purest": "3.0.0",
     "redis": "2.8.0",
-    "request": "2.85.0",
+    "request": "2.88.0",
     "semver": "6.1.1",
     "serialize-error": "^2.1.0",
     "tus-js-client": "^1.8.0-0",


### PR DESCRIPTION
I got a security advisory that a package downstream of request v2.85.0 and thus, @uppy/companion v1.4.0 had a vulnerability. updating request removes the offending package.