### PR TITLE
companion-client: rename serverHeaders to companionHeaders

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -33,9 +33,11 @@ module.exports = class RequestClient {
   }
 
   headers () {
-    return Promise.resolve(
-      Object.assign({}, this.defaultHeaders, this.opts.serverHeaders || {})
-    )
+    const userHeaders = this.opts.companionHeaders || this.opts.serverHeaders || {}
+    return Promise.resolve({
+      ...this.defaultHeaders,
+      ...userHeaders
+    })
   }
 
   _getPostResponseFunc (skip) {

--- a/packages/@uppy/companion-client/types/index.d.ts
+++ b/packages/@uppy/companion-client/types/index.d.ts
@@ -1,5 +1,9 @@
 export interface RequestClientOptions {
   companionUrl: string;
+  companionHeaders?: object;
+  /**
+   * Deprecated, use `companionHeaders` instead.
+   */
   serverHeaders?: object;
 }
 

--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -19,7 +19,7 @@ module.exports = class Dropbox extends Plugin {
 
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders,
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'dropbox',
       pluginId: this.id

--- a/packages/@uppy/facebook/src/index.js
+++ b/packages/@uppy/facebook/src/index.js
@@ -25,7 +25,7 @@ module.exports = class Facebook extends Plugin {
 
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders,
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'facebook',
       pluginId: this.id

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -24,7 +24,7 @@ module.exports = class GoogleDrive extends Plugin {
 
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders,
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'drive',
       authProvider: 'google',

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -21,7 +21,7 @@ module.exports = class Instagram extends Plugin {
 
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders,
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'instagram',
       authProvider: 'instagram',

--- a/packages/@uppy/onedrive/src/index.js
+++ b/packages/@uppy/onedrive/src/index.js
@@ -20,7 +20,7 @@ module.exports = class OneDrive extends Plugin {
 
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders,
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       storage: this.opts.storage,
       provider: 'onedrive',
       pluginId: this.id

--- a/packages/@uppy/robodog/src/addProviders.js
+++ b/packages/@uppy/robodog/src/addProviders.js
@@ -15,6 +15,7 @@ const localProviders = {
 const remoteProviderOptionNames = [
   'companionUrl',
   'companionAllowedHosts',
+  'companionHeaders',
   'serverHeaders',
   'target'
 ]

--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -54,7 +54,7 @@ module.exports = class Url extends Plugin {
 
     this.client = new RequestClient(uppy, {
       companionUrl: this.opts.companionUrl,
-      serverHeaders: this.opts.serverHeaders
+      companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders
     })
   }
 

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -60,7 +60,7 @@ uppy.use(AwsS3, {
 })
 ```
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 > Note: This only applies when using [Companion][companion docs] to sign S3 uploads.
 

--- a/website/src/docs/dropbox.md
+++ b/website/src/docs/dropbox.md
@@ -73,7 +73,7 @@ DOM element, CSS selector, or plugin to mount the Dropbox provider into. This sh
 
 URL to a [Companion](/docs/companion) instance.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers that should be sent along to [Companion](/docs/companion) on every request.
 

--- a/website/src/docs/facebook.md
+++ b/website/src/docs/facebook.md
@@ -74,7 +74,7 @@ DOM element, CSS selector, or plugin to mount the Facebook provider into. This s
 
 URL to a [Companion](/docs/companion) instance.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers that should be sent along to [Companion](/docs/companion) on every request.
 

--- a/website/src/docs/google-drive.md
+++ b/website/src/docs/google-drive.md
@@ -72,7 +72,7 @@ DOM element, CSS selector, or plugin to mount the Google Drive provider into. Th
 
 URL to a [Companion](/docs/companion) instance.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers that should be sent along to [Companion](/docs/companion) on every request.
 

--- a/website/src/docs/instagram.md
+++ b/website/src/docs/instagram.md
@@ -74,7 +74,7 @@ DOM element, CSS selector, or plugin to mount the Instagram provider into. This 
 
 URL to a [Companion](/docs/companion) instance.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers that should be sent along to [Companion](/docs/companion) on every request.
 

--- a/website/src/docs/onedrive.md
+++ b/website/src/docs/onedrive.md
@@ -74,7 +74,7 @@ DOM element, CSS selector, or plugin to mount the OneDrive provider into. This s
 
 URL to a [Companion](/docs/companion) instance.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers that should be sent along to [Companion](/docs/companion) on every request.
 

--- a/website/src/docs/robodog-picker.md
+++ b/website/src/docs/robodog-picker.md
@@ -89,7 +89,7 @@ This value can be a `String`, a `Regex` pattern, or an `Array` of both.
 
 This is useful when you have your [Uppy Companion][companion] running on multiple hosts. Otherwise, the default value should do just fine.
 
-### `serverHeaders: {}`
+### `companionHeaders: {}`
 
 Custom headers to send to [Uppy Companion][companion].
 


### PR DESCRIPTION
For consistency with `companionUrl` etc.

`serverHeaders` still works but is no longer documented. We can remove it in V2.