### PR TITLE
companion: override grant's default redirect_uri for consistent provider options

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -12,7 +12,6 @@ module.exports = class Provider extends RequestClient {
     super(uppy, opts)
     this.provider = opts.provider
     this.id = this.provider
-    this.authProvider = opts.authProvider || this.provider
     this.name = this.opts.name || _getName(this.id)
     this.pluginId = this.opts.pluginId
     this.tokenKey = `companion-${this.pluginId}-auth-token`

--- a/packages/@uppy/companion-client/types/index.d.ts
+++ b/packages/@uppy/companion-client/types/index.d.ts
@@ -37,7 +37,6 @@ export interface PublicProviderOptions extends RequestClientOptions {
  */
 export interface ProviderOptions extends PublicProviderOptions {
   provider: string
-  authProvider?: string
   name?: string
   pluginId: string
 }

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -335,4 +335,14 @@ const validateConfig = (companionOptions) => {
       `No access to "${companionOptions.filePath}". Please ensure the directory exists and with read/write permissions.`
     )
   }
+
+  const { providerOptions } = companionOptions
+  if (providerOptions) {
+    const deprecatedOptions = { microsoft: 'onedrive', google: 'drive' }
+    Object.keys(deprecatedOptions).forEach((deprected) => {
+      if (providerOptions[deprected]) {
+        throw new Error(`The Provider option "${deprected}" is no longer supported. Please use the option "${deprecatedOptions[deprected]}" instead.`)
+      }
+    })
+  }
 }

--- a/packages/@uppy/companion/src/config/grant.js
+++ b/packages/@uppy/companion/src/config/grant.js
@@ -1,6 +1,7 @@
 // oauth configuration for provider services that are used.
 module.exports = () => {
   return {
+    // for drive
     google: {
       transport: 'session',
       scope: [
@@ -23,6 +24,7 @@ module.exports = () => {
       scope: ['email', 'user_photos'],
       callback: '/facebook/callback'
     },
+    // for onedrive
     microsoft: {
       transport: 'session',
       scope: ['files.read.all', 'offline_access', 'User.Read'],

--- a/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
+++ b/packages/@uppy/companion/src/server/controllers/oauth-redirect.js
@@ -9,6 +9,12 @@ const oAuthState = require('../helpers/oauth-state')
  * @param {object} res
  */
 module.exports = function oauthRedirect (req, res) {
+  const params = qs.stringify(req.query)
+  const authProvider = req.companion.provider.authProvider
+  if (!req.companion.options.server.oauthDomain) {
+    return res.redirect(`/connect/${authProvider}/callback?${params}`)
+  }
+
   const dynamic = (req.session.grant || {}).dynamic || {}
   const state = dynamic.state
   if (!state) {
@@ -18,9 +24,7 @@ module.exports = function oauthRedirect (req, res) {
   const handlerHostName = (new URL(handler)).host
 
   if (hasMatch(handlerHostName, req.companion.options.server.validHosts)) {
-    const providerName = req.companion.provider.authProvider
-    const params = qs.stringify(req.query)
-    const url = `${handler}/connect/${providerName}/callback?${params}`
+    const url = `${handler}/connect/${authProvider}/callback?${params}`
     return res.redirect(url)
   }
 

--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -110,9 +110,10 @@ module.exports.addProviderOptions = (companionOptions, grantConfig) => {
       Object.assign(grantConfig[authProvider], provider.getExtraConfig())
 
       // override grant.js redirect uri with companion's custom redirect url
+      const isExternal = !!server.implicitPath
+      const redirectPath = `/${providerName}/redirect`
+      grantConfig[authProvider].redirect_uri = getURLBuilder(companionOptions)(redirectPath, isExternal)
       if (oauthDomain) {
-        const redirectPath = `/${providerName}/redirect`
-        const isExternal = !!server.implicitPath
         const fullRedirectPath = getURLBuilder(companionOptions)(redirectPath, isExternal, true)
         grantConfig[authProvider].redirect_uri = `${server.protocol}://${oauthDomain}${fullRedirectPath}`
       }

--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -100,17 +100,17 @@ module.exports.addProviderOptions = (companionOptions, grantConfig) => {
 
   const { oauthDomain } = server
   const keys = Object.keys(providerOptions).filter((key) => key !== 'server')
-  keys.forEach((authProvider) => {
-    if (grantConfig[authProvider]) {
+  keys.forEach((providerName) => {
+    const authProvider = providerNameToAuthName(providerName, companionOptions)
+    if (authProvider && grantConfig[authProvider]) {
       // explicitly add providerOptions so users don't override other providerOptions.
-      grantConfig[authProvider].key = providerOptions[authProvider].key
-      grantConfig[authProvider].secret = providerOptions[authProvider].secret
-      const { provider, name } = authNameToProvider(authProvider, companionOptions)
+      grantConfig[authProvider].key = providerOptions[providerName].key
+      grantConfig[authProvider].secret = providerOptions[providerName].secret
+      const provider = exports.getDefaultProviders(companionOptions)[providerName]
       Object.assign(grantConfig[authProvider], provider.getExtraConfig())
 
       // override grant.js redirect uri with companion's custom redirect url
       if (oauthDomain) {
-        const providerName = name
         const redirectPath = `/${providerName}/redirect`
         const isExternal = !!server.implicitPath
         const fullRedirectPath = getURLBuilder(companionOptions)(redirectPath, isExternal, true)
@@ -131,19 +131,13 @@ module.exports.addProviderOptions = (companionOptions, grantConfig) => {
 
 /**
  *
- * @param {string} authProvider
+ * @param {string} name of the provider
  * @param {{server: object, providerOptions: object}} options
- * @return {{name: string, provider: typeof Provider}}
+ * @return {string} the authProvider for this provider
  */
-const authNameToProvider = (authProvider, options) => {
+const providerNameToAuthName = (name, options) => {
   const providers = exports.getDefaultProviders(options)
-  const providerNames = Object.keys(providers)
-  for (const name of providerNames) {
-    const provider = providers[name]
-    if (provider.authProvider === authProvider) {
-      return { name, provider }
-    }
-  }
+  return (providers[name] || {}).authProvider
 }
 
 /**

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -29,7 +29,7 @@ const getConfigFromEnv = () => {
 
   return {
     providerOptions: {
-      google: {
+      drive: {
         key: process.env.COMPANION_GOOGLE_KEY,
         secret: getSecret('COMPANION_GOOGLE_SECRET')
       },
@@ -45,7 +45,7 @@ const getConfigFromEnv = () => {
         key: process.env.COMPANION_FACEBOOK_KEY,
         secret: getSecret('COMPANION_FACEBOOK_SECRET')
       },
-      microsoft: {
+      onedrive: {
         key: process.env.COMPANION_ONEDRIVE_KEY,
         secret: getSecret('COMPANION_ONEDRIVE_SECRET')
       },

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -182,7 +182,7 @@ if (process.env.COMPANION_PATH) {
 // Only set COMPANION_ONEDRIVE_DOMAIN_VALIDATION if you are sure that you are setting the
 // correct value for COMPANION_ONEDRIVE_KEY (i.e application ID). If there's a slightest possiblilty
 // that you might have mixed the values for COMPANION_ONEDRIVE_KEY and COMPANION_ONEDRIVE_SECRET,
-// please do not set a value for COMPANION_ONEDRIVE_DOMAIN_VALIDATION
+// please DO NOT set any value for COMPANION_ONEDRIVE_DOMAIN_VALIDATION
 if (process.env.COMPANION_ONEDRIVE_DOMAIN_VALIDATION === 'true' && process.env.COMPANION_ONEDRIVE_KEY) {
   app.get('/.well-known/microsoft-identity-association.json', (req, res) => {
     const content = JSON.stringify({

--- a/packages/@uppy/google-drive/src/index.js
+++ b/packages/@uppy/google-drive/src/index.js
@@ -25,7 +25,6 @@ module.exports = class GoogleDrive extends Plugin {
       companionUrl: this.opts.companionUrl,
       companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       provider: 'drive',
-      authProvider: 'google',
       pluginId: this.id
     })
 

--- a/packages/@uppy/instagram/src/index.js
+++ b/packages/@uppy/instagram/src/index.js
@@ -24,7 +24,6 @@ module.exports = class Instagram extends Plugin {
       companionUrl: this.opts.companionUrl,
       companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
       provider: 'instagram',
-      authProvider: 'instagram',
       pluginId: this.id
     })
 


### PR DESCRIPTION
With this PR, all redirect_uris that will be provided to oauth dashboards can now be consistent with the pattern: 
`/${providerName}/redirect`

so for Google Drive: `/drive/redirect` previously `/connect/google/callback`
for OneDrive: `/onedrive/redirect` previously `/connect/microsoft/callback` (confusing, I know)
for Facebook: `/facebook/redirect` previously `/connect/facebook/callback`

It'll avoid confusions like [this one](https://github.com/transloadit/uppy/pull/2345#discussion_r446966856)

PS: I created this PR against the `rename-microsoft-opt` branch to avoid conflicts pending the time the #2346 PR gets merged.