### PR TITLE
Update the pagination limit / boundary on the zoom provider

### DIFF
--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -50,7 +50,10 @@ exports.getDateFolderModified = (end) => {
   return end.format('YYYY-MM-DD')
 }
 
-exports.getDateNextPagePath = (start) => {
+exports.getDateNextPagePath = (start, allResultsShown) => {
+  if (allResultsShown) {
+    return ''
+  }
   return `?cursor=${start.subtract(1, 'days').format('YYYY-MM-DD')}`
 }
 

--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -50,11 +50,8 @@ exports.getDateFolderModified = (end) => {
   return end.format('YYYY-MM-DD')
 }
 
-exports.getDateNextPagePath = (start, allResultsShown) => {
-  if (allResultsShown) {
-    return ''
-  }
-  return `?cursor=${start.subtract(1, 'days').format('YYYY-MM-DD')}`
+exports.getDateNextPagePath = (end) => {
+  return `?cursor=${end.format('YYYY-MM-DD')}`
 }
 
 exports.getNextPagePath = (results) => {

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -189,16 +189,18 @@ class Zoom extends Provider {
     let start = end.clone().date(1)
 
     const accountCreation = adapter.getAccountCreationDate(body)
-    const defaultLimit = end.clone().subtract(DEFAULT_RANGE_MOS, 'months')
-    const limit = accountCreation > defaultLimit ? accountCreation : defaultLimit
+    const defaultLimit = end.clone().subtract(DEFAULT_RANGE_MOS, 'months').date(1)
+    const allResultsShown = accountCreation > defaultLimit
+    const limit = allResultsShown ? accountCreation : defaultLimit
 
     const data = {
       items: [],
       username: adapter.getUserEmail(body)
     }
 
-    while (start > limit) {
-      start = end.clone().date(1)
+    while (start.isSameOrAfter(limit, 'month')) {
+      start = end.isSame(limit, 'month') ? limit.clone() : end.clone().date(1)
+
       data.items.push({
         isFolder: true,
         icon: 'folder',
@@ -210,9 +212,15 @@ class Zoom extends Provider {
         modifiedDate: adapter.getDateFolderModified(end),
         size: null
       })
+
+      if (end.isSame(limit, 'month')) {
+        break
+      }
+
       end = start.clone().subtract(1, 'days')
     }
-    data.nextPagePath = adapter.getDateNextPagePath(start)
+
+    data.nextPagePath = adapter.getDateNextPagePath(start.clone(), allResultsShown)
     return data
   }
 

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -186,21 +186,19 @@ class Zoom extends Provider {
 
   _initializeData (body, initialEnd = null) {
     let end = initialEnd || moment()
-    let start = end.clone().date(1)
-
     const accountCreation = adapter.getAccountCreationDate(body)
     const defaultLimit = end.clone().subtract(DEFAULT_RANGE_MOS, 'months').date(1)
     const allResultsShown = accountCreation > defaultLimit
     const limit = allResultsShown ? accountCreation : defaultLimit
+    // if the limit is mid-month, keep that exact date
+    let start = (end.isSame(limit, 'month') && limit.date() !== 1) ? limit.clone() : end.clone().date(1)
 
     const data = {
       items: [],
       username: adapter.getUserEmail(body)
     }
 
-    while (start.isSameOrAfter(limit, 'month')) {
-      start = end.isSame(limit, 'month') ? limit.clone() : end.clone().date(1)
-
+    while (end.isAfter(limit)) {
       data.items.push({
         isFolder: true,
         icon: 'folder',
@@ -212,15 +210,11 @@ class Zoom extends Provider {
         modifiedDate: adapter.getDateFolderModified(end),
         size: null
       })
-
-      if (end.isSame(limit, 'month')) {
-        break
-      }
-
       end = start.clone().subtract(1, 'days')
+      // if the limit is mid-month, keep that exact date
+      start = (end.isSame(limit, 'month') && limit.date() !== 1) ? limit.clone() : end.clone().date(1)
     }
-
-    data.nextPagePath = adapter.getDateNextPagePath(start.clone(), allResultsShown)
+    data.nextPagePath = allResultsShown ? null : adapter.getDateNextPagePath(end.clone())
     return data
   }
 


### PR DESCRIPTION
This PR fixes an issue with the pagination when an account creation date is the same month as the date range limit.
Example scenario: user account creation date is September 20, 2018 (so just over the date range limit) if I'm querying today (September 4, 2020

- we set the default limit to start on the first of the month (prevents the awkward start date on the oldest folder on default page load)
- if the limit is set by the account creation, we keep that specific mid-month date
- if the limit is set by the account creation and it's within the same month as the range to show, we'll just tack it on
- we adjust the cursor query accordingly for pagination 

To test:
- For local testing, you should be able to modify the user account json response, or modify the limit date and handle pagination 