### PR TITLE
aws-s3-multipart: fix stuck upload with `limit: 1`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -180,7 +180,10 @@ class MultipartUploader {
     }
 
     candidates.forEach((index) => {
-      this._uploadPartRetryable(index).catch((err) => {
+      this._uploadPartRetryable(index).then(() => {
+        // Continue uploading parts
+        this._uploadParts()
+      }, (err) => {
         this._onError(err)
       })
     })
@@ -281,8 +284,6 @@ class MultipartUploader {
     this.parts.push(part)
 
     this.options.onPartComplete(part)
-
-    this._uploadParts()
   }
 
   _uploadPartBytes (index, url, headers) {


### PR DESCRIPTION
Fixes #2463

There was an issue with the timing of the `_uploadParts()` call. That
function is responsible for _starting_ the upload of multiple parts of
the file. It can start up to `limit` simultaneous uploads, depending on
how many parts are currently uploading.

`_uploadParts()` was called during the completion code for an individual
part. However, the `partsInProgress` state would not be updated until
_after_ the completion code had run. So, inside `_uploadParts()`, it
would see an outdated `partsInProgress` value. Often, this worked OK (if
not optimally) because there would likely be another part in progress,
and once _that_ finished, there would be space again in the
`partsInProgress` value. However, this was _not_ the case if `limit` was
set to 1. In that case, the first part would finish, then we would enter
`_uploadParts()`, and it would see that we were at the limit: it would
not start a new part upload. After, it would never be called again.

This moves the `_uploadParts()` call to _after_ the part upload
completion code. It is now inside `_uploadParts()`, which I think
generally makes the sequencing a bit more clear. Everything related to a
single part upload now has to be complete before `_uploadParts()` runs
again.