### PR TITLE
drag-drop: Add label for the input for better a11y

### DIFF
--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -142,6 +142,7 @@ module.exports = class DragDrop extends Plugin {
     const restrictions = this.uppy.opts.restrictions
     return (
       <input
+        id={'input-' + this.id}
         class="uppy-DragDrop-input"
         type="file"
         tabindex={-1}
@@ -165,11 +166,11 @@ module.exports = class DragDrop extends Plugin {
 
   renderLabel () {
     return (
-      <div class="uppy-DragDrop-label">
+      <label class="uppy-DragDrop-label" for={'uppy-input-' + this.id}>
         {this.i18nArray('dropHereOr', {
           browse: <span class="uppy-DragDrop-browse">{this.i18n('browse')}</span>
         })}
-      </div>
+      </label>
     )
   }
 

--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -142,7 +142,7 @@ module.exports = class DragDrop extends Plugin {
     const restrictions = this.uppy.opts.restrictions
     return (
       <input
-        id={'uppy-input-' + this.id}
+        id={this.uppy.id + '-' + this.id}
         class="uppy-DragDrop-input"
         type="file"
         tabindex={-1}
@@ -166,7 +166,7 @@ module.exports = class DragDrop extends Plugin {
 
   renderLabel () {
     return (
-      <label class="uppy-DragDrop-label" for={'uppy-input-' + this.id}>
+      <label class="uppy-DragDrop-label" for={this.uppy.id + '-' + this.id}>
         {this.i18nArray('dropHereOr', {
           browse: <span class="uppy-DragDrop-browse">{this.i18n('browse')}</span>
         })}

--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -142,7 +142,7 @@ module.exports = class DragDrop extends Plugin {
     const restrictions = this.uppy.opts.restrictions
     return (
       <input
-        id={'input-' + this.id}
+        id={'uppy-input-' + this.id}
         class="uppy-DragDrop-input"
         type="file"
         tabindex={-1}

--- a/packages/@uppy/drag-drop/src/style.scss
+++ b/packages/@uppy/drag-drop/src/style.scss
@@ -61,16 +61,16 @@
 
 .uppy-DragDrop-label {
   display: block;
-  cursor: pointer;
   font-size: 1.15em;
   margin-bottom: 5px;
+}
+
+.uppy-DragDrop-browse {
+  color: $blue;
+  cursor: pointer;
 }
 
 .uppy-DragDrop-note {
   font-size: 1em;
   color: lighten($gray-500, 10%);
-}
-
-.uppy-DragDrop-browse {
-  color: $blue;
 }


### PR DESCRIPTION
Fixes #2249

Although I’m not sure if we should also stop wrapping the whole thing with a `button`, because `label+input` inside a button seems semantically incorrect.