### PR TITLE
Import url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ jobs:
       services:
         - docker
       script:
-        - nvm install 8.0.0
-        - nvm use 8.0.0
+        - nvm install 8.16.0
+        - nvm use 8.16.0
         - npm run test:companion
     # Build the website when things are merged to master
     # https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,14 @@ jobs:
         - nvm install 10.0.0
         - nvm use 10.0.0
         - npm run test:companion
+    - name: 'Run Companion tests (Node.js 8)'
+      node_js: 12
+      services:
+        - docker
+      script:
+        - nvm install 8.0.0
+        - nvm use 8.0.0
+        - npm run test:companion
     # Build the website when things are merged to master
     # https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on
     - name: 'Build website'

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -1,5 +1,6 @@
 const http = require('http')
 const https = require('https')
+const { URL } = require('url')
 const dns = require('dns')
 const ipAddress = require('ip-address')
 const FORBIDDEN_IP_ADDRESS = 'Forbidden IP address'


### PR DESCRIPTION
it seems companion.uppy.io is running on node < 10.0 where `URL` is not a global object, so it's breaking as reported here #2327 

The tests (or trying it locally) couldn't catch this because it runs on node 10+

fixes #2327 