### PR TITLE
Only _startIfAutoProceed if some files were actually added

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -677,7 +677,9 @@ class Uppy {
       })
     }
 
-    this._startIfAutoProceed()
+    if (newFiles.length > 0) {
+      this._startIfAutoProceed()
+    }
 
     if (errors.length > 0) {
       let message = 'Multiple errors occurred while adding files:\n'


### PR DESCRIPTION
Fixes #2126 

With the new `addFiles()` method from https://github.com/transloadit/uppy/pull/1949, `autoProceed` was run even if no files were actually added, because of errors/restrictions. 

This PR fixes that — `_startIfAutoProceed` is only called if `newFiles > 0`.