### PR TITLE
dashboard: preact version fun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7551,7 +7551,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.0.4",
         "preact": "8.2.9",
-        "preact-css-transition-group": "^1.3.0",
+        "preact8-css-transition-group": "^2.0.0",
         "resize-observer-polyfill": "^1.5.0"
       },
       "dependencies": {
@@ -31164,11 +31164,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
       "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA=="
     },
-    "preact-css-transition-group": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/preact-css-transition-group/-/preact-css-transition-group-1.3.0.tgz",
-      "integrity": "sha1-Bv5Giyb3gC6VuCmnYtsLwZmu85k="
-    },
     "preact-render-to-string": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-4.1.0.tgz",
@@ -31183,6 +31178,11 @@
           "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
         }
       }
+    },
+    "preact8-css-transition-group": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/preact8-css-transition-group/-/preact8-css-transition-group-2.0.0.tgz",
+      "integrity": "sha512-jW6kO5eN9q5ySRlz5KsXNkUQ5h/bfK+0iDrokg1txtcaWvYoBp7IesnITe9CdG+ucmbIPReD1LNFkq9+kSAURw=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -35,7 +35,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.0.4",
     "preact": "8.2.9",
-    "preact8-css-transition-group": "^2.0.0",
+    "preact8-css-transition-group": "^2.1.0",
     "resize-observer-polyfill": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -35,7 +35,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.0.4",
     "preact": "8.2.9",
-    "preact-css-transition-group": "^1.3.0",
+    "preact8-css-transition-group": "^2.0.0",
     "resize-observer-polyfill": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/@uppy/dashboard/src/components/Dashboard.js
+++ b/packages/@uppy/dashboard/src/components/Dashboard.js
@@ -8,7 +8,7 @@ const FileCard = require('./FileCard')
 const classNames = require('classnames')
 const isDragDropSupported = require('@uppy/utils/lib/isDragDropSupported')
 const { h } = require('preact')
-const PreactCSSTransitionGroup = require('preact-css-transition-group')
+const PreactCSSTransitionGroup = require('preact8-css-transition-group')
 
 // http://dev.edenspiekermann.com/2016/02/11/introducing-accessible-modal-dialog
 // https://github.com/ghosh/micromodal


### PR DESCRIPTION
Fixes #2226 
Fixes #2377 

preact-css-transition-group has specified a peerDependency on _any_ preact version.
```json
"peerDependencies": {
  "preact": "*"
}
```
this means that if you have a Preact X-based app with a dependency tree like this:

```
app
 - preact@10
 - @uppy/dashboard
   - preact@8
   - preact-css-transition-group
```
npm is allowed to hoist preact-css-transition-group up like this:
```
app
 - preact@10
 - preact-css-transition-group
 - @uppy/dashboard
   - preact@8
```

Now, when preact-css-transition-group does `require('preact')`, it gets preact X and not preact 8. This way preact 8 nodes created by the Dashboard can flow into preact 10 nodes created by preact-css-transition-group.

I tried to address this by pinning the peer dependency and republishing the package as [preact8-css-transition-group](https://github.com/goto-bus-stop/preact8-css-transition-group):
```json
"peerDependencies": {
  "preact": "^8.0.0"
}
```
Unfortunately, it looks like npm's peer dependency resolution does not take it into account the way I hoped, and the above issue could still occur (but now at least npm would warn about the peer dependency being the wrong version.)

In the end, I added a regular dependency on preact@^8.0.0, which should hopefully do the trick here.
```json
"dependencies": {
  "preact": "^8.0.0"
}
```