### PR TITLE
Add meta.relativePath explicit example

### DIFF
--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -373,7 +373,8 @@ uppy.addFile({
   type: 'image/jpeg', // file type
   data: blob, // file blob
   meta: {
-      relativePath: string, // optional, determines the unique relative path to build the file uppy id
+    // optional, store the directory path of a file so Uppy can tell identical files in different directories apart
+    relativePath: webkitFileSystemEntry.relativePath,
   },
   source: 'Local', // optional, determines the source of the file, for example, Instagram
   isRemote: false // optional, set to true if actual file is not in the browser, but on some remote server, for example, when using companion in combination with Instagram

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -372,6 +372,9 @@ uppy.addFile({
   name: 'my-file.jpg', // file name
   type: 'image/jpeg', // file type
   data: blob, // file blob
+  meta: {
+      relativePath: string, // optional, determines the unique relative path to build the file uppy id
+  },
   source: 'Local', // optional, determines the source of the file, for example, Instagram
   isRemote: false // optional, set to true if actual file is not in the browser, but on some remote server, for example, when using companion in combination with Instagram
 })


### PR DESCRIPTION
Spent hours to test it to add a relativePath and non unique ids for files with the same name but coming from different folders.

It works like it but it's confusing with the `setMeta` method.