### PR TITLE
locales: Rename es_GL → gl_ES

### DIFF
--- a/bin/locale-packs.js
+++ b/bin/locale-packs.js
@@ -191,6 +191,8 @@ function test () {
   const localePackagePath = path.join(__dirname, '..', 'packages', '@uppy', 'locales', 'src', '*.js')
   glob.sync(localePackagePath).forEach((localePath) => {
     const localeName = path.basename(localePath, '.js')
+    // we renamed the es_GL → gl_ES locale, and kept the old name
+    // for backwards-compat, see https://github.com/transloadit/uppy/pull/1929
     if (localeName === 'es_GL') return
 
     // Builds array with items like: 'uploadingXFiles.2'

--- a/bin/locale-packs.js
+++ b/bin/locale-packs.js
@@ -191,6 +191,8 @@ function test () {
   const localePackagePath = path.join(__dirname, '..', 'packages', '@uppy', 'locales', 'src', '*.js')
   glob.sync(localePackagePath).forEach((localePath) => {
     const localeName = path.basename(localePath, '.js')
+    if (localeName === 'es_GL') return
+
     // Builds array with items like: 'uploadingXFiles.2'
     followerValues[localeName] = flat(require(localePath).strings)
     followerLocales[localeName] = Object.keys(followerValues[localeName])

--- a/packages/@uppy/locales/src/es_GL.js
+++ b/packages/@uppy/locales/src/es_GL.js
@@ -1,0 +1,1 @@
+module.exports = require('./gl_ES')

--- a/packages/@uppy/locales/src/gl_ES.js
+++ b/packages/@uppy/locales/src/gl_ES.js
@@ -1,6 +1,6 @@
-const es_GL = {}
+const gl_ES = {}
 
-es_GL.strings = {
+gl_ES.strings = {
   addMore: 'añadir más',
   addMoreFiles: 'Agregar máis arquivos',
   addingMoreFiles: 'Agregando máis arquivos',
@@ -138,7 +138,7 @@ es_GL.strings = {
   openFolderNamed: 'Carpeta abierta %{name}'
 }
 
-es_GL.pluralize = function (n) {
+gl_ES.pluralize = function (n) {
   if (n === 1) {
     return 0
   }
@@ -146,7 +146,7 @@ es_GL.pluralize = function (n) {
 }
 
 if (typeof window !== 'undefined' && typeof window.Uppy !== 'undefined') {
-  window.Uppy.locales.es_GL = es_GL
+  window.Uppy.locales.gl_ES = gl_ES
 }
 
-module.exports = es_GL
+module.exports = gl_ES

--- a/website/inject.js
+++ b/website/inject.js
@@ -192,6 +192,7 @@ function injectLocaleList () {
 
   glob.sync(localePackagePath).forEach((localePath) => {
     const localeName = path.basename(localePath, '.js')
+    if (localeName === 'es_GL') return
     let localeNameWithDash = localeName.replace(/_/g, '-')
 
     const parts = localeNameWithDash.split('-')

--- a/website/inject.js
+++ b/website/inject.js
@@ -192,6 +192,8 @@ function injectLocaleList () {
 
   glob.sync(localePackagePath).forEach((localePath) => {
     const localeName = path.basename(localePath, '.js')
+    // we renamed the es_GL → gl_ES locale, and kept the old name
+    // for backwards-compat, see https://github.com/transloadit/uppy/pull/1929
     if (localeName === 'es_GL') return
     let localeNameWithDash = localeName.replace(/_/g, '-')
 


### PR DESCRIPTION
the `es-GL` locale means Spanish in Greenland.
`gl-ES` means Galician in Spain.

I just renamed the file here which is a breaking change. I think that's
acceptable for the locales package, as it isn't a dependency of anything
else. `@uppy/locales@2.0` doesn't affect anything. what do y'all think?