### PR TITLE
Fix mime type checking bug

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -433,7 +433,7 @@ class Uppy {
         // is this is a mime-type
         if (type.indexOf('/') > -1) {
           if (!file.type) return false
-          return match(type, file.type)
+          return match(file.type.replace(/;.*?$/, ''), type)
         }
 
         // otherwise this is likely an extension

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -631,20 +631,27 @@ describe('src/Core', () => {
     it('should not allow a file that does not meet the restrictions', () => {
       const core = new Core({
         restrictions: {
-          allowedFileTypes: ['image/gif']
+          allowedFileTypes: ['image/gif', 'video/webm']
         }
       })
-      try {
+
+      expect(() => {
         core.addFile({
           source: 'jest',
           name: 'foo.jpg',
           type: 'image/jpeg',
           data: new File([sampleImage], { type: 'image/jpeg' })
         })
-        throw new Error('File was allowed through')
-      } catch (err) {
-        expect(err.message).toEqual('You can only upload: image/gif')
-      }
+      }).toThrow('You can only upload: image/gif, video/webm')
+
+      expect(() => {
+        core.addFile({
+          source: 'jest',
+          name: 'foo.webm',
+          type: 'video/webm; codecs="vp8, opus"',
+          data: new File([sampleImage], { type: 'video/webm; codecs="vp8, opus"' })
+        })
+      }).not.toThrow()
     })
 
     it('should not allow a dupicate file, a file with the same id', () => {


### PR DESCRIPTION
This PR aims to fix the bug mentioned in Issue #1988 .

For instance, if we have a restriction `video/webm` and the mime-type of the recorded video is `video/webm; codecs=\"vp8, opus\"`:

The existing code makes the comparison `match('video/webm; codecs=\"vp8, opus\"','video/webm')` which will return false.

We need to be doing `match('video/webm','video/webm; codecs=\"vp8, opus\"')` for it to return true. So I just swappedthe params

Fixes #1988 