### PR TITLE
webcam: Show “enable camera” screen if no camera device was detected

### DIFF
--- a/packages/@uppy/locales/src/en_US.js
+++ b/packages/@uppy/locales/src/en_US.js
@@ -63,6 +63,8 @@ en_US.strings = {
   logOut: 'Log out',
   micDisabled: 'Microphone access denied by user',
   myDevice: 'My Device',
+  noCameraDescription: 'In order to take pictures or record video with your camera, please connect or turn on your camera device',
+  noCameraTitle: 'Camera Not Available',
   noDuplicates: 'Cannot add the duplicate file \'%{fileName}\', it already exists',
   noFilesFound: 'You have no files or folders here',
   noInternetConnection: 'No Internet connection',

--- a/packages/@uppy/webcam/src/PermissionsScreen.js
+++ b/packages/@uppy/webcam/src/PermissionsScreen.js
@@ -4,8 +4,8 @@ module.exports = (props) => {
   return (
     <div class="uppy-Webcam-permissons">
       <div class="uppy-Webcam-permissonsIcon">{props.icon()}</div>
-      <h1 class="uppy-Webcam-title">{props.i18n('allowAccessTitle')}</h1>
-      <p>{props.i18n('allowAccessDescription')}</p>
+      <h1 class="uppy-Webcam-title">{props.hasCamera ? props.i18n('allowAccessTitle') : props.i18n('noCameraTitle')}</h1>
+      <p>{props.hasCamera ? props.i18n('allowAccessDescription') : props.i18n('noCameraDescription')}</p>
     </div>
   )
 }

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -98,7 +98,7 @@ module.exports = class Webcam extends Plugin {
         allowAccessTitle: 'Please allow access to your camera',
         allowAccessDescription: 'In order to take pictures or record video with your camera, please allow camera access for this site.',
         noCameraTitle: 'Camera Not Available',
-        noCameraDescription: 'In order to take pictures or record video with your camera, please connect or turn on your camera device',
+        noCameraDescription: 'In order to take pictures or record video, please connect a camera device',
         recordingStoppedMaxSize: 'Recording stopped because the file size is about to exceed the limit',
         recordingLength: 'Recording length %{recording_length}'
       }


### PR DESCRIPTION
@nqst:

> When I opened the Import from Camera screen, the access dialog didn't show up. I thought it's a Safari bug, but then realized I'm using an external display which have no camera :slightly_smiling_face:
Question: can we detect that there's no camera and show a relevant message instead?
(Tested on Safari, macOS; Display is connected to MacBook in clamshell mode)