### PR TITLE
react: fix typescript proptypes for DashboardModal, fixes #2124

### DIFF
--- a/packages/@uppy/react/src/DashboardModal.d.ts
+++ b/packages/@uppy/react/src/DashboardModal.d.ts
@@ -1,13 +1,23 @@
-import { DashboardProps } from './Dashboard'
+import { Omit, ToUppyProps } from './CommonTypes'
+import Dashboard = require('@uppy/dashboard')
 
-export interface DashboardModalProps extends DashboardProps {
+// This type is mapped into `DashboardModalProps` below so IntelliSense doesn't display this big mess of nested types
+type DashboardModalPropsInner = {
   open?: boolean
   onRequestClose?: VoidFunction
+} & Omit<
+  ToUppyProps<Dashboard.DashboardOptions>,
+  // Remove the inline-only and force-overridden props
+  'inline' | 'onRequestCloseModal'
+>
+
+export type DashboardModalProps = {
+  [K in keyof DashboardModalPropsInner]: DashboardModalPropsInner[K]
 }
 
 /**
- * React Component that renders a Dashboard for an Uppy instance in a Modal
- * dialog. Visibility of the Modal is toggled using the `open` prop.
+ * React Component that renders a Dashboard for an Uppy instance. This component
+ * renders the Dashboard inline so you can put it anywhere you want.
  */
 declare const DashboardModal: React.ComponentType<DashboardModalProps>
 export default DashboardModal

--- a/packages/@uppy/react/types/index.test-d.tsx
+++ b/packages/@uppy/react/types/index.test-d.tsx
@@ -18,6 +18,8 @@ function TestComponent() {
 // inline option should be removed from proptypes because it is always overridden
 // by the component
 expectError(<components.Dashboard inline />)
+expectError(<components.DashboardModal inline />)
+expectError(<components.DashboardModal replaceTargetContent />)
 
 {
   const el = (
@@ -37,4 +39,20 @@ expectError(<components.Dashboard inline />)
       }}
     />
   )
+}
+
+{
+  const el = (
+    <components.DashboardModal
+      uppy={uppy}
+      open
+      animateOpenClose
+      onRequestClose={() => {
+        alert('no')
+      }}
+    />
+  )
+
+  // use onRequestClose instead.
+  expectError(<components.DashboardModal onRequestCloseModal />)
 }


### PR DESCRIPTION
The DashboardModal proptypes inherited from the Dashboard proptypes, but the Dashboard proptypes excluded all the modal-specific props. So, the DashboardModal did not support modal-specific props.

Now, the DashboardModal proptypes are derived separately from the Dashboard options.