### PR TITLE
Docs: fix incorrect link to Dashboard in locale.md

### DIFF
--- a/website/src/docs/locales.md
+++ b/website/src/docs/locales.md
@@ -46,7 +46,7 @@ var uppy = Uppy.Core({
 
 ## Overriding locale strings for a specific plugin
 
-Many plugins come with their own locale strings, and the packs we provide consist of most of those strings. You can, however, override a locale string for a specific plugin, regardless of whether you are using locale pack or not. See the plugin documentation for the list of locale strings it uses (for example, [here’s Dashboard](http://localhost:4000/docs/dashboard/#locale)).
+Many plugins come with their own locale strings, and the packs we provide consist of most of those strings. You can, however, override a locale string for a specific plugin, regardless of whether you are using locale pack or not. See the plugin documentation for the list of locale strings it uses (for example, [here’s how to use it with the Dashboard UI](https://uppy.io/docs/dashboard/#locale)).
 
 ```js
 const Uppy = require('@uppy/core')


### PR DESCRIPTION
- Replaced incorrect link to the Dashboard docs: `http://localhost/docs/dashboard/#locale` -> `https://uppy.io/docs/dashboard/#locale`
- Replaced `here's Dashboard` with a meaningful sentence.