### PR TITLE
core: add typings for `setOptions()`.

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -53,6 +53,7 @@ declare module Uppy {
     uppy: Uppy
     type: string
     constructor(uppy: Uppy, opts?: TOptions)
+    setOptions(update: Partial<TOptions>): void
     getPluginState(): object
     setPluginState(update: IndexedObject<any>): object
     update(state?: object): void
@@ -156,10 +157,11 @@ declare module Uppy {
     on(event: Event, callback: (...args: any[]) => void): this
     off(event: Event, callback: (...args: any[]) => void): this
     /**
-     * For use by plugins only!
+     * For use by plugins only.
      */
     emit(event: Event, ...args: any[]): void
     updateAll(state: object): void
+    setOptions(update: Partial<UppyOptions>): void
     setState(patch: object): void
     getState<TMeta extends IndexedObject<any> = {}>(): State<TMeta>
     readonly state: State

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -89,3 +89,14 @@ import DefaultStore = require('@uppy/store-default')
   // can register listners on custom events
   uppy.on('dashboard:modal-closed', () => {})
 }
+
+{
+  const uppy = Uppy()
+  uppy.setOptions({
+    restrictions: {
+      allowedFileTypes: ['.png']
+    }
+  })
+  expectError(uppy.setOptions({ restrictions: false }))
+  expectError(uppy.setOptions({ unknownKey: false }))
+}

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -100,3 +100,15 @@ import DefaultStore = require('@uppy/store-default')
   expectError(uppy.setOptions({ restrictions: false }))
   expectError(uppy.setOptions({ unknownKey: false }))
 }
+
+{
+  interface TestOptions extends Uppy.PluginOptions {
+    testOption: string
+  }
+  class TestPlugin extends Uppy.Plugin<TestOptions> {}
+
+  const strict = Uppy<Uppy.StrictTypes>().use(TestPlugin, { testOption: 'hello' })
+  ;(strict.getPlugin('TestPlugin') as TestPlugin).setOptions({ testOption: 'world' })
+  expectError((strict.getPlugin('TestPlugin') as TestPlugin).setOptions({ testOption: 0 }))
+  expectError((strict.getPlugin('TestPlugin') as TestPlugin).setOptions({ unknownKey: false }))
+}


### PR DESCRIPTION
Adds `uppy.setOptions()` and `plugin.setOptions()`. Both accept any subset of the options that can be passed to the Uppy constructor or to the plugin respectively.