### PR TITLE
thumbnail-generator: generate 80% quality jpegs

### DIFF
--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -82,7 +82,7 @@ module.exports = class ThumbnailGenerator extends Plugin {
         const dimensions = this.getProportionalDimensions(image, targetWidth, targetHeight, orientation.rotation)
         const rotatedImage = this.rotateImage(image, orientation)
         const resizedImage = this.resizeImage(rotatedImage, dimensions.width, dimensions.height)
-        return this.canvasToBlob(resizedImage, 'image/png')
+        return this.canvasToBlob(resizedImage, 'image/jpeg', 80)
       })
       .then(blob => {
         return URL.createObjectURL(blob)


### PR DESCRIPTION
As suggested in #2204. In my unscientific test, this is actually quite a bit faster, by about 33%!

Though not exactly configurable, I think this closes https://github.com/transloadit/uppy/issues/2204