### PR TITLE
website: list robodog size, sort plugins by name

### DIFF
--- a/website/inject.js
+++ b/website/inject.js
@@ -30,29 +30,35 @@ const defaultConfig = {
 // Keeping a whitelist so utils etc are excluded
 // It may be easier to maintain a blacklist instead
 const packages = [
+  // Bundles
   'uppy',
+  '@uppy/robodog',
+  // Integrations
+  '@uppy/react',
+  // Core
   '@uppy/core',
-  '@uppy/dashboard',
-  '@uppy/drag-drop',
-  '@uppy/file-input',
-  '@uppy/webcam',
-  '@uppy/screen-capture',
-  '@uppy/dropbox',
-  '@uppy/google-drive',
-  '@uppy/instagram',
-  '@uppy/url',
-  '@uppy/tus',
-  '@uppy/xhr-upload',
+  // Plugins -- please keep these sorted alphabetically
   '@uppy/aws-s3',
   '@uppy/aws-s3-multipart',
-  '@uppy/status-bar',
-  '@uppy/progress-bar',
-  '@uppy/informer',
-  '@uppy/transloadit',
+  '@uppy/dashboard',
+  '@uppy/drag-drop',
+  '@uppy/dropbox',
+  '@uppy/file-input',
   '@uppy/form',
   '@uppy/golden-retriever',
-  '@uppy/react',
+  '@uppy/google-drive',
+  '@uppy/informer',
+  '@uppy/instagram',
+  '@uppy/progress-bar',
+  '@uppy/screen-capture',
+  '@uppy/status-bar',
   '@uppy/thumbnail-generator',
+  '@uppy/transloadit',
+  '@uppy/tus',
+  '@uppy/url',
+  '@uppy/webcam',
+  '@uppy/xhr-upload',
+  // Stores
   '@uppy/store-default',
   '@uppy/store-redux'
 ]


### PR DESCRIPTION
when looking for the size of a plugin, I could never find it without
Ctrl+F because the order was essentially arbitrary. This change sorts
the plugins in the package size table alphabetically, while still
keeping the `uppy` and `@uppy/core` packages on top, and the
`@uppy/store-` packages at the bottom (unlikely to be interesting to
most people).

![image](https://user-images.githubusercontent.com/1006268/81561818-167daf80-9394-11ea-8ad5-eaf2c84aefc6.png)
