### PR TITLE
Include response object on upload-error

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -248,17 +248,17 @@ module.exports = class XHRUpload extends Plugin {
           this.uploaderEvents[file.id] = null
         }
 
+        const body = opts.getResponseData(xhr.responseText, xhr)
+        const uploadURL = body[opts.responseUrlFieldName]
+
+        const response = {
+          status: ev.target.status,
+          body,
+          uploadURL
+        }
+
         if (opts.validateStatus(ev.target.status, xhr.responseText, xhr)) {
-          const body = opts.getResponseData(xhr.responseText, xhr)
-          const uploadURL = body[opts.responseUrlFieldName]
-
-          const uploadResp = {
-            status: ev.target.status,
-            body,
-            uploadURL
-          }
-
-          this.uppy.emit('upload-success', file, uploadResp)
+          this.uppy.emit('upload-success', file, response)
 
           if (uploadURL) {
             this.uppy.log(`Download ${file.name} from ${uploadURL}`)
@@ -266,13 +266,7 @@ module.exports = class XHRUpload extends Plugin {
 
           return resolve(file)
         } else {
-          const body = opts.getResponseData(xhr.responseText, xhr)
           const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
-
-          const response = {
-            status: ev.target.status,
-            body
-          }
 
           this.uppy.emit('upload-error', file, error, response)
           return reject(error)

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -281,9 +281,17 @@ module.exports = class XHRUpload extends Plugin {
           this.uploaderEvents[file.id].remove()
           this.uploaderEvents[file.id] = null
         }
+        const body = opts.getResponseData(xhr.responseText, xhr)
+        const uploadURL = body[opts.responseUrlFieldName]
+
+        const response = {
+          status: ev.target.status,
+          body,
+          uploadURL
+        }
 
         const error = buildResponseError(xhr, opts.getResponseError(xhr.responseText, xhr))
-        this.uppy.emit('upload-error', file, error)
+        this.uppy.emit('upload-error', file, error, response)
         return reject(error)
       })
 


### PR DESCRIPTION
Including a response object when emitting the `upload-error`. Enabling better error messaging with the event status included in the event. And helps consistency with docs and other upload-result events.

Refactoring the building of `response` on the load event. Both blocks of the validateStatus conditional use the response object. Building it out of the conditional once to be used in both places.

```
        const response = {
          status: ev.target.status,
          body,
          uploadURL
        }
```