### PR TITLE
fix: remove conditional to replace `google` with `drive` 

### DIFF
--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -195,10 +195,6 @@ exports.buildHelpfulStartupMessage = (companionOptions) => {
       return
     }
 
-    if (providerName === 'google') {
-      providerName = 'drive'
-    }
-
     callbackURLs.push(buildURL(`/connect/${providerName}/callback`, true))
   })
 


### PR DESCRIPTION
* Google drive callback url now uses 'google' and not 'drive'
* Fixes callback url by removing the conditional for google providerName

The callback for google drive should be `https://upload.redmtnsci.com/connect/google/callback`

I just set this up and the conditional statement should be removed because the callback is `google` not `drive`.

```
- Be sure to add https://upload.redmtnsci.com/connect/drive/callback, https://upload.redmtnsci.com/connect/dropbox/callback, https://upload.redmtnsci.com/connect/instagram/callback, https://upload.redmtnsci.com/connect/facebook/callback, https://upload.redmtnsci.com/connect/microsoft/callback as your Oauth redirect uris on their corresponding developer interfaces.
- The URL https://upload.redmtnsci.com/metrics is available for  statistics to keep Companion running smoothly
- https://github.com/transloadit/uppy/issues - report your bugs here
```