### PR TITLE
fix: provider views breadcrumbs is failed to render

### DIFF
--- a/packages/@uppy/provider-views/src/Breadcrumbs.js
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.js
@@ -8,7 +8,10 @@ const Breadcrumb = (props) => {
       <button
         type="button"
         class="uppy-u-reset"
-        onclick={props.getFolder}>{props.title}</button>
+        onclick={props.getFolder}
+      >
+        {props.title}
+      </button>
       {!props.isLast ? ' / ' : ''}
     </span>
   )

--- a/packages/@uppy/provider-views/src/Breadcrumbs.js
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.js
@@ -1,7 +1,6 @@
 const { h } = require('preact')
 
 // TODO use Fragment when upgrading to preact X
-/* eslint-disable react/jsx-key */
 const Breadcrumb = (props) => {
   return (
     <span>
@@ -16,7 +15,6 @@ const Breadcrumb = (props) => {
     </span>
   )
 }
-/* eslint-enable react/jsx-key */
 
 module.exports = (props) => {
   return (
@@ -24,11 +22,12 @@ module.exports = (props) => {
       <div class="uppy-Provider-breadcrumbsIcon">{props.breadcrumbsIcon}</div>
       {
         props.directories.map((directory, i) => (
-          Breadcrumb({
-            getFolder: () => props.getFolder(directory.id),
-            title: i === 0 ? props.title : directory.title,
-            isLast: i + 1 === props.directories.length
-          })
+          <Breadcrumb
+            key={directory.id}
+            getFolder={() => props.getFolder(directory.id)}
+            title={i === 0 ? props.title : directory.title}
+            isLast={i + 1 === props.directories.length}
+          />
         ))
       }
     </div>

--- a/packages/@uppy/provider-views/src/Breadcrumbs.js
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.js
@@ -2,16 +2,17 @@ const { h } = require('preact')
 
 // TODO use Fragment when upgrading to preact X
 /* eslint-disable react/jsx-key */
-const Breadcrumb = (props) => [
-  <button
-    type="button"
-    class="uppy-u-reset"
-    onclick={props.getFolder}
-  >
-    {props.title}
-  </button>,
-  !props.isLast ? ' / ' : ''
-]
+const Breadcrumb = (props) => {
+  return (
+    <span>
+      <button
+        type="button"
+        class="uppy-u-reset"
+        onclick={props.getFolder}>{props.title}</button>
+      {!props.isLast ? ' / ' : ''}
+    </span>
+  )
+}
 /* eslint-enable react/jsx-key */
 
 module.exports = (props) => {


### PR DESCRIPTION
Currently, the provider views breadcrumbs is failed to render due to using `Fragment`