### PR TITLE
screen-capture: add type tests

### DIFF
--- a/packages/@uppy/screen-capture/src/index.js
+++ b/packages/@uppy/screen-capture/src/index.js
@@ -59,10 +59,10 @@ module.exports = class ScreenCapture extends Plugin {
           frameRate: {
             ideal: 3,
             max: 5
-          }
-        },
-        cursor: 'motion',
-        displaySurface: 'monitor'
+          },
+          cursor: 'motion',
+          displaySurface: 'monitor'
+        }
       },
       // https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints/audio
       userMediaConstraints: {

--- a/packages/@uppy/screen-capture/types/index.d.ts
+++ b/packages/@uppy/screen-capture/types/index.d.ts
@@ -1,30 +1,24 @@
 import Uppy = require('@uppy/core');
 
 declare module ScreenCapture {
+  // https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_shared_screen_tracks
+  // TODO: use the global DisplayMediaStreamConstraints once typescript includes it by default
+  interface DisplayMediaStreamConstraints {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | (MediaTrackConstraints & {
+      cursor?: 'always' | 'motion' | 'never',
+      displaySurface?: 'application' | 'browser' | 'monitor' | 'window',
+      logicalSurface?: boolean
+    });
+  }
 
   export interface ScreenCaptureOptions extends Uppy.PluginOptions {
-    displayMediaConstraints: {
-      audio: boolean,
-      video: { 
-        width: number, 
-        height: number,
-        frameRate: { 
-          ideal: number, 
-          max: number } 
-        }
-    },
-    preferredVideoMimeType: string
+    displayMediaConstraints?: DisplayMediaStreamConstraints,
+    userMediaConstraints?: MediaStreamConstraints,
+    preferredVideoMimeType?: string
   }
 }
 
-declare class ScreenCapture extends Uppy.Plugin {
-  constructor(uppy: Uppy.Uppy, opts: Partial<ScreenCapture.ScreenCaptureOptions>);
-}
+declare class ScreenCapture extends Uppy.Plugin<ScreenCapture.ScreenCaptureOptions> {}
 
 export = ScreenCapture;
-
-declare module '@uppy/core' {
-  export interface Uppy {
-    use(pluginClass: typeof ScreenCapture, opts: Partial<ScreenCapture.ScreenCaptureOptions>): Uppy.Uppy;
-  }
-}

--- a/packages/@uppy/screen-capture/types/index.test-d.ts
+++ b/packages/@uppy/screen-capture/types/index.test-d.ts
@@ -1,0 +1,21 @@
+import { expectError } from 'tsd'
+import Uppy = require('@uppy/core')
+import ScreenCapture = require('../')
+
+Uppy<Uppy.StrictTypes>().use(ScreenCapture)
+Uppy<Uppy.StrictTypes>().use(ScreenCapture, {})
+Uppy<Uppy.StrictTypes>().use(ScreenCapture, { preferredVideoMimeType: 'video/mp4' })
+expectError(Uppy<Uppy.StrictTypes>().use(ScreenCapture, { preferredVideoMimeType: 10 }))
+
+function constraints () {
+  Uppy<Uppy.StrictTypes>().use(ScreenCapture, {
+    displayMediaConstraints: {
+      video: { displaySurface: 'window' }
+    }
+  })
+  expectError(Uppy<Uppy.StrictTypes>().use(ScreenCapture, {
+    displayMediaConstraints: {
+      video: { displaySurface: 'some nonsense' }
+    }
+  }))
+}


### PR DESCRIPTION
plugins have to be explicitly excluded in `npm run test:type` if they
don't have a type test file, so this was causing tests to fail.

updated the types to the new style capable of strict typechecking, and
made them use the actual DOM types for the Constraints options.

Looking at mdn, the `displaySurface` and similar options are actually
properties of the `constraints.video` object, so i moved them in there
in our `defaultOptions`.