### PR TITLE
Fixing Safari type error

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -37,7 +37,9 @@ const qsStringify = require('qs-stringify')
 const MiniXHRUpload = require('./MiniXHRUpload')
 
 function resolveUrl (origin, link) {
-  return new URL_(link, origin).toString()
+  return origin 
+    ? new URL_(link, origin).toString() 
+    : new URL_(link).toString()
 }
 
 function isXml (content, xhr) {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -37,8 +37,8 @@ const qsStringify = require('qs-stringify')
 const MiniXHRUpload = require('./MiniXHRUpload')
 
 function resolveUrl (origin, link) {
-  return origin 
-    ? new URL_(link, origin).toString() 
+  return origin
+    ? new URL_(link, origin).toString()
     : new URL_(link).toString()
 }
 
@@ -162,7 +162,8 @@ module.exports = class AwsS3 extends Plugin {
     /**
      * keep track of `getUploadParameters()` responses
      * so we can cancel the calls individually using just a file ID
-     * @type {Object.<string, Promise>}
+     *
+     * @type {object.<string, Promise>}
      */
     const paramsPromises = Object.create(null)
 


### PR DESCRIPTION
When using native URL function (`typeof URL === 'function'`: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) the second optional parameter is causing a crash resulting in the uploading failing at 100%

According to the definition:
>`base` Optional
>A `USVString` representing the base URL to use in case URL is a relative URL. If not specified, it defaults to `''`.

Safari does not allows the usage of `undefined`, `null` or `''`. , triggering a `Type error` exception.