### PR TITLE
S3 multipart: Do not store completed parts in state

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -34,7 +34,7 @@ class MultipartUploader {
 
     this.key = this.options.key || null
     this.uploadId = this.options.uploadId || null
-    this.parts = this.options.parts || []
+    this.parts = []
 
     // Do `this.createdPromise.then(OP)` to execute an operation `OP` _only_ if the
     // upload was created already. That also ensures that the sequencing is right

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -135,7 +135,6 @@ module.exports = class AwsS3Multipart extends Plugin {
             ...cFile.s3Multipart,
             key: data.key,
             uploadId: data.uploadId,
-            parts: []
           }
         })
       }
@@ -175,20 +174,10 @@ module.exports = class AwsS3Multipart extends Plugin {
       }
 
       const onPartComplete = (part) => {
-        // Store completed parts in state.
         const cFile = this.uppy.getFile(file.id)
         if (!cFile) {
           return
         }
-        this.uppy.setFileState(file.id, {
-          s3Multipart: {
-            ...cFile.s3Multipart,
-            parts: [
-              ...cFile.s3Multipart.parts,
-              part
-            ]
-          }
-        })
 
         this.uppy.emit('s3-multipart:part-uploaded', cFile, part)
       }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -134,7 +134,7 @@ module.exports = class AwsS3Multipart extends Plugin {
           s3Multipart: {
             ...cFile.s3Multipart,
             key: data.key,
-            uploadId: data.uploadId,
+            uploadId: data.uploadId
           }
         })
       }


### PR DESCRIPTION
Do not store completed parts in state as they can be retrieved from S3 and do not need to be stored locally (this also fixes #2324)

closes #2325