### PR TITLE
transloadit: add typings for Companion URL constants

### DIFF
--- a/packages/@uppy/transloadit/types/index.d.ts
+++ b/packages/@uppy/transloadit/types/index.d.ts
@@ -38,6 +38,9 @@ declare module Transloadit {
       | AssemblyOptions)
 }
 
-declare class Transloadit extends Uppy.Plugin<Transloadit.TransloaditOptions> {}
+declare class Transloadit extends Uppy.Plugin<Transloadit.TransloaditOptions> {
+  static COMPANION: string
+  static COMPANION_PATTERN: RegExp
+}
 
 export = Transloadit

--- a/packages/@uppy/transloadit/types/index.test-d.ts
+++ b/packages/@uppy/transloadit/types/index.test-d.ts
@@ -2,6 +2,9 @@ import { expectError, expectType } from 'tsd'
 import Uppy = require('@uppy/core')
 import Transloadit = require('../')
 
+expectType<string>(Transloadit.COMPANION)
+expectType<RegExp>(Transloadit.COMPANION_PATTERN)
+
 const validParams = {
   auth: { key: 'not so secret key' }
 }


### PR DESCRIPTION
Fixes #2243

Omitting `UPPY_SERVER` because it should not be used. It will be removed
from the JS source too with the 2.0 release.