### PR TITLE
companion,website: make encryption shorter + enable onedrive on website

### DIFF
--- a/packages/@uppy/companion/test/__tests__/companion.js
+++ b/packages/@uppy/companion/test/__tests__/companion.js
@@ -98,7 +98,7 @@ describe('test authentication', () => {
       .expect(200)
       .expect((res) => {
         const authToken = res.header['set-cookie'][0].split(';')[0].split('uppyAuthToken--google=')[1]
-        expect(decodeURIComponent(authToken)).toEqual(token)
+        expect(authToken).toEqual(token)
         const body = `
     <!DOCTYPE html>
     <html>

--- a/website/src/examples/dashboard/app.html
+++ b/website/src/examples/dashboard/app.html
@@ -108,11 +108,5 @@
     facebookCheckbox.style.display = 'inline-block'
   }
 
-  const onedriveCheckbox = document.getElementById('onedrive-checkbox')
-  onedriveCheckbox.style.display = 'none'
-  if (document.location.hash === '#enable-onedrive') {
-    onedriveCheckbox.style.display = 'inline-block'
-  }
-
   toggleModalBtn()
 </script>


### PR DESCRIPTION
This PR is an extension of this [commit](https://github.com/transloadit/uppy/commit/1971117ee316e337b7d00b2703dcf6ae8ba8cb69) which makes the encryption output shorter by encoding them as `base64` instead of `hex`. This is needed because encrypted tokens were coming out too long for Onedrive and servers were throwing errors as a result.

fixes #2006 