### PR TITLE
companion: set debug based on NODE_ENV only if the env var is available

### DIFF
--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -77,7 +77,7 @@ const getConfigFromEnv = () => {
     sendSelfEndpoint: process.env.COMPANION_SELF_ENDPOINT,
     uploadUrls: uploadUrls ? uploadUrls.split(',') : null,
     secret: getSecret('COMPANION_SECRET') || generateSecret(),
-    debug: process.env.NODE_ENV !== 'production',
+    debug: process.env.NODE_ENV && process.env.NODE_ENV !== 'production',
     // TODO: this is a temporary hack to support distributed systems.
     // it is not documented, because it should be changed soon.
     cookieDomain: process.env.COMPANION_COOKIE_DOMAIN,


### PR DESCRIPTION
in a system where the `NODE_ENV` variable is never used as part of their config variables to begin with, it'll be unsafe to assume the system is in `debug` mode by merely checking `NODE_ENV !== 'production'`