### PR TITLE
companion: add required 'content-length' header if not present

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -488,6 +488,12 @@ class Uploader {
       reqOptions.body = file
     }
 
+    if (!Object.keys(headers).some(key => key.toLowerCase() === 'content-length')) {
+      const stats = fs.statSync(this.path)
+      const fileSizeInBytes = stats.size
+      reqOptions.headers['content-length'] = fileSizeInBytes
+    }
+
     request[httpMethod](reqOptions, (error, response, body) => {
       if (error) {
         logger.error(error, 'upload.multipart.error')


### PR DESCRIPTION
This fixes an issue of uploads to s3 from companion failing due to no 'content-length' header being sent. 