### PR TITLE
website: optionally point to companion with graph instagram API

### DIFF
--- a/website/src/examples/transloadit/app.es6
+++ b/website/src/examples/transloadit/app.es6
@@ -83,6 +83,18 @@ function initUppy (opts = {}) {
     return { params, signature }
   }
 
+  let instagramOptions = {
+    target: Dashboard,
+    companionUrl: 'https://api2.transloadit.com/companion',
+    companionAllowedHosts: Transloadit.COMPANION_PATTERN
+  }
+  if (document.location.hash === '#enable-new-instagram') {
+    instagramOptions = {
+      target: Dashboard,
+      companionUrl: 'https://intense-meadow-61813.herokuapp.com/'
+    }
+  }
+
   uppy
     .use(Transloadit, {
       getAssemblyOptions,
@@ -94,11 +106,7 @@ function initUppy (opts = {}) {
       target: '#uppy-dashboard-container',
       note: 'Images only, 1–2 files, up to 1 MB'
     })
-    .use(Instagram, {
-      target: Dashboard,
-      companionUrl: 'https://api2.transloadit.com/companion',
-      companionAllowedHosts: Transloadit.COMPANION_PATTERN
-    })
+    .use(Instagram, instagramOptions)
     .use(Facebook, {
       target: Dashboard,
       companionUrl: COMPANION


### PR DESCRIPTION
in order to have the Instagram Graph app verified by Facebook, we need to make it publicly testable. Because https://companion.uppy.io is currently using the old Instagram API, we are not able to override it with the new one, and make it testable (because the new one isn't verified yet, and won't be usable by all users).

I have hosted a companion instance [here](https://intense-meadow-61813.herokuapp.com/) which uses the new Instagram API. The repo is [here](https://github.com/ifedapoolarewaju/companion-sample). This PR now in turn adds a temporary option to point the Instagram Plugin to this companion instance which uses the new Instagram Graph API.