### PR TITLE
Zoom Plugin - Fix cases where a meeting UUID has slashes

### DIFF
--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -108,6 +108,7 @@ exports.getRequestPath = (item) => {
   } else if (item.file_type) {
     return `${encodeURIComponent(item.meeting_id)}?recordingId=${encodeURIComponent(item.id)}`
   }
+  // Zoom meeting ids are reused so we need to use the UUID. Also, these UUIDs can contain `/` characters which require double encoding (see https://devforum.zoom.us/t/double-encode-meeting-uuids/23729)
   return `${encodeURIComponent(encodeURIComponent(item.uuid))}`
 }
 

--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -108,7 +108,7 @@ exports.getRequestPath = (item) => {
   } else if (item.file_type) {
     return `${encodeURIComponent(item.meeting_id)}?recordingId=${encodeURIComponent(item.id)}`
   }
-  return `${encodeURIComponent(item.uuid)}`
+  return `${encodeURIComponent(encodeURIComponent(item.uuid))}`
 }
 
 exports.getStartDate = (item) => {

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -76,7 +76,7 @@ class Zoom extends Provider {
           })
       })
     } else if (meetingId) {
-      const GET_MEETING_FILES = `/meetings/${meetingId}/recordings`
+      const GET_MEETING_FILES = `/meetings/${encodeURIComponent(meetingId)}/recordings`
       recordingsPromise = new Promise((resolve, reject) => {
         this.client
           .get(`${BASE_URL}${GET_MEETING_FILES}`)


### PR DESCRIPTION
We currently have an issue where the call to retrieve files fails when a meeting UUID contains '/' character. This pr fixes this issue by double encoding the UUID

The Zoom API docs notes ( https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingget) :
```To get Cloud Recordings of a meeting, provide the meeting ID or meeting UUID. If the meeting ID is provided instead of UUID,the response will be for the latest meeting instance. \n\nTo get Cloud Recordings of a webinar, provide the webinar ID or the webinar UUID. If the webinar ID is provided instead of UUID,the response will be for the latest webinar instance. \n\nIf a UUID starts with \"/\" or contains \"//\" (example: \"/ajXp112QmuoKj4854875==\"), you must **double encode** the UUID before making an API request.``` 

