### PR TITLE
companion: also pass metadata to getKey for multipart S3 uploads

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -518,7 +518,7 @@ class Uploader {
 
     const upload = client.upload({
       Bucket: options.bucket,
-      Key: options.getKey(null, filename),
+      Key: options.getKey(null, filename, this.options.metadata),
       ACL: options.acl,
       ContentType: this.options.metadata.type,
       Body: stream


### PR DESCRIPTION
Forgot this in the previous PR https://github.com/transloadit/uppy/pull/1866.

Closes https://github.com/transloadit/uppy/issues/2014
Closes https://github.com/transloadit/uppy/issues/1957