### PR TITLE
Upload downloadable zip archive of releases to CDN

### DIFF
--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -165,7 +165,7 @@ async function main (packageName, version) {
     // Create downloadable zip archive
     const zip = new AdmZip()
     for (const [filename, buffer] of files.entries()) {
-      zip.addFile(filename, buffer, 'entry comment goes here')
+      zip.addFile(filename, buffer)
     }
 
     files.set(`uppy-v${version}.zip`, zip.toBuffer())

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -41,10 +41,10 @@ const AWS_DIRECTORY = '756b8efaed084669b02cb99d4540d81f/default'
 
 /**
  * Get remote dist/ files by fetching the tarball for the given version
- * from npm and filtering it down to package/dist/ files.
+from npm and filtering it down to package/dist/ files.
  *
- * @param {string} Package name, eg. @uppy/robodog
- * @param {string} Package version, eg. "1.2.0"
+ * @param {string} packageName eg. @uppy/robodog
+ * @param {string} version eg. 1.8.0
  * @returns a Map<string, Buffer>, filename → content
  */
 async function getRemoteDistFiles (packageName, version) {
@@ -74,7 +74,7 @@ async function getRemoteDistFiles (packageName, version) {
  * Get local dist/ files by asking npm-packlist what files would be added
  * to an npm package during publish, and filtering those down to just dist/ files.
  *
- * @param {string} Base file path of the package, eg. ./packages/@uppy/locales
+ * @param {string} packagePath Base file path of the package, eg. ./packages/@uppy/locales
  * @returns a Map<string, Buffer>, filename → content
  */
 async function getLocalDistFiles (packagePath) {

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -30,7 +30,7 @@ const mime = require('mime-types')
 const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const finished = promisify(require('stream').finished)
-var AdmZip = require('adm-zip')
+const AdmZip = require('adm-zip')
 
 function delay (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -161,13 +161,15 @@ async function main (packageName, version) {
     ? await getRemoteDistFiles(packageName, version)
     : await getLocalDistFiles(packagePath)
 
-  // Create downloadable zip archive
-  const zip = new AdmZip()
-  for (const [filename, buffer] of files.entries()) {
-    zip.addFile(filename, buffer, 'entry comment goes here')
-  }
+  if (packageName === 'uppy') {
+    // Create downloadable zip archive
+    const zip = new AdmZip()
+    for (const [filename, buffer] of files.entries()) {
+      zip.addFile(filename, buffer, 'entry comment goes here')
+    }
 
-  files.set(`uppy-v${version}.zip`, zip.toBuffer())
+    files.set(`uppy-v${version}.zip`, zip.toBuffer())
+  }
 
   for (const [filename, buffer] of files.entries()) {
     const key = path.posix.join(AWS_DIRECTORY, outputPath, filename)

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -30,6 +30,7 @@ const mime = require('mime-types')
 const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const finished = promisify(require('stream').finished)
+var AdmZip = require('adm-zip')
 
 function delay (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -159,6 +160,14 @@ async function main (packageName, version) {
   const files = remote
     ? await getRemoteDistFiles(packageName, version)
     : await getLocalDistFiles(packagePath)
+
+  // Create downloadable zip archive
+  const zip = new AdmZip()
+  for (const [filename, buffer] of files.entries()) {
+    zip.addFile(filename, buffer, 'entry comment goes here')
+  }
+
+  files.set(`uppy-v${version}.zip`, zip.toBuffer())
 
   for (const [filename, buffer] of files.entries()) {
     const key = path.posix.join(AWS_DIRECTORY, outputPath, filename)

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@uppy/utils": "file:packages/@uppy/utils",
     "@uppy/webcam": "file:packages/@uppy/webcam",
     "@uppy/xhr-upload": "file:packages/@uppy/xhr-upload",
+    "adm-zip": "0.4.13",
     "uppy": "file:packages/uppy",
     "uppy.io": "file:website"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@uppy/utils": "file:packages/@uppy/utils",
     "@uppy/webcam": "file:packages/@uppy/webcam",
     "@uppy/xhr-upload": "file:packages/@uppy/xhr-upload",
-    "adm-zip": "0.4.13",
     "uppy": "file:packages/uppy",
     "uppy.io": "file:website"
   },
@@ -104,6 +103,7 @@
     "@wdio/local-runner": "^5.16.15",
     "@wdio/mocha-framework": "^5.16.15",
     "@wdio/sauce-service": "^5.16.10",
+    "adm-zip": "0.4.13",
     "aliasify": "^2.1.0",
     "autoprefixer": "^9.7.3",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
After merging this PR, with every new CDN release, an extra file is uploaded, such as:

https://transloadit.edgly.net/releases/uppy/v1.8.0/uppy-v1.8.0.zip

We can still decide if/how we want to integrate that in our website, but i can imagine download buttons having an appeal to _a_ user base.