### PR TITLE
core: provide default error message

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -783,12 +783,12 @@ class Uppy {
    */
   _addListeners () {
     this.on('error', (error) => {
-      this.setState({ error: error.message })
+      this.setState({ error: error.message || 'Unknown error' })
     })
 
     this.on('upload-error', (file, error, response) => {
       this.setFileState(file.id, {
-        error: error.message,
+        error: error.message || 'Unknown error',
         response
       })
 


### PR DESCRIPTION
We were already doing `if (file.error)` in places, now that is
guaranteed to work even if the error message was empty or the error
object is custom and doesn't have a `.message` property.

fixes https://github.com/transloadit/uppy/issues/882, I think.