### PR TITLE
companion: test companion on node 6 + fix incompatible code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       env: COMPANION=true
       addons:
         apt: *APT
-    - node_js: 6
+    - node_js: 'stable'
       env: COMPANION_NODE6=true
       addons:
         apt: *APT
@@ -66,6 +66,7 @@ script:
 - 'if [ -n "${LINT-}" ]; then npm run lint; fi'
 - 'if [ -n "${LINT-}" ]; then npm run test:type; fi'
 - 'if [ -n "${UNIT-}" ]; then npm run test:unit; fi'
+- 'if [ -n "${COMPANION_NODE6-}" ]; then nvm install 6.0.0 && nvm use 6.0.0; fi'
 - 'if [ -n "${COMPANION-}" ] || [ -n "${COMPANION_NODE6-}" ]; then npm run test:companion; fi'
 - 'if [ -n "${ENDTOEND-}" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:endtoend; fi'
 - 'if [ -n "${BUILD-}" ]; then npm run build; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ matrix:
       env: COMPANION=true
       addons:
         apt: *APT
+    - node_js: 6
+      env: COMPANION_NODE6=true
+      addons:
+        apt: *APT
     # Build the website when things are merged to master
     - node_js: 10
       env: WEBSITE=true
@@ -62,7 +66,7 @@ script:
 - 'if [ -n "${LINT-}" ]; then npm run lint; fi'
 - 'if [ -n "${LINT-}" ]; then npm run test:type; fi'
 - 'if [ -n "${UNIT-}" ]; then npm run test:unit; fi'
-- 'if [ -n "${COMPANION-}" ]; then npm run test:companion; fi'
+- 'if [ -n "${COMPANION-}" ] || [ -n "${COMPANION_NODE6-}" ]; then npm run test:companion; fi'
 - 'if [ -n "${ENDTOEND-}" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:endtoend; fi'
 - 'if [ -n "${BUILD-}" ]; then npm run build; fi'
 # Publish release commits to CDN after a `BUILD=true` run, because we have all the files now

--- a/packages/@uppy/companion/src/server/provider/drive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/drive/adapter.js
@@ -75,9 +75,8 @@ exports.getNextPagePath = (data, currentQuery, currentPath) => {
   if (!data.nextPageToken) {
     return null
   }
-  const query = {
-    ...currentQuery,
+  const query = Object.assign({}, currentQuery, {
     cursor: data.nextPageToken
-  }
+  })
   return `${currentPath}?${querystring.stringify(query)}`
 }

--- a/packages/@uppy/companion/src/server/provider/facebook/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/adapter.js
@@ -43,10 +43,10 @@ exports.getNextPagePath = (data, currentQuery, currentPath) => {
   if (!data.paging || !data.paging.cursors) {
     return null
   }
-  const query = {
-    ...currentQuery,
+
+  const query = Object.assign({}, currentQuery, {
     cursor: data.paging.cursors.after
-  }
+  })
   return `${currentPath || ''}?${querystring.stringify(query)}`
 }
 

--- a/packages/@uppy/companion/src/server/provider/instagram/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/adapter.js
@@ -14,12 +14,11 @@ exports.getItemSubList = (item) => {
   item.data.forEach((subItem) => {
     if (subItem.carousel_media) {
       subItem.carousel_media.forEach((i, index) => {
-        const newSubItem = {
-          ...i,
+        const newSubItem = Object.assign({}, i, {
           id: subItem.id,
           created_time: subItem.created_time,
           carousel_id: index
-        }
+        })
         subItems.push(newSubItem)
       })
     } else {


### PR DESCRIPTION
IIRC, node 6 compatibility is enforced because of [api2](https://github.com/transloadit/transloadit-api2/blob/master/api2/package.json#L11) (gonna double check if this is still the case), so it makes sense to test that we continuously compatible with this version.