### PR TITLE
transloadit: fix progress with very different Assembly runtimes

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -694,7 +694,10 @@ module.exports = class Transloadit extends Plugin {
 
     const incompleteFiles = files.filter(file => !hasProperty(this.completedFiles, file.id))
     incompleteFiles.forEach((file) => {
-      this.uppy.emit('postprocess-progress', file)
+      this.uppy.emit('postprocess-progress', file, {
+        mode: 'indeterminate',
+        message: this.i18n('encoding')
+      })
     })
 
     const watcher = this.assemblyWatchers[uploadID]

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -258,16 +258,6 @@ module.exports = class Transloadit extends Plugin {
   // AssemblyWatcher tracks completion states of all Assemblies in this upload.
     const watcher = new AssemblyWatcher(this.uppy, assemblyID)
 
-    watcher.on('assembly-upload', (id) => {
-      const files = this.getAssemblyFiles(id)
-      files.forEach((file) => {
-        this.uppy.emit('postprocess-progress', file, {
-          mode: 'indeterminate',
-          message: this.i18n('encoding')
-        })
-      })
-    })
-
     watcher.on('assembly-complete', (id) => {
       const files = this.getAssemblyFiles(id)
       this.completedFiles = [...this.completedFiles, ...files]
@@ -703,7 +693,7 @@ module.exports = class Transloadit extends Plugin {
 
     const incompleteFiles = files.filter(file => !this.completedFiles.includes(file))
     incompleteFiles.forEach((file) => {
-      this.uppy.emit('postprocess-complete', file)
+      this.uppy.emit('postprocess-progress', file)
     })
 
     const watcher = this.assemblyWatchers[uploadID]

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -362,7 +362,7 @@ module.exports = class Transloadit extends Plugin {
   _onAssemblyFinished (status) {
     const url = status.assembly_ssl_url
     this.client.getAssemblyStatus(url).then((finalStatus) => {
-      const assemblyId = finalStatus.assemblyId;
+      const assemblyId = finalStatus.assemblyId
       const state = this.getPluginState()
       this.setPluginState({
         assemblies: {

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -493,10 +493,23 @@ module.exports = class Transloadit extends Plugin {
       })
     }
 
-    // Set up the Assembly instances for existing Assemblies.
+    // Set up the Assembly instances and AssemblyWatchers for existing Assemblies.
     const restoreAssemblies = () => {
-      const { assemblies } = this.getPluginState()
-      Object.keys(assemblies).forEach((id) => {
+      const { assemblies, uploadsAssemblies } = this.getPluginState()
+
+      // Set up the assembly watchers again for all the ongoing uploads.
+      Object.keys(uploadsAssemblies).forEach((uploadID) => {
+        const assemblyIDs = uploadsAssemblies[uploadID]
+        const fileIDsInUpload = assemblyIDs.reduce((acc, assemblyID) => {
+          const fileIDsInAssembly = this.getAssemblyFiles(assemblyID).map((file) => file.id)
+          acc.push(...fileIDsInAssembly)
+          return acc
+        }, [])
+        this._createAssemblyWatcher(assemblyIDs, fileIDsInUpload, uploadID)
+      })
+
+      const allAssemblyIDs = Object.keys(assemblies)
+      allAssemblyIDs.forEach((id) => {
         const assembly = new Assembly(assemblies[id])
         this._connectAssembly(assembly)
       })


### PR DESCRIPTION
…se it was smaller than other files in the batch), complete it during post processing

Durning an internal QA of our migration to the most recent version of Uppy, we came across a bug during large batch uploads using the transloadit plugin with several assemblies. In some cases if the file sizes in the different assemblies were dramatically different, the smaller uploads would have their assembly complete before the rest of the files finished uploading. This would mean that during the postProcessing step, the assemblyWatcher would never receive a `assembly-complete`event for that assembly so the step would hang.

This is a naive attempt to remedy the bug by keeping track of what assemblies have completed and when we start postProcessing, emiting `postprocess-complete `for any that have already finished up.