### PR TITLE
Use .js import for exifr in Thumbnail Generator

### DIFF
--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -4,7 +4,7 @@ const dataURItoBlob = require('@uppy/utils/lib/dataURItoBlob')
 const isObjectURL = require('@uppy/utils/lib/isObjectURL')
 const isPreviewSupported = require('@uppy/utils/lib/isPreviewSupported')
 const ORIENTATIONS = require('./image-orientations')
-const exifr = require('exifr/dist/mini.legacy.umd.cjs')
+const exifr = require('exifr/dist/mini.legacy.umd.js')
 
 /**
  * The Thumbnail Generator plugin


### PR DESCRIPTION
Fixes #2172 

Current build tools, including Create React App on the latest version, seem to have issues importing .cjs files. This results in thumbnail generation failing with the following error:

    TypeError: exifr.orientation is not a function

`exifr/dist/mini.legacy.umd.cjs` and `exifr/dist/mini.legacy.umd.js` are identical on the current version of exifr and this fixes the issue with CRA.