### PR TITLE
dash: Add support for AVIF images in thumbnails

### DIFF
--- a/packages/@uppy/utils/src/isPreviewSupported.js
+++ b/packages/@uppy/utils/src/isPreviewSupported.js
@@ -2,7 +2,7 @@ module.exports = function isPreviewSupported (fileType) {
   if (!fileType) return false
   const fileTypeSpecific = fileType.split('/')[1]
   // list of images that browsers can preview
-  if (/^(jpe?g|gif|png|svg|svg\+xml|bmp|webp)$/.test(fileTypeSpecific)) {
+  if (/^(jpe?g|gif|png|svg|svg\+xml|bmp|webp|avif)$/.test(fileTypeSpecific)) {
     return true
   }
   return false

--- a/packages/@uppy/utils/src/isPreviewSupported.test.js
+++ b/packages/@uppy/utils/src/isPreviewSupported.test.js
@@ -2,7 +2,7 @@ const isPreviewSupported = require('./isPreviewSupported')
 
 describe('isPreviewSupported', () => {
   it('should return true for any filetypes that browsers can preview', () => {
-    const supported = ['image/jpeg', 'image/gif', 'image/png', 'image/svg', 'image/svg+xml', 'image/bmp', 'image/jpg', 'image/webp']
+    const supported = ['image/jpeg', 'image/gif', 'image/png', 'image/svg', 'image/svg+xml', 'image/bmp', 'image/jpg', 'image/webp', 'image/avif']
     supported.forEach(ext => {
       expect(isPreviewSupported(ext)).toEqual(true)
     })


### PR DESCRIPTION
I added support to load thumbnails when uploading AVIF images, by adding 'avif' to the regex. I also updated the unit test.

Note that support for this is dependant on browser support, and currently only Chrome 85+ and Firefox 77+ support it (Firefox requires flag to be set to allow it)

Resolves #2357 