### PR TITLE
make s3 signed url expiry configurable in companion

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -19,6 +19,7 @@ const { STORAGE_PREFIX } = require('./server/Uploader')
 const middlewares = require('./server/middlewares')
 const { shortenToken } = require('./server/Uploader')
 const { ProviderApiError, ProviderAuthError } = require('./server/provider/error')
+const ms = require('ms')
 
 const defaultOptions = {
   server: {
@@ -31,7 +32,8 @@ const defaultOptions = {
       endpoint: 'https://{service}.{region}.amazonaws.com',
       conditions: [],
       useAccelerateEndpoint: false,
-      getKey: (req, filename) => filename
+      getKey: (req, filename) => filename,
+      expires: ms('5 minutes') / 1000
     }
   },
   debug: true

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -1,5 +1,4 @@
 const router = require('express').Router
-const ms = require('ms')
 
 module.exports = function s3 (config) {
   if (typeof config.acl !== 'string') {
@@ -46,7 +45,7 @@ module.exports = function s3 (config) {
 
     client.createPresignedPost({
       Bucket: config.bucket,
-      Expires: ms('5 minutes') / 1000,
+      Expires: config.expires,
       Fields: fields,
       Conditions: config.conditions
     }, (err, data) => {
@@ -94,7 +93,7 @@ module.exports = function s3 (config) {
       ACL: config.acl,
       ContentType: type,
       Metadata: metadata,
-      Expires: ms('5 minutes') / 1000
+      Expires: config.expires
     }, (err, data) => {
       if (err) {
         next(err)
@@ -191,7 +190,7 @@ module.exports = function s3 (config) {
       UploadId: uploadId,
       PartNumber: partNumber,
       Body: '',
-      Expires: ms('5 minutes') / 1000
+      Expires: config.expires
     }, (err, url) => {
       if (err) {
         next(err)

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -56,7 +56,8 @@ const getConfigFromEnv = () => {
         endpoint: process.env.COMPANION_AWS_ENDPOINT,
         region: process.env.COMPANION_AWS_REGION,
         useAccelerateEndpoint:
-          process.env.COMPANION_AWS_USE_ACCELERATE_ENDPOINT === 'true'
+          process.env.COMPANION_AWS_USE_ACCELERATE_ENDPOINT === 'true',
+        expires: parseInt(process.env.COMPANION_AWS_EXPIRES || '300', 10)
       }
     },
     server: {

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -199,6 +199,8 @@ export COMPANION_AWS_BUCKET="YOUR AWS S3 BUCKET"
 export COMPANION_AWS_REGION="AWS REGION"
 # to enable S3 Transfer Acceleration (default: false)
 export COMPANION_AWS_USE_ACCELERATE_ENDPOINT="false"
+# to set X-Amz-Expires query param in presigned urls (in seconds, default: 300)
+export COMPANION_AWS_EXPIRES="300"
 
 # corresponds to the server.oauthDomain option
 export COMPANION_OAUTH_DOMAIN="sub.domain.com"

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -248,7 +248,8 @@ See [env.example.sh](https://github.com/transloadit/uppy/blob/master/env.example
       secret: "***",
       bucket: "bucket-name",
       region: "us-east-1",
-      useAccelerateEndpoint: false // default: false
+      useAccelerateEndpoint: false, // default: false,
+      expires: 3600 // default: 300 (5 minutes)
     }
   },
   server: {


### PR DESCRIPTION
**Problem**
Companion generates presigned URLs for S3 with a fixed 5-minute expiration; as noted in #1915 and #1724, this can be problematic depending on upload size and network conditions.

**Solution**
Make the expiration configurable through companion `providerOptions`.

Ref #1915
Ref #1724