### PR TITLE
companion,google-drive: drop deprecated usage for Google Drive's "shared drive"

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -21,7 +21,7 @@ exports.getItemSize = (item) => {
 }
 
 exports.getItemIcon = (item) => {
-  if (item.kind === 'drive#teamDrive') {
+  if (exports.isSharedDrive(item)) {
     const size = '=w16-h16-n'
     const sizeParamRegex = /=[-whncsp0-9]*$/
     return item.backgroundImageLink.match(sizeParamRegex)

--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -13,7 +13,7 @@ exports.getUsername = (data) => {
 }
 
 exports.isFolder = (item) => {
-  return item.mimeType === 'application/vnd.google-apps.folder' || item.kind === 'drive#teamDrive'
+  return item.mimeType === 'application/vnd.google-apps.folder' || exports.isSharedDrive(item)
 }
 
 exports.getItemSize = (item) => {
@@ -67,8 +67,8 @@ exports.getItemThumbnailUrl = (item) => {
   return `/drive/thumbnail/${exports.getItemRequestPath(item)}`
 }
 
-exports.isTeamDrive = (item) => {
-  return item.kind === 'drive#teamDrive'
+exports.isSharedDrive = (item) => {
+  return item.kind === 'drive#drive'
 }
 
 exports.getNextPagePath = (data, currentQuery, currentPath) => {

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -6,7 +6,7 @@ const adapter = require('./adapter')
 const AuthError = require('../error')
 const DRIVE_FILE_FIELDS = 'kind,id,name,mimeType,ownedByMe,permissions(role,emailAddress),size,modifiedTime,iconLink,thumbnailLink,teamDriveId'
 const DRIVE_FILES_FIELDS = `kind,nextPageToken,incompleteSearch,files(${DRIVE_FILE_FIELDS})`
-const SHARED_DRIVE_FIELDS = 'drives(kind,id,name,backgroundImageLink)'
+const SHARED_DRIVE_FIELDS = 'drives(kind,id,name,backgroundImageLink,hidden)'
 
 class Drive {
   constructor (options) {

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -6,7 +6,8 @@ const adapter = require('./adapter')
 const AuthError = require('../error')
 const DRIVE_FILE_FIELDS = 'kind,id,name,mimeType,ownedByMe,permissions(role,emailAddress),size,modifiedTime,iconLink,thumbnailLink,teamDriveId'
 const DRIVE_FILES_FIELDS = `kind,nextPageToken,incompleteSearch,files(${DRIVE_FILE_FIELDS})`
-const SHARED_DRIVE_FIELDS = 'drives(kind,id,name,backgroundImageLink,hidden)'
+// using wildcard to get all 'drive' fields because specifying fields seems no to work for the /drives endpoint
+const SHARED_DRIVE_FIELDS = '*'
 
 class Drive {
   constructor (options) {

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -70,10 +70,10 @@ class Drive {
 
     Promise.all([sharedDrivesPromise, filesPromise])
       .then(
-        ([teamDrives, filesResponse]) => {
+        ([sharedDrives, filesResponse]) => {
           const returnData = this.adaptData(
             filesResponse.body,
-            teamDrives && teamDrives.body,
+            sharedDrives && sharedDrives.body,
             options.uppy,
             directory,
             query

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -6,7 +6,7 @@ const adapter = require('./adapter')
 const AuthError = require('../error')
 const DRIVE_FILE_FIELDS = 'kind,id,name,mimeType,ownedByMe,permissions(role,emailAddress),size,modifiedTime,iconLink,thumbnailLink,teamDriveId'
 const DRIVE_FILES_FIELDS = `kind,nextPageToken,incompleteSearch,files(${DRIVE_FILE_FIELDS})`
-const TEAM_DRIVE_FIELDS = 'teamDrives(kind,id,name,backgroundImageLink)'
+const SHARED_DRIVE_FIELDS = 'drives(kind,id,name,backgroundImageLink)'
 
 class Drive {
   constructor (options) {
@@ -25,19 +25,19 @@ class Drive {
     const directory = options.directory || 'root'
     const query = options.query || {}
 
-    let teamDrivesPromise = Promise.resolve(undefined)
+    let sharedDrivesPromise = Promise.resolve(undefined)
 
-    const shouldListTeamDrives = directory === 'root' && !query.cursor
-    if (shouldListTeamDrives) {
-      teamDrivesPromise = new Promise((resolve) => {
+    const shouldListSharedDrives = directory === 'root' && !query.cursor
+    if (shouldListSharedDrives) {
+      sharedDrivesPromise = new Promise((resolve) => {
         this.client
           .query()
-          .get('teamdrives')
-          .qs({ fields: TEAM_DRIVE_FIELDS })
+          .get('drives')
+          .qs({ fields: SHARED_DRIVE_FIELDS })
           .auth(options.token)
           .request((err, resp) => {
             if (err) {
-              logger.error(err, 'provider.drive.teamDrive.error')
+              logger.error(err, 'provider.drive.sharedDrive.error')
               return
             }
             resolve(resp)
@@ -68,7 +68,7 @@ class Drive {
         })
     })
 
-    Promise.all([teamDrivesPromise, filesPromise])
+    Promise.all([sharedDrivesPromise, filesPromise])
       .then(
         ([teamDrives, filesResponse]) => {
           const returnData = this.adaptData(
@@ -91,7 +91,7 @@ class Drive {
     return this.client
       .query()
       .get(`files/${id}`)
-      .qs({ fields: DRIVE_FILE_FIELDS, supportsTeamDrives: true })
+      .qs({ fields: DRIVE_FILE_FIELDS, supportsAllDrives: true })
       .auth(token)
       .request(done)
   }
@@ -100,7 +100,7 @@ class Drive {
     return this.client
       .query()
       .get(`files/${id}`)
-      .qs({ alt: 'media', supportsTeamDrives: true })
+      .qs({ alt: 'media', supportsAllDrives: true })
       .auth(token)
       .request()
       .on('data', onData)
@@ -133,7 +133,7 @@ class Drive {
     })
   }
 
-  adaptData (res, teamDrivesResp, uppy, directory, query) {
+  adaptData (res, sharedDrivesResp, uppy, directory, query) {
     const adaptItem = (item) => ({
       isFolder: adapter.isFolder(item),
       icon: adapter.getItemIcon(item),
@@ -145,14 +145,17 @@ class Drive {
       modifiedDate: adapter.getItemModifiedDate(item),
       size: adapter.getItemSize(item),
       custom: {
-        isTeamDrive: adapter.isTeamDrive(item)
+        // @todo isTeamDrive is left for backward compatibility. We should remove it in the next
+        // major release.
+        isTeamDrive: adapter.isSharedDrive(item),
+        isSharedDrive: adapter.isSharedDrive(item)
       }
     })
 
     const items = adapter.getItemSubList(res)
-    const teamDrives = teamDrivesResp ? teamDrivesResp.teamDrives || [] : []
+    const sharedDrives = sharedDrivesResp ? sharedDrivesResp.drives || [] : []
 
-    const adaptedItems = teamDrives.concat(items).map(adaptItem)
+    const adaptedItems = sharedDrives.concat(items).map(adaptItem)
 
     return {
       username: adapter.getUsername(res),

--- a/packages/@uppy/google-drive/src/DriveProviderViews.js
+++ b/packages/@uppy/google-drive/src/DriveProviderViews.js
@@ -5,8 +5,10 @@ module.exports = class DriveProviderViews extends ProviderViews {
     e.stopPropagation()
     e.preventDefault()
 
-    // Team Drives aren't selectable; for all else, defer to the base ProviderView.
-    if (!file.custom.isTeamDrive) {
+    // Shared Drives aren't selectable; for all else, defer to the base ProviderView.
+    // @todo isTeamDrive is left for backward compatibility. We should remove it in the next
+    // major release.
+    if (!file.custom.isTeamDrive && !file.custom.isSharedDrive) {
       super.toggleCheckbox(e, file)
     }
   }


### PR DESCRIPTION
Google Drive API has [deprecated](https://cloud.google.com/blog/products/application-development/upcoming-changes-to-the-google-drive-api-and-google-picker-api) the use of `Team Drives`, and replaced it with just `Drives`. This PR drops the deprecated implementation and adds the newly support implementation.