### PR TITLE
Zoom Plugin - Fix meeting timestamp for user timezones and explicitly include moment-timezone dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8122,7 +8122,8 @@
         "aliasify": "^2.1.0",
         "browserify": "^16.5.2",
         "drag-drop": "^4.2.0",
-        "ecstatic": "^3.0.0"
+        "ecstatic": "^3.0.0",
+        "marked": "^0.7.0"
       }
     },
     "@uppy-example/uppy-with-companion": {
@@ -8190,6 +8191,7 @@
         "jsonwebtoken": "8.5.1",
         "lodash.merge": "4.6.2",
         "mime-types": "2.1.25",
+        "moment-timezone": "^0.5.31",
         "morgan": "1.10.0",
         "ms": "2.1.2",
         "node-redis-pubsub": "4.0.0",
@@ -28367,6 +28369,11 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
+      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
     },
     "math-clamp-x": {
       "version": "3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8057,6 +8057,8 @@
           "integrity": "sha512-cRQ5Qw87SNS4b2v+UfjUW5uAVx4nv6pj9I0cu6ys8x+t7NjVo3cOjaT4Bns1/xxy6xzWv/4WT0LbG5h+NNGNMA==",
           "requires": {
             "@types/tus-js-client": "^1.8.0",
+            "@uppy/companion-client": "^1.5.0",
+            "@uppy/utils": "^3.1.0",
             "tus-js-client": "^1.8.0"
           }
         },
@@ -8120,8 +8122,7 @@
         "aliasify": "^2.1.0",
         "browserify": "^16.5.2",
         "drag-drop": "^4.2.0",
-        "ecstatic": "^3.0.0",
-        "marked": "^0.6.0"
+        "ecstatic": "^3.0.0"
       }
     },
     "@uppy-example/uppy-with-companion": {
@@ -22034,7 +22035,6 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -22044,8 +22044,7 @@
         "eventemitter3": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-          "dev": true
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         }
       }
     },
@@ -26996,6 +26995,7 @@
         "connect-history-api-fallback": "^1.6.0",
         "connect-injector": "^0.4.4",
         "gaze": "^1.1.3",
+        "http-proxy": "^1.18.1",
         "morgan": "~1.10.0",
         "opener": "^1.5.1",
         "parseurl": "^1.3.3",
@@ -28367,11 +28367,6 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
     },
     "math-clamp-x": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "minify-stream": "2.0.1",
     "minimist": "^1.2.5",
     "mkdirp": "0.5.1",
+    "moment-timezone": "^0.5.31",
     "multi-glob": "1.0.2",
     "namespace-emitter": "2.0.1",
     "nock": "9.6.1",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,6 @@
     "minify-stream": "2.0.1",
     "minimist": "^1.2.5",
     "mkdirp": "0.5.1",
-    "moment-timezone": "^0.5.31",
     "multi-glob": "1.0.2",
     "namespace-emitter": "2.0.1",
     "nock": "9.6.1",

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -49,6 +49,7 @@
     "isobject": "3.0.1",
     "jsonwebtoken": "8.5.1",
     "lodash.merge": "4.6.2",
+    "moment-timezone": "^0.5.31",
     "mime-types": "2.1.25",
     "morgan": "1.10.0",
     "ms": "2.1.2",

--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -1,4 +1,4 @@
-const moment = require('moment')
+const moment = require('moment-timezone')
 
 const MIMETYPES = {
   MP4: 'video/mp4',
@@ -31,7 +31,7 @@ exports.getDateName = (start, end) => {
 }
 
 exports.getAccountCreationDate = (results) => {
-  return moment(results.created_at)
+  return moment.utc(results.created_at)
 }
 
 exports.getUserEmail = (results) => {
@@ -65,10 +65,9 @@ exports.getIsFolder = (item) => {
   return !item.file_type
 }
 
-exports.getItemName = (item) => {
-  const start = moment(item.start_time || item.recording_start)
-    .clone()
-    .format('YYYY-MM-DD, kk:mm')
+exports.getItemName = (item, userResponse) => {
+  const start = moment.tz(item.start_time || item.recording_start, userResponse.timezone || 'UTC')
+    .format('YYYY-MM-DD, HH:mm')
 
   if (item.file_type) {
     const ext = EXT[item.file_type] ? `.${EXT[item.file_type]}` : ''

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -52,7 +52,7 @@ class Zoom extends Provider {
         }
 
         if (from && to) {
-          this._meetingInfo({ token, query }, userResponse, (err, meetingResp) => {
+          this._meetingsInfo({ token, query }, userResponse, (err, meetingResp) => {
             if (err || meetingResp.statusCode !== 200) {
               return this._listError(err, meetingResp, done)
             }
@@ -69,7 +69,7 @@ class Zoom extends Provider {
       })
   }
 
-  _meetingInfo ({ token, query }, userResponse, done) {
+  _meetingsInfo ({ token, query }, userResponse, done) {
     const { cursor, from, to } = query
     /*  we need to convert local datetime to UTC date for Zoom query
     eg: user in PST (UTC-08:00) wants 2020-08-01 (00:00) to 2020-08-31 (23:59)
@@ -210,7 +210,7 @@ class Zoom extends Provider {
       return { items: [] }
     }
 
-    // convert start limit from local time to UTC
+    // we query the zoom api by date (from 00:00 - 23:59 UTC) which may include extra results for 00:00 - 23:59 local time that we want to filter out
     const utcFrom = moment.tz(query.from, userResponse.timezone || 'UTC').startOf('day').tz('UTC')
     const utcTo = moment.tz(query.to, userResponse.timezone || 'UTC').endOf('day').tz('UTC')
 

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -28,7 +28,7 @@ class Zoom extends Provider {
     return 'zoom'
   }
 
-  async list (options, done) {
+  list (options, done) {
     /*
     - returns list of months by default
     - drill down for specific files in each month
@@ -52,9 +52,13 @@ class Zoom extends Provider {
         })
     })
 
-    const userResponse = await userPromise
+    const userResponse = userPromise
 
     if (from && to) {
+      /*  we need to convert local time to UTC for Zoom query
+      eg: user in PST (UTC-08:00) wants 2020-08-01 (00:00) to 2020-08-31 (23:59)
+      => API call needs to request 2020-07-31 (16:00) to 2020-08-31 (15:59) UTC - but api only takes date, so we remove extra time info
+      */
       const queryObj = {
         page_size: PAGE_SIZE,
         from: moment.tz(from, userResponse.body.timezone || 'UTC').startOf('day').tz('UTC').format('YYYY-MM-DD'),


### PR DESCRIPTION
This PR resolves a couple issues:

- it adds moment-timezone as an explicit dependency (right now, we're relying on the fact that moment is a global js object, which is implicitly available because the "expo" dependency installs a copy) and updates the package-lock file accordingly. I wasn't sure if there were intentional edits to package-lock previously done or if it's fully auto-generated so please let me know if the package-lock update is an issue / should be omitted

- it fixes the zoom provider to use UTC time rather than the default server time, and the timezone provided by the user's zoom settings where required. In particular:
- account creation date should now be displayed in local time 
- each date range folder should correctly display meetings for that range in local time
- each meeting or recording label should be displayed in local time

For the sake of simplicity, this PR only uses the user's timezone settings. I was hoping we could wait and see if we get user feedback that the timezone used is confusing, at which point we can re-evaluate the implementation.  Below are other alternatives considered.  I had a hard time keeping track of timezones / found this generally confusing, so i've added some examples below and in the comments to hopefully clarify.

alternative 1 - user's browser timezone
- the user browser's timezone was considered but not used, because the api call to Zoom for a list of recordings by date range accepts dates, not date times which would result in returning too few or too many results
- E.g.: User in California (PST, UTC−07:00) clicks into 2020-08-01 to 2020-08-31
- User has recording for 2020-08-31 20:00 PST and 2020-09-01 9:00 PST --> 2020-09-01 3:00 UTC and 2020-09-01 16:00
- API call to zoom needs to be 2020-08-01 to 2020-09-01 (to include record from 2020-08-31 evening). Otherwise, we will be missing items.
- Results returns both recordings from 2020-09-01 but we need to filter the later recording out because it's actually on 2020-09-01 for the user's timezone

alternative 2 - meeting timezone
- the meeting timezone was also considered but we only have access to this after we have queried the API for the date range
- ultimately omitted because it could result in a mixture of timezones (which could be even more confusing) or conflicting meeting times. If it's ok, the preference is to wait for user feedback and adjust if needed 

