### PR TITLE
Add cuid dependency to @uppy/aws-s3

### DIFF
--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -25,6 +25,7 @@
     "@uppy/companion-client": "file:../companion-client",
     "@uppy/utils": "file:../utils",
     "@uppy/xhr-upload": "file:../xhr-upload",
+    "cuid": "^2.1.1",
     "qs-stringify": "^1.1.0",
     "url-parse": "^1.4.7"
   },


### PR DESCRIPTION
I received the following error message:

> ModuleNotFoundError: Module not found: Error: Package "@uppy/aws-s3@1.6.4" (via "/usr/local/share/.cache/yarn/v6/npm-@uppy-aws-s3-1.6.4-c78ef1c89fb6a97455d10fad4d7c4b6f4abca47b-integrity/node_modules/@uppy/aws-s3/lib/MiniXHRUpload.js") is trying to require the package "cuid" (via "cuid") without it being listed in its dependencies (@uppy/core, @uppy/companion-client, @uppy/utils, @uppy/xhr-upload, qs-stringify, url-parse, @uppy/aws-s3)

Commit ab764485080da1774836f34b8b345f957335873f introduced a new direct dependency to cuid

