### PR TITLE
Test aws s3 plugin

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -55,12 +55,6 @@ module.exports = class AwsS3 extends Plugin {
 
     this.opts = { ...defaultOptions, ...opts }
 
-    if (!this.opts.includes('companionUrl')) {
-      console.warn(
-        'This plugin expects `companionUrl` option to be configured.',
-        'See the documentation for more help https://uppy.io/docs/aws-s3/')
-    }
-
     this.i18nInit()
 
     this.client = new RequestClient(uppy, opts)

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -55,6 +55,12 @@ module.exports = class AwsS3 extends Plugin {
 
     this.opts = { ...defaultOptions, ...opts }
 
+    if (!this.opts.includes('companionUrl')) {
+      console.warn(
+        'This plugin expects `companionUrl` option to be configured.',
+        'See the documentation for more help https://uppy.io/docs/aws-s3/')
+    }
+
     this.i18nInit()
 
     this.client = new RequestClient(uppy, opts)

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -18,5 +18,19 @@ describe('AwsS3', () => {
 
       expect(awsS3.opts.getUploadParameters).toThrow()
     })
+
+    it('Does not throw an error with campanionUrl configured', () => {
+      const core = new Core()
+      core.use(AwsS3, { companionUrl: 'https://uppy-companion.myapp.com/' })
+      const awsS3 = core.getPlugin('AwsS3')
+      const file = {
+        meta: {
+          name: 'foo.jpg',
+          type: 'image/jpg'
+        }
+      }
+
+      expect(() => awsS3.opts.getUploadParameters(file)).not.toThrow()
+    })
   })
 })

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -9,4 +9,14 @@ describe('AwsS3', () => {
     const pluginNames = core.plugins.uploader.map((plugin) => plugin.constructor.name)
     expect(pluginNames).toContain('AwsS3')
   })
+
+  describe('getUploadParameters', () => {
+    it('Throws an error if configured without companionUrl', () => {
+      const core = new Core()
+      core.use(AwsS3)
+      const awsS3 = core.getPlugin('AwsS3')
+
+      expect(awsS3.opts.getUploadParameters).toThrow()
+    })
+  })
 })

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -1,0 +1,12 @@
+const Core = require('@uppy/core')
+const AwsS3 = require('./')
+
+describe('AwsS3', () => {
+  it('Registers AwsS3 upload plugin', () => {
+    const core = new Core()
+    core.use(AwsS3)
+
+    const pluginNames = core.plugins.uploader.map((plugin) => plugin.constructor.name)
+    expect(pluginNames).toContain('AwsS3')
+  })
+})


### PR DESCRIPTION
The start of a test suite for the awsS3 plugin. The first few are always the hardest.

Since `getUploadParameters` throws without the configuration option `companionURL` a warning message was included in the constructor.