### PR TITLE
companion: use original file name in S3 Multipart uploads

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -510,7 +510,7 @@ class Uploader {
       return
     }
 
-    const filename = this.options.metadata.filename || path.basename(this.path)
+    const filename = this.options.metadata.name || path.basename(this.path)
     const { client, options } = this.options.s3
 
     const upload = client.upload({


### PR DESCRIPTION
We were using the wrong `meta` field for the file name.