### PR TITLE
companion: validate companion options for non-standalone usage as well

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const express = require('express')
 // @ts-ignore
 const Grant = require('grant').express()
@@ -48,6 +49,8 @@ module.exports.errors = { ProviderApiError, ProviderAuthError }
  * @param {object} options
  */
 module.exports.app = (options = {}) => {
+  validateConfig(options)
+
   options = merge({}, defaultOptions, options)
   const providers = providerManager.getDefaultProviders(options)
   providerManager.addProviderOptions(options, grantConfig)
@@ -299,4 +302,39 @@ const maskLogger = (companionOptions) => {
   }
 
   logger.setMaskables(secrets)
+}
+
+/**
+ * validates that the mandatory companion options are set.
+ * If it is invalid, it will console an error of unset options and exits the process.
+ * If it is valid, nothing happens.
+ *
+ * @param {object} companionOptions
+ */
+const validateConfig = (companionOptions) => {
+  const mandatoryOptions = ['secret', 'filePath', 'server.host']
+  /** @type {string[]} */
+  const unspecified = []
+
+  mandatoryOptions.forEach((i) => {
+    const value = i.split('.').reduce((prev, curr) => prev ? prev[curr] : undefined, companionOptions)
+
+    if (!value) unspecified.push(`"${i}"`)
+  })
+
+  // vaidate that all required config is specified
+  if (unspecified.length) {
+    const messagePrefix = 'Please specify the following options to use companion:'
+    throw new Error(`${messagePrefix}\n${unspecified.join(',\n')}`)
+  }
+
+  // validate that specified filePath is writeable/readable.
+  try {
+    // @ts-ignore
+    fs.accessSync(`${companionOptions.filePath}`, fs.R_OK | fs.W_OK)
+  } catch (err) {
+    throw new Error(
+      `No access to "${companionOptions.filePath}". Please ensure the directory exists and with read/write permissions.`
+    )
+  }
 }

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -144,43 +144,6 @@ const getConfigPath = () => {
 }
 
 /**
- * validates that the mandatory companion options are set.
- * If it is invalid, it will console an error of unset options and exits the process.
- * If it is valid, nothing happens.
- *
- * @param {object} config
- */
-exports.validateConfig = (config) => {
-  const mandatoryOptions = ['secret', 'filePath', 'server.host']
-  /** @type {string[]} */
-  const unspecified = []
-
-  mandatoryOptions.forEach((i) => {
-    const value = i.split('.').reduce((prev, curr) => prev[curr], config)
-
-    if (!value) unspecified.push(`"${i}"`)
-  })
-
-  // vaidate that all required config is specified
-  if (unspecified.length) {
-    console.error('\x1b[31m', 'Please specify the following options',
-      'to run companion as Standalone:\n', unspecified.join(',\n'), '\x1b[0m')
-    process.exit(1)
-  }
-
-  // validate that specified filePath is writeable/readable.
-  // TODO: consider moving this into the companion module itself.
-  try {
-    // @ts-ignore
-    fs.accessSync(`${config.filePath}`, fs.R_OK | fs.W_OK)
-  } catch (err) {
-    console.error('\x1b[31m', `No access to "${config.filePath}".`,
-      'Please ensure the directory exists and with read/write permissions.', '\x1b[0m')
-    process.exit(1)
-  }
-}
-
-/**
  *
  * @param {string} url
  */

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -162,12 +162,20 @@ app.get('/', (req, res) => {
   res.send(helper.buildHelpfulStartupMessage(companionOptions))
 })
 
-// initialize companion
-helper.validateConfig(companionOptions)
+let companionApp
+try {
+  // initialize companion
+  companionApp = companion.app(companionOptions)
+} catch (error) {
+  console.error('\x1b[31m', error.message, '\x1b[0m')
+  process.exit(1)
+}
+
+// add companion to server middlewear
 if (process.env.COMPANION_PATH) {
-  app.use(process.env.COMPANION_PATH, companion.app(companionOptions))
+  app.use(process.env.COMPANION_PATH, companionApp)
 } else {
-  app.use(companion.app(companionOptions))
+  app.use(companionApp)
 }
 
 // WARNING: This route is added in order to validate your app with OneDrive.


### PR DESCRIPTION
this is a breaking change since the validation may throw an error