### PR TITLE
Fix for #2324 (parts duplicate on repeated upload restart)

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -34,7 +34,7 @@ class MultipartUploader {
 
     this.key = this.options.key || null
     this.uploadId = this.options.uploadId || null
-    this.parts = this.options.parts || []
+    this.parts = this.options.parts ? [...this.options.parts] : []
 
     // Do `this.createdPromise.then(OP)` to execute an operation `OP` _only_ if the
     // upload was created already. That also ensures that the sequencing is right


### PR DESCRIPTION
Making sure MultipartUploader.parts and <uppy file state>.s3Multipart.parts are always different arrays and do not become the same on upload retry.