### PR TITLE
website: exclude preact from plugin bundle size calculations

### DIFF
--- a/website/inject.js
+++ b/website/inject.js
@@ -69,6 +69,8 @@ async function getMinifiedSize (pkg, name) {
   const b = browserify(pkg)
   if (name !== '@uppy/core' && name !== 'uppy') {
     b.exclude('@uppy/core')
+    // Already unconditionally included through @uppy/core
+    b.exclude('preact')
   }
   if (excludes[name]) {
     b.exclude(excludes[name])


### PR DESCRIPTION
This makes the sizes a little more accurate to the actual effect on the bundle, because preact is already unconditionally included in @uppy/core. They still over-estimate the effect (which is probably more "honest" than underestimating it).