### PR TITLE
companion: oneDrive domain validation

### DIFF
--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -136,6 +136,24 @@ if (process.env.COMPANION_PATH) {
   app.use(companion.app(companionOptions))
 }
 
+// WARNING: This route is added in order to validate your app with OneDrive.
+// Only set COMPANION_ONEDRIVE_DOMAIN_VALIDATION if you are sure that you are setting the
+// correct value for COMPANION_ONEDRIVE_KEY (i.e application ID). If there's a slightest possiblilty
+// that you might have mixed the values for COMPANION_ONEDRIVE_KEY and COMPANION_ONEDRIVE_SECRET,
+// please do not set a value for COMPANION_ONEDRIVE_DOMAIN_VALIDATION
+if (process.env.COMPANION_ONEDRIVE_DOMAIN_VALIDATION === 'true' && process.env.COMPANION_ONEDRIVE_KEY) {
+  app.get('/.well-known/microsoft-identity-association.json', (req, res) => {
+    res.json(
+      {
+        associatedApplications: [
+          {
+            applicationId: process.env.COMPANION_ONEDRIVE_KEY
+          }
+        ]
+      })
+  })
+}
+
 app.use((req, res, next) => {
   return res.status(404).json({ message: 'Not Found' })
 })


### PR DESCRIPTION
This change is added in order to validate our companion.uppy.io domain with OneDrive