### PR TITLE
companion: rename uppy occurrences to companion

### DIFF
--- a/packages/@uppy/companion/README.md
+++ b/packages/@uppy/companion/README.md
@@ -28,7 +28,7 @@ companion may either be used as pluggable express app, which you plug to your al
 var express = require('express')
 var bodyParser = require('body-parser')
 var session = require('express-session')
-var uppy = require('@uppy/companion')
+var companion = require('@uppy/companion')
 
 var app = express()
 app.use(bodyParser.json())
@@ -49,17 +49,17 @@ const options = {
   filePath: '/path/to/folder/'
 }
 
-app.use(uppy.app(options))
+app.use(companion.app(options))
 
 ```
 
-To enable uppy socket for realtime feed to the client while upload is going on, you call the `socket` method like so.
+To enable companion socket for realtime feed to the client while upload is going on, you call the `socket` method like so.
 
 ```javascript
 ...
 var server = app.listen(PORT)
 
-uppy.socket(server, options)
+companion.socket(server, options)
 
 ```
 

--- a/packages/@uppy/companion/examples/serverless/index.js
+++ b/packages/@uppy/companion/examples/serverless/index.js
@@ -7,7 +7,7 @@ const session = require('express-session')
 const compression = require('compression')
 const awsServerlessExpress = require('aws-serverless-express')
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
-const uppy = require('@uppy/companion')
+const companion = require('@uppy/companion')
 
 const app = express()
 
@@ -53,7 +53,7 @@ const options = {
   secret: process.env.UPPY_SECRET
 }
 
-app.use(uppy.app(options))
+app.use(companion.app(options))
 
 app.get('/', (req, res) => {
   res.setHeader('Content-Type', 'text/plain')
@@ -62,5 +62,5 @@ app.get('/', (req, res) => {
 
 const server = awsServerlessExpress.createServer(app)
 
-exports.uppy = (event, context) =>
+exports.companion = (event, context) =>
   awsServerlessExpress.proxy(server, event, context)

--- a/packages/@uppy/companion/examples/serverless/serverless.yml
+++ b/packages/@uppy/companion/examples/serverless/serverless.yml
@@ -28,8 +28,8 @@ provider:
     # DROPBOX_SECRET: <YOUR_DROPBOX_SECRET>
 
 functions:
-  uppy:
-    handler: index.uppy
+  companion:
+    handler: index.companion
 
     events:
       - http: ANY /

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -237,13 +237,16 @@ const getOptionsMiddleware = (options) => {
    */
   const middleware = (req, res, next) => {
     const versionFromQuery = req.query.uppyVersions ? decodeURIComponent(req.query.uppyVersions) : null
-    req.uppy = {
+    req.companion = {
       options,
       s3Client,
       authToken: req.header('uppy-auth-token') || req.query.uppyAuthToken,
       clientVersion: req.header('uppy-versions') || versionFromQuery || '1.0.0',
       buildURL: getURLBuilder(options)
     }
+
+    // @todo remove req.uppy in next major release
+    req.uppy = req.companion
     next()
   }
 

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -33,7 +33,7 @@ class Uploader {
    * @property {string} pathPrefix
    * @property {any=} s3
    * @property {any} metadata
-   * @property {any} uppyOptions
+   * @property {any} companionOptions
    * @property {any=} storage
    * @property {any=} headers
    *
@@ -104,18 +104,18 @@ class Uploader {
 
   static reqToOptions (req, size) {
     return {
-      uppyOptions: req.uppy.options,
+      companionOptions: req.companion.options,
       endpoint: req.body.endpoint,
       uploadUrl: req.body.uploadUrl,
       protocol: req.body.protocol,
       metadata: req.body.metadata,
       size: size,
       fieldname: req.body.fieldname,
-      pathPrefix: `${req.uppy.options.filePath}`,
+      pathPrefix: `${req.companion.options.filePath}`,
       storage: redis.client(),
-      s3: req.uppy.s3Client ? {
-        client: req.uppy.s3Client,
-        options: req.uppy.options.providerOptions.s3
+      s3: req.companion.s3Client ? {
+        client: req.companion.s3Client,
+        options: req.companion.options.providerOptions.s3
       } : null,
       headers: req.body.headers
     }
@@ -147,14 +147,14 @@ class Uploader {
       return false
     }
 
-    const validatorOpts = { require_protocol: true, require_tld: !options.uppyOptions.debug }
+    const validatorOpts = { require_protocol: true, require_tld: !options.companionOptions.debug }
     return [options.endpoint, options.uploadUrl].every((url) => {
       if (url && !validator.isURL(url, validatorOpts)) {
         this._errRespMessage = 'Invalid destination url'
         return false
       }
 
-      const allowedUrls = options.uppyOptions.uploadUrls
+      const allowedUrls = options.companionOptions.uploadUrls
       if (allowedUrls && url && !hasMatch(url, allowedUrls)) {
         this._errRespMessage = 'upload destination does not match any allowed destinations'
         return false

--- a/packages/@uppy/companion/src/server/controllers/callback.js
+++ b/packages/@uppy/companion/src/server/controllers/callback.js
@@ -13,12 +13,12 @@ const logger = require('../logger')
 module.exports = function callback (req, res, next) {
   const providerName = req.params.providerName
 
-  if (!req.uppy.providerTokens) {
-    req.uppy.providerTokens = {}
+  if (!req.companion.providerTokens) {
+    req.companion.providerTokens = {}
   }
 
-  req.uppy.providerTokens[providerName] = req.session.grant.response.access_token
+  req.companion.providerTokens[providerName] = req.session.grant.response.access_token
   logger.debug(`Generating auth token for provider ${providerName}.`, null, req.id)
-  const uppyAuthToken = tokenService.generateToken(req.uppy.providerTokens, req.uppy.options.secret)
-  return res.redirect(req.uppy.buildURL(`/${providerName}/send-token?uppyAuthToken=${uppyAuthToken}`, true))
+  const uppyAuthToken = tokenService.generateToken(req.companion.providerTokens, req.companion.options.secret)
+  return res.redirect(req.companion.buildURL(`/${providerName}/send-token?uppyAuthToken=${uppyAuthToken}`, true))
 }

--- a/packages/@uppy/companion/src/server/controllers/connect.js
+++ b/packages/@uppy/companion/src/server/controllers/connect.js
@@ -9,7 +9,7 @@ const atob = require('atob')
  * @param {object} res
  */
 module.exports = function connect (req, res) {
-  const secret = req.uppy.options.secret
+  const secret = req.companion.options.secret
   let state = oAuthState.generateState(secret)
   if (req.query.state) {
     // todo change this query from state to "origin"
@@ -17,13 +17,13 @@ module.exports = function connect (req, res) {
     state = oAuthState.addToState(state, origin, secret)
   }
 
-  if (req.uppy.options.server.oauthDomain) {
-    state = oAuthState.addToState(state, { uppyInstance: req.uppy.buildURL('', true) }, secret)
+  if (req.companion.options.server.oauthDomain) {
+    state = oAuthState.addToState(state, { companionInstance: req.companion.buildURL('', true) }, secret)
   }
 
-  if (req.uppy.clientVersion) {
-    state = oAuthState.addToState(state, { clientVersion: req.uppy.clientVersion }, secret)
+  if (req.companion.clientVersion) {
+    state = oAuthState.addToState(state, { clientVersion: req.companion.clientVersion }, secret)
   }
 
-  res.redirect(req.uppy.buildURL(`/connect/${req.uppy.provider.authProvider}?state=${state}`, true))
+  res.redirect(req.companion.buildURL(`/connect/${req.companion.provider.authProvider}?state=${state}`, true))
 }

--- a/packages/@uppy/companion/src/server/controllers/get.js
+++ b/packages/@uppy/companion/src/server/controllers/get.js
@@ -4,8 +4,8 @@ const logger = require('../logger')
 function get (req, res, next) {
   const providerName = req.params.providerName
   const id = req.params.id
-  const token = req.uppy.providerTokens[providerName]
-  const provider = req.uppy.provider
+  const token = req.companion.providerTokens[providerName]
+  const provider = req.companion.provider
 
   // get the file size before proceeding
   provider.size({ id, token }, (err, size) => {

--- a/packages/@uppy/companion/src/server/controllers/list.js
+++ b/packages/@uppy/companion/src/server/controllers/list.js
@@ -1,8 +1,8 @@
-function list ({ query, params, uppy }, res, next) {
+function list ({ query, params, companion }, res, next) {
   const providerName = params.providerName
-  const token = uppy.providerTokens[providerName]
+  const token = companion.providerTokens[providerName]
 
-  uppy.provider.list({ uppy, token, directory: params.id, query }, (err, data) => {
+  companion.provider.list({ companion, token, directory: params.id, query }, (err, data) => {
     if (err) {
       return err.isAuthError ? res.sendStatus(401) : next(err)
     }

--- a/packages/@uppy/companion/src/server/controllers/logout.js
+++ b/packages/@uppy/companion/src/server/controllers/logout.js
@@ -13,15 +13,15 @@ function logout (req, res, next) {
     }
   }
   const providerName = req.params.providerName
-  const token = req.uppy.providerTokens ? req.uppy.providerTokens[providerName] : null
+  const token = req.companion.providerTokens ? req.companion.providerTokens[providerName] : null
   if (token) {
-    req.uppy.provider.logout({ token }, (err, data) => {
+    req.companion.provider.logout({ token }, (err, data) => {
       if (err) {
         return next(err)
       }
 
-      delete req.uppy.providerTokens[providerName]
-      tokenService.removeFromCookies(res, req.uppy.options, req.uppy.provider.authProviderName)
+      delete req.companion.providerTokens[providerName]
+      tokenService.removeFromCookies(res, req.companion.options, req.companion.provider.authProviderName)
       cleanSession()
       res.json(Object.assign({ ok: true }, data))
     })

--- a/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
+++ b/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
@@ -12,11 +12,11 @@ module.exports = function oauthRedirect (req, res) {
   if (!req.query.state) {
     return res.status(400).send('Cannot find state param in reques')
   }
-  const handler = oAuthState.getFromState(req.query.state, 'uppyInstance', req.uppy.options.secret)
+  const handler = oAuthState.getFromState(req.query.state, 'companionInstance', req.companion.options.secret)
   const handlerHostName = parseUrl(handler).host
 
-  if (hasMatch(handlerHostName, req.uppy.options.server.validHosts)) {
-    const providerName = req.uppy.provider.authProvider
+  if (hasMatch(handlerHostName, req.companion.options.server.validHosts)) {
+    const providerName = req.companion.provider.authProvider
     const params = qs.stringify(req.query)
     const url = `${handler}/connect/${providerName}/callback?${params}`
     return res.redirect(url)

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -23,8 +23,8 @@ module.exports = function s3 (config) {
    *  - fields - Form fields to send along.
    */
   function getUploadParameters (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const key = config.getKey(req, req.query.filename)
     if (typeof key !== 'string') {
       return res.status(500).json({ error: 's3: filename returned from `getKey` must be a string' })
@@ -68,8 +68,8 @@ module.exports = function s3 (config) {
    *  - uploadId - The ID of this multipart upload, to be used in later requests.
    */
   function createMultipartUpload (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const key = config.getKey(req, req.body.filename)
     const { type, metadata } = req.body
     if (typeof key !== 'string') {
@@ -112,8 +112,8 @@ module.exports = function s3 (config) {
    *     - Size - size of this part.
    */
   function getUploadedParts (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const { uploadId } = req.params
     const { key } = req.query
 
@@ -164,8 +164,8 @@ module.exports = function s3 (config) {
    *  - url - The URL to upload to, including signed query parameters.
    */
   function signPartUpload (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const { uploadId, partNumber } = req.params
     const { key } = req.query
 
@@ -203,8 +203,8 @@ module.exports = function s3 (config) {
    *   Empty.
    */
   function abortMultipartUpload (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const { uploadId } = req.params
     const { key } = req.query
 
@@ -238,8 +238,8 @@ module.exports = function s3 (config) {
    *  - location - The full URL to the object in the S3 bucket.
    */
   function completeMultipartUpload (req, res, next) {
-    // @ts-ignore The `uppy` property is added by middleware before reaching here.
-    const client = req.uppy.s3Client
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
     const { uploadId } = req.params
     const { key } = req.query
     const { parts } = req.body

--- a/packages/@uppy/companion/src/server/controllers/send-token.js
+++ b/packages/@uppy/companion/src/server/controllers/send-token.js
@@ -15,19 +15,19 @@ const versionCmp = require('../helpers/version')
  * @param {function} next
  */
 module.exports = function sendToken (req, res, next) {
-  const uppyAuthToken = req.uppy.authToken
+  const uppyAuthToken = req.companion.authToken
   // add the token to cookies for thumbnail/image requests
-  tokenService.addToCookies(res, uppyAuthToken, req.uppy.options, req.uppy.provider.authProvider)
+  tokenService.addToCookies(res, uppyAuthToken, req.companion.options, req.companion.provider.authProvider)
 
   const state = (req.session.grant || {}).state
   if (state) {
-    const origin = oAuthState.getFromState(state, 'origin', req.uppy.options.secret)
+    const origin = oAuthState.getFromState(state, 'origin', req.companion.options.secret)
     const clientVersion = oAuthState.getFromState(
       state,
       'clientVersion',
-      req.uppy.options.secret
+      req.companion.options.secret
     )
-    const allowedClients = req.uppy.options.clients
+    const allowedClients = req.companion.options.clients
     // if no preset clients then allow any client
     if (!allowedClients || hasMatch(origin, allowedClients) || hasMatch(parseUrl(origin).host, allowedClients)) {
       const allowsStringMessage = versionCmp.gte(clientVersion, '1.0.2')

--- a/packages/@uppy/companion/src/server/controllers/thumbnail.js
+++ b/packages/@uppy/companion/src/server/controllers/thumbnail.js
@@ -6,8 +6,8 @@
 function thumbnail (req, res, next) {
   const providerName = req.params.providerName
   const id = req.params.id
-  const token = req.uppy.providerTokens[providerName]
-  const provider = req.uppy.provider
+  const token = req.companion.providerTokens[providerName]
+  const provider = req.companion.provider
 
   provider.thumbnail({ id, token }, (err, response) => {
     if (err) {

--- a/packages/@uppy/companion/src/server/controllers/url.js
+++ b/packages/@uppy/companion/src/server/controllers/url.js
@@ -20,7 +20,7 @@ module.exports = () => {
 const meta = (req, res) => {
   logger.debug('URL file import handler running', null, req.id)
 
-  if (!validator.isURL(req.body.url, { require_protocol: true, require_tld: !req.uppy.options.debug })) {
+  if (!validator.isURL(req.body.url, { require_protocol: true, require_tld: !req.companion.options.debug })) {
     logger.debug('Invalid request body detected. Exiting url meta handler.', null, req.id)
     return res.status(400).json({ error: 'Invalid request body' })
   }

--- a/packages/@uppy/companion/src/server/helpers/jwt.js
+++ b/packages/@uppy/companion/src/server/helpers/jwt.js
@@ -28,17 +28,17 @@ module.exports.verifyToken = (token, secret) => {
  *
  * @param {object} res
  * @param {string} token
- * @param {object=} uppyOptions
+ * @param {object=} companionOptions
  * @param {string} providerName
  */
-module.exports.addToCookies = (res, token, uppyOptions, providerName) => {
+module.exports.addToCookies = (res, token, companionOptions, providerName) => {
   const cookieOptions = {
     maxAge: 1000 * 60 * 60 * 24 * 30, // would expire after 30 days
     httpOnly: true
   }
 
-  if (uppyOptions.cookieDomain) {
-    cookieOptions.domain = uppyOptions.cookieDomain
+  if (companionOptions.cookieDomain) {
+    cookieOptions.domain = companionOptions.cookieDomain
   }
   // send signed token to client.
   res.cookie(`uppyAuthToken--${providerName}`, token, cookieOptions)
@@ -47,17 +47,17 @@ module.exports.addToCookies = (res, token, uppyOptions, providerName) => {
 /**
  *
  * @param {object} res
- * @param {object=} uppyOptions
+ * @param {object=} companionOptions
  * @param {string} providerName
  */
-module.exports.removeFromCookies = (res, uppyOptions, providerName) => {
+module.exports.removeFromCookies = (res, companionOptions, providerName) => {
   const cookieOptions = {
     maxAge: 1000 * 60 * 60 * 24 * 30, // would expire after 30 days
     httpOnly: true
   }
 
-  if (uppyOptions.cookieDomain) {
-    cookieOptions.domain = uppyOptions.cookieDomain
+  if (companionOptions.cookieDomain) {
+    cookieOptions.domain = companionOptions.cookieDomain
   }
 
   res.clearCookie(`uppyAuthToken--${providerName}`, cookieOptions)

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -72,11 +72,11 @@ exports.getURLMeta = (url) => {
 /**
  * Returns a url builder
  *
- * @param {object} options uppy options
+ * @param {object} options companion options
  */
 module.exports.getURLBuilder = (options) => {
   /**
-   * Builds uppy targeted url
+   * Builds companion targeted url
    *
    * @param {string} path the tail path of the url
    * @param {boolean} isExternal if the url is for the external world

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -7,7 +7,7 @@ exports.hasSessionAndProvider = (req, res, next) => {
     return res.sendStatus(400)
   }
 
-  if (!req.uppy.provider) {
+  if (!req.companion.provider) {
     logger.debug('No provider/provider-handler found. Exiting dispatcher.', null, req.id)
     return res.sendStatus(400)
   }
@@ -17,27 +17,27 @@ exports.hasSessionAndProvider = (req, res, next) => {
 
 exports.verifyToken = (req, res, next) => {
   const providerName = req.params.providerName
-  const { err, payload } = tokenService.verifyToken(req.uppy.authToken, req.uppy.options.secret)
+  const { err, payload } = tokenService.verifyToken(req.companion.authToken, req.companion.options.secret)
   if (err || !payload[providerName]) {
     return res.sendStatus(401)
   }
-  req.uppy.providerTokens = payload
+  req.companion.providerTokens = payload
   next()
 }
 
 // does not fail if token is invalid
 exports.gentleVerifyToken = (req, res, next) => {
   const providerName = req.params.providerName
-  if (req.uppy.authToken) {
-    const { err, payload } = tokenService.verifyToken(req.uppy.authToken, req.uppy.options.secret)
+  if (req.companion.authToken) {
+    const { err, payload } = tokenService.verifyToken(req.companion.authToken, req.companion.options.secret)
     if (!err && payload[providerName]) {
-      req.uppy.providerTokens = payload
+      req.companion.providerTokens = payload
     }
   }
   next()
 }
 
 exports.cookieAuthToken = (req, res, next) => {
-  req.uppy.authToken = req.cookies[`uppyAuthToken--${req.uppy.provider.authProvider}`]
+  req.companion.authToken = req.cookies[`uppyAuthToken--${req.companion.provider.authProvider}`]
   return next()
 }

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -75,7 +75,7 @@ class Drive {
           const returnData = this.adaptData(
             filesResponse.body,
             sharedDrives && sharedDrives.body,
-            options.uppy,
+            options.companion,
             directory,
             query
           )
@@ -148,14 +148,14 @@ class Drive {
       })
   }
 
-  adaptData (res, sharedDrivesResp, uppy, directory, query) {
+  adaptData (res, sharedDrivesResp, companion, directory, query) {
     const adaptItem = (item) => ({
       isFolder: adapter.isFolder(item),
       icon: adapter.getItemIcon(item),
       name: adapter.getItemName(item),
       mimeType: adapter.getMimeType(item),
       id: adapter.getItemId(item),
-      thumbnail: uppy.buildURL(adapter.getItemThumbnailUrl(item), true),
+      thumbnail: companion.buildURL(adapter.getItemThumbnailUrl(item), true),
       requestPath: adapter.getItemRequestPath(item),
       modifiedDate: adapter.getItemModifiedDate(item),
       size: adapter.getItemSize(item),

--- a/packages/@uppy/companion/src/server/provider/dropbox/index.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/index.js
@@ -55,7 +55,7 @@ class DropBox {
         done(err)
       } else {
         stats.body.user_email = userInfo.body.email
-        done(null, this.adaptData(stats.body, options.uppy))
+        done(null, this.adaptData(stats.body, options.companion))
       }
     }
 
@@ -175,7 +175,7 @@ class DropBox {
       })
   }
 
-  adaptData (res, uppy) {
+  adaptData (res, companion) {
     const data = { username: adapter.getUsername(res), items: [] }
     const items = adapter.getItemSubList(res)
     items.forEach((item) => {
@@ -185,7 +185,7 @@ class DropBox {
         name: adapter.getItemName(item),
         mimeType: adapter.getMimeType(item),
         id: adapter.getItemId(item),
-        thumbnail: uppy.buildURL(adapter.getItemThumbnailUrl(item), true),
+        thumbnail: companion.buildURL(adapter.getItemThumbnailUrl(item), true),
         requestPath: adapter.getItemRequestPath(item),
         modifiedDate: adapter.getItemModifiedDate(item),
         size: adapter.getItemSize(item)

--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -78,8 +78,8 @@ module.exports.getProviderMiddleware = (providers) => {
    * @param {string} providerName
    */
   const middleware = (req, res, next, providerName) => {
-    if (providers[providerName] && validOptions(req.uppy.options)) {
-      req.uppy.provider = new providers[providerName]({ providerName, config })
+    if (providers[providerName] && validOptions(req.companion.options)) {
+      req.companion.provider = new providers[providerName]({ providerName, config })
     } else {
       logger.warn('invalid provider options detected. Provider will not be loaded', 'provider.middleware.invalid', req.id)
     }
@@ -137,7 +137,7 @@ module.exports.addProviderOptions = (options, grantConfig) => {
       grantConfig[authProvider].key = providerOptions[authProvider].key
       grantConfig[authProvider].secret = providerOptions[authProvider].secret
 
-      // override grant.js redirect uri with uppy's custom redirect url
+      // override grant.js redirect uri with companion's custom redirect url
       if (oauthDomain) {
         const providerName = authToProviderName(authProvider)
         const redirectPath = `/${providerName}/redirect`

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -13,7 +13,7 @@ const { version } = require('../../package.json')
  *
  * @returns {object}
  */
-exports.getUppyOptions = () => {
+exports.getCompanionOptions = () => {
   return merge({}, getConfigFromEnv(), getConfigFromFile())
 }
 
@@ -167,7 +167,7 @@ exports.validateConfig = (config) => {
   }
 
   // validate that specified filePath is writeable/readable.
-  // TODO: consider moving this into the uppy module itself.
+  // TODO: consider moving this into the companion module itself.
   try {
     // @ts-ignore
     fs.accessSync(`${config.filePath}`, fs.R_OK | fs.W_OK)
@@ -186,10 +186,10 @@ exports.hasProtocol = (url) => {
   return url.startsWith('http://') || url.startsWith('https://')
 }
 
-exports.buildHelpfulStartupMessage = (uppyOptions) => {
-  const buildURL = utils.getURLBuilder(uppyOptions)
+exports.buildHelpfulStartupMessage = (companionOptions) => {
+  const buildURL = utils.getURLBuilder(companionOptions)
   const callbackURLs = []
-  Object.keys(uppyOptions.providerOptions).forEach((providerName) => {
+  Object.keys(companionOptions.providerOptions).forEach((providerName) => {
     // s3 does not need redirect_uris
     if (providerName === 's3') {
       return

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const qs = require('querystring')
-const uppy = require('../companion')
+const companion = require('../companion')
 const helmet = require('helmet')
 const morgan = require('morgan')
 const bodyParser = require('body-parser')
@@ -66,7 +66,7 @@ app.use(helmet.noSniff())
 app.use(helmet.ieNoOpen())
 app.disable('x-powered-by')
 
-const companionOptions = helper.getUppyOptions()
+const companionOptions = helper.getCompanionOptions()
 const sessionOptions = {
   secret: companionOptions.secret,
   resave: true,
@@ -128,12 +128,12 @@ app.get('/', (req, res) => {
   res.send(helper.buildHelpfulStartupMessage(companionOptions))
 })
 
-// initialize uppy
+// initialize companion
 helper.validateConfig(companionOptions)
 if (process.env.COMPANION_PATH) {
-  app.use(process.env.COMPANION_PATH, uppy.app(companionOptions))
+  app.use(process.env.COMPANION_PATH, companion.app(companionOptions))
 } else {
-  app.use(uppy.app(companionOptions))
+  app.use(companion.app(companionOptions))
 }
 
 app.use((req, res, next) => {

--- a/packages/@uppy/companion/src/standalone/start-server.js
+++ b/packages/@uppy/companion/src/standalone/start-server.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-const uppy = require('../companion')
+const companion = require('../companion')
 // @ts-ignore
 const { version } = require('../../package.json')
 const { app } = require('.')
 const port = process.env.COMPANION_PORT || 3020
 
-uppy.socket(app.listen(port))
+companion.socket(app.listen(port))
 
 console.log(`Welcome to Companion! v${version}`)
 console.log(`Listening on http://0.0.0.0:${port}`)

--- a/packages/@uppy/companion/test/__tests__/provider-manager.js
+++ b/packages/@uppy/companion/test/__tests__/provider-manager.js
@@ -2,16 +2,16 @@
 
 const providerManager = require('../../src/server/provider')
 let grantConfig
-let uppyOptions
+let companionOptions
 
 describe('Test Provider options', () => {
   beforeEach(() => {
     grantConfig = require('../../src/config/grant')()
-    uppyOptions = require('../../src/standalone/helper').getUppyOptions()
+    companionOptions = require('../../src/standalone/helper').getCompanionOptions()
   })
 
   test('adds provider options', () => {
-    providerManager.addProviderOptions(uppyOptions, grantConfig)
+    providerManager.addProviderOptions(companionOptions, grantConfig)
     expect(grantConfig.dropbox.key).toBe('dropbox_key')
     expect(grantConfig.dropbox.secret).toBe('dropbox_secret')
 
@@ -27,9 +27,9 @@ describe('Test Provider options', () => {
     process.env.COMPANION_GOOGLE_SECRET_FILE = process.env.PWD + '/test/resources/google_secret_file'
     process.env.COMPANION_INSTAGRAM_SECRET_FILE = process.env.PWD + '/test/resources/instagram_secret_file'
 
-    uppyOptions = require('../../src/standalone/helper').getUppyOptions()
+    companionOptions = require('../../src/standalone/helper').getCompanionOptions()
 
-    providerManager.addProviderOptions(uppyOptions, grantConfig)
+    providerManager.addProviderOptions(companionOptions, grantConfig)
 
     expect(grantConfig.dropbox.secret).toBe('xobpord')
     expect(grantConfig.google.secret).toBe('elgoog')
@@ -37,10 +37,10 @@ describe('Test Provider options', () => {
   })
 
   test('does not add provider options if protocol and host are not set', () => {
-    delete uppyOptions.server.host
-    delete uppyOptions.server.protocol
+    delete companionOptions.server.host
+    delete companionOptions.server.protocol
 
-    providerManager.addProviderOptions(uppyOptions, grantConfig)
+    providerManager.addProviderOptions(companionOptions, grantConfig)
     expect(grantConfig.dropbox.key).toBeUndefined()
     expect(grantConfig.dropbox.secret).toBeUndefined()
 
@@ -52,8 +52,8 @@ describe('Test Provider options', () => {
   })
 
   test('sets a master redirect uri, if oauthDomain is set', () => {
-    uppyOptions.server.oauthDomain = 'domain.com'
-    providerManager.addProviderOptions(uppyOptions, grantConfig)
+    companionOptions.server.oauthDomain = 'domain.com'
+    providerManager.addProviderOptions(companionOptions, grantConfig)
 
     expect(grantConfig.dropbox.redirect_uri).toBe('http://domain.com/dropbox/redirect')
     expect(grantConfig.google.redirect_uri).toBe('http://domain.com/drive/redirect')


### PR DESCRIPTION
renaming all occurrences of uppy / uppyOptions to companion / companionOptions to reduce confusion when reading the codebase (especially for possible contributors).

@kiloreux added you just in case you spot anything of with the `packages/@uppy/companion/examples/serverless/` part