### PR TITLE
Allow webcam to accept constraints as option (#876)

### DIFF
--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -168,9 +168,12 @@ module.exports = class Webcam extends Plugin {
       this.opts.modes.indexOf('video-only') !== -1 ||
       this.opts.modes.indexOf('picture') !== -1
 
+    const videoConstraints = this.opts.constraints ?? {}
+    videoConstraints.facingMode = this.opts.facingMode
+
     return {
       audio: acceptsAudio,
-      video: acceptsVideo ? { facingMode: this.opts.facingMode } : false
+      video: acceptsVideo ? videoConstraints : false
     }
   }
 


### PR DESCRIPTION
Implements #876

Allows the `Webcam` plugin to accept a `constraints` option for specifying desired camera resolutions.

Example:
```
        Uppy().use(Webcam, {
          modes: ["video-audio"],
          constraints: {
            width: { min: 640, ideal: 1280, max: 1920 },
            height: { min: 400, ideal: 720, max: 1080 },
          },
        })
```