### PR TITLE
Fix: Incorrect File Added Count

### DIFF
--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -194,10 +194,12 @@ module.exports = class ProviderView {
     this.plugin.uppy.log('Adding remote file')
     try {
       this.plugin.uppy.addFile(tagFile)
+      return true
     } catch (err) {
       if (!err.isRestriction) {
         this.plugin.uppy.log(err)
       }
+      return false
     }
   }
 
@@ -369,8 +371,10 @@ module.exports = class ProviderView {
     folders[folderId] = { loading: true, files: [] }
     this.plugin.setPluginState({ selectedFolders: folders })
     return this.listAllFiles(folder.requestPath).then((files) => {
+      let count = 0
       files.forEach((file) => {
-        this.addFile(file)
+        const success = this.addFile(file)
+        if (success) count++
       })
       const ids = files.map(this.providerFileToId)
       state = this.plugin.getPluginState()
@@ -380,7 +384,7 @@ module.exports = class ProviderView {
       let message
       if (files.length) {
         message = this.plugin.uppy.i18n('folderAdded', {
-          smart_count: files.length, folder: folder.name
+          smart_count: count, folder: folder.name
         })
       } else {
         message = this.plugin.uppy.i18n('emptyFolderAdded')


### PR DESCRIPTION
On the dashboard, when uploading a folder, if files from that folder are not successfully added, the count would still say they are there

For example, If you're using Google Drive, and upload a folder with 3 images and 2 mp3 files. If you also have a restriction set to only allow images, Dashboard would still read something like "5 Files Added", even though only 3 would be there. 

I resolved this by making the `addFile` method in the `provider-views` package return a boolean value based on whether or not the file was added successfully. I then created a count variable with the `addFolder` method and added to that count for every successful addition. Using that count instead of the total count of files in the folder fixes this problem

Resolves #2038