### PR TITLE
companion: read state from session in oauth-redirect controller

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
+++ b/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
@@ -9,10 +9,12 @@ const oAuthState = require('../helpers/oauth-state')
  * @param {object} res
  */
 module.exports = function oauthRedirect (req, res) {
-  if (!req.query.state) {
-    return res.status(400).send('Cannot find state param in reques')
+  const dynamic = (req.session.grant || {}).dynamic || {}
+  const state = dynamic.state
+  if (!state) {
+    return res.status(400).send('Cannot find state in session')
   }
-  const handler = oAuthState.getFromState(req.query.state, 'companionInstance', req.companion.options.secret)
+  const handler = oAuthState.getFromState(state, 'companionInstance', req.companion.options.secret)
   const handlerHostName = parseUrl(handler).host
 
   if (hasMatch(handlerHostName, req.companion.options.server.validHosts)) {

--- a/packages/@uppy/companion/test/mockserver.js
+++ b/packages/@uppy/companion/test/mockserver.js
@@ -2,7 +2,7 @@ const { app } = require('../src/standalone')
 
 const express = require('express')
 const session = require('express-session')
-var authServer = express()
+const authServer = express()
 
 authServer.use(session({ secret: 'grant', resave: true, saveUninitialized: true }))
 authServer.all('*/callback', (req, res, next) => {
@@ -11,7 +11,7 @@ authServer.all('*/callback', (req, res, next) => {
   }
   next()
 })
-authServer.all('*/send-token', (req, res, next) => {
+authServer.all(['*/send-token', '*/redirect'], (req, res, next) => {
   req.session.grant = { dynamic: { state: req.query.state || 'non-empty-value' } }
   next()
 })


### PR DESCRIPTION
this was left out from [this change](https://github.com/transloadit/uppy/pull/1668/files). It wasn't spotted all this while because the controller is only called when you are running multiple instances of companion in different domains (which is not a very common use case).