### PR TITLE
Free rate limit queue when upload times out (#2016)

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -217,6 +217,7 @@ module.exports = class XHRUpload extends Plugin {
 
       const timer = new ProgressTimeout(opts.timeout, () => {
         xhr.abort()
+        queuedRequest.done()
         const error = new Error(this.i18n('timedOut', { seconds: Math.ceil(opts.timeout / 1000) }))
         this.uppy.emit('upload-error', file, error)
         reject(error)


### PR DESCRIPTION
This PR is to fix the bug #2016 .
When a limit parameter is provided to the XHR plugin, and some uploads time out, it is possible that the RateLimitQueue get stuck.
This fix free a slot in the RateLimitQueue when an upload times out.