### PR TITLE
aws-s3: MiniXHRUpload: don't use method that requires a XMLHttpRequest instance with socket reponse object

### DIFF
--- a/bin/build-lib.js
+++ b/bin/build-lib.js
@@ -47,7 +47,7 @@ async function buildLib () {
       }
     }
 
-    const { code, map } = await transformFile(file, {})
+    const { code, map } = await transformFile(file, { sourceMaps: true })
     await mkdirp(path.dirname(libFile))
     await Promise.all([
       writeFile(libFile, code),

--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -324,13 +324,9 @@ module.exports = class MiniXHRUpload {
         socket.on('progress', (progressData) => emitSocketProgress(this, progressData, file))
 
         socket.on('success', (data) => {
-          const body = opts.getResponseData(data.response.responseText, data.response)
-          const uploadURL = body[opts.responseUrlFieldName]
-
           const uploadResp = {
             status: data.response.status,
-            body,
-            uploadURL
+            body: data.response.responseText
           }
 
           this.uppy.emit('upload-success', file, uploadResp)
@@ -343,10 +339,7 @@ module.exports = class MiniXHRUpload {
         })
 
         socket.on('error', (errData) => {
-          const resp = errData.response
-          const error = resp
-            ? opts.getResponseError(resp.responseText, resp)
-            : Object.assign(new Error(errData.error.message), { cause: errData.error })
+          const error = Object.assign(new Error(errData.error.message), { cause: errData.error })
           this.uppy.emit('upload-error', file, error)
           queuedRequest.done()
           if (this.uploaderEvents[file.id]) {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -34,6 +34,7 @@ const hasProperty = require('@uppy/utils/lib/hasProperty')
 const { RequestClient } = require('@uppy/companion-client')
 const qsStringify = require('qs-stringify')
 const MiniXHRUpload = require('./MiniXHRUpload')
+const isXml = require('./isXml')
 
 function resolveUrl (origin, link) {
   return origin
@@ -41,33 +42,18 @@ function resolveUrl (origin, link) {
     : new URL_(link).toString()
 }
 
-function isXml (content, xhr) {
-  const rawContentType = (xhr.headers ? xhr.headers['content-type'] : xhr.getResponseHeader('Content-Type'))
-
-  if (rawContentType === null) {
-    return false
-  }
-
-  // Get rid of mime parameters like charset=utf-8
-  const contentType = rawContentType.replace(/;.*$/, '').toLowerCase()
-  if (typeof contentType === 'string') {
-    if (contentType === 'application/xml' || contentType === 'text/xml') {
-      return true
-    }
-    // GCS uses text/html for some reason
-    // https://github.com/transloadit/uppy/issues/896
-    if (contentType === 'text/html' && /^<\?xml /.test(content)) {
-      return true
-    }
-  }
-  return false
-}
-
-function getXmlValue (source, key) {
-  const start = source.indexOf(`<${key}>`)
-  const end = source.indexOf(`</${key}>`, start)
+/**
+ * Get the contents of a named tag in an XML source string.
+ *
+ * @param {string} source - The XML source string.
+ * @param {string} tagName - The name of the tag.
+ * @returns {string} The contents of the tag, or the empty string if the tag does not exist.
+ */
+function getXmlValue (source, tagName) {
+  const start = source.indexOf(`<${tagName}>`)
+  const end = source.indexOf(`</${tagName}>`, start)
   return start !== -1 && end !== -1
-    ? source.slice(start + key.length + 2, end)
+    ? source.slice(start + tagName.length + 2, end)
     : ''
 }
 

--- a/packages/@uppy/aws-s3/src/isXml.js
+++ b/packages/@uppy/aws-s3/src/isXml.js
@@ -1,0 +1,39 @@
+/**
+ * Remove parameters like `charset=utf-8` from the end of a mime type string.
+ *
+ * @param {string} mimeType - The mime type string that may have optional parameters.
+ * @returns {string} The "base" mime type, i.e. only 'category/type'.
+ */
+function removeMimeParameters (mimeType) {
+  return mimeType.replace(/;.*$/, '')
+}
+
+/**
+ * Check if a response contains XML based on the response object and its text content.
+ *
+ * @param {string} content - The text body of the response.
+ * @param {object|XMLHttpRequest} xhr - The XHR object or response object from Companion.
+ * @returns {bool} Whether the content is (probably) XML.
+ */
+function isXml (content, xhr) {
+  const rawContentType = (xhr.headers ? xhr.headers['content-type'] : xhr.getResponseHeader('Content-Type'))
+
+  if (rawContentType == null) {
+    return false
+  }
+
+  if (typeof rawContentType === 'string') {
+    const contentType = removeMimeParameters(rawContentType).toLowerCase()
+    if (contentType === 'application/xml' || contentType === 'text/xml') {
+      return true
+    }
+    // GCS uses text/html for some reason
+    // https://github.com/transloadit/uppy/issues/896
+    if (contentType === 'text/html' && /^<\?xml /.test(content)) {
+      return true
+    }
+  }
+  return false
+}
+
+module.exports = isXml

--- a/packages/@uppy/aws-s3/src/isXml.test.js
+++ b/packages/@uppy/aws-s3/src/isXml.test.js
@@ -1,0 +1,64 @@
+const isXml = require('./isXml')
+
+describe('AwsS3', () => {
+  describe('isXml', () => {
+    it('returns true for XML documents', () => {
+      const content = '<?xml version="1.0" encoding="UTF-8"?><Key>image.jpg</Key>'
+      expect(isXml(content, {
+        getResponseHeader: () => 'application/xml'
+      })).toEqual(true)
+      expect(isXml(content, {
+        getResponseHeader: () => 'text/xml'
+      })).toEqual(true)
+      expect(isXml(content, {
+        getResponseHeader: () => 'text/xml; charset=utf-8'
+      })).toEqual(true)
+      expect(isXml(content, {
+        getResponseHeader: () => 'application/xml; charset=iso-8859-1'
+      })).toEqual(true)
+    })
+
+    it('returns true for GCS XML documents', () => {
+      const content = '<?xml version="1.0" encoding="UTF-8"?><Key>image.jpg</Key>'
+      expect(isXml(content, {
+        getResponseHeader: () => 'text/html'
+      })).toEqual(true)
+      expect(isXml(content, {
+        getResponseHeader: () => 'text/html; charset=utf8'
+      })).toEqual(true)
+    })
+
+    it('returns true for remote response objects', () => {
+      const content = '<?xml version="1.0" encoding="UTF-8"?><Key>image.jpg</Key>'
+      expect(isXml(content, {
+        headers: { 'content-type': 'application/xml' }
+      })).toEqual(true)
+      expect(isXml(content, {
+        headers: { 'content-type': 'application/xml' }
+      })).toEqual(true)
+      expect(isXml(content, {
+        headers: { 'content-type': 'text/html' }
+      })).toEqual(true)
+    })
+
+    it('returns false when content-type is missing', () => {
+      const content = '<?xml version="1.0" encoding="UTF-8"?><Key>image.jpg</Key>'
+      expect(isXml(content, {
+        getResponseHeader: () => null
+      })).toEqual(false)
+      expect(isXml(content, {
+        headers: { 'content-type': null }
+      })).toEqual(false)
+      expect(isXml(content, {
+        headers: {}
+      })).toEqual(false)
+    })
+
+    it('returns false for HTML documents', () => {
+      const content = '<!DOCTYPE html><html>'
+      expect(isXml(content, {
+        getResponseHeader: () => 'text/html'
+      })).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
The deeper problem to an issue I submited a fix for https://github.com/transloadit/uppy/pull/2388/commits is that `MiniXHRUpload.js` is calling `opts.getResponseData` which calls `defaultGetResponseData` which expects an `XMLHttpRequest` object as a param. This causes an error when `defaultGetResponseData` calls `isXml` which tries to call `getResponseHeader` on what it expects to be an `XMLHttpRequest` object but it's not so the methd doesn't exist and returns an unhandled `undefined`.

Since the socket response value is not a `XMLHttpRequest` these methods cannot be used in their current state.
My solution my not be the most desirable but hopefully this is a useful prod in the right direction.