### PR TITLE
companion: add calculated content-length for formdata and body cases

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -492,11 +492,18 @@ class Uploader {
         req._form = form
       })
     } else {
-      const stats = fs.statSync(this.path)
-      const fileSizeInBytes = stats.size
-      reqOptions.headers['content-length'] = fileSizeInBytes
-      reqOptions.body = file
-      request[httpMethod](reqOptions, (error, response, body) => this._onMultipartComplete(error, response, body, bytesUploaded))
+      fs.stat(this.path, (err, stats) => {
+        if (err) {
+          logger.error(err, 'upload.multipart.size.error')
+          this.emitError(err)
+          return
+        }
+
+        const fileSizeInBytes = stats.size
+        reqOptions.headers['content-length'] = fileSizeInBytes
+        reqOptions.body = file
+        request[httpMethod](reqOptions, (error, response, body) => this._onMultipartComplete(error, response, body, bytesUploaded))
+      })
     }
   }
 

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -476,10 +476,15 @@ class Uploader {
       for (const property in this.options.metadata) {
         form.append(property, this.options.metadata[property])
       }
-      form.append('file', file)
+      form.append(this.options.fieldname, file, {
+        filename: this.uploadFileName,
+        contentType: this.options.metadata.type
+      })
       form.getLength((error, length) => {
         if (error) {
-          logger.error(error, 'upload.multipart.error')
+          logger.error(error, 'upload.multipart.size.error')
+          this.emitError(error)
+          return
         }
         reqOptions.headers['content-length'] = length
         const req = request[httpMethod](reqOptions, (error, response, body) => this._handleUploadMultipart(error, response, body, bytesUploaded))

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -487,7 +487,7 @@ class Uploader {
           return
         }
         reqOptions.headers['content-length'] = length
-        const req = request[httpMethod](reqOptions, (error, response, body) => this._handleUploadMultipart(error, response, body, bytesUploaded))
+        const req = request[httpMethod](reqOptions, (error, response, body) => this._onMultipartComplete(error, response, body, bytesUploaded))
         // @ts-ignore
         req._form = form
       })
@@ -496,11 +496,11 @@ class Uploader {
       const fileSizeInBytes = stats.size
       reqOptions.headers['content-length'] = fileSizeInBytes
       reqOptions.body = file
-      request[httpMethod](reqOptions, (error, response, body) => this._handleUploadMultipart(error, response, body, bytesUploaded))
+      request[httpMethod](reqOptions, (error, response, body) => this._onMultipartComplete(error, response, body, bytesUploaded))
     }
   }
 
-  _handleUploadMultipart (error, response, body, bytesUploaded) {
+  _onMultipartComplete (error, response, body, bytesUploaded) {
     if (error) {
       logger.error(error, 'upload.multipart.error')
       this.emitError(error)


### PR DESCRIPTION
Hi, as described in this [PR](https://github.com/transloadit/uppy/pull/2387) `content-length` is an expected header when uploading to s3. In this PR I'm adding context-length calculation for the formData scenario. Had to factor out the http request since `form.getLength` from form-data expects a callback. 