### PR TITLE
transloadit: only cancel assemblies belonging to ongoing upload

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -413,9 +413,14 @@ module.exports = class Transloadit extends Plugin {
    * When all files are removed, cancel in-progress Assemblies.
    */
   _onCancelAll () {
-    const { assemblies } = this.getPluginState()
+    const { uploadsAssemblies } = this.getPluginState()
 
-    const cancelPromises = Object.keys(assemblies).map((assemblyID) => {
+    const assemblyIDs = Object.keys(uploadsAssemblies).reduce((acc, uploadID) => {
+      acc.push(...uploadsAssemblies[uploadID])
+      return acc
+    }, [])
+
+    const cancelPromises = assemblyIDs.map((assemblyID) => {
       const assembly = this.getAssembly(assemblyID)
       return this._cancelAssembly(assembly)
     })


### PR DESCRIPTION
When canceling an upload, we would previously cancel all assemblies. But the Transloadit plugin state still contains Assemblies that had already finished. Instead of cancelling everything we know about, we need to only cancel Assemblies that belong to an ongoing upload. We can do that by cancelling all Assemblies that are reachable through the `uploadsAssemblies` state value.