### PR TITLE
facebook, provider-views: support list + grid view for facebook

### DIFF
--- a/packages/@uppy/facebook/src/index.js
+++ b/packages/@uppy/facebook/src/index.js
@@ -72,6 +72,12 @@ module.exports = class Facebook extends Plugin {
   }
 
   render (state) {
-    return this.view.render(state)
+    const viewOptions = {}
+    if (this.getPluginState().files.length && !this.getPluginState().folders.length) {
+      viewOptions.viewType = 'grid'
+      viewOptions.showFilter = false
+      viewOptions.showTitles = false
+    }
+    return this.view.render(state, viewOptions)
   }
 }

--- a/packages/@uppy/provider-views/src/Breadcrumbs.js
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.js
@@ -20,12 +20,11 @@ module.exports = (props) => {
       <div class="uppy-Provider-breadcrumbsIcon">{props.breadcrumbsIcon}</div>
       {
         props.directories.map((directory, i) => (
-          <Breadcrumb
-            key={directory.id}
-            getFolder={() => props.getFolder(directory.id)}
-            title={i === 0 ? props.title : directory.title}
-            isLast={i + 1 === props.directories.length}
-          />
+          Breadcrumb({
+            getFolder: () => props.getFolder(directory.id),
+            title: i === 0 ? props.title : directory.title,
+            isLast: i + 1 === props.directories.length
+          })
         ))
       }
     </div>

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -593,7 +593,7 @@ module.exports = class ProviderView {
       )
     }
 
-    const targetViewOptions = Object.assign({}, this.opts, viewOptions)
+    const targetViewOptions = { ...this.opts, ...viewOptions }
     console.log(targetViewOptions)
     const browserProps = Object.assign({}, this.plugin.getPluginState(), {
       username: this.username,

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -563,7 +563,7 @@ module.exports = class ProviderView {
     this.plugin.setPluginState({ loading: true })
   }
 
-  render (state) {
+  render (state, viewOptions = {}) {
     const { authenticated, didFirstRender } = this.plugin.getPluginState()
     if (!didFirstRender) {
       this.preFirstRender()
@@ -593,6 +593,8 @@ module.exports = class ProviderView {
       )
     }
 
+    const targetViewOptions = Object.assign({}, this.opts, viewOptions)
+    console.log(targetViewOptions)
     const browserProps = Object.assign({}, this.plugin.getPluginState(), {
       username: this.username,
       getNextFolder: this.getNextFolder,
@@ -611,10 +613,10 @@ module.exports = class ProviderView {
       done: this.donePicking,
       cancel: this.cancelPicking,
       title: this.plugin.title,
-      viewType: this.opts.viewType,
-      showTitles: this.opts.showTitles,
-      showFilter: this.opts.showFilter,
-      showBreadcrumbs: this.opts.showBreadcrumbs,
+      viewType: targetViewOptions.viewType,
+      showTitles: targetViewOptions.showTitles,
+      showFilter: targetViewOptions.showFilter,
+      showBreadcrumbs: targetViewOptions.showBreadcrumbs,
       pluginIcon: this.plugin.icon,
       i18n: this.plugin.uppy.i18n
     })

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -594,7 +594,6 @@ module.exports = class ProviderView {
     }
 
     const targetViewOptions = { ...this.opts, ...viewOptions }
-    console.log(targetViewOptions)
     const browserProps = Object.assign({}, this.plugin.getPluginState(), {
       username: this.username,
       getNextFolder: this.getNextFolder,


### PR DESCRIPTION
This PR adjusts the facebook provider such that, when listing **folders**, it displays it in **list view**, and when listing just **images**, it displays in **grid view**
