### PR TITLE
aws-s3-multipart: make chunk size configurable, fixes #1543

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -200,6 +200,7 @@ module.exports = class AwsS3Multipart extends Plugin {
         prepareUploadPart: this.opts.prepareUploadPart.bind(this, file),
         completeMultipartUpload: this.opts.completeMultipartUpload.bind(this, file),
         abortMultipartUpload: this.opts.abortMultipartUpload.bind(this, file),
+        getChunkSize: this.opts.getChunkSize ? this.opts.getChunkSize.bind(this) : null,
 
         onStart,
         onProgress,

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -11,6 +11,7 @@ declare module AwsS3Multipart {
 
   interface AwsS3MultipartOptions extends Uppy.PluginOptions {
     companionUrl?: string
+    getChunkSize?: (file: Uppy.UppyFile) => number
     createMultipartUpload?: (
       file: Uppy.UppyFile
     ) => MaybePromise<{ uploadId: string; key: string }>

--- a/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import Uppy = require('@uppy/core')
 import AwsS3Multipart = require('../')
 
@@ -36,4 +36,12 @@ import AwsS3Multipart = require('../')
       return {}
     }
   })
+}
+
+{
+  const uppy = Uppy<Uppy.StrictTypes>()
+  expectError(uppy.use(AwsS3Multipart, { getChunkSize: 100 }))
+  expectError(uppy.use(AwsS3Multipart, { getChunkSize: () => 'not a number' }))
+  uppy.use(AwsS3Multipart, { getChunkSize: () => 100 })
+  uppy.use(AwsS3Multipart, { getChunkSize: (file) => file.size })
 }

--- a/packages/@uppy/aws-s3/types/index.d.ts
+++ b/packages/@uppy/aws-s3/types/index.d.ts
@@ -12,7 +12,6 @@ declare module AwsS3 {
 
   interface AwsS3Options extends Uppy.PluginOptions {
     companionUrl?: string
-    getChunkSize?: (file: Uppy.UppyFile) => number
     getUploadParameters?: (
       file: Uppy.UppyFile
     ) => MaybePromise<AwsS3UploadParameters>

--- a/packages/@uppy/aws-s3/types/index.d.ts
+++ b/packages/@uppy/aws-s3/types/index.d.ts
@@ -12,10 +12,11 @@ declare module AwsS3 {
 
   interface AwsS3Options extends Uppy.PluginOptions {
     companionUrl?: string
+    getChunkSize?: (file: Uppy.UppyFile) => number
     getUploadParameters?: (
       file: Uppy.UppyFile
     ) => MaybePromise<AwsS3UploadParameters>
-    metaFields?: string[],
+    metaFields?: string[]
     timeout?: number
     limit?: number
   }

--- a/packages/@uppy/aws-s3/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import Uppy = require('@uppy/core')
 import AwsS3 = require('../')
 
@@ -10,4 +10,12 @@ import AwsS3 = require('../')
       return { url: '' }
     }
   })
+}
+
+{
+  const uppy = Uppy<Uppy.StrictTypes>()
+  expectError(uppy.use(AwsS3, { getChunkSize: 100 }))
+  expectError(uppy.use(AwsS3, { getChunkSize: () => 'not a number' }))
+  uppy.use(AwsS3, { getChunkSize: () => 100 })
+  uppy.use(AwsS3, { getChunkSize: (file) => file.size })
 }

--- a/packages/@uppy/aws-s3/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd'
+import { expectType } from 'tsd'
 import Uppy = require('@uppy/core')
 import AwsS3 = require('../')
 
@@ -10,12 +10,4 @@ import AwsS3 = require('../')
       return { url: '' }
     }
   })
-}
-
-{
-  const uppy = Uppy<Uppy.StrictTypes>()
-  expectError(uppy.use(AwsS3, { getChunkSize: 100 }))
-  expectError(uppy.use(AwsS3, { getChunkSize: () => 'not a number' }))
-  uppy.use(AwsS3, { getChunkSize: () => 100 })
-  uppy.use(AwsS3, { getChunkSize: (file) => file.size })
 }

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -54,6 +54,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 This will be used by the default implementations of the upload-related functions below. If you provide your own implementations, these headers are not sent automatically.
 
+### getChunkSize(file)
+
+A function that returns the minimum chunk size to use when uploading the given file.
+
+The S3 Multipart plugin uploads files in chunks. Each chunk requires a signing request ([`prepareUploadPart()`](#prepareUploadPart-file-partData)). To reduce the amount of requests for large files, you can choose a larger chunk size, at the cost of having to re-upload more data if one chunk fails to upload.
+
+S3 requires a minimum chunk size of 5MB, and supports at most 10,000 chunks per multipart upload. If `getChunkSize()` returns a size that's too small, Uppy will increase it to S3's minimum requirements.
+
 ### createMultipartUpload(file)
 
 A function that calls the S3 Multipart API to create a new upload. `file` is the file object from Uppy's state. The most relevant keys are `file.name` and `file.type`.


### PR DESCRIPTION
Lets you provide a `getChunkSize` function to calculate the chunk size to use to split up files when doing an s3-multipart upload. We default to the old behaviour of using chunks that are as small as possible.