### PR TITLE
aws-s3-multipart: fix queueing behaviours

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -18,19 +18,32 @@ function remove (arr, el) {
 
 class MultipartUploader {
   constructor (file, options) {
-    this.options = Object.assign({}, defaultOptions, options)
+    this.options = {
+      ...defaultOptions,
+      ...options
+    }
     this.file = file
 
     this.key = this.options.key || null
     this.uploadId = this.options.uploadId || null
     this.parts = this.options.parts || []
 
+    // Do `this.createdPromise.then(OP)` to execute an operation `OP` _only_ if the
+    // upload was created already. That also ensures that the sequencing is right
+    // (so the `OP` definitely happens if the upload is created).
+    //
+    // This mostly exists to make `_abortUpload` work well: only sending the abort request if
+    // the upload was already created, and if the createMultipartUpload request is still in flight,
+    // aborting it immediately after it finishes.
+    this.createdPromise = Promise.reject() // eslint-disable-line prefer-promise-reject-errors
     this.isPaused = false
     this.chunks = null
     this.chunkState = null
     this.uploading = []
 
     this._initChunks()
+
+    this.createdPromise.catch(() => {}) // silence uncaught rejection warning
   }
 
   _initChunks () {
@@ -51,22 +64,21 @@ class MultipartUploader {
   }
 
   _createUpload () {
-    return Promise.resolve().then(() =>
+    this.createdPromise = Promise.resolve().then(() =>
       this.options.createMultipartUpload()
-    ).then((result) => {
+    )
+    return this.createdPromise.then((result) => {
       const valid = typeof result === 'object' && result &&
         typeof result.uploadId === 'string' &&
         typeof result.key === 'string'
       if (!valid) {
         throw new TypeError(`AwsS3/Multipart: Got incorrect result from 'createMultipartUpload()', expected an object '{ uploadId, key }'.`)
       }
-      return result
-    }).then((result) => {
+
       this.key = result.key
       this.uploadId = result.uploadId
 
       this.options.onStart(result)
-    }).then(() => {
       this._uploadParts()
     }).catch((err) => {
       this._onError(err)
@@ -250,9 +262,13 @@ class MultipartUploader {
     this.uploading.slice().forEach(xhr => {
       xhr.abort()
     })
-    this.options.abortMultipartUpload({
-      key: this.key,
-      uploadId: this.uploadId
+    this.createdPromise.then(() => {
+      this.options.abortMultipartUpload({
+        key: this.key,
+        uploadId: this.uploadId
+      })
+    }, () => {
+      // if the creation failed we do not need to abort
     })
     this.uploading = []
   }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -194,15 +194,11 @@ module.exports = class AwsS3Multipart extends Plugin {
 
       const upload = new Uploader(file.data, {
         // .bind to pass the file object to each handler.
-        createMultipartUpload: this.requests.wrapPromiseFunction(
-          this.opts.createMultipartUpload.bind(this, file)),
-        listParts: this.requests.wrapPromiseFunction(
-          this.opts.listParts.bind(this, file)),
+        createMultipartUpload: this.opts.createMultipartUpload.bind(this, file),
+        listParts: this.opts.listParts.bind(this, file),
         prepareUploadPart: this.opts.prepareUploadPart.bind(this, file),
-        completeMultipartUpload: this.requests.wrapPromiseFunction(
-          this.opts.completeMultipartUpload.bind(this, file)),
-        abortMultipartUpload: this.requests.wrapPromiseFunction(
-          this.opts.abortMultipartUpload.bind(this, file)),
+        completeMultipartUpload: this.opts.completeMultipartUpload.bind(this, file),
+        abortMultipartUpload: this.opts.abortMultipartUpload.bind(this, file),
 
         onStart,
         onProgress,

--- a/packages/@uppy/utils/src/RateLimitedQueue.js
+++ b/packages/@uppy/utils/src/RateLimitedQueue.js
@@ -29,16 +29,25 @@ module.exports = class RateLimitedQueue {
         done = true
         this.activeRequests -= 1
         cancelActive()
-        this._next()
+        this._queueNext()
       },
 
       done: () => {
         if (done) return
         done = true
         this.activeRequests -= 1
-        this._next()
+        this._queueNext()
       }
     }
+  }
+
+  _queueNext () {
+    // Do it soon but not immediately, this allows clearing out the entire queue synchronously
+    // one by one without continuously _advancing_ it (and starting new tasks before immediately
+    // aborting them)
+    Promise.resolve().then(() => {
+      this._next()
+    })
   }
 
   _next () {


### PR DESCRIPTION
Fixes an issue where the plugin was queueing too many things, causing deadlock. The entire `MultipartUpload` object was added as a queue entry, but then that object would queue more things, and wait for those things to complete; but the `MultipartUpload` objects were clogging up the queue, so those things would never start. Since the MultipartUpload object manages its requests internally, and it participates in the rate limiting queue, its requests don't need to be queued again.

Fixes an issue where cancelling many queued uploads would cause them to quickly start and then immediately be cancelled, because cancelling the ongoing uploads would synchronously push the queued uploads to the front of the upload queue, synchronously start them, and then synchronously cancel them. Now, queue items are not moved immediately when an earlier upload is cancelled, but wait until the end of the JavaScript tick before moving. The queue can be cleared out synchronously without causing queued items to start and then cancel.

Fixes #1146, where aws-s3-multipart would send abort requests for uploads that had not yet started (either because they were queued or because the `createMultipartUpload()` request was ongoing). Now, abort requests are not sent at all if an upload was not started, and abort requests wait for the createMultipartUpload() request to succeed before aborting.