### PR TITLE
thumbnail-generator: Add webp to the list of supported types

### DIFF
--- a/packages/@uppy/utils/src/isPreviewSupported.js
+++ b/packages/@uppy/utils/src/isPreviewSupported.js
@@ -2,7 +2,7 @@ module.exports = function isPreviewSupported (fileType) {
   if (!fileType) return false
   const fileTypeSpecific = fileType.split('/')[1]
   // list of images that browsers can preview
-  if (/^(jpe?g|gif|png|svg|svg\+xml|bmp)$/.test(fileTypeSpecific)) {
+  if (/^(jpe?g|gif|png|svg|svg\+xml|bmp|webp)$/.test(fileTypeSpecific)) {
     return true
   }
   return false

--- a/packages/@uppy/utils/src/isPreviewSupported.test.js
+++ b/packages/@uppy/utils/src/isPreviewSupported.test.js
@@ -2,7 +2,7 @@ const isPreviewSupported = require('./isPreviewSupported')
 
 describe('isPreviewSupported', () => {
   it('should return true for any filetypes that browsers can preview', () => {
-    const supported = ['image/jpeg', 'image/gif', 'image/png', 'image/svg', 'image/svg+xml', 'image/bmp', 'image/jpg']
+    const supported = ['image/jpeg', 'image/gif', 'image/png', 'image/svg', 'image/svg+xml', 'image/bmp', 'image/jpg', 'image/webp']
     supported.forEach(ext => {
       expect(isPreviewSupported(ext)).toEqual(true)
     })


### PR DESCRIPTION
Fixes #1931 

Works in (MacOS): Chrome, Firefox. Silently ignored on Safari, which doesn’t support `webp` yet. (In Safari the file currently returns an `application/octet-stream` for `webp`, instead of `image/*`).