### PR TITLE
dashboard: fix retry icons on individual files

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.js
@@ -27,7 +27,7 @@ module.exports = pure(function FileItem (props) {
     { 'is-processing': isProcessing },
     { 'is-complete': isUploaded },
     { 'is-paused': isPaused },
-    { 'is-error': error },
+    { 'is-error': !!error },
     { 'is-resumable': props.resumableUploads },
     { 'is-noIndividualCancellation': !props.individualCancellation }
   )
@@ -40,9 +40,10 @@ module.exports = pure(function FileItem (props) {
           showLinkToFileUploadResult={props.showLinkToFileUploadResult}
         />
         <FileProgress
+          {...props}
+          file={file}
           error={error}
           isUploaded={isUploaded}
-          {...props}
         />
       </div>
 


### PR DESCRIPTION
The `...props` object that we were spreading into `<FileProgress />`
contained another, different `error` prop, which was empty for
individual file upload failures. By putting the `...props` spread in
front, the file-specific error takes precedence over the global error.

Fixes #1881