### PR TITLE
feat(s3-multipart): add optional headers for signed url

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -160,8 +160,8 @@ class MultipartUploader {
         throw new TypeError('AwsS3/Multipart: Got incorrect result from `prepareUploadPart()`, expected an object `{ url }`.')
       }
       return result
-    }).then(({ url }) => {
-      this._uploadPartBytes(index, url)
+    }).then(({ url, headers }) => {
+      this._uploadPartBytes(index, url, headers)
     }, (err) => {
       this._onError(err)
     })
@@ -189,10 +189,15 @@ class MultipartUploader {
     this._uploadParts()
   }
 
-  _uploadPartBytes (index, url) {
+  _uploadPartBytes (index, url, headers) {
     const body = this.chunks[index]
     const xhr = new XMLHttpRequest()
     xhr.open('PUT', url, true)
+    if (headers) {
+      Object.keys(headers).map((key) => {
+        xhr.setRequestHeader(key, headers[key])
+      })
+    }
     xhr.responseType = 'text'
 
     this.uploading.push(xhr)

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -11,7 +11,7 @@ declare module AwsS3Multipart {
     companionUrl: string;
     createMultipartUpload(file: Uppy.UppyFile): Promise<{ uploadId: string, key: string }>;
     listParts(file: Uppy.UppyFile, opts: { uploadId: string, key: string }): Promise<AwsS3Part[]>;
-    prepareUploadPart(file: Uppy.UppyFile, partData: { uploadId: string, key: string, body: Blob, number: number }): Promise<{ url: string }>;
+    prepareUploadPart(file: Uppy.UppyFile, partData: { uploadId: string, key: string, body: Blob, number: number }): Promise<{ url: string, headers?: {[k: string]: string}}>;
     abortMultipartUpload(file: Uppy.UppyFile, opts: { uploadId: string, key: string }): Promise<void>;
     completeMultipartUpload(file: Uppy.UppyFile, opts: { uploadId: string, key: string, parts: AwsS3Part[] }): Promise<{ location?: string }>;
     timeout: number;

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -103,6 +103,7 @@ Return a Promise for an object with keys:
      Expires: 5 * 60,
    }, (err, url) => { /* there's the url! */ })
    ```
+ - `headers` - **(Optional)** Custom headers that should be sent to the S3 presigned URL.
 
 ### abortMultipartUpload(file, { uploadId, key })
 


### PR DESCRIPTION
Fixes #1984

Update `prepareUploadPart` contract to accept an optional `headers` property in the returned value.
If `headers` are present, they will be sent along the S3 presigned URL

Note: I've tested by locally publishing the package, and it works well.

Here is an example of implementation of a custom `prepareUploadPart`:
```typescript
export const prepareUploadPart = async (
    file: Uppy.UppyFile,
    partData: { uploadId: string; key: string; body: Blob; number: number },
) => {
    const response = await fetch(`/api/upload/tickets/${partData.uploadId}/parts/${partData.number}`, {
        method: 'GET'
    });

    const data = await response.json();
    return {
        url: data.uploadUrl,
        // here is the new property:
        headers: data.headers,
    };
};
```

## Documentation overview
![Screen Shot 2019-12-11 at 16 29 32](https://user-images.githubusercontent.com/1867939/70662130-a37cdb00-1c33-11ea-9e37-8110b28da7b4.png)
