### PR TITLE
fix: translations for capturing

### DIFF
--- a/packages/@uppy/screen-capture/src/RecordButton.js
+++ b/packages/@uppy/screen-capture/src/RecordButton.js
@@ -9,8 +9,8 @@ module.exports = function RecordButton ({ recording, onStartRecording, onStopRec
       <button
         class="uppy-u-reset uppy-c-btn uppy-ScreenCapture-button uppy-ScreenCapture-button--video uppy-ScreenCapture-button--stop-rec"
         type="button"
-        title={i18n('stopRecording')}
-        aria-label={i18n('stopRecording')}
+        title={i18n('stopCapturing')}
+        aria-label={i18n('stopCapturing')}
         onclick={onStopRecording}
         data-uppy-super-focusable
       >
@@ -26,7 +26,7 @@ module.exports = function RecordButton ({ recording, onStartRecording, onStopRec
       class="uppy-u-reset uppy-c-btn uppy-ScreenCapture-button uppy-ScreenCapture-button--video"
       type="button"
       title={i18n('startCapturing')}
-      aria-label={i18n('stopCapturing')}
+      aria-label={i18n('startCapturing')}
       onclick={onStartRecording}
       data-uppy-super-focusable
     >


### PR DESCRIPTION
This PR fixes the translations in the screen capture plugin which makes it work again.