### PR TITLE
Remove duplicate check of element type

### DIFF
--- a/packages/@uppy/utils/src/findDOMElement.js
+++ b/packages/@uppy/utils/src/findDOMElement.js
@@ -11,7 +11,7 @@ module.exports = function findDOMElement (element, context = document) {
     return context.querySelector(element)
   }
 
-  if (typeof element === 'object' && isDOMElement(element)) {
+  if (isDOMElement(element)) {
     return element
   }
 }


### PR DESCRIPTION
`isDOMElement` already checks if the element is typed as `object`