### PR TITLE
companion: conditionally set Access-Control-Allow-Credentials

### DIFF
--- a/examples/custom-provider/server/index.js
+++ b/examples/custom-provider/server/index.js
@@ -24,7 +24,6 @@ app.use((req, res, next) => {
     'Access-Control-Allow-Headers',
     'Authorization, Origin, Content-Type, Accept'
   )
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
   next()
 })
 

--- a/examples/uppy-with-companion/server/index.js
+++ b/examples/uppy-with-companion/server/index.js
@@ -22,7 +22,6 @@ app.use((req, res, next) => {
     'Access-Control-Allow-Headers',
     'Authorization, Origin, Content-Type, Accept'
   )
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
   next()
 })
 

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -101,6 +101,8 @@ app.use((req, res, next) => {
     // @ts-ignore
     if (req.headers.origin && whitelist.indexOf(req.headers.origin) > -1) {
       res.setHeader('Access-Control-Allow-Origin', req.headers.origin)
+      // only allow credentials when origin is whitelisted
+      res.setHeader('Access-Control-Allow-Credentials', 'true')
     }
   } else {
     res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*')
@@ -114,7 +116,6 @@ app.use((req, res, next) => {
     'Access-Control-Allow-Headers',
     'Authorization, Origin, Content-Type, Accept'
   )
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
   next()
 })
 


### PR DESCRIPTION
This PR addresses this [lgtm security issue](https://lgtm.com/projects/g/transloadit/uppy/snapshot/b3545d3244e34b6945d55a7256df8bfcdffaa558/files/packages/@uppy/companion/src/standalone/index.js?sort=name&dir=ASC&mode=heatmap#x2a1b855e0849df53:1). The solution is to only allow credentials when request origins are whitelisted.