### PR TITLE
dashboard: mostly restore backwards compatibility for the `browse` strings

### DIFF
--- a/packages/@uppy/dashboard/src/components/AddFiles.js
+++ b/packages/@uppy/dashboard/src/components/AddFiles.js
@@ -109,23 +109,59 @@ class AddFiles extends Component {
     )
   }
 
+  // TODO(2.x) remove all the backwards compatibility garbage here
   renderDropPasteBrowseTagline = () => {
     const numberOfAcquirers = this.props.acquirers.length
-    const browseFiles = this.renderBrowseButton(this.props.i18n('browseFiles'), this.triggerFileInputClick)
-    const browseFolders = this.renderBrowseButton(this.props.i18n('browseFolders'), this.triggerFolderInputClick)
+
+    // For backwards compatibility, we need to support both 'browse' and 'browseFiles'/'browseFolders' as strings here.
+    let browseFilesText = 'browse'
+    let browseFoldersText = 'browse'
+    try {
+      browseFilesText = this.props.i18n('browse')
+      browseFoldersText = this.props.i18n('browse')
+    } catch {
+      // Ignore, hopefully we can use the 'browseFiles' / 'browseFolders' strings
+    }
+    try {
+      browseFilesText = this.props.i18n('browseFiles')
+      browseFoldersText = this.props.i18n('browseFolders')
+    } catch {
+      // Ignore, use the 'browse' string
+    }
+
+    const browseFiles = this.renderBrowseButton(browseFilesText, this.triggerFileInputClick)
+    const browseFolders = this.renderBrowseButton(browseFoldersText, this.triggerFolderInputClick)
 
     // in order to keep the i18n CamelCase and options lower (as are defaults) we will want to transform a lower
     // to Camel
     const lowerFMSelectionType = this.props.fileManagerSelectionType
     const camelFMSelectionType = lowerFMSelectionType.charAt(0).toUpperCase() + lowerFMSelectionType.slice(1)
 
+    // Before the `fileManagerSelectionType` feature existed, we had two possible
+    // strings here, but now we have six. We use the new-style strings by default:
+    let titleText
+    if (numberOfAcquirers > 0) {
+      titleText = this.props.i18nArray(`dropPasteImport${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
+    } else {
+      titleText = this.props.i18nArray(`dropPasteImport${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
+    }
+
+    // We use the old-style strings if available: this implies that the user has
+    // manually specified them, so they should take precedence over the new-style
+    // defaults.
+    try {
+      if (numberOfAcquirers > 0) {
+        titleText = this.props.i18nArray('dropPaste', { browse: browseFiles })
+      } else {
+        titleText = this.props.i18nArray('dropPasteImport', { browse: browseFiles })
+      }
+    } catch {
+      // Ignore, the new-style strings will be used.
+    }
+
     return (
       <div class="uppy-Dashboard-AddFiles-title">
-        {
-          numberOfAcquirers > 0
-            ? this.props.i18nArray(`dropPasteImport${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
-            : this.props.i18nArray(`dropPaste${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
-        }
+        {titleText}
       </div>
     )
   }

--- a/packages/@uppy/dashboard/src/components/AddFiles.js
+++ b/packages/@uppy/dashboard/src/components/AddFiles.js
@@ -112,15 +112,21 @@ class AddFiles extends Component {
   // TODO(2.x) remove all the backwards compatibility garbage here
   renderDropPasteBrowseTagline = () => {
     const numberOfAcquirers = this.props.acquirers.length
+    // in order to keep the i18n CamelCase and options lower (as are defaults) we will want to transform a lower
+    // to Camel
+    const lowerFMSelectionType = this.props.fileManagerSelectionType
+    const camelFMSelectionType = lowerFMSelectionType.charAt(0).toUpperCase() + lowerFMSelectionType.slice(1)
 
     // For backwards compatibility, we need to support both 'browse' and 'browseFiles'/'browseFolders' as strings here.
     let browseFilesText = 'browse'
     let browseFoldersText = 'browse'
-    try {
-      browseFilesText = this.props.i18n('browse')
-      browseFoldersText = this.props.i18n('browse')
-    } catch {
-      // Ignore, hopefully we can use the 'browseFiles' / 'browseFolders' strings
+    if (lowerFMSelectionType === 'files') {
+      try {
+        browseFilesText = this.props.i18n('browse')
+        browseFoldersText = this.props.i18n('browse')
+      } catch {
+        // Ignore, hopefully we can use the 'browseFiles' / 'browseFolders' strings
+      }
     }
     try {
       browseFilesText = this.props.i18n('browseFiles')
@@ -131,11 +137,6 @@ class AddFiles extends Component {
 
     const browseFiles = this.renderBrowseButton(browseFilesText, this.triggerFileInputClick)
     const browseFolders = this.renderBrowseButton(browseFoldersText, this.triggerFolderInputClick)
-
-    // in order to keep the i18n CamelCase and options lower (as are defaults) we will want to transform a lower
-    // to Camel
-    const lowerFMSelectionType = this.props.fileManagerSelectionType
-    const camelFMSelectionType = lowerFMSelectionType.charAt(0).toUpperCase() + lowerFMSelectionType.slice(1)
 
     // Before the `fileManagerSelectionType` feature existed, we had two possible
     // strings here, but now we have six. We use the new-style strings by default:
@@ -149,14 +150,16 @@ class AddFiles extends Component {
     // We use the old-style strings if available: this implies that the user has
     // manually specified them, so they should take precedence over the new-style
     // defaults.
-    try {
-      if (numberOfAcquirers > 0) {
-        titleText = this.props.i18nArray('dropPaste', { browse: browseFiles })
-      } else {
-        titleText = this.props.i18nArray('dropPasteImport', { browse: browseFiles })
+    if (lowerFMSelectionType === 'files') {
+      try {
+        if (numberOfAcquirers > 0) {
+          titleText = this.props.i18nArray('dropPaste', { browse: browseFiles })
+        } else {
+          titleText = this.props.i18nArray('dropPasteImport', { browse: browseFiles })
+        }
+      } catch {
+        // Ignore, the new-style strings will be used.
       }
-    } catch {
-      // Ignore, the new-style strings will be used.
     }
 
     return (

--- a/packages/@uppy/locales/src/ar_SA.js
+++ b/packages/@uppy/locales/src/ar_SA.js
@@ -10,6 +10,7 @@ ar_SA.strings = {
   authenticateWithTitle: 'ارجو الربط مع %{pluginName} من اجل اختيار الملفات',
   back: 'رجوع',
   browse: 'تصفح',
+  browseFiles: 'تصفح',
   cancel: 'الغاء',
   cancelUpload: 'الغاء الدفع',
   chooseFiles: 'اختار الملفات',

--- a/packages/@uppy/locales/src/bg_BG.js
+++ b/packages/@uppy/locales/src/bg_BG.js
@@ -14,6 +14,7 @@ bg_BG.strings = {
   authenticateWithTitle: 'Моля, впишете се с %{pluginName}, за да изберете файлове',
   back: 'Назад',
   browse: 'преглед',
+  browseFiles: 'преглед',
   cancel: 'Отказ',
   cancelUpload: 'Отказване на качването',
   chooseFiles: 'Изберете файлове',

--- a/packages/@uppy/locales/src/cs_CZ.js
+++ b/packages/@uppy/locales/src/cs_CZ.js
@@ -10,6 +10,7 @@ cs_CZ.strings = {
   authenticateWithTitle: 'Prosím přihlaste se k %{pluginName} pro výběr souborů',
   back: 'Zpět',
   browse: 'procházet',
+  browseFiles: 'procházet',
   cancel: 'Zrušit',
   cancelUpload: 'Zrušit nahrávání',
   chooseFiles: 'Vyberte soubory',

--- a/packages/@uppy/locales/src/da_DK.js
+++ b/packages/@uppy/locales/src/da_DK.js
@@ -10,6 +10,7 @@ da_DK.strings = {
   authenticateWithTitle: 'Venligst autentificer med %{pluginName} for at vælge filer',
   back: 'Tilbage',
   browse: 'gennemse',
+  browseFiles: 'gennemse',
   cancel: 'Annuller',
   cancelUpload: 'Annuller upload',
   chooseFiles: 'Vælg filer',

--- a/packages/@uppy/locales/src/el_GR.js
+++ b/packages/@uppy/locales/src/el_GR.js
@@ -10,6 +10,7 @@ el_GR.strings = {
   authenticateWithTitle: 'Παρακαλούμε συνδεθείτε με %{pluginName} για να επιλέξετε αρχεία',
   back: 'Πίσω',
   browse: 'Περιήγηση',
+  browseFiles: 'Περιήγηση',
   cancel: 'Άκυρο',
   cancelUpload: 'Ακύρωση μεταφόρτωσης',
   chooseFiles: 'Επιλέξτε αρχεία',

--- a/packages/@uppy/locales/src/es_ES.js
+++ b/packages/@uppy/locales/src/es_ES.js
@@ -10,6 +10,7 @@ es_ES.strings = {
   back: 'Atrás',
   addMore: 'Agregar más',
   browse: 'navegar',
+  browseFiles: 'navegar',
   cancel: 'Cancelar',
   cancelUpload: 'Cancelar subida',
   chooseFiles: 'Seleccionar archivos',

--- a/packages/@uppy/locales/src/fa_IR.js
+++ b/packages/@uppy/locales/src/fa_IR.js
@@ -10,6 +10,7 @@ fa_IR.strings = {
   back: 'بازگشت',
   addMore: 'اضافه کردن بیشتر',
   browse: 'انتخاب کنید',
+  browseFiles: 'انتخاب کنید',
   cancel: 'انصراف',
   cancelUpload: 'لغو بارگذاری',
   chooseFiles: 'انتخاب فایل',

--- a/packages/@uppy/locales/src/fi_FI.js
+++ b/packages/@uppy/locales/src/fi_FI.js
@@ -10,6 +10,7 @@ fi_FI.strings = {
   authenticateWithTitle: '%{pluginName} vaadittu tunnistautumiseen, jotta voit valita tiedostoja',
   back: 'Takaisin',
   browse: 'selaa',
+  browseFiles: 'selaa',
   cancel: 'Peruuta',
   cancelUpload: 'Peruuta lähetys',
   chooseFiles: 'Valitse tiedostot',

--- a/packages/@uppy/locales/src/fr_FR.js
+++ b/packages/@uppy/locales/src/fr_FR.js
@@ -14,6 +14,7 @@ fr_FR.strings = {
   authenticateWithTitle: 'Veuillez vous authentifier avec %{pluginName} pour sélectionner les fichiers',
   back: 'Retour',
   browse: 'naviguer',
+  browseFiles: 'naviguer',
   cancel: 'Annuler',
   cancelUpload: 'Annuler téléchargement',
   chooseFiles: 'Choisir des fichiers',

--- a/packages/@uppy/locales/src/gl_ES.js
+++ b/packages/@uppy/locales/src/gl_ES.js
@@ -10,6 +10,7 @@ gl_ES.strings = {
   authenticateWithTitle: 'Por favor autentícate con %{pluginName} para seleccionar arquivos',
   back: 'Atrás',
   browse: 'navegar',
+  browseFiles: 'navegar',
   cancel: 'Cancelar',
   cancelUpload: 'Cancelar subida',
   chooseFiles: 'Seleccionar arquivos',

--- a/packages/@uppy/locales/src/he_IL.js
+++ b/packages/@uppy/locales/src/he_IL.js
@@ -10,6 +10,7 @@ he_IL.strings = {
   authenticateWithTitle: 'אנא בצע הזדהות עם %{pluginName} על מנת לבחור קבצים',
   back: 'חזרה',
   browse: 'בחר',
+  browseFiles: 'בחר',
   cancel: 'ביטול',
   cancelUpload: 'בטל העלאה',
   chooseFiles: 'בחר קבצים',

--- a/packages/@uppy/locales/src/hr_HR.js
+++ b/packages/@uppy/locales/src/hr_HR.js
@@ -10,6 +10,7 @@ hr_HR.strings = {
   authenticateWithTitle: 'Molimo Vas da se prijavite putem %{pluginName} kako biste preuzeli datoteke',
   back: 'Natrag',
   browse: 'pretraži',
+  browseFiles: 'pretraži',
   cancel: 'Otkaži',
   cancelUpload: 'Otkaži prijenos',
   chooseFiles: 'Izaberi datoteke',

--- a/packages/@uppy/locales/src/hu_HU.js
+++ b/packages/@uppy/locales/src/hu_HU.js
@@ -12,6 +12,7 @@ hu_HU.strings = {
   authenticateWithTitle: 'Kérjük lépjen be a %{pluginName}-ba a fájlok kiválasztásához',
   back: 'Vissza',
   browse: 'válasszon',
+  browseFiles: 'válasszon',
   cancel: 'Mégse',
   cancelUpload: 'Feltöltés megszakítása',
   chooseFiles: 'Fájlok kiválasztása',

--- a/packages/@uppy/locales/src/id_ID.js
+++ b/packages/@uppy/locales/src/id_ID.js
@@ -10,6 +10,7 @@ id_ID.strings = {
   authenticateWithTitle: 'Silahkan mengotentifikasi menggunakan %{pluginName} untuk memilih berkas',
   back: 'Kembali',
   browse: 'Telusuri',
+  browseFiles: 'Telusuri',
   cancel: 'Batal',
   cancelUpload: 'Batalkan pengungahan',
   chooseFiles: 'Pilih berkas',

--- a/packages/@uppy/locales/src/is_IS.js
+++ b/packages/@uppy/locales/src/is_IS.js
@@ -12,6 +12,7 @@ is_IS.strings = {
         'Vinsamlegast auðkenndu %{pluginName} til þess að velja skrár',
   back: 'Til baka',
   browse: 'skoða',
+  browseFiles: 'skoða',
   cancel: 'Hætta við',
   cancelUpload: 'Hætta við að hlaða upp',
   chooseFiles: 'Veldu skrár',

--- a/packages/@uppy/locales/src/it_IT.js
+++ b/packages/@uppy/locales/src/it_IT.js
@@ -10,6 +10,7 @@ it_IT.strings = {
   back: 'Indietro',
   addMore: 'Aggiungi più',
   browse: 'sfoglia',
+  browseFiles: 'sfoglia',
   cancel: 'Annulla',
   cancelUpload: 'Annulla upload',
   chooseFiles: 'Scegli i file',

--- a/packages/@uppy/locales/src/ja_JP.js
+++ b/packages/@uppy/locales/src/ja_JP.js
@@ -10,6 +10,7 @@ ja_JP.strings = {
   authenticateWithTitle: 'ファイルを選択するには%{pluginName}で認証してください',
   back: '戻る',
   browse: '参照',
+  browseFiles: '参照',
   cancel: 'キャンセル',
   cancelUpload: 'アップロードをキャンセル',
   chooseFiles: 'ファイルを選択',

--- a/packages/@uppy/locales/src/nl_NL.js
+++ b/packages/@uppy/locales/src/nl_NL.js
@@ -10,6 +10,7 @@ nl_NL.strings = {
   back: 'Terug',
   addMore: 'Meer toevoegen',
   browse: 'blader',
+  browseFiles: 'blader',
   cancel: 'Annuleer',
   cancelUpload: 'Annuleer upload',
   chooseFiles: 'Kies bestanden',

--- a/packages/@uppy/locales/src/pl_PL.js
+++ b/packages/@uppy/locales/src/pl_PL.js
@@ -14,6 +14,7 @@ pl_PL.strings = {
   authenticateWithTitle: 'Zaloguj się do %{pluginName} aby wybrać pliki',
   back: 'Wstecz',
   browse: 'Wybierz',
+  browseFiles: 'Wybierz',
   cancel: 'Anuluj',
   cancelUpload: 'Anuluj wysyłkę',
   chooseFiles: 'Wybierz pliki',

--- a/packages/@uppy/locales/src/pt_BR.js
+++ b/packages/@uppy/locales/src/pt_BR.js
@@ -10,6 +10,7 @@ pt_BR.strings = {
   authenticateWithTitle: 'Por favor conecte com %{pluginName} para selecionar arquivos',
   back: 'Voltar',
   browse: 'navegue',
+  browseFiles: 'navegue',
   cancel: 'Cancelar',
   cancelUpload: 'Cancelar envio de arquivos',
   chooseFiles: 'Selecionar arquivos',

--- a/packages/@uppy/locales/src/ro_RO.js
+++ b/packages/@uppy/locales/src/ro_RO.js
@@ -14,6 +14,7 @@ ro_RO.strings = {
   authenticateWithTitle: 'Vă rugăm conectați-vă cu %{pluginName} pentru a selecta fișiere',
   back: 'Înapoi',
   browse: 'rasfoiește',
+  browseFiles: 'rasfoiește',
   cancel: 'Anulare',
   cancelUpload: 'Anulează încărcarea',
   chooseFiles: 'Selectează fișiere',

--- a/packages/@uppy/locales/src/ru_RU.js
+++ b/packages/@uppy/locales/src/ru_RU.js
@@ -10,6 +10,7 @@ ru_RU.strings = {
   back: 'Назад',
   addMore: 'Добавить еще',
   browse: 'выберите',
+  browseFiles: 'выберите',
   cancel: 'Отменить',
   cancelUpload: 'Отменить загрузку',
   chooseFiles: 'Выбрать файлы',

--- a/packages/@uppy/locales/src/sk_SK.js
+++ b/packages/@uppy/locales/src/sk_SK.js
@@ -15,6 +15,7 @@ sk_SK.strings = {
   authenticateWithTitle: 'Prosím príhláste sa k %{pluginName} pre výber súborov',
   back: 'Späť',
   browse: 'prechádzať',
+  browseFiles: 'prechádzať',
   cancel: 'Zrušiť',
   cancelUpload: 'Zrušiť nahrávanie',
   chooseFiles: 'Vyberte súbory',

--- a/packages/@uppy/locales/src/sr_RS_Cyrillic.js
+++ b/packages/@uppy/locales/src/sr_RS_Cyrillic.js
@@ -10,6 +10,7 @@ sr_RS_Cyrillic.strings = {
   authenticateWithTitle: 'Молимо Вас да се пријавите путем %{pluginName} како бисте преузели датотеке',
   back: 'Назад',
   browse: 'потражи',
+  browseFiles: 'потражи',
   cancel: 'Откажи',
   cancelUpload: 'Откажи отпремање',
   chooseFiles: 'Изабери датотеке',

--- a/packages/@uppy/locales/src/sr_RS_Latin.js
+++ b/packages/@uppy/locales/src/sr_RS_Latin.js
@@ -10,6 +10,7 @@ sr_RS_Latin.strings = {
   authenticateWithTitle: 'Molimo Vas da se prijavite putem %{pluginName} kako biste preuzeli datoteke',
   back: 'Nazad',
   browse: 'potraži',
+  browseFiles: 'potraži',
   cancel: 'Otkaži',
   cancelUpload: 'Otkaži otpremanje',
   chooseFiles: 'Izaberi datoteke',

--- a/packages/@uppy/locales/src/sv_SE.js
+++ b/packages/@uppy/locales/src/sv_SE.js
@@ -10,6 +10,7 @@ sv_SE.strings = {
   authenticateWithTitle: 'Anslut till %{pluginName} för att välja filer',
   back: 'Tillbaka',
   browse: 'bläddra',
+  browseFiles: 'bläddra',
   cancel: 'Avbryt',
   cancelUpload: 'Avbryt uppladdning',
   chooseFiles: 'Välj filer',

--- a/packages/@uppy/locales/src/th_TH.js
+++ b/packages/@uppy/locales/src/th_TH.js
@@ -10,6 +10,7 @@ th_TH.strings = {
   authenticateWithTitle: 'กรุณาเข้าใช้งานกับ %{pluginName} เพื่อเลือกไฟล์',
   back: 'ย้อนกลับ',
   browse: 'เรียกดู',
+  browseFiles: 'เรียกดู',
   cancel: 'ยกเลิก',
   cancelUpload: 'ยกเลิกการอัปโหลด',
   chooseFiles: 'เลือกไฟล์',

--- a/packages/@uppy/locales/src/tr_TR.js
+++ b/packages/@uppy/locales/src/tr_TR.js
@@ -10,6 +10,7 @@ tr_TR.strings = {
   authenticateWithTitle: 'Lütfen dosyaları seçmek için %{pluginName} ile bağlanın',
   back: 'Geri',
   browse: 'gözat',
+  browseFiles: 'gözat',
   cancel: 'İptal',
   cancelUpload: 'Yüklemeyi İptal Et',
   chooseFiles: 'Dosyaları seç',

--- a/packages/@uppy/locales/src/vi_VN.js
+++ b/packages/@uppy/locales/src/vi_VN.js
@@ -10,6 +10,7 @@ vi_VN.strings = {
   authenticateWithTitle: 'Xác thực với %{pluginName} để chọn tập tin',
   back: 'Quay lại',
   browse: 'chọn',
+  browseFiles: 'chọn',
   cancel: 'Huỷ',
   cancelUpload: 'Huỷ tải lên',
   chooseFiles: 'Chọn tập tin',

--- a/packages/@uppy/locales/src/zh_CN.js
+++ b/packages/@uppy/locales/src/zh_CN.js
@@ -14,6 +14,7 @@ zh_CN.strings = {
   authenticateWithTitle: '请使用 %{pluginName} 进行认证以选择文件',
   back: '返回',
   browse: '浏览',
+  browseFiles: '浏览',
   cancel: '取消',
   cancelUpload: '取消上传',
   chooseFiles: '选择文件',

--- a/packages/@uppy/locales/src/zh_TW.js
+++ b/packages/@uppy/locales/src/zh_TW.js
@@ -14,6 +14,7 @@ zh_TW.strings = {
   authenticateWithTitle: '請使用%{pluginName}進行身份驗證以選擇檔案',
   back: '返回',
   browse: '瀏覽',
+  browseFiles: '瀏覽',
   cancel: '取消',
   cancelUpload: '取消上傳',
   chooseFiles: '選擇檔案',

--- a/packages/@uppy/utils/src/Translator.js
+++ b/packages/@uppy/utils/src/Translator.js
@@ -125,6 +125,10 @@ module.exports = class Translator {
    * @returns {Array} The translated and interpolated parts, in order.
    */
   translateArray (key, options) {
+    if (!has(this.locale.strings, key)) {
+      throw new Error(`missing string: ${key}`)
+    }
+
     const string = this.locale.strings[key]
     const hasPluralForms = typeof string === 'object'
 


### PR DESCRIPTION
Fixes #2384

This makes the old-style `dropPaste` and `dropPasteImport` strings take precedence over the new strings.

Adds `browseFiles` strings to all the languages that don't have them yet—just a copy of the `browse` string for now. Prevents bad results like:
![image](https://user-images.githubusercontent.com/1006268/88480314-a542a700-cf55-11ea-8f56-33fa1185df20.png)


We should learn from this and be more careful about locale changes in the future. This probably could've gone smoothly, but I merged the PR without properly thinking this through, and now we have to support both styles which makes it a big mess.

Todo:
 - [x] the old style strings should probably only take precedence if the selection type is 'files', so that the new style will still be used if you do use a different selection type. Otherwise it might look like the feature is totally broken