### PR TITLE
Fixed translation of uploadingX in french locale

### DIFF
--- a/packages/@uppy/locales/src/fr_FR.js
+++ b/packages/@uppy/locales/src/fr_FR.js
@@ -126,9 +126,9 @@ fr_FR.strings = {
   },
   uploading: 'Téléchargement en cours',
   uploadingXFiles: {
-    '0': 'Uploading %{smart_count} file',
-    '1': 'Uploading %{smart_count} files',
-    '2': 'Uploading %{smart_count} files'
+    '0': 'Téléchargement de %{smart_count} fichier',
+    '1': 'Téléchargement de %{smart_count} fichiers',
+    '2': 'Téléchargement de %{smart_count} fichiers'
   },
   xFilesSelected: {
     '0': '%{smart_count} fichier sélectionné',


### PR DESCRIPTION
There was an issue with the translation in `fr_FR` locale where the text was in english. I fixed it with a wording similar to other translations around it but I'm wondering why the `'1'` translation is ending with an `'s'` when it's singular