### PR TITLE
companion: pass `endpoint` and `region` to AWS SDK constructor

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -231,6 +231,8 @@ const getOptionsMiddleware = (options) => {
 
     const s3ClientOptions = Object.assign({
       signatureVersion: 'v4',
+      endpoint: s3ProviderOptions.endpoint,
+      region: s3ProviderOptions.region,
       // backwards compat
       useAccelerateEndpoint: s3ProviderOptions.useAccelerateEndpoint
     }, rawClientOptions)


### PR DESCRIPTION
These were accidentally removed in #2030. A missing region could cause AWS to reject upload requests, and without `endpoint` uploads to alternative services like GCS or DigitalOcean Spaces were made impossible.