### PR TITLE
Fix fragment URL

### DIFF
--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -99,7 +99,7 @@ This takes your `server` instance and your Uppy [Options](#Options) as parameter
 ### Running as a standalone server
 
 > Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#configuring-a-standalone-server) for the variables required.
-
+> Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#Configuring-a-standalone-server) for the variables required.
 Set environment variables first:
 
 ```bash

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -98,7 +98,7 @@ This takes your `server` instance and your Uppy [Options](#Options) as parameter
 
 ### Running as a standalone server
 
-> Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#Configure-Standalone) for the variables required.
+> Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#configuring-a-standalone-server) for the variables required.
 
 Set environment variables first:
 

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -98,7 +98,6 @@ This takes your `server` instance and your Uppy [Options](#Options) as parameter
 
 ### Running as a standalone server
 
-> Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#configuring-a-standalone-server) for the variables required.
 > Please ensure that the required environment variables are set before running/using Companion as a standalone server. See [Configure Standalone](#Configuring-a-standalone-server) for the variables required.
 Set environment variables first:
 


### PR DESCRIPTION
The hashtag: "#Configure-Standalone" is not correct and doesn't lead to anything. Fixed that.