### PR TITLE
core: Always log errors

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -9,7 +9,7 @@ const getFileType = require('@uppy/utils/lib/getFileType')
 const getFileNameAndExtension = require('@uppy/utils/lib/getFileNameAndExtension')
 const generateFileID = require('@uppy/utils/lib/generateFileID')
 const supportsUploadProgress = require('./supportsUploadProgress')
-const { nullLogger, debugLogger } = require('./loggers')
+const { justErrorsLogger, debugLogger } = require('./loggers')
 const Plugin = require('./Plugin') // Exported from here.
 
 class RestrictionError extends Error {
@@ -100,7 +100,7 @@ class Uppy {
       onBeforeFileAdded: (currentFile, files) => currentFile,
       onBeforeUpload: (files) => files,
       store: DefaultStore(),
-      logger: nullLogger
+      logger: justErrorsLogger
     }
 
     // Merge default options with the ones set by user,
@@ -115,7 +115,7 @@ class Uppy {
     }
 
     // Support debug: true for backwards-compatability, unless logger is set in opts
-    // opts instead of this.opts to avoid comparing objects — we set logger: nullLogger in defaultOptions
+    // opts instead of this.opts to avoid comparing objects — we set logger: justErrorsLogger in defaultOptions
     if (opts && opts.logger && opts.debug) {
       this.log('You are using a custom `logger`, but also set `debug: true`, which uses built-in logger to output logs to console. Ignoring `debug: true` and using your custom `logger`.', 'warning')
     } else if (opts && opts.debug) {

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -1856,7 +1856,7 @@ describe('src/Core', () => {
       expect(console.error.mock.calls.length).toBe(1)
     })
 
-    it('should not log to console when logger is not set', () => {
+    it('should only log errors to console when logger is not set', () => {
       console.debug = jest.fn()
       console.error = jest.fn()
 
@@ -1867,7 +1867,7 @@ describe('src/Core', () => {
       core.log('beep beep', 'error')
 
       expect(console.debug.mock.calls.length).toBe(0)
-      expect(console.error.mock.calls.length).toBe(0)
+      expect(console.error.mock.calls.length).toBe(1)
     })
   })
 })

--- a/packages/@uppy/core/src/loggers.js
+++ b/packages/@uppy/core/src/loggers.js
@@ -1,10 +1,11 @@
 const getTimeStamp = require('@uppy/utils/lib/getTimeStamp')
 
-// Swallow logs, default if logger is not set or debug: false
-const nullLogger = {
+// Swallow all logs, except errors.
+// default if logger is not set or debug: false
+const justErrorsLogger = {
   debug: (...args) => {},
   warn: (...args) => {},
-  error: (...args) => {}
+  error: (...args) => console.error(`[Uppy] [${getTimeStamp()}]`, ...args)
 }
 
 // Print logs to console with namespace + timestamp,
@@ -20,6 +21,6 @@ const debugLogger = {
 }
 
 module.exports = {
-  nullLogger,
+  justErrorsLogger,
   debugLogger
 }

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -108,6 +108,7 @@ module.exports = (props) => {
     uploadState !== statusBarStates.STATE_WAITING &&
     uploadState !== statusBarStates.STATE_PREPROCESSING &&
     uploadState !== statusBarStates.STATE_POSTPROCESSING &&
+    uploadState !== statusBarStates.STATE_ERROR &&
     uploadState !== statusBarStates.STATE_COMPLETE
   const showRetryBtn = error && !hideRetryButton
 

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -51,7 +51,7 @@ const uppy = Uppy({
   onBeforeUpload: (files) => {},
   locale: {},
   store: new DefaultStore(),
-  logger: nullLogger
+  logger: justErrorsLogger
 })
 ```
 
@@ -96,7 +96,7 @@ const uppy = Uppy({
 
 You can also provide your own logger object: it should expose `debug`, `warn` and `error` methods, as shown in the examples below.
 
-By default `logger` is set to `nullLogger`, which does nothing:
+Here’s an example of `logger` that does nothing:
 
 ```js
 const nullLogger = {

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -96,7 +96,7 @@ const uppy = Uppy({
 
 You can also provide your own logger object: it should expose `debug`, `warn` and `error` methods, as shown in the examples below.
 
-Here’s an example of `logger` that does nothing:
+Here’s an example of a `logger` that does nothing:
 
 ```js
 const nullLogger = {


### PR DESCRIPTION
Show errors in logs always. `nullLogger` --> `justErrorsLogger`

Reasoning: too often we ended up showing errors in the Informer bubble, but not in the console, which is wrong and annoying. Devs still have an option to silence logs or direct them elsewhere by setting a custom logger.