### PR TITLE
For React Initialization Docs, update useMemo to useRef

### DIFF
--- a/website/src/docs/react-initializing.md
+++ b/website/src/docs/react-initializing.md
@@ -12,39 +12,39 @@ When using Uppy's React components, an Uppy instance must be passed in to the `u
 
 ## Functional Components
 
-With React Hooks, the `useMemo` hook can be used to create an instance once and remember it for all rerenders. The `useEffect` hook can close the Uppy instance when the component unmounts.
+With React Hooks, the `useRef` hook can be used to create an instance once and remember it for all rerenders. The `useEffect` hook can close the Uppy instance when the component unmounts.
 
 ```js
 const MyComponent = () => {
-  const uppy = React.useMemo(() => {
-    // Do all the configuration here
-    return new Uppy()
+  const uppy = useRef(null);
+  if (uppy.current === null) {
+    uppy.current = new Uppy()
       .use(Transloadit, {})
-  }, []);
+  }
 
   React.useEffect(() => {
-    return () => uppy.close()
+    return () => uppy.current.close()
   }, [])
 
   return <DashboardModal uppy={uppy} />
 }
 ```
 
-Both hooks must receive the `[]` dependency array parameter, or the Uppy instance will be recreated and/or destroyed every time the component rerenders. To make sure you never forget that, a custom hook could be used:
+With useRef you must call `current` to access the Uppy instance and its functions. useEffect must receive the `[]` dependency array parameter, or the Uppy instance will be destroyed every time the component rerenders. To make sure you never forget these requirements, a custom hook could be used:
 ```js
-function useUppy (factory) {
-  const uppy = React.useMemo(factory, [])
+function useUppy(uppyInstance) {
+  const uppy = React.useRef(uppyInstance)
   React.useEffect(() => {
-    return () => uppy.close()
+    return () => uppy.current.close()
   }, [])
-  return new uppy
+  return uppy.current
 }
 
 // Then use it as:
-const uppy = useUppy(() => {
-  return new Uppy()
+const uppy = useUppy(
+  new Uppy()
     .use(Tus, {})
-})
+)
 ```
 
 ## Class Components

--- a/website/src/docs/react-initializing.md
+++ b/website/src/docs/react-initializing.md
@@ -15,14 +15,16 @@ When using Uppy's React components, an Uppy instance must be passed in to the `u
 With React Hooks, the `useRef` hook can be used to create an instance once and remember it for all rerenders. The `useEffect` hook can close the Uppy instance when the component unmounts.
 
 ```js
-const MyComponent = () => {
-  const uppy = useRef(null);
-  if (uppy.current === null) {
+function MyComponent () {
+  const uppy = useRef(undefined);
+  // Make sure we only initialize it the first time:
+  if (uppy.current === undefined) {
     uppy.current = new Uppy()
       .use(Transloadit, {})
   }
 
   React.useEffect(() => {
+    // Return a cleanup function:
     return () => uppy.current.close()
   }, [])
 
@@ -30,10 +32,18 @@ const MyComponent = () => {
 }
 ```
 
-With useRef you must call `current` to access the Uppy instance and its functions. useEffect must receive the `[]` dependency array parameter, or the Uppy instance will be destroyed every time the component rerenders. To make sure you never forget these requirements, a custom hook could be used:
+With `useRef`, the Uppy instance and its functions are stored on the `.current` property.
+`useEffect()` must receive the `[]` dependency array parameter, or the Uppy instance will be destroyed every time the component rerenders.
+To make sure you never forget these requirements, you could wrap it up in a custom hook:
+
 ```js
-function useUppy(uppyInstance) {
-  const uppy = React.useRef(uppyInstance)
+function useUppy (factory) {
+  const uppy = React.useRef(undefined)
+  // Make sure we only initialize it the first time:
+  if (uppy.current === undefined) {
+    uppy.current = factory()
+  }
+
   React.useEffect(() => {
     return () => uppy.current.close()
   }, [])
@@ -41,15 +51,17 @@ function useUppy(uppyInstance) {
 }
 
 // Then use it as:
-const uppy = useUppy(
+const uppy = useUppy(() =>
   new Uppy()
     .use(Tus, {})
 )
 ```
 
+(The function wrapper is required here so you don't create an unused Uppy instance on each rerender.)
+
 ## Class Components
 
-A simple approach is to initialize it in your React component's `constructor()` and destroy it in `componentWillUnmount()`.
+A simple approach is to create an Uppy instance in your React component's `constructor()` and destroy it in `componentWillUnmount()`.
 
 > ⚠ Uppy instances are stateful, so the same instance must be used across different renders.
 > Do **NOT** initialize Uppy in a `render()` method!


### PR DESCRIPTION
Based on #2509 updating `useMemo` to `useRef` and updating the `useUppy` example hook to reflect that change.

In the hooks example, I chose to expose `uppy.current` from the hook as opposed to the ref directly and relying on the caller to remember to use `.current`. This felt like a good encapsulation and less likely for a caller to forget to include `.current` - but open to thoughts on this if there's a good reason to expose the ref directly I'm missing.