### PR TITLE
core: do not create an upload in retryAll() if there were no errors

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -853,6 +853,13 @@ class Uppy {
 
     this.emit('retry-all', filesToRetry)
 
+    if (filesToRetry.length === 0) {
+      return Promise.resolve({
+        successful: [],
+        failed: []
+      })
+    }
+
     const uploadID = this._createUpload(filesToRetry, {
       forceAllowNewUpload: true // create new upload even if allowNewUpload: false
     })

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -983,6 +983,48 @@ describe('src/Core', () => {
     })
   })
 
+  describe('retries', () => {
+    it('should start a new upload with failed files', async () => {
+      const onUpload = jest.fn()
+      const onRetryAll = jest.fn()
+
+      const core = new Core()
+      core.on('upload', onUpload)
+      core.on('retry-all', onRetryAll)
+
+      const id = core.addFile({
+        source: 'jest',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: new File([sampleImage], { type: 'image/jpeg' })
+      })
+      core.setFileState(id, {
+        error: 'something went wrong'
+      })
+
+      await core.retryAll()
+      expect(onRetryAll).toHaveBeenCalled()
+      expect(onUpload).toHaveBeenCalled()
+    })
+
+    it('should not start a new upload if there are no failed files', async () => {
+      const onUpload = jest.fn()
+
+      const core = new Core()
+      core.on('upload', onUpload)
+
+      core.addFile({
+        source: 'jest',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: new File([sampleImage], { type: 'image/jpeg' })
+      })
+
+      await core.retryAll()
+      expect(onUpload).not.toHaveBeenCalled()
+    })
+  })
+
   describe('restoring a file', () => {
     xit('should restore a file', () => {})
 


### PR DESCRIPTION
fixes #2298

If there are no files to retry, short-circuit instead of running through the entire upload pipeline without any files.