### PR TITLE
add event type

### DIFF
--- a/packages/@uppy/core/types/core-tests.ts
+++ b/packages/@uppy/core/types/core-tests.ts
@@ -53,19 +53,19 @@ import DefaultStore = require('@uppy/store-default')
 
 {
   const uppy = Uppy()
-  uppy.on('file-added', () => {})
-  uppy.on('file-removed', () => {})
+  // can emit events with internal event types
+  uppy.emit('upload')
+  uppy.emit('complete', () => {})
+  uppy.emit('error', () => {})
+
+  // can emit events with custom event types
+  uppy.emit('dashboard:modal-closed', () => {})
+
+  // can register listners for internal events
   uppy.on('upload', () => {})
-  uppy.on('upload-progress', () => {})
-  uppy.on('upload-success', () => {})
   uppy.on('complete', () => {})
   uppy.on('error', () => {})
-  uppy.on('upload-error', () => {})
-  uppy.on('upload-retry', () => {})
-  uppy.on('info-visible', () => {})
-  uppy.on('info-hidden', () => {})
-  uppy.on('cancel-all', () => {})
-  uppy.on('restriction-failed', () => {})
-  uppy.on('reset-progress', () => {})
-  uppy.on('reset-progress', () => {})
+
+  // can register listners on custom events
+  uppy.on('dashboard:modal-closed', () => {})
 }

--- a/packages/@uppy/core/types/core-tests.ts
+++ b/packages/@uppy/core/types/core-tests.ts
@@ -50,3 +50,22 @@ import DefaultStore = require('@uppy/store-default')
     meta: { path: 'path/to/file' }
   })
 }
+
+{
+  const uppy = Uppy()
+  uppy.on('file-added', () => {})
+  uppy.on('file-removed', () => {})
+  uppy.on('upload', () => {})
+  uppy.on('upload-progress', () => {})
+  uppy.on('upload-success', () => {})
+  uppy.on('complete', () => {})
+  uppy.on('error', () => {})
+  uppy.on('upload-error', () => {})
+  uppy.on('upload-retry', () => {})
+  uppy.on('info-visible', () => {})
+  uppy.on('info-hidden', () => {})
+  uppy.on('cancel-all', () => {})
+  uppy.on('restriction-failed', () => {})
+  uppy.on('reset-progress', () => {})
+  uppy.on('reset-progress', () => {})
+}

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -100,8 +100,9 @@ declare module Uppy {
   }
   type LogLevel = 'info' | 'warning' | 'error';
 
-  type Event = 'file-added' | 'file-removed' | 'upload' | 'upload-progress' | 'upload-success' | 'complete' | 'error' | 'upload-error' |
-               'upload-retry' | 'info-visible' | 'info-hidden' | 'cancel-all' | 'restriction-failed' | 'reset-progress';
+  type LiteralUnion<T extends U, U = string> = T | (U & { });
+  type Event = LiteralUnion<'file-added' | 'file-removed' | 'upload' | 'upload-progress' | 'upload-success' | 'complete' | 'error' | 'upload-error' |
+               'upload-retry' | 'info-visible' | 'info-hidden' | 'cancel-all' | 'restriction-failed' | 'reset-progress'>;
 
   class Uppy {
     constructor(opts?: Partial<UppyOptions>);

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -99,16 +99,20 @@ declare module Uppy {
     totalProgress: number;
   }
   type LogLevel = 'info' | 'warning' | 'error';
+
+  type Event = 'file-added' | 'file-removed' | 'upload' | 'upload-progress' | 'upload-success' | 'complete' | 'error' | 'upload-error' |
+               'upload-retry' | 'info-visible' | 'info-hidden' | 'cancel-all' | 'restriction-failed' | 'reset-progress';
+
   class Uppy {
     constructor(opts?: Partial<UppyOptions>);
     on<TMeta extends IndexedObject<any> = {}>(event: 'upload-success', callback: (file: UppyFile<TMeta>, body: any, uploadURL: string) => void): Uppy;
     on<TMeta extends IndexedObject<any> = {}>(event: 'complete', callback: (result: UploadResult<TMeta>) => void): Uppy;
-    on(event: string, callback: (...args: any[]) => void): Uppy;
-    off(event: string, callback: any): Uppy;
+    on(event: Event, callback: (...args: any[]) => void): Uppy;
+    off(event: Event, callback: any): Uppy;
     /**
      * For use by plugins only!
      */
-    emit(event: string, ...args: any[]): void;
+    emit(event: Event, ...args: any[]): void;
     updateAll(state: object): void;
     setState(patch: object): void;
     getState<TMeta extends IndexedObject<any> = {}>(): State<TMeta>;

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -100,6 +100,8 @@ declare module Uppy {
   }
   type LogLevel = 'info' | 'warning' | 'error';
 
+  // This hack accepts _any_ string for `Event`, but also tricks VSCode and friends into providing autocompletions
+  // for the names listed. https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
   type LiteralUnion<T extends U, U = string> = T | (U & { });
   type Event = LiteralUnion<'file-added' | 'file-removed' | 'upload' | 'upload-progress' | 'upload-success' | 'complete' | 'error' | 'upload-error' |
                'upload-retry' | 'info-visible' | 'info-hidden' | 'cancel-all' | 'restriction-failed' | 'reset-progress'>;


### PR DESCRIPTION
Casting event param to Event type rather than string. This offers stricter parameter checking avoiding fat fingering and code completion.