### PR TITLE
companion: make npm run test work on windows

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -86,7 +86,7 @@
     "deploy": "kubectl apply -f infra/kube/companion-kube.yml",
     "prepublishOnly": "npm run build",
     "start": "node ./lib/standalone/start-server.js",
-    "test": "bash -c 'npm run build && source env.test.sh && jest'",
+    "test": "node test/run",
     "test:watch": "npm test -- --watch"
   },
   "engines": {

--- a/packages/@uppy/companion/test/run.js
+++ b/packages/@uppy/companion/test/run.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process')
+const path = require('path')
+
+process.chdir(path.join(__dirname, '..'))
+try {
+  execSync('jest --version', { shell: 'bash' })
+} catch (err) {
+  console.error('could not start jest, make sure this script is ran using `npm test`')
+  process.exit(1)
+}
+
+execSync('npm run build', { stdio: 'inherit' })
+execSync('source env.test.sh && jest', { shell: 'bash', stdio: 'inherit' })


### PR DESCRIPTION
I think it's the quotes in the npm run script that are not working, so this uses a node.js script to do the spawning instead.