### PR TITLE
provider-views: handle all plugin state in provider-views

### DIFF
--- a/packages/@uppy/dropbox/src/index.js
+++ b/packages/@uppy/dropbox/src/index.js
@@ -35,16 +35,6 @@ module.exports = class Dropbox extends Plugin {
     this.view = new ProviderViews(this, {
       provider: this.provider
     })
-    // Set default state for Dropbox
-    this.setPluginState({
-      authenticated: false,
-      files: [],
-      folders: [],
-      directories: [],
-      activeRow: -1,
-      filterInput: '',
-      isSearchVisible: false
-    })
 
     const target = this.opts.target
     if (target) {

--- a/packages/@uppy/facebook/src/index.js
+++ b/packages/@uppy/facebook/src/index.js
@@ -35,16 +35,6 @@ module.exports = class Facebook extends Plugin {
     this.view = new ProviderViews(this, {
       provider: this.provider
     })
-    // Set default state for Dropbox
-    this.setPluginState({
-      authenticated: false,
-      files: [],
-      folders: [],
-      directories: [],
-      activeRow: -1,
-      filterInput: '',
-      isSearchVisible: false
-    })
 
     const target = this.opts.target
     if (target) {

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -37,19 +37,6 @@ module.exports = class GoogleDrive extends Plugin {
     this.view = new DriveProviderViews(this, {
       provider: this.provider
     })
-    // Set default state for Google Drive
-    this.setPluginState({
-      authenticated: false,
-      files: [],
-      folders: [],
-      directories: [],
-      activeRow: -1,
-      filterInput: '',
-      isSearchVisible: false,
-      hasTeamDrives: false,
-      teamDrives: [],
-      teamDriveId: ''
-    })
 
     const target = this.opts.target
     if (target) {

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -40,16 +40,6 @@ module.exports = class Instagram extends Plugin {
       showFilter: false,
       showBreadcrumbs: false
     })
-    // Set default state for Instagram
-    this.setPluginState({
-      authenticated: false,
-      files: [],
-      folders: [],
-      directories: [],
-      activeRow: -1,
-      filterInput: '',
-      isSearchVisible: false
-    })
 
     const target = this.opts.target
     if (target) {

--- a/packages/@uppy/onedrive/src/index.js
+++ b/packages/@uppy/onedrive/src/index.js
@@ -38,16 +38,6 @@ module.exports = class OneDrive extends Plugin {
     this.view = new ProviderViews(this, {
       provider: this.provider
     })
-    // Set default state for Dropbox
-    this.setPluginState({
-      authenticated: false,
-      files: [],
-      folders: [],
-      directories: [],
-      activeRow: -1,
-      filterInput: '',
-      isSearchVisible: false
-    })
 
     const target = this.opts.target
     if (target) {

--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -85,6 +85,17 @@ module.exports = class ProviderView {
     this.render = this.render.bind(this)
 
     this.clearSelection()
+
+    // Set default state for the plugin
+    this.plugin.setPluginState({
+      authenticated: false,
+      files: [],
+      folders: [],
+      directories: [],
+      activeRow: -1,
+      filterInput: '',
+      isSearchVisible: false
+    })
   }
 
   tearDown () {


### PR DESCRIPTION
Once again, after [putting this tutorial together](https://github.com/transloadit/uppy/pull/2310/files) it became more obvious that Plugins shouldn't be concerned with setting state fields that is specifically used by only the `ProviderViews`. It should all be left to the `ProviderViews` to handle it.