### PR TITLE
Fixing an error that would prevent the ProgressBar from hiding

### DIFF
--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -32,7 +32,7 @@ module.exports = class ProgressBar extends Plugin {
     const progress = state.totalProgress || 0
     // before starting and after finish should be hidden
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
-    // hide the class if the bar is hidden
+    // `uppy-hidden` class gets added when the bar is set as hidden
     const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -32,11 +32,9 @@ module.exports = class ProgressBar extends Plugin {
     const progress = state.totalProgress || 0
     // before starting and after finish should be hidden
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
-    // `uppy-hidden` class gets added when the bar is set as hidden
-    const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div
-        class={{ barClass }}
+        class="uppy uppy-ProgressBar"
         style={{ position: this.opts.fixed ? 'fixed' : 'initial' }}
         aria-hidden={isHidden}
       >

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -30,10 +30,13 @@ module.exports = class ProgressBar extends Plugin {
 
   render (state) {
     const progress = state.totalProgress || 0
-    const isHidden = progress === 100 && this.opts.hideAfterFinish
+    // before starting and after finish should be hidden
+    const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
+    // hide the class if the bar is hidden
+    const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div
-        class="uppy uppy-ProgressBar"
+        class={{ barClass }}
         style={{ position: this.opts.fixed ? 'fixed' : 'initial' }}
         aria-hidden={isHidden}
       >


### PR DESCRIPTION
Fixing an error that would prevent the ProgressBar from hiding, displaying a `0` in the HTML element .uppy-ProgressBar-inner whenever no files were being uploaded. This fix sets the .uppy-ProgressBar element a class, so the user can decide when to hide it (or what to do)