### PR TITLE
companion: block redirects to urls with different protocol

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -75,6 +75,22 @@ function isPrivateIP (ipAddress) {
 
 module.exports.FORBIDDEN_IP_ADDRESS = FORBIDDEN_IP_ADDRESS
 
+module.exports.getRedirectEvaluator = (requestURL, blockPrivateIPs) => {
+  const protocol = (new URL(requestURL)).protocol
+  return (res) => {
+    if (!blockPrivateIPs) {
+      return true
+    }
+
+    const redirectURL = res.headers.location
+    if (!redirectURL) {
+      return false
+    }
+
+    return new URL(redirectURL).protocol === protocol
+  }
+}
+
 /**
  * Returns http Agent that will prevent requests to private IPs (to preven SSRF)
  * @param {string} protocol http or http: or https: or https protocol needed for the request

--- a/packages/@uppy/companion/test/__tests__/http-agent.js
+++ b/packages/@uppy/companion/test/__tests__/http-agent.js
@@ -1,9 +1,39 @@
 /* global test:false, expect:false, describe:false, */
 
-const { getProtectedHttpAgent, FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
+const { getProtectedHttpAgent, getRedirectEvaluator, FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
 const request = require('request')
 const http = require('http')
 const https = require('https')
+
+describe('test getRedirectEvaluator', () => {
+  const httpURL = 'http://uppy.io'
+  const httpsURL = 'https://uppy.io'
+  const httpRedirectResp = {
+    headers: {
+      location: 'http://transloadit.com'
+    }
+  }
+
+  const httpsRedirectResp = {
+    headers: {
+      location: 'https://transloadit.com'
+    }
+  }
+
+  test('when original URL has "https:" as protocol', (done) => {
+    const shouldRedirectHttps = getRedirectEvaluator(httpsURL, true)
+    expect(shouldRedirectHttps(httpsRedirectResp)).toEqual(true)
+    expect(shouldRedirectHttps(httpRedirectResp)).toEqual(false)
+    done()
+  })
+
+  test('when original URL has "http:" as protocol', (done) => {
+    const shouldRedirectHttp = getRedirectEvaluator(httpURL, true)
+    expect(shouldRedirectHttp(httpRedirectResp)).toEqual(true)
+    expect(shouldRedirectHttp(httpsRedirectResp)).toEqual(false)
+    done()
+  })
+})
 
 describe('test getProtectedHttpAgent', () => {
   test('setting "https:" as protocol', (done) => {


### PR DESCRIPTION
following up from [this PR](https://github.com/transloadit/uppy/pull/2083), it was reported that the SSRF issue may persist via redirects. The reason is because, even though [this custom dnsLookup](https://github.com/transloadit/uppy/blob/9355c1e3130700653179d6d7cc761e574b4a5ebd/packages/%40uppy/companion/src/server/helpers/request.js#L91-L108) is meant to prevent ips related to redirects as well, our custom [httpAgents](https://github.com/transloadit/uppy/blob/9355c1e3130700653179d6d7cc761e574b4a5ebd/packages/%40uppy/companion/src/server/helpers/request.js#L91-L108) (which contain the custom dnsLookup) get dropped whenever [the protocol of the redirect URL is different from the protocol of the original URL](https://github.com/request/request/blob/master/lib/redirect.js#L110-L113).

So in summary:

- if https://someurl.com redirects to https://someotherurl.com SSRF CANNOT occur
- if https://someurl.com redirects to http://someotherurl.com SSRF CAN occur
- if http://someurl.com redirects to http://someotherurl.com SSRF CANNOT occur
- if http://someurl.com redirects to https://someotherurl.com SSRF CAN occur

in order to fix this, this PR adds a custom redirect inspection function which allows redirects only when the protocol remains the same throughout the request+redirects. Once a redirect with different protocol is detected, the redirect will be disabled, and request will NOT continue. 



