### PR TITLE
Omit timeline files from zoom plugin

### DIFF
--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -225,7 +225,8 @@ class Zoom extends Provider {
       items: [],
       username: adapter.getUserEmail(userResponse)
     }
-    const items = results.meetings || results.recording_files
+    const items = results.meetings || results.recording_files.filter(file => file.file_type !== 'TIMELINE')
+
     items.forEach(item => {
       data.items.push({
         isFolder: adapter.getIsFolder(item),


### PR DESCRIPTION
this diff hides zoom timeline.json files from end users when they're selecting / downloading files. 
It sounds like we shouldn't really be showing timeline files since it's a .json file that's really meant more for programmatic use (it's also hidden from Zoom's own "recordings" section, so it's not really meant for end users to upload/download).  This is just removing the files from view. You can check out the follow up PR here https://github.com/transloadit/uppy/pull/2508 which converts timeline checks to CC filetype checks (you can get more context there). 

to test, the zoom user settings need to be updated so that `Add a timestamp to the recording` is enabled (https://zoom.us/profile/setting?tab=recording).