### PR TITLE
transloadit: fully disable Tus fingerprinting

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -787,6 +787,7 @@ module.exports = class Transloadit extends Plugin {
         // Golden Retriever. So, Golden Retriever is required to do resumability with the Transloadit plugin,
         // and we disable Tus's default resume implementation to prevent bad behaviours.
         storeFingerprintForResuming: false,
+        resume: false,
         // Disable Companion's retry optimisation; we need to change the endpoint on retry
         // so it can't just reuse the same tus.Upload instance server-side.
         useFastRemoteRetry: false,


### PR DESCRIPTION
In #2239, I added a backwards compatible implementation for the `resume`
option from tus-js-client v1, but forgot to disable it again in the
Transloadit plugin.

Fixes #2382