### PR TITLE
companion: return the right httpAgent when protocol value contains ":"

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -251,6 +251,7 @@ const getOptionsMiddleware = (options) => {
       buildURL: getURLBuilder(options)
     }
 
+    logger.info(`uppy client version ${req.companion.clientVersion}`, 'companion.client.version')
     // @todo remove req.uppy in next major release
     req.uppy = req.companion
     next()

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -77,15 +77,15 @@ module.exports.FORBIDDEN_IP_ADDRESS = FORBIDDEN_IP_ADDRESS
 
 /**
  * Returns http Agent that will prevent requests to private IPs (to preven SSRF)
- * @param {string} protocol http or https protocol needed for the request
+ * @param {string} protocol http or http: or https: or https protocol needed for the request
  * @param {boolean} blockPrivateIPs if set to false, this protection will be disabled
  */
 module.exports.getProtectedHttpAgent = (protocol, blockPrivateIPs) => {
   if (blockPrivateIPs) {
-    return protocol === 'https' ? HttpsAgent : HttpAgent
+    return protocol.startsWith('https') ? HttpsAgent : HttpAgent
   }
 
-  return protocol === 'https' ? https.Agent : http.Agent
+  return protocol.startsWith('https') ? https.Agent : http.Agent
 }
 
 function dnsLookup (hostname, options, callback) {

--- a/packages/@uppy/companion/test/__tests__/http-agent.js
+++ b/packages/@uppy/companion/test/__tests__/http-agent.js
@@ -2,6 +2,34 @@
 
 const { getProtectedHttpAgent, FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
 const request = require('request')
+const http = require('http')
+const https = require('https')
+
+describe('test getProtectedHttpAgent', () => {
+  test('setting "https:" as protocol', (done) => {
+    const Agent = getProtectedHttpAgent('https:')
+    expect(Agent).toEqual(https.Agent)
+    done()
+  })
+
+  test('setting "https" as protocol', (done) => {
+    const Agent = getProtectedHttpAgent('https')
+    expect(Agent).toEqual(https.Agent)
+    done()
+  })
+
+  test('setting "http:" as protocol', (done) => {
+    const Agent = getProtectedHttpAgent('http:')
+    expect(Agent).toEqual(http.Agent)
+    done()
+  })
+
+  test('setting "http" as protocol', (done) => {
+    const Agent = getProtectedHttpAgent('http')
+    expect(Agent).toEqual(http.Agent)
+    done()
+  })
+})
 
 describe('test protected request Agent', () => {
   test('allows URLs without IP addresses', (done) => {


### PR DESCRIPTION
The last release is broken for the Url plugin when the URL is an https URL. The reason is because the URLParser sets protocols as `https:` (not `https`), where as our implementation expects `https`. This PR now allows for both to be supported.
I also updated the tests to test this case.