### PR TITLE
aws-s3-multipart: advance queue after local file upload completes, fixes #1883

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -153,6 +153,7 @@ module.exports = class AwsS3Multipart extends Plugin {
         this.uppy.emit('upload-error', file, err)
         err.message = `Failed because: ${err.message}`
 
+        queuedRequest.done()
         this.resetUploaderReferences(file.id)
         reject(err)
       }
@@ -162,6 +163,7 @@ module.exports = class AwsS3Multipart extends Plugin {
           uploadURL: result.location
         }
 
+        queuedRequest.done()
         this.resetUploaderReferences(file.id)
 
         this.uppy.emit('upload-success', file, uploadResp)


### PR DESCRIPTION
I must've tested with just remote files and missed these missing bits in
the local file upload code :weary:

Will do a patch release asap when this lands.