### PR TITLE
Adds user_videos to facebook oauth scope

### DIFF
--- a/packages/@uppy/companion/src/config/grant.js
+++ b/packages/@uppy/companion/src/config/grant.js
@@ -21,7 +21,7 @@ module.exports = () => {
     },
     facebook: {
       transport: 'session',
-      scope: ['email', 'user_photos'],
+      scope: ['email', 'user_photos', 'user_videos'],
       callback: '/facebook/callback'
     },
     // for onedrive


### PR DESCRIPTION
Adds 'user_videos' to facebook oauth scope to add support for uploading video files from the user's facebook account.

Closes https://github.com/transloadit/uppy/issues/2424