### PR TITLE
tus: resetUploaderRefs before emitting

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -183,10 +183,11 @@ module.exports = class Tus extends Plugin {
           err = new NetworkError(err, err.originalRequest)
         }
 
-        this.uppy.emit('upload-error', file, err)
-
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
+
+        this.uppy.emit('upload-error', file, err)
+
         reject(err)
       }
 
@@ -204,14 +205,15 @@ module.exports = class Tus extends Plugin {
           uploadURL: upload.url
         }
 
+        this.resetUploaderReferences(file.id)
+        queuedRequest.done()
+
         this.uppy.emit('upload-success', file, uploadResp)
 
         if (upload.url) {
           this.uppy.log('Download ' + upload.file.name + ' from ' + upload.url)
         }
 
-        this.resetUploaderReferences(file.id)
-        queuedRequest.done()
         resolve(upload)
       }
 
@@ -464,6 +466,7 @@ module.exports = class Tus extends Plugin {
         this.uppy.emit('upload-success', file, uploadResp)
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
+
         resolve()
       })
 


### PR DESCRIPTION
Fixes #2200 for tus in a similar way AwsS3 was fixed (#1650).

This fixed the issues I saw in my dev environment and didn't introduce any new failures when unit testing, e2e testing, starting and looking at dashboard, etc. as far as I could see!

If I missed some step in the process/testing process let me know @goto-bus-stop. 