### PR TITLE
Remove the --save flag

### DIFF
--- a/packages/@uppy/aws-s3-multipart/README.md
+++ b/packages/@uppy/aws-s3-multipart/README.md
@@ -25,7 +25,7 @@ uppy.use(AwsS3Multipart, {
 ## Installation
 
 ```bash
-$ npm install @uppy/aws-s3-multipart --save
+$ npm install @uppy/aws-s3-multipart
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/aws-s3/README.md
+++ b/packages/@uppy/aws-s3/README.md
@@ -26,7 +26,7 @@ uppy.use(AwsS3, {
 ## Installation
 
 ```bash
-$ npm install @uppy/aws-s3 --save
+$ npm install @uppy/aws-s3
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/companion-client/README.md
+++ b/packages/@uppy/companion-client/README.md
@@ -35,7 +35,7 @@ socket.on('progress', () => {})
 > Unless you are writing a custom provider plugin, you do not need to install this.
 
 ```bash
-$ npm install @uppy/companion-client --save
+$ npm install @uppy/companion-client
 ```
 
 <!-- Undocumented currently

--- a/packages/@uppy/core/README.md
+++ b/packages/@uppy/core/README.md
@@ -27,7 +27,7 @@ uppy.use(SomePlugin)
 ## Installation
 
 ```bash
-$ npm install @uppy/core --save
+$ npm install @uppy/core
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/dashboard/README.md
+++ b/packages/@uppy/dashboard/README.md
@@ -34,7 +34,7 @@ uppy.use(Dashboard, {
 ## Installation
 
 ```bash
-$ npm install @uppy/dashboard --save
+$ npm install @uppy/dashboard
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/drag-drop/README.md
+++ b/packages/@uppy/drag-drop/README.md
@@ -26,7 +26,7 @@ uppy.use(DragDrop, {
 ## Installation
 
 ```bash
-$ npm install @uppy/drag-drop --save
+$ npm install @uppy/drag-drop
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/dropbox/README.md
+++ b/packages/@uppy/dropbox/README.md
@@ -24,7 +24,7 @@ uppy.use(Dropbox, {
 ## Installation
 
 ```bash
-$ npm install @uppy/dropbox --save
+$ npm install @uppy/dropbox
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/facebook/README.md
+++ b/packages/@uppy/facebook/README.md
@@ -24,7 +24,7 @@ uppy.use(Facebook, {
 ## Installation
 
 ```bash
-$ npm install @uppy/facebook --save
+$ npm install @uppy/facebook
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/file-input/README.md
+++ b/packages/@uppy/file-input/README.md
@@ -26,7 +26,7 @@ uppy.use(FileInput, {
 ## Installation
 
 ```bash
-$ npm install @uppy/file-input --save
+$ npm install @uppy/file-input
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/form/README.md
+++ b/packages/@uppy/form/README.md
@@ -28,7 +28,7 @@ uppy.use(Form, {
 ## Installation
 
 ```bash
-$ npm install @uppy/form --save
+$ npm install @uppy/form
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/golden-retriever/README.md
+++ b/packages/@uppy/golden-retriever/README.md
@@ -24,7 +24,7 @@ uppy.use(GoldenRetriever, {
 ## Installation
 
 ```bash
-$ npm install @uppy/golden-retriever --save
+$ npm install @uppy/golden-retriever
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/google-drive/README.md
+++ b/packages/@uppy/google-drive/README.md
@@ -27,7 +27,7 @@ uppy.use(GoogleDrive, {
 ## Installation
 
 ```bash
-$ npm install @uppy/google-drive --save
+$ npm install @uppy/google-drive
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/image-editor/README.md
+++ b/packages/@uppy/image-editor/README.md
@@ -31,7 +31,7 @@ uppy.use(ImageEditor, {
 ## Installation
 
 ```bash
-$ npm install @uppy/image-editor --save
+$ npm install @uppy/image-editor
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/informer/README.md
+++ b/packages/@uppy/informer/README.md
@@ -24,7 +24,7 @@ uppy.use(Informer, {
 ## Installation
 
 ```bash
-$ npm install @uppy/informer --save
+$ npm install @uppy/informer
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/instagram/README.md
+++ b/packages/@uppy/instagram/README.md
@@ -25,7 +25,7 @@ uppy.use(Instagram, {
 ## Installation
 
 ```bash
-$ npm install @uppy/instagram --save
+$ npm install @uppy/instagram
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/locales/README.md
+++ b/packages/@uppy/locales/README.md
@@ -10,13 +10,13 @@ This packages contains all of the locale packs that you can use to make Uppy spe
 ## Installation
 
 ```bash
-$ npm install @uppy/locales --save
+$ npm install @uppy/locales
 ```
 
 ## Documentation
 
 ```bash
-$ npm install @uppy/core @uppy/locales --save
+$ npm install @uppy/core @uppy/locales
 ```
 
 ```js

--- a/packages/@uppy/onedrive/README.md
+++ b/packages/@uppy/onedrive/README.md
@@ -24,7 +24,7 @@ uppy.use(Facebook, {
 ## Installation
 
 ```bash
-$ npm install @uppy/facebook --save
+$ npm install @uppy/facebook
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/progress-bar/README.md
+++ b/packages/@uppy/progress-bar/README.md
@@ -24,7 +24,7 @@ uppy.use(ProgressBar, {
 ## Installation
 
 ```bash
-$ npm install @uppy/progress-bar --save
+$ npm install @uppy/progress-bar
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/provider-views/README.md
+++ b/packages/@uppy/provider-views/README.md
@@ -37,7 +37,7 @@ class GoogleDrive extends Plugin {
 > Unless you are creating a custom provider plugin, you do not need to install this.
 
 ```bash
-$ npm install @uppy/provider-views --save
+$ npm install @uppy/provider-views
 ```
 
 <!-- Undocumented currently

--- a/packages/@uppy/react-native/README.md
+++ b/packages/@uppy/react-native/README.md
@@ -12,7 +12,7 @@ Basic Uppy component for React Native with Expo. It is in Beta, and is not full-
 ## Installation
 
 ```bash
-$ npm install @uppy/react-native --save
+$ npm install @uppy/react-native
 ```
 
 ## Documentation

--- a/packages/@uppy/react/README.md
+++ b/packages/@uppy/react/README.md
@@ -35,7 +35,7 @@ class Example extends React.Component {
 ## Installation
 
 ```bash
-$ npm install @uppy/react --save
+$ npm install @uppy/react
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/redux-dev-tools/README.md
+++ b/packages/@uppy/redux-dev-tools/README.md
@@ -22,7 +22,7 @@ uppy.use(ReduxDevTools)
 ## Installation
 
 ```bash
-$ npm install @uppy/redux-dev-tools --save
+$ npm install @uppy/redux-dev-tools
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/robodog/README.md
+++ b/packages/@uppy/robodog/README.md
@@ -10,7 +10,7 @@ Robodog is an Uppy-based library that pulls your files through Transloadit for a
 ## Installation
 
 ```bash
-$ npm install @uppy/robodog --save
+$ npm install @uppy/robodog
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](http://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/screen-capture/README.md
+++ b/packages/@uppy/screen-capture/README.md
@@ -22,7 +22,7 @@ uppy.use(ScreenCapture)
 ## Installation
 
 ```bash
-$ npm install @uppy/screen-capture --save
+$ npm install @uppy/screen-capture
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/status-bar/README.md
+++ b/packages/@uppy/status-bar/README.md
@@ -28,7 +28,7 @@ uppy.use(StatusBar, {
 ## Installation
 
 ```bash
-$ npm install @uppy/status-bar --save
+$ npm install @uppy/status-bar
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/store-default/README.md
+++ b/packages/@uppy/store-default/README.md
@@ -23,7 +23,7 @@ const uppy = new Uppy({
 ## Installation
 
 ```bash
-$ npm install @uppy/store-default --save
+$ npm install @uppy/store-default
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/store-redux/README.md
+++ b/packages/@uppy/store-redux/README.md
@@ -37,7 +37,7 @@ const uppy = new Uppy({
 ## Installation
 
 ```bash
-$ npm install @uppy/store-redux --save
+$ npm install @uppy/store-redux
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/thumbnail-generator/README.md
+++ b/packages/@uppy/thumbnail-generator/README.md
@@ -24,7 +24,7 @@ uppy.use(ThumbnailGenerator, {
 ## Installation
 
 ```bash
-$ npm install @uppy/thumbnail-generator --save
+$ npm install @uppy/thumbnail-generator
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -26,7 +26,7 @@ uppy.use(Transloadit, {
 ## Installation
 
 ```bash
-$ npm install @uppy/transloadit --save
+$ npm install @uppy/transloadit
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/tus/README.md
+++ b/packages/@uppy/tus/README.md
@@ -27,7 +27,7 @@ uppy.use(Tus, {
 ## Installation
 
 ```bash
-$ npm install @uppy/tus --save
+$ npm install @uppy/tus
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/url/README.md
+++ b/packages/@uppy/url/README.md
@@ -26,7 +26,7 @@ uppy.use(Url, {
 ## Installation
 
 ```bash
-$ npm install @uppy/url --save
+$ npm install @uppy/url
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/utils/README.md
+++ b/packages/@uppy/utils/README.md
@@ -14,7 +14,7 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 > Unless you are creating a custom plugin, you should not need to install this manually.
 
 ```bash
-$ npm install @uppy/utils --save
+$ npm install @uppy/utils
 ```
 
 ## License

--- a/packages/@uppy/webcam/README.md
+++ b/packages/@uppy/webcam/README.md
@@ -26,7 +26,7 @@ uppy.use(Webcam, {
 ## Installation
 
 ```bash
-$ npm install @uppy/webcam --save
+$ npm install @uppy/webcam
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/xhr-upload/README.md
+++ b/packages/@uppy/xhr-upload/README.md
@@ -24,7 +24,7 @@ uppy.use(Uppy, {
 ## Installation
 
 ```bash
-$ npm install @uppy/xhr-upload --save
+$ npm install @uppy/xhr-upload
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/packages/@uppy/zoom/README.md
+++ b/packages/@uppy/zoom/README.md
@@ -24,7 +24,7 @@ uppy.use(Zoom, {
 ## Installation
 
 ```bash
-$ npm install @uppy/zoom --save
+$ npm install @uppy/zoom
 ```
 
 We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).

--- a/website/src/docs/robodog.md
+++ b/website/src/docs/robodog.md
@@ -18,7 +18,7 @@ Robodog is an Uppy-based library that helps you talk to the Transloadit API. It 
 Robodog can be downloaded from npm:
 
 ```shell
-npm install --save @uppy/robodog
+npm install @uppy/robodog
 ```
 
 Then, with a bundler such as [webpack][webpack] or [Browserify][browserify], do:


### PR DESCRIPTION
Since `npm` version 5, the `--save` flag is no longer required. The official release was on May 25th, 2017, so most people should have version 5 or later. 

Node `v8.17.0` (code-named carbon), is on `npm` v6, and has already reached the end of it's lifespan. In other words, this flag is definitely not needed anymore

So, I removed it in the documentation/README's for all packages that include it. Let me know if I missed anything
