### PR TITLE
[Dashboard] Allow setting the input type when editing files in Dashboard plugin

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -49,16 +49,24 @@ class FileCard extends Component {
 
   renderMetaFields = () => {
     const metaFields = this.props.metaFields || []
+    const fieldCSSClasses = {
+      text: 'uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input'
+    }
+
     return metaFields.map((field) => {
       const id = `uppy-Dashboard-FileCard-input-${field.id}`
       return (
         <fieldset key={field.id} class="uppy-Dashboard-FileCard-fieldset">
           <label class="uppy-Dashboard-FileCard-label" for={id}>{field.name}</label>
           {field.render !== undefined
-            ? field.render({ value: this.state.formState[field.id], onChange: (newVal) => this.updateMeta(newVal, field.id) }, h)
+            ? field.render({
+              value: this.state.formState[field.id],
+              onChange: (newVal) => this.updateMeta(newVal, field.id),
+              fieldCSSClasses: fieldCSSClasses
+            }, h)
             : (
               <input
-                class="uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input"
+                class={inputCSSClasses.text}
                 id={id}
                 type={field.type || 'text'}
                 value={this.state.formState[field.id]}

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -66,7 +66,7 @@ class FileCard extends Component {
             }, h)
             : (
               <input
-                class={inputCSSClasses.text}
+                class={fieldCSSClasses.text}
                 id={id}
                 type={field.type || 'text'}
                 value={this.state.formState[field.id]}

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -29,11 +29,13 @@ class FileCard extends Component {
     }
   }
 
-  tempStoreMeta = (ev, name) => {
+  tempStoreMeta = (ev, name, type) => {
+    var value = ev.target.value
+    if (type === 'checkbox') value = ev.target.checked ? 'on' : 'off'
     this.setState({
       formState: {
         ...this.state.formState,
-        [name]: ev.target.value
+        [name]: value
       }
     })
   }
@@ -47,26 +49,58 @@ class FileCard extends Component {
     this.props.toggleFileCard()
   }
 
+  renderInputField = (type, id, field) => {
+    console.log(this.state.formState, field.id)
+    if (type === 'checkbox') {
+      return (
+        <input
+          class=""
+          id={id}
+          type="checkbox"
+          onChange={ev => this.tempStoreMeta(ev, field.id, type)}
+          defaultChecked={this.state.formState[field.id] === 'on'}
+          data-uppy-super-focusable
+        />
+      )
+    } else if (type === 'select') {
+      return (
+        <select
+          id={id}
+          onChange={ev => this.tempStoreMeta(ev, field.id, type)}
+          class="uppy-Dashboard-FileCard-input uppy-c-textInput"
+          value={this.state.formState[field.id]}
+        >
+          {field.options.map((opt) => {
+            return (<option key={opt.value} value={opt.value}>{opt.text}</option>)
+          })}
+        </select>
+      )
+    } else {
+      return (
+        <input
+          class="uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input"
+          id={id}
+          type={field.type || 'text'}
+          value={this.state.formState[field.id]}
+          placeholder={field.placeholder}
+          onkeyup={this.saveOnEnter}
+          onkeydown={this.saveOnEnter}
+          onkeypress={this.saveOnEnter}
+          oninput={ev => this.tempStoreMeta(ev, field.id, type)}
+          data-uppy-super-focusable
+        />)
+    }
+  }
+
   renderMetaFields = () => {
     const metaFields = this.props.metaFields || []
-
+    console.log(metaFields)
     return metaFields.map((field) => {
       const id = `uppy-Dashboard-FileCard-input-${field.id}`
       return (
         <fieldset key={field.id} class="uppy-Dashboard-FileCard-fieldset">
           <label class="uppy-Dashboard-FileCard-label" for={id}>{field.name}</label>
-          <input
-            class="uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input"
-            id={id}
-            type="text"
-            value={this.state.formState[field.id]}
-            placeholder={field.placeholder}
-            onkeyup={this.saveOnEnter}
-            onkeydown={this.saveOnEnter}
-            onkeypress={this.saveOnEnter}
-            oninput={ev => this.tempStoreMeta(ev, field.id)}
-            data-uppy-super-focusable
-          />
+          {this.renderInputField(field.type || 'text', id, field)}
         </fieldset>
       )
     })

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -50,7 +50,6 @@ class FileCard extends Component {
   }
 
   renderInputField = (type, id, field) => {
-    console.log(this.state.formState, field.id)
     if (type === 'checkbox') {
       return (
         <input
@@ -94,7 +93,6 @@ class FileCard extends Component {
 
   renderMetaFields = () => {
     const metaFields = this.props.metaFields || []
-    console.log(metaFields)
     return metaFields.map((field) => {
       const id = `uppy-Dashboard-FileCard-input-${field.id}`
       return (

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -29,13 +29,11 @@ class FileCard extends Component {
     }
   }
 
-  tempStoreMeta = (ev, name, type) => {
-    var value = ev.target.value
-    if (type === 'checkbox') value = ev.target.checked ? 'on' : 'off'
+  updateMeta = (newVal, name) => {
     this.setState({
       formState: {
         ...this.state.formState,
-        [name]: value
+        [name]: newVal
       }
     })
   }
@@ -49,48 +47,6 @@ class FileCard extends Component {
     this.props.toggleFileCard()
   }
 
-  renderInputField = (type, id, field) => {
-    if (type === 'checkbox') {
-      return (
-        <input
-          class=""
-          id={id}
-          type="checkbox"
-          onChange={ev => this.tempStoreMeta(ev, field.id, type)}
-          defaultChecked={this.state.formState[field.id] === 'on'}
-          data-uppy-super-focusable
-        />
-      )
-    } else if (type === 'select') {
-      return (
-        <select
-          id={id}
-          onChange={ev => this.tempStoreMeta(ev, field.id, type)}
-          class="uppy-Dashboard-FileCard-input uppy-c-textInput"
-          value={this.state.formState[field.id]}
-        >
-          {field.options.map((opt) => {
-            return (<option key={opt.value} value={opt.value}>{opt.text}</option>)
-          })}
-        </select>
-      )
-    } else {
-      return (
-        <input
-          class="uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input"
-          id={id}
-          type={field.type || 'text'}
-          value={this.state.formState[field.id]}
-          placeholder={field.placeholder}
-          onkeyup={this.saveOnEnter}
-          onkeydown={this.saveOnEnter}
-          onkeypress={this.saveOnEnter}
-          oninput={ev => this.tempStoreMeta(ev, field.id, type)}
-          data-uppy-super-focusable
-        />)
-    }
-  }
-
   renderMetaFields = () => {
     const metaFields = this.props.metaFields || []
     return metaFields.map((field) => {
@@ -98,7 +54,22 @@ class FileCard extends Component {
       return (
         <fieldset key={field.id} class="uppy-Dashboard-FileCard-fieldset">
           <label class="uppy-Dashboard-FileCard-label" for={id}>{field.name}</label>
-          {this.renderInputField(field.type || 'text', id, field)}
+          {field.render !== undefined
+            ? field.render({ value: this.state.formState[field.id], onChange: (newVal) => this.updateMeta(newVal, field.id) }, h)
+            : (
+              <input
+                class="uppy-u-reset uppy-c-textInput uppy-Dashboard-FileCard-input"
+                id={id}
+                type={field.type || 'text'}
+                value={this.state.formState[field.id]}
+                placeholder={field.placeholder}
+                onkeyup={this.saveOnEnter}
+                onkeydown={this.saveOnEnter}
+                onkeypress={this.saveOnEnter}
+                oninput={ev => this.updateMeta(ev.target.value, field.id)}
+                data-uppy-super-focusable
+              />
+            )}
         </fieldset>
       )
     })

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -6,6 +6,7 @@ interface MetaField {
   id: string
   name: string
   placeholder?: string
+  render?(field: {value: string, onChange(newVal: string): void}, h: any): void
 }
 
 declare module Dashboard {

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -1,12 +1,13 @@
 import Uppy = require('@uppy/core')
 import StatusBar = require('@uppy/status-bar')
 import DashboardLocale = require('./generatedLocale')
+import Preact = require('preact')
 
 interface MetaField {
   id: string
   name: string
   placeholder?: string
-  render?(field: {value: string, onChange(newVal: string): void}, h: any): void
+  render?(field: {value: string, onChange(newVal: string): void}, h: typeof Preact.h): Preact.VNode
 }
 
 declare module Dashboard {

--- a/packages/@uppy/dashboard/types/index.test-d.ts
+++ b/packages/@uppy/dashboard/types/index.test-d.ts
@@ -25,6 +25,24 @@ import Dashboard = require('../')
         id: 'license',
         name: 'License',
         placeholder: 'Creative Commons, Apache 2.0, ...'
+      },
+      {
+        id: 'public',
+        name: 'Public',
+        render ({ value, onChange }, h) {
+          expectType<string>(value)
+          expectType<(val: string) => void>(onChange)
+          // `h` should be the Preact `h`
+          expectError(h([], 'error'))
+          return h('input', {
+            type: 'checkbox',
+            checked: value === 'yes',
+            onChange: (event) => {
+              expectType<Event>(event)
+              onChange((event.target as HTMLInputElement).checked ? 'yes' : 'no')
+            }
+          })
+        }
       }
     ]
   })

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -197,7 +197,11 @@ An array of UI field objects that will be shown when a user clicks the â€œeditâ€
 
 - `id`, the name of the meta field. Note: this will also be used in CSS/HTML as part of the `id` attribute, so itâ€™s better to [avoid using characters like periods, semicolons, etc](https://stackoverflow.com/a/79022).
 - `name`, the label shown in the interface.
-- `placeholder`, the text shown when no value is set in the field.
+- `placeholder`, the text shown when no value is set in the field. (Not needed when a custom render function is provided)
+
+Optionally, you can specify `render: ({value, onChange}, h) => void`, a function for rendering a custom form element.
+It gets passed `({value, onChange}, h)` where `value` is the current value of the meta field, `onChange: (newVal) => void` is a function saving the new value and `h` is the `createElement` function from [preact](https://preactjs.com/guide/v10/api-reference#h--createelement).
+`h` can be useful when using uppy from plain JavaScript, where you cannot write JSX.
 
 ```js
 .use(Dashboard, {
@@ -205,7 +209,10 @@ An array of UI field objects that will be shown when a user clicks the â€œeditâ€
   metaFields: [
     { id: 'name', name: 'Name', placeholder: 'file name' },
     { id: 'license', name: 'License', placeholder: 'specify license' },
-    { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }
+    { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' },
+    { id: 'public', name: 'Public', render: function({value, onChange}, h) {
+      return h('input', { type: 'checkbox', onChange: (ev) => onChange(ev.target.checked ? 'on' : 'off'), defaultChecked: value === 'on' })
+    } }
   ]
 })
 ```


### PR DESCRIPTION
Issue #617 is related to this. It proposes the ability to set custom render functions for metadata fields. However, IMO this can be kinda overcomplicated, especially if you want to use Uppy in an app without React (which we are).

Hence, I propose the ability to set the type of input field used for the different metadata fields. This could be replaced / improved in the future by also providing the aforementioned custom render function. Currently supported fields are:

- Normal Text Input (default)
- Select (including options)
- Checkbox

I can add more, but these are the ones we would currently need :)

This change should be backwards compatible, since by default I just use the normal text input.

Let me know, if I should add any text or documentation.

Closes #2007