### PR TITLE
companion: set grant related options for custom providers

### DIFF
--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -70,7 +70,13 @@ module.exports.getDefaultProviders = (companionOptions) => {
 module.exports.addCustomProviders = (customProviders, providers, grantConfig) => {
   Object.keys(customProviders).forEach((providerName) => {
     providers[providerName] = customProviders[providerName].module
-    grantConfig[providerName] = customProviders[providerName].config
+    const providerConfig = Object.assign({}, customProviders[providerName].config)
+    // todo: consider setting these options from a universal point also used
+    // by official providers. It'll prevent these from getting left out if the
+    // requirement changes.
+    providerConfig.callback = `/${providerName}/callback`
+    providerConfig.transport = 'session'
+    grantConfig[providerName] = providerConfig
   })
 }
 


### PR DESCRIPTION
following from [this PR](https://github.com/transloadit/uppy/pull/2310/files), it occurred to me that it don't make so much sense that users have to set [these options](https://github.com/transloadit/uppy/blob/4d54bf63633f90ac6b23456183e15d3622972805/examples/custom-provider/server/index.js#L57-L58).

Hence, in this PR, I am setting those options internally, so users won't have to set them anymore.