### PR TITLE
Change Deployment type to stable api

### DIFF
--- a/packages/@uppy/companion/infra/kube/companion/companion-redis.yaml
+++ b/packages/@uppy/companion/infra/kube/companion/companion-redis.yaml
@@ -10,7 +10,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Change Deployment to `apps/v1` since our cluster is now on 1.16. 