### PR TITLE
Enable uploading zero-sized file with aws-s3-multipart-upload

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -82,7 +82,7 @@ class MultipartUploader {
     const minChunkSize = Math.max(5 * MB, Math.ceil(this.file.size / 10000))
     const chunkSize = Math.max(desiredChunkSize, minChunkSize)
 
-    for (let i = 0; i < this.file.size; i += chunkSize) {
+    for (let i = 0; i <= this.file.size; i += chunkSize) {
       const end = Math.min(this.file.size, i + chunkSize)
       chunks.push(this.file.slice(i, end))
     }

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -82,9 +82,14 @@ class MultipartUploader {
     const minChunkSize = Math.max(5 * MB, Math.ceil(this.file.size / 10000))
     const chunkSize = Math.max(desiredChunkSize, minChunkSize)
 
-    for (let i = 0; i <= this.file.size; i += chunkSize) {
-      const end = Math.min(this.file.size, i + chunkSize)
-      chunks.push(this.file.slice(i, end))
+    // Upload zero-sized files in one zero-sized chunk
+    if (this.file.size === 0) {
+      chunks.push(this.file)
+    } else {
+      for (let i = 0; i < this.file.size; i += chunkSize) {
+        const end = Math.min(this.file.size, i + chunkSize)
+        chunks.push(this.file.slice(i, end))
+      }
     }
 
     this.chunks = chunks


### PR DESCRIPTION
I'm creating this pull request since I have real use case when I need to upload zero-sized file and currently it's not possible to do using **aws-s3-multipart** uploader.

After fixing, I tested it and it works normally, same as it's any other file.
Also, as far as I checked, this change doesn't affect upload of other non-zero sized files.

Before commit _zero-sized_ file couldn't be uploaded successfully since _chunks_ array was always empty and `_completeUpload()` method was called immediately without reserving and uploading any part of the file.

Chunks array wasn't populated because inside `_initChunks()` method there was a size check using `<` sign, so if _zero-sized_ file comes, it would never enter the for loop.

After commit there is size check with `<=` sign, so even for _zero-sized_ file, it will enter the loop once and create one chunk for it, so it can be successfully reserved and uploaded.