### PR TITLE
companion: fixes docker version tagging. fixes #1579.

### DIFF
--- a/packages/@uppy/companion/infra/kube/gcloud-deploy.sh
+++ b/packages/@uppy/companion/infra/kube/gcloud-deploy.sh
@@ -20,12 +20,16 @@ mv ./kubectl ${HOME}/.local/bin/
 docker build -t transloadit/companion:latest -t transloadit/companion:$TRAVIS_COMMIT -f packages/@uppy/companion/Dockerfile packages/@uppy/companion;
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
 
-if [[ -z "${TRAVIS_TAG}" ]]; then
-  docker push transloadit/companion:$TRAVIS_COMMIT;
-else
+# Push the commit tagged docker image.
+docker push transloadit/companion:$TRAVIS_COMMIT;
+
+# If this build includes a git tag, tag the image with the git version tag and push the version.
+if [[ ! -z "${TRAVIS_TAG}" ]]; then
+  docker tag transloadit/companion:$TRAVIS_COMMIT transloadit/companion:$TRAVIS_TAG;
   docker push transloadit/companion:$TRAVIS_TAG;
 fi
 
+# Lastly, update the pointer to latest.
 docker push transloadit/companion:latest;
 
 


### PR DESCRIPTION
So, turns out I never checked in on the code fix for this..
Currently what happens:

```sh
docker build -t transloadit/companion:latest -t transloadit/companion:$TRAVIS_COMMIT -f packages/@uppy/companion/Dockerfile packages/@uppy/companion;

# `docker images` returns:
# REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
# transloadit/companion   latest              123456789           2020-06-30          5MB
# transloadit/companion   d33db33f            123456789           2020-06-30          5MB

if [[ -z "${TRAVIS_TAG}" ]]; then
  # Pushes up the image ONLY if tag is empty
  docker push transloadit/companion:$TRAVIS_COMMIT;
else
  # 💥 docker can't find version tagged image, as it was never tagged...
  docker push transloadit/companion:$TRAVIS_TAG;
fi
```

So now, we have:
```sh
docker build -t transloadit/companion:latest -t transloadit/companion:$TRAVIS_COMMIT -f packages/@uppy/companion/Dockerfile packages/@uppy/companion;

# `docker images` returns:
# REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
# transloadit/companion   latest              123456789           2020-06-30          5MB
# transloadit/companion   d33db33f            123456789           2020-06-30          5MB

# If tag is not empty; then....
if [[ ! -z "${TRAVIS_TAG}" ]]; then
  # Tag the image with the git tag...
  # Refer: https://docs.docker.com/engine/reference/commandline/tag/
  docker tag transloadit/companion:$TRAVIS_COMMIT transloadit/companion:$TRAVIS_TAG;

# `docker images` returns:
# REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
# transloadit/companion   latest              123456789           2020-06-30          5MB
# transloadit/companion   d33db33f            123456789           2020-06-30          5MB
# transloadit/companion   vL.0.L              123456789           2020-06-30          5MB
  
  # Docker can now find and successfully push up the version tagged image 🐳🎉
  docker push transloadit/companion:$TRAVIS_TAG;
fi
```