### PR TITLE
tus,xhr-upload: emit error when companion returns error during upload creation

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -338,7 +338,8 @@ module.exports = class Tus extends Plugin {
       }).then(() => {
         resolve()
       }).catch((err) => {
-        reject(new Error(err))
+        this.uppy.emit('upload-error', file, err)
+        reject(err)
       })
     })
   }

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -431,6 +431,9 @@ module.exports = class XHRUpload extends Plugin {
 
           return () => socket.close()
         })
+      }).catch((err) => {
+        this.uppy.emit('upload-error', file, err)
+        reject(err)
       })
     })
   }


### PR DESCRIPTION
During upload instantiation, if companion returns an error, the `upload-error` even is not emitted, so the progress bar just waits infinitely.

Before this commit:
![Kapture 2020-04-01 at 16 02 52](https://user-images.githubusercontent.com/8383781/78156318-8bc1a080-7436-11ea-9dc7-d7fdf3b58f0f.gif)

After this commit:
![Kapture 2020-04-01 at 16 19 27](https://user-images.githubusercontent.com/8383781/78156702-0d193300-7437-11ea-84a3-d324d56a26d5.gif)
