### PR TITLE
chores: catch custom version suffices (alpha, beta etc.)

### DIFF
--- a/bin/make-new-versions-table
+++ b/bin/make-new-versions-table
@@ -21,12 +21,13 @@ const commit = match[1]
 
 const tagStdout = execSync(`git tag --list --contains ${commit}`)
 const tags = tagStdout.toString()
-const rx = /([@/\w-]+)@(\d+\.\d+\.\d+)/g
+const rx = /([@\/\w-]+)@(\d+\.\d+\.\d+)(-alpha\.\d+|-beta\.\d+)?/g
 
 const versions = []
 let m
 while ((m = rx.exec(tags))) {
-  const [, pkg, version] = m
+  const [, pkg, versionPrefix, versionSuffix] = m
+  const version = `${versionPrefix}${versionSuffix || ''}`
   versions.push({ pkg, version })
 }
 


### PR DESCRIPTION
avoids [this](https://github.com/transloadit/uppy/commit/239a97b23f057c2657c9873f7506948b1cf41da5) in the future.