### PR TITLE
Add Content-Type header to presigned url example

### DIFF
--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -335,7 +335,7 @@ uppy.use(AwsS3, {
         fields: data.fields,
         // Provide content type header required by S3
         headers: {
-           "Content-Type": file.type
+          'Content-Type': file.type
         }
       }
     })

--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -332,7 +332,11 @@ uppy.use(AwsS3, {
       return {
         method: data.method,
         url: data.url,
-        fields: data.fields
+        fields: data.fields,
+        // Provide content type header required by S3
+        headers: {
+           "Content-Type": file.type
+        }
       }
     })
   }


### PR DESCRIPTION
Prevents the main presigned url example from failing in many cases, as the browser does not assign a content type in many cases, but a content type is required by S3. Based on issue https://github.com/transloadit/uppy/issues/1233