### PR TITLE
add UppyFile.response typing

### DIFF
--- a/packages/@uppy/core/types/core-tests.ts
+++ b/packages/@uppy/core/types/core-tests.ts
@@ -1,21 +1,21 @@
-import Uppy = require('../');
-import DefaultStore = require('@uppy/store-default');
+import Uppy = require('../')
+import DefaultStore = require('@uppy/store-default')
 
 {
-  const uppy = Uppy();
+  const uppy = Uppy()
   uppy.addFile({
     data: new Blob([new ArrayBuffer(1024)], { type: 'application/octet-stream' })
-  });
+  })
 
   uppy.upload().then((result) => {
-    result.successful[0]; // $ExpectType UppyFile
-    result.failed[0]; // $ExpectType UppyFile
-  });
+    result.successful[0] // $ExpectType UppyFile
+    result.failed[0] // $ExpectType UppyFile
+  })
 }
 
 {
-  const store = DefaultStore();
-  const uppy = Uppy({ store });
+  const store = DefaultStore()
+  const uppy = Uppy({ store })
 }
 
 {
@@ -25,13 +25,28 @@ import DefaultStore = require('@uppy/store-default');
   if (f && f.progress && f.progress.uploadStarted === null) {
     f.progress.uploadStarted = Date.now()
   }
+
+  if (f && f.response && f.response.status === 200) {
+    f.response.body // $ExpectType any
+  }
+  // f.response!.status === '200' // $ExpectError
 }
 
 {
-  const uppy = Uppy();
+  type Meta = {};
+  type ResponseBody = {
+    averageColor: string
+  }
+  const uppy = Uppy()
+  const f = uppy.getFile<Meta, ResponseBody>('virtual')!
+  f.response!.body // $ExpectType ResponseBody
+}
+
+{
+  const uppy = Uppy()
   uppy.addFile({
     name: 'empty.json',
     data: new Blob(['null'], { type: 'application/json' }),
     meta: { path: 'path/to/file' }
-  });
+  })
 }

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -5,7 +5,7 @@ declare module Uppy {
   type OmitKey<T, Key> = Pick<T, Exclude<keyof T, Key>>;
 
   // These are defined in @uppy/utils instead of core so it can be used there without creating import cycles
-  export type UppyFile<TMeta extends IndexedObject<any> = {}> = UppyUtils.UppyFile<TMeta>;
+  export type UppyFile<TMeta extends IndexedObject<any> = {}, TBody extends IndexedObject<any> = {}> = UppyUtils.UppyFile<TMeta, TBody>;
   export type Store = UppyUtils.Store;
   export type InternalMetadata = UppyUtils.InternalMetadata;
 
@@ -14,17 +14,17 @@ declare module Uppy {
     [key: number]: T;
   }
 
-  interface UploadedUppyFile<TMeta> extends UppyFile<TMeta> {
+  interface UploadedUppyFile<TMeta, TBody> extends UppyFile<TMeta, TBody> {
     uploadURL: string;
   }
 
-  interface FailedUppyFile<TMeta> extends UppyFile<TMeta> {
+  interface FailedUppyFile<TMeta, TBody> extends UppyFile<TMeta, TBody> {
     error: string;
   }
 
   // Replace the `meta` property type with one that allows omitting internal metadata; addFile() will add that
-  type UppyFileWithoutMeta<TMeta> = OmitKey<UppyFile<TMeta>, 'meta'>;
-  interface AddFileOptions<TMeta = IndexedObject<any>> extends Partial<UppyFileWithoutMeta<TMeta>> {
+  type UppyFileWithoutMeta<TMeta, TBody> = OmitKey<UppyFile<TMeta, TBody>, 'meta'>;
+  interface AddFileOptions<TMeta = IndexedObject<any>, TBody = IndexedObject<any>> extends Partial<UppyFileWithoutMeta<TMeta, TBody>> {
     // `.data` is the only required property here.
     data: Blob | File;
     meta?: Partial<InternalMetadata> & TMeta;
@@ -79,16 +79,16 @@ declare module Uppy {
     store: Store;
   }
 
-  interface UploadResult<TMeta extends IndexedObject<any> = {}> {
-    successful: UploadedUppyFile<TMeta>[];
-    failed: FailedUppyFile<TMeta>[];
+  interface UploadResult<TMeta extends IndexedObject<any> = {}, TBody extends IndexedObject<any> = {}> {
+    successful: UploadedUppyFile<TMeta, TBody>[];
+    failed: FailedUppyFile<TMeta, TBody>[];
   }
 
-  interface State<TMeta extends IndexedObject<any> = {}> extends IndexedObject<any> {
+  interface State<TMeta extends IndexedObject<any> = {}, TBody extends IndexedObject<any> = {}> extends IndexedObject<any> {
     capabilities?: {resumableUploads?: boolean};
     currentUploads: {};
     error?: string;
-    files: {[key: string]: UploadedUppyFile<TMeta> | FailedUppyFile<TMeta>};
+    files: {[key: string]: UploadedUppyFile<TMeta, TBody> | FailedUppyFile<TMeta, TBody>};
     info?: {
       isHidden: boolean;
       type: string;
@@ -119,8 +119,8 @@ declare module Uppy {
     removeUploader(fn: any): void;
     setMeta<TMeta extends IndexedObject<any> = {}>(data: TMeta): void;
     setFileMeta<TMeta extends IndexedObject<any> = {}>(fileID: string, data: TMeta): void;
-    getFile<TMeta extends IndexedObject<any> = {}>(fileID: string): UppyFile<TMeta>;
-    getFiles<TMeta extends IndexedObject<any> = {}>(): Array<UppyFile<TMeta>>;
+    getFile<TMeta extends IndexedObject<any> = {}, TBody extends IndexedObject<any> = {}>(fileID: string): UppyFile<TMeta, TBody>;
+    getFiles<TMeta extends IndexedObject<any> = {}, TBody extends IndexedObject<any> = {}>(): Array<UppyFile<TMeta, TBody>>;
     addFile<TMeta extends IndexedObject<any> = {}>(file: AddFileOptions<TMeta>): void;
     removeFile(fileID: string): void;
     pauseResume(fileID: string): boolean;

--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -140,7 +140,7 @@ declare module '@uppy/utils' {
     [key: number]: T;
   }
   export type InternalMetadata = { name: string, type?: string };
-  export interface UppyFile<TMeta = IndexedObject<any>> {
+  export interface UppyFile<TMeta = IndexedObject<any>, TBody = IndexedObject<any>> {
     data: Blob | File;
     extension: string;
     id: string;
@@ -164,6 +164,11 @@ declare module '@uppy/utils' {
     size: number;
     source?: string;
     type?: string;
+    response?: {
+      body: TBody;
+      status: number;
+      uploadURL: string | undefined;
+    };
   }
   export interface Store {
     getState(): object;


### PR DESCRIPTION
This PR adds the proper typing for `UppyFile.response` as indicated in #1856.