### PR TITLE
fix double encoding of the upload params

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -131,8 +131,8 @@ module.exports = class AwsS3 extends Plugin {
       throw new Error('Expected a `companionUrl` option containing a Companion address.')
     }
 
-    const filename = encodeURIComponent(file.meta.name)
-    const type = encodeURIComponent(file.meta.type)
+    const filename = file.meta.name;
+    const type = file.meta.type;
     const metadata = {}
     this.opts.metaFields.forEach((key) => {
       if (file.meta[key] != null) {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -131,8 +131,8 @@ module.exports = class AwsS3 extends Plugin {
       throw new Error('Expected a `companionUrl` option containing a Companion address.')
     }
 
-    const filename = file.meta.name;
-    const type = file.meta.type;
+    const filename = file.meta.name
+    const type = file.meta.type
     const metadata = {}
     this.opts.metaFields.forEach((key) => {
       if (file.meta[key] != null) {


### PR DESCRIPTION
By encoding `filename` and `type` we have the upload parameters encoded twice.
`qsStringify({...})` (called at [line 143](https://github.com/romain-preston/uppy/blob/aed402aeaba6626f5a9628eb70809d27d724d66d/packages/%40uppy/aws-s3/src/index.js#L143)) already encodes the values by default according to their ([documentation](https://github.com/ljharb/qs#stringifying)):

> When stringifying, qs by default URI encodes output. 

Not encoding them before fixes the issue.

