### PR TITLE
Add S3 useAccelerateEndpoint to Companion

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -30,6 +30,7 @@ const defaultOptions = {
       acl: 'public-read',
       endpoint: 'https://{service}.{region}.amazonaws.com',
       conditions: [],
+      useAccelerateEndpoint: false,
       getKey: (req, filename) => filename
     }
   },
@@ -223,8 +224,9 @@ const getOptionsMiddleware = (options) => {
       region: config.region,
       endpoint: config.endpoint,
       credentials,
-      signatureVersion: 'v4'
-    })
+      signatureVersion: "v4",
+      useAccelerateEndpoint: config.useAccelerateEndpoint
+    });
   }
 
   /**

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -54,7 +54,9 @@ const getConfigFromEnv = () => {
         secret: getSecret('COMPANION_AWS_SECRET'),
         bucket: process.env.COMPANION_AWS_BUCKET,
         endpoint: process.env.COMPANION_AWS_ENDPOINT,
-        region: process.env.COMPANION_AWS_REGION
+        region: process.env.COMPANION_AWS_REGION,
+        useAccelerateEndpoint:
+          process.env.COMPANION_AWS_USE_ACCELERATE_ENDPOINT == "true"
       }
     },
     server: {

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -190,6 +190,8 @@ export COMPANION_AWS_SECRET="YOUR AWS SECRET"
 export COMPANION_AWS_SECRET_FILE="PATH/TO/AWS/SECRET/FILE"
 export COMPANION_AWS_BUCKET="YOUR AWS S3 BUCKET"
 export COMPANION_AWS_REGION="AWS REGION"
+# to enable S3 Transfer Acceleration (default: false)
+export export COMPANION_AWS_USE_ACCELERATE_ENDPOINT="false"
 
 # corresponds to the server.oauthDomain option
 export COMPANION_OAUTH_DOMAIN="sub.domain.com"
@@ -232,7 +234,8 @@ See [env.example.sh](https://github.com/transloadit/uppy/blob/master/env.example
       key: "***",
       secret: "***",
       bucket: "bucket-name",
-      region: "us-east-1"
+      region: "us-east-1",
+      useAccelerateEndpoint: false // default: false
     }
   },
   server: {


### PR DESCRIPTION
Expose S3 client's useAccelerateEndpoint option that enables usage of Transfer Acceleration endpoint - https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html