### PR TITLE
dashboard: hide top bar cancel button when `hideCancelButton: t…

### DIFF
--- a/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
+++ b/packages/@uppy/dashboard/src/components/PickerPanelTopBar.js
@@ -78,7 +78,7 @@ function PanelTopBar (props) {
 
   return (
     <div class="uppy-DashboardContent-bar">
-      {!props.isAllComplete ? (
+      {!props.isAllComplete && !props.hideCancelButton ? (
         <button
           class="uppy-DashboardContent-back"
           type="button"

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -835,6 +835,7 @@ module.exports = class Dashboard extends Plugin {
       height: this.opts.height,
       showLinkToFileUploadResult: this.opts.showLinkToFileUploadResult,
       proudlyDisplayPoweredByUppy: this.opts.proudlyDisplayPoweredByUppy,
+      hideCancelButton: this.opts.hideCancelButton,
       containerWidth: pluginState.containerWidth,
       containerHeight: pluginState.containerHeight,
       areInsidesReadyToBeVisible: pluginState.areInsidesReadyToBeVisible,


### PR DESCRIPTION
Previously, only the cancel button in the status bar was hidden.

fixes https://github.com/transloadit/uppy/issues/1950