### PR TITLE
companion,xhr-upload: add option to set http method for remote multipart uploads

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -36,6 +36,7 @@ class Uploader {
    * @property {any} companionOptions
    * @property {any=} storage
    * @property {any=} headers
+   * @property {string=} httpMethod
    *
    * @param {UploaderOptions} options
    */
@@ -112,6 +113,7 @@ class Uploader {
       uploadUrl: req.body.uploadUrl,
       protocol: req.body.protocol,
       metadata: req.body.metadata,
+      httpMethod: req.body.httpMethod,
       size: size,
       fieldname: req.body.fieldname,
       pathPrefix: `${req.companion.options.filePath}`,
@@ -455,8 +457,9 @@ class Uploader {
         }
       }
     )
+    const httpMethod = (this.options.httpMethod || '').toLowerCase() === 'put' ? 'put' : 'post'
     const headers = headerSanitize(this.options.headers)
-    request.post({ url: this.options.endpoint, headers, formData, encoding: null }, (error, response, body) => {
+    request[httpMethod]({ url: this.options.endpoint, headers, formData, encoding: null }, (error, response, body) => {
       if (error) {
         logger.error(error, 'upload.multipart.error')
         this.emitError(error)

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -356,6 +356,7 @@ module.exports = class XHRUpload extends Plugin {
         size: file.data.size,
         fieldname: opts.fieldName,
         metadata: fields,
+        httpMethod: this.opts.method,
         headers: opts.headers
       }).then((res) => {
         const token = res.token


### PR DESCRIPTION
fixes #2019 (we can all go one year backwards once this is merged)