### PR TITLE
companion:dropbox: exclude non downloadable files in fetched list

### DIFF
--- a/packages/@uppy/companion/src/server/provider/dropbox/index.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/index.js
@@ -105,7 +105,8 @@ class DropBox extends Provider {
       .qs(query)
       .auth(token)
       .json({
-        path: `${directory || ''}`
+        path: `${directory || ''}`,
+        include_non_downloadable_files: false
       })
       .request(done)
   }


### PR DESCRIPTION
Currently when DropBox fetches a list of files it includes files with `is_downloadable: false`.
This causes companion to return a `409 conflict` when trying to upload these files from DropBox.
This simple fix tells DropBox not to include these files in the fetched list.

This seems like the best fix to me although there are two alternatives:
1. Add an indicator when displaying the file so users know they can't upload the file.
This way users aren't confused to why they can't see the file.
2. Use DropBox's api to export the file to a downloadable format and upload that. [See](https://www.dropbox.com/developers/documentation/http/documentation#files-export)

If either of those two options are desirable it still seems best to merge this change as a better intermediate solution.
Showing a user `request to dropbox returned 409` is not desirable or actionable. 

