### PR TITLE
Hide Progressbar if no upload in progress

### DIFF
--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -32,7 +32,7 @@ module.exports = class ProgressBar extends Plugin {
     const progress = state.totalProgress || 0
     // before starting and after finish should be hidden
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
-    // hide the class if the bar is hidden
+    // `uppy-hidden` class gets added when the bar is set as hidden
     const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -32,11 +32,9 @@ module.exports = class ProgressBar extends Plugin {
     const progress = state.totalProgress || 0
     // before starting and after finish should be hidden
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
-    // `uppy-hidden` class gets added when the bar is set as hidden
-    const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div
-        class={{ barClass }}
+        class="uppy uppy-ProgressBar"
         style={{ position: this.opts.fixed ? 'fixed' : 'initial' }}
         aria-hidden={isHidden}
       >

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -30,10 +30,13 @@ module.exports = class ProgressBar extends Plugin {
 
   render (state) {
     const progress = state.totalProgress || 0
-    const isHidden = progress === 100 && this.opts.hideAfterFinish
+    // before starting and after finish should be hidden
+    const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
+    // hide the class if the bar is hidden
+    const barClass = 'uppy uppy-ProgressBar' + (isHidden ? ' uppy-hidden' : '')
     return (
       <div
-        class="uppy uppy-ProgressBar"
+        class={{ barClass }}
         style={{ position: this.opts.fixed ? 'fixed' : 'initial' }}
         aria-hidden={isHidden}
       >

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -30,7 +30,7 @@ module.exports = class ProgressBar extends Plugin {
 
   render (state) {
     const progress = state.totalProgress || 0
-    // before starting and after finish should be hidden
+    // before starting and after finish should be hidden if specified in the options
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
     return (
       <div


### PR DESCRIPTION
`state.totalProgress` is not `100`. It's `0` instead   
----------

To reproduce the error:  
```
.use(ProgressBar, {
  target: '._progress_bar_',
  fixed: false,
  hideAfterFinish: true
})
```

This will set a `div` inside the `_progress_bar_` element, and this element will be visible, showing `0` to the user.

The problem is that, currently, the bar only hides when `progress === 100`, but that is never true, as `progress` resets to `0` once the upload has been completed.
That means, it is __always__ visible, and only hidden for a brief period after an upload completes (when the `progress === 100`, briefly).

This fix allows the bar to be hidden also when the progress is `0` (after and before uploads)