### PR TITLE
Fix typo in thumbnail-generator doc

### DIFF
--- a/website/src/docs/thumbnail-generator.md
+++ b/website/src/docs/thumbnail-generator.md
@@ -79,7 +79,7 @@ If both width and height are given, only width is taken into account.
 
 ### `waitForThumbnailsBeforeUpload: false`
 
-Whether to wait for all thumbnails to be ready before starting the upload. If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing stage and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
+Whether to wait for all thumbnails to be ready before starting the upload. If set to `true`, Thumbnail Generator will invoke Uppy’s internal processing stage and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
 
 This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be available on the server after the upload.
 


### PR DESCRIPTION
Just a simple typing mistake I noticed today :)