### PR TITLE
Omit timeline files and fix cc type files for zoom provider

### DIFF
--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -94,8 +94,8 @@ exports.getMimeType = (item) => {
 }
 
 exports.getId = (item) => {
-  if (item.file_type && item.file_type === 'TIMELINE') {
-    return `${encodeURIComponent(item.meeting_id)}__TIMELINE`
+  if (item.file_type && item.file_type === 'CC') {
+    return `${encodeURIComponent(item.meeting_id)}__CC__${encodeURIComponent(item.recording_start)}`
   } else if (item.file_type) {
     return `${encodeURIComponent(item.meeting_id)}__${encodeURIComponent(item.id)}`
   }
@@ -103,8 +103,8 @@ exports.getId = (item) => {
 }
 
 exports.getRequestPath = (item) => {
-  if (item.file_type && item.file_type === 'TIMELINE') {
-    return `${encodeURIComponent(item.meeting_id)}?recordingId=TIMELINE`
+  if (item.file_type && item.file_type === 'CC') {
+    return `${encodeURIComponent(item.meeting_id)}?recordingId=CC&recordingStart=${encodeURIComponent(item.recording_start)}`
   } else if (item.file_type) {
     return `${encodeURIComponent(item.meeting_id)}?recordingId=${encodeURIComponent(item.id)}`
   }
@@ -112,14 +112,14 @@ exports.getRequestPath = (item) => {
 }
 
 exports.getStartDate = (item) => {
-  if (item.file_type === 'TIMELINE') {
+  if (item.file_type === 'CC') {
     return item.recording_start
   }
   return item.start_time
 }
 
 exports.getSize = (item) => {
-  if (item.file_type && item.file_type === 'TIMELINE') {
+  if (item.file_type && item.file_type === 'CC') {
     const maxExportFileSize = 1024 * 1024
     return maxExportFileSize
   } else if (item.file_type) {


### PR DESCRIPTION
This diff fixes the file uploads for closed captioning (CC VTT) files because they lack file IDs, similarly to timeline files earlier.  It also cleans up / removes code around processing timeline files because these should be omitted from results for the end user (they are json files meant for programmatic use, and omitted from Zoom's own website when showing cloud recordings to users).  Note: stopping and starting a recording produces 2 seperate sets of CC VTT files which is why we've got the additional recording start information added to the id and the query paramter 


To test this out end to end:
-  the zoom account settings need to be changed so that closed captioning is enabled under settings -> Meetings -> Closed Captioning (note this setting is not under cloud recordings, but under meetings!)
- start a recording, pause recording, and continue
- select these files for upload. 

Additionally, if testing locally, it looks like zoom was silently redirecting our http://localhost callbacks to https://localhost (see https://devforum.zoom.us/t/oauth-callback-redirects-automatically-to-https/27993).  I know it's not the best solution, but in the interest of time, these are the steps I took to get this working:
- Ran a local ssl proxy (this one https://www.npmjs.com/package/local-ssl-proxy to be specific)
- Updated the zoom app to point to the proxy. I noticed that the settings around the allowed oauth redirect sometimes seemed to cache / wouldn't update, so it might be easier to just create a new oauth app if you start to notice this
- The dashboard companion url, uppyOptions and buildUtils were also updated to point to the new address:
- https://github.com/transloadit/uppy/blob/master/examples/dev/Dashboard.js#L31 
- https://github.com/transloadit/uppy/blob/master/examples/uppy-with-companion/server/index.js#L47 
- https://github.com/transloadit/uppy/blob/master/packages/%40uppy/companion/src/server/helpers/utils.js#L102 
