### PR TITLE
transloadit: fix property name typo

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -390,7 +390,7 @@ module.exports = class Transloadit extends Plugin {
   _onAssemblyFinished (status) {
     const url = status.assembly_ssl_url
     this.client.getAssemblyStatus(url).then((finalStatus) => {
-      const assemblyId = finalStatus.assemblyId
+      const assemblyId = finalStatus.assembly_id
       const state = this.getPluginState()
       this.setPluginState({
         assemblies: {


### PR DESCRIPTION
This was causing the `ASSEMBLY_COMPLETED` Assembly statuses to be stored
under an `undefined` key, so you wouldn't actually get the final status
in the result data for the upload.