### PR TITLE
tus: fix typo, fixes #2376

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -271,7 +271,7 @@ module.exports = class Tus extends Plugin {
       if (opts.resume) {
         upload.findPreviousUploads().then((previousUploads) => {
           const previousUpload = previousUploads[0]
-          if (previousUploads) {
+          if (previousUpload) {
             this.uppy.log(`[Tus] Resuming upload of ${file.id} started at ${previousUpload.creationTime}`)
             upload.resumeFromPreviousUpload(previousUpload)
           }


### PR DESCRIPTION
We should be checking if the array _element_ exists, not if the _array_ exists.