### PR TITLE
aws-s3: replace resolve-url by url-parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6092,15 +6092,14 @@
         "@uppy/companion-client": "file:packages/@uppy/companion-client",
         "@uppy/utils": "file:packages/@uppy/utils",
         "@uppy/xhr-upload": "file:packages/@uppy/xhr-upload",
-        "resolve-url": "^0.2.1"
+        "url-parse": "^1.4.7"
       }
     },
     "@uppy/aws-s3-multipart": {
       "version": "file:packages/@uppy/aws-s3-multipart",
       "requires": {
         "@uppy/companion-client": "file:packages/@uppy/companion-client",
-        "@uppy/utils": "file:packages/@uppy/utils",
-        "resolve-url": "^0.2.1"
+        "@uppy/utils": "file:packages/@uppy/utils"
       }
     },
     "@uppy/companion": {

--- a/packages/@uppy/aws-s3-multipart/package.json
+++ b/packages/@uppy/aws-s3-multipart/package.json
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@uppy/companion-client": "file:../companion-client",
-    "@uppy/utils": "file:../utils",
-    "resolve-url": "^0.2.1"
+    "@uppy/utils": "file:../utils"
   },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -25,7 +25,7 @@
     "@uppy/companion-client": "file:../companion-client",
     "@uppy/utils": "file:../utils",
     "@uppy/xhr-upload": "file:../xhr-upload",
-    "resolve-url": "^0.2.1"
+    "url-parse": "^1.4.7"
   },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -1,9 +1,14 @@
-const resolveUrl = require('resolve-url')
+// If global `URL` constructor is available, use it
+const URL_ = typeof URL === 'function' ? URL : require('url-parse')
 const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
 const { RequestClient } = require('@uppy/companion-client')
 const XHRUpload = require('@uppy/xhr-upload')
+
+function resolveUrl (origin, link) {
+  return new URL_(link, origin).toString()
+}
 
 function isXml (xhr) {
   const contentType = xhr.headers ? xhr.headers['content-type'] : xhr.getResponseHeader('Content-Type')


### PR DESCRIPTION
So it works in browser-ish, but non-DOM, environments. Will use the
global `URL` API if available, and fall back to url-parse, which has a
compatible-enough API.

Fixes https://github.com/transloadit/uppy/issues/1720