### PR TITLE
feat: add autoRetry option to aws-s3-multipart plugin

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -26,6 +26,7 @@ module.exports = class AwsS3Multipart extends Plugin {
     this.client = new RequestClient(uppy, opts)
 
     const defaultOptions = {
+      autoRetry: false,
       timeout: 30 * 1000,
       limit: 0,
       createMultipartUpload: this.createMultipartUpload.bind(this),
@@ -481,6 +482,10 @@ module.exports = class AwsS3Multipart extends Plugin {
       }
     })
     this.uppy.addUploader(this.upload)
+
+    if (this.opts.autoRetry) {
+      this.uppy.on('back-online', this.uppy.retryAll)
+    }
   }
 
   uninstall () {

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -42,6 +42,10 @@ The `@uppy/aws-s3-multipart` plugin has the following configurable options:
 
 The maximum amount of chunks to upload simultaneously. Set to `0` to disable limiting.
 
+### autoRetry: false
+
+Configures whether or not to auto-retry the upload when the user’s internet connection is back online after an outage.
+
 ### companionUrl: null
 
 The Companion URL to use for proxying calls to the S3 Multipart API.


### PR DESCRIPTION
Fixes #1448 

Adds `autoRetry` option to the aws-s3-multipart plugin.
- defaults to `false` to maintain backward compatibility.
- updates docs

