### PR TITLE
Add S3 ACL option to companion docs

### DIFF
--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -249,7 +249,8 @@ See [env.example.sh](https://github.com/transloadit/uppy/blob/master/env.example
       bucket: "bucket-name",
       region: "us-east-1",
       useAccelerateEndpoint: false, // default: false,
-      expires: 3600 // default: 300 (5 minutes)
+      expires: 3600, // default: 300 (5 minutes)
+      acl: "private" // default: public-read
     }
   },
   server: {


### PR DESCRIPTION
S3 uploads from Companion were failing with S3 AccessDenied errors (I noticed these in the Websocket messages). I thought I might be missing something in the config, read through the docs and then after reading through the source, I realized that the S3 ACL option is being defaulted to `public-read` [here](https://github.com/transloadit/uppy/blob/7525440229bde28241e34ba3eacf3fad77269c05/packages/%40uppy/companion/src/companion.js#L31), while I was trying to upload private files to my S3 bucket that has public objects disabled. So S3 was preventing this file with a public ACL from being uploaded.

There's already provisions to override the S3 ACL parameter, so figured it would be good to mention the existence of this option in the docs, especially since it's being defaulted to a specific setting.