### PR TITLE
companion: don't log redundant errors in production

### DIFF
--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -178,9 +178,11 @@ app.use((req, res, next) => {
 if (app.get('env') === 'production') {
   // @ts-ignore
   app.use((err, req, res, next) => {
-    // if the error is as a result of bad request from client, no need
-    //  to flood production logs with this.
-    if (err.status !== 400) {
+    // if the error is a URIError from the requested URL we only log the error message
+    // to avoid uneccessary error alerts
+    if (err.status === 400 && err instanceof URIError) {
+      console.error('\x1b[31m', req.id, err.message, '\x1b[0m')
+    } else {
       console.error('\x1b[31m', req.id, err, '\x1b[0m')
     }
     res.status(err.status || 500).json({ message: 'Something went wrong', requestId: req.id })

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -178,7 +178,11 @@ app.use((req, res, next) => {
 if (app.get('env') === 'production') {
   // @ts-ignore
   app.use((err, req, res, next) => {
-    console.error('\x1b[31m', req.id, err, '\x1b[0m')
+    // if the error is as a result of bad request from client, no need
+    //  to flood production logs with this.
+    if (!err.status || err.status !== 400) {
+      console.error('\x1b[31m', req.id, err, '\x1b[0m')
+    }
     res.status(err.status || 500).json({ message: 'Something went wrong', requestId: req.id })
   })
 } else {

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -180,7 +180,7 @@ if (app.get('env') === 'production') {
   app.use((err, req, res, next) => {
     // if the error is as a result of bad request from client, no need
     //  to flood production logs with this.
-    if (!err.status || err.status !== 400) {
+    if (err.status !== 400) {
       console.error('\x1b[31m', req.id, err, '\x1b[0m')
     }
     res.status(err.status || 500).json({ message: 'Something went wrong', requestId: req.id })


### PR DESCRIPTION
in this PR, companion refrains from logging errors due to `400 (Bad Request)` when in production mode. This is to avoid unnecessarily flooding the logs with undesired output. 