### PR TITLE
Added new string 'browseFiles' (same as 'browse')

### DIFF
--- a/packages/@uppy/locales/src/de_DE.js
+++ b/packages/@uppy/locales/src/de_DE.js
@@ -10,6 +10,7 @@ de_DE.strings = {
   back: 'Zurück',
   addMore: 'Dateien hinzufügen',
   browse: 'Suche',
+  browseFiles: 'Suche',
   cancel: 'Abbrechen',
   cancelUpload: 'Upload abbrechen',
   chooseFiles: 'Dateien auswählen',


### PR DESCRIPTION
If 'browseFiles' isn't defined, the default English text will show, which is ofc. undesired.