### PR TITLE
aws-s3-multipart: emit upload-error when companion returns error during upload

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -303,7 +303,8 @@ module.exports = class AwsS3Multipart extends Plugin {
       }).then(() => {
         resolve()
       }).catch((err) => {
-        reject(new Error(err))
+        this.uppy.emit('upload-error', file, err)
+        reject(err)
       })
     })
   }


### PR DESCRIPTION
as @arturi mentioned [here](https://github.com/transloadit/uppy/pull/2166#issuecomment-607326550), we do need it for `aws-s3-multipart`