### PR TITLE
Dashboard: add options to show remove button after complete

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
@@ -42,7 +42,7 @@ function RemoveButton ({ i18n, onClick }) {
   )
 }
 
-const copyLinkToClipboard = (event, props) =>
+const copyLinkToClipboard = (event, props) => {
   copyToClipboard(props.file.uploadURL, props.i18n('copyLinkToClipboardFallback'))
     .then(() => {
       props.log('Link copied to clipboard.')
@@ -51,6 +51,7 @@ const copyLinkToClipboard = (event, props) =>
     .catch(props.log)
     // avoid losing focus
     .then(() => event.target.focus({ preventScroll: true }))
+}
 
 function CopyLinkButton (props) {
   return (
@@ -93,7 +94,9 @@ module.exports = function Buttons (props) {
     showRemoveButton,
     i18n,
     removeFile,
-    toggleFileCard
+    toggleFileCard,
+    log,
+    info
   } = props
 
   return (
@@ -112,7 +115,12 @@ module.exports = function Buttons (props) {
         onClick={() => toggleFileCard(file.id)}
       />
       {showLinkToFileUploadResult && file.uploadURL ? (
-        <CopyLinkButton i18n={i18n} />
+        <CopyLinkButton
+          file={file}
+          i18n={i18n}
+          info={info}
+          log={log}
+        />
       ) : null}
       {showRemoveButton ? (
         <RemoveButton

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
@@ -43,7 +43,8 @@ function progressIndicatorTitle (props) {
 }
 
 module.exports = function FileProgress (props) {
-  if (props.hideRetryButton && props.error) {
+  if ((props.hideRetryButton && props.error) ||
+      (props.isUploaded && props.showRemoveButtonAfterComplete)) {
     return <div class="uppy-DashboardItem-progress" />
   } else if (
     props.isUploaded ||

--- a/packages/@uppy/dashboard/src/components/FileItem/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.js
@@ -35,9 +35,13 @@ module.exports = class FileItem extends Component {
     const isPaused = file.isPaused || false
     const error = file.error || false
 
-    const showRemoveButton = this.props.individualCancellation
+    let showRemoveButton = this.props.individualCancellation
       ? !isUploaded
       : !uploadInProgress && !isUploaded
+
+    if (isUploaded && this.props.showRemoveButtonAfterComplete) {
+      showRemoveButton = true
+    }
 
     const dashboardItemClass = classNames({
       'uppy-u-reset': true,
@@ -69,6 +73,7 @@ module.exports = class FileItem extends Component {
 
             hideRetryButton={this.props.hideRetryButton}
             hidePauseResumeCancelButtons={this.props.hidePauseResumeCancelButtons}
+            showRemoveButtonAfterComplete={this.props.showRemoveButtonAfterComplete}
 
             resumableUploads={this.props.resumableUploads}
             individualCancellation={this.props.individualCancellation}

--- a/packages/@uppy/dashboard/src/components/FileList.js
+++ b/packages/@uppy/dashboard/src/components/FileList.js
@@ -49,6 +49,7 @@ module.exports = (props) => {
     hideRetryButton: props.hideRetryButton,
     hidePauseResumeCancelButtons: props.hidePauseResumeCancelButtons,
     showLinkToFileUploadResult: props.showLinkToFileUploadResult,
+    showRemoveButtonAfterComplete: props.showRemoveButtonAfterComplete,
     isWide: props.isWide,
     metaFields: props.metaFields,
     // callbacks

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -121,6 +121,7 @@ module.exports = class Dashboard extends Plugin {
       proudlyDisplayPoweredByUppy: true,
       onRequestCloseModal: () => this.closeModal(),
       showSelectedFiles: true,
+      showRemoveButtonAfterComplete: false,
       browserBackButtonClose: false,
       theme: 'light'
     }
@@ -852,6 +853,7 @@ module.exports = class Dashboard extends Plugin {
       showLinkToFileUploadResult: this.opts.showLinkToFileUploadResult,
       proudlyDisplayPoweredByUppy: this.opts.proudlyDisplayPoweredByUppy,
       hideCancelButton: this.opts.hideCancelButton,
+      showRemoveButtonAfterComplete: this.opts.showRemoveButtonAfterComplete,
       containerWidth: pluginState.containerWidth,
       containerHeight: pluginState.containerHeight,
       areInsidesReadyToBeVisible: pluginState.areInsidesReadyToBeVisible,

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -42,6 +42,7 @@ declare module Dashboard {
     showLinkToFileUploadResult?: boolean
     showProgressDetails?: boolean
     showSelectedFiles?: boolean
+    showRemoveButtonAfterComplete: boolean
     replaceTargetContent?: boolean
     target?: Uppy.PluginTarget
     theme?: 'auto' | 'dark' | 'light'

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -42,7 +42,7 @@ declare module Dashboard {
     showLinkToFileUploadResult?: boolean
     showProgressDetails?: boolean
     showSelectedFiles?: boolean
-    showRemoveButtonAfterComplete: boolean
+    showRemoveButtonAfterComplete?: boolean
     replaceTargetContent?: boolean
     target?: Uppy.PluginTarget
     theme?: 'auto' | 'dark' | 'light'

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -91,6 +91,7 @@ uppy.use(Dashboard, {
   proudlyDisplayPoweredByUppy: true,
   onRequestCloseModal: () => this.closeModal(),
   showSelectedFiles: true,
+  showRemoveButtonAfterComplete: false,
   locale: defaultLocale,
   browserBackButtonClose: false,
   theme: 'light'
@@ -187,6 +188,10 @@ Hide Status Bar after the upload has finished.
 Show the list (grid) of selected files with preview and file name. In case you are showing selected files in your own app’s UI and want the Uppy Dashboard to just be a picker, the list can be hidden with this option.
 
 See also `disableStatusBar` option, which can hide the progress and upload button.
+
+### `showRemoveButtonAfterComplete: false`
+
+Sometimes you might want to let users remove an uploaded file. Enabling this option only shows the remove `X` button in the Dashboard UI, but to actually send a request you should listen to [`file-removed`](https://uppy.io/docs/uppy/#file-removed) event and add your logic there.
 
 ### `note: null`
 


### PR DESCRIPTION
Closes #2131 and so many others:

>  yamifr07 commented on Mar 27
> If the library just display a delete button developers can implement their own delete logic. I really like this plugin but I must be able to edit uploaded data

Also fixes an issue which broke “copy link” functionality after #2161