### PR TITLE
docs: make Robodog naming more consistent

### DIFF
--- a/website/src/docs/robodog-dashboard.md
+++ b/website/src/docs/robodog-dashboard.md
@@ -13,7 +13,7 @@ Add the [Dashboard UI][dashboard] to your page, all wired up and ready to go! Th
 <div id="dashboard"></div>
 
 <script>
-robodog.dashboard('#dashboard', {
+Robodog.dashboard('#dashboard', {
   params: {
     auth: { key: '' },
     template_id: ''
@@ -25,13 +25,13 @@ robodog.dashboard('#dashboard', {
 This API can still be used as a modal, too, by specifying `inline: false`:
 
 ```js
-robodog.dashboard(selector, { inline: false })
+Robodog.dashboard(selector, { inline: false })
 ```
 
-The `robodog.dashboard()` function returns an Uppy instance, which you can use to listen for any Uppy events.
+The `Robodog.dashboard()` function returns an Uppy instance, which you can use to listen for any Uppy events.
 
 ```js
-const uppy = robodog.dashboard(selector, { ...options })
+const uppy = Robodog.dashboard(selector, { ...options })
   .on('transloadit:result', (result) => {
     console.log(result)
   })

--- a/website/src/docs/robodog-form.md
+++ b/website/src/docs/robodog-form.md
@@ -10,13 +10,13 @@ category: "File Processing"
 Add resumable uploads and Transloadit's processing to your existing HTML upload forms. Selected files will be uploaded to Transloadit, and the Assembly information will be submitted to your form endpoint.
 
 ```html
-<form id="myForm" method="POST" action="/upload">
+<form id="upload-form" method="POST" action="/upload">
   <input type="file" multiple>
   ...
 </form>
 
 <script>
-window.Robodog.form('form#myForm', {
+window.Robodog.form('form#upload-form', {
   params: {
     auth: { key: '' },
     template_id: ''
@@ -78,12 +78,12 @@ Uploads using HTML forms have no builtin progress reporting. With Robodog, you c
 Point it to an element or a CSS selector:
 
 ```html
-<form id="my-form" ...>
+<form id="upload-form" ...>
   <div class="progress"></div>
 </form>
 <script>
-window.Robodog.form('form#my-form', {
-  statusBar: '#my-form .progress'
+window.Robodog.form('form#upload-form', {
+  statusBar: '#upload-form .progress'
   // ...
 })
 </script>
@@ -98,11 +98,11 @@ By default, `Robodog.form` starts uploads when the user submits the form. There 
 The `triggerUploadOnSubmit: false` option is available for this purpose. We recommend using it together with the `modal: true` and `closeAfterFinish: true` options:
 
 ```js
-// Replace file input in #my-form with a button that opens the modal;
+// Replace file input in #upload-form with a button that opens the modal;
 // after the user clicks the "Upload" button inside the modal and all
 // files have been successfully uploaded, the modal closes and the user
 // can submit the form.
-window.Robodog.form('form#my-form', {
+window.Robodog.form('form#upload-form', {
   modal: true,
   closeAfterFinish: true,
   triggerUploadOnSubmit: false

--- a/website/src/docs/robodog-picker.md
+++ b/website/src/docs/robodog-picker.md
@@ -10,7 +10,7 @@ category: "File Processing"
 Show a modal UI that allows users to pick files from their device and from the web. It uploads files to Transloadit for processing.
 
 ```js
-const resultPromise = transloadit.pick({
+const resultPromise = Robodog.pick({
   params: {
     auth: { key: '' },
     template_id: ''

--- a/website/src/docs/robodog-upload.md
+++ b/website/src/docs/robodog-upload.md
@@ -10,7 +10,7 @@ category: "File Processing"
 Upload files straight to Transloadit from your own custom UI. Give us an array of files, and we'll give you an array of results!
 
 ```js
-const resultPromise = robodog.upload(files, {
+const resultPromise = Robodog.upload(files, {
   params: {
     auth: { key: '' },
     template_id: ''

--- a/website/src/docs/robodog.md
+++ b/website/src/docs/robodog.md
@@ -75,14 +75,14 @@ resultPromise.then((bundle) => {
 Add resumable uploads and Transloadit's processing to your existing HTML upload forms. Selected files will be uploaded to Transloadit, and the Assembly information will be submitted to your form endpoint.
 
 ```html
-<form id="myForm" method="POST" action="/upload">
+<form id="upload-form" method="POST" action="/upload">
   <input type="file" multiple>
   <!-- Will be inserted by `robodog.form()`: -->
   <!-- <input type="hidden" name="transloadit" value="{...json...}"> -->
   <button type="submit">Upload</button>
 </form>
 <script>
-robodog.form('form#myForm', {
+robodog.form('form#upload-form', {
   params: {
     auth: { key: '' },
     template_id: ''

--- a/website/src/docs/robodog.md
+++ b/website/src/docs/robodog.md
@@ -53,7 +53,7 @@ And if any of these methods are not flexible enough, you can always replace them
 Show a modal UI that allows users to pick files from their device and from the web. It uploads files to Transloadit for processing.
 
 ```js
-const resultPromise = robodog.pick({
+const resultPromise = Robodog.pick({
   target: 'body',
   params: {
     auth: { key: '' },
@@ -77,12 +77,12 @@ Add resumable uploads and Transloadit's processing to your existing HTML upload 
 ```html
 <form id="upload-form" method="POST" action="/upload">
   <input type="file" multiple>
-  <!-- Will be inserted by `robodog.form()`: -->
+  <!-- Will be inserted by `Robodog.form()`: -->
   <!-- <input type="hidden" name="transloadit" value="{...json...}"> -->
   <button type="submit">Upload</button>
 </form>
 <script>
-robodog.form('form#upload-form', {
+Robodog.form('form#upload-form', {
   params: {
     auth: { key: '' },
     template_id: ''
@@ -98,7 +98,7 @@ robodog.form('form#upload-form', {
 Upload files straight to Transloadit from your own custom UI. Give us an array of files, and we'll give you an array of results!
 
 ```js
-const resultPromise = robodog.upload(files, {
+const resultPromise = Robodog.upload(files, {
   params: {
     auth: { key: '' },
     template_id: ''

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -190,7 +190,7 @@ uppy.use(Transloadit, {
 You can also pass an array of field names to send global or file metadata along to the Assembly. Global metadata is set using the [`meta` option](/docs/uppy/#meta) in the Uppy constructor, or using the [`setMeta` method](/docs/uppy/#uppy-setMeta-data). File metadata is set using the [`setFileMeta`](/docs/uppy/#uppy-setFileMeta-fileID-data) method. The [Form](/docs/form) plugin also sets global metadata based on the values of `<input />`s in the form, providing a handy way to use values from HTML form fields:
 
 ```js
-uppy.use(Form, { target: 'form#my-form', getMetaFromForm: true })
+uppy.use(Form, { target: 'form#upload-form', getMetaFromForm: true })
 uppy.use(Transloadit, {
   fields: ['field_name', 'other_field_name'],
   params: { ... }


### PR DESCRIPTION
- Uses `#upload-form` as a CSS selector for all the form examples, so copy-pasting parts from different examples works
- Uses uppercase `Robodog` variable for all Robodog namespace references, which is what the CDN exports. There was also one pre-Robodog-name reference to `transloadit.form()` which is now fixed.