### PR TITLE
core: add postprocess progress when upload success

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1076,7 +1076,9 @@ class Uppy {
       const currentProgress = this.getFile(file.id).progress
       this.setFileState(file.id, {
         progress: Object.assign({}, currentProgress, {
-          postprocess: this.postProcessors.length > 0,
+          postprocess: this.postProcessors.length > 0 ? {
+            mode: 'indeterminate'
+          } : null,
           uploadComplete: true,
           percentage: 100,
           bytesUploaded: currentProgress.bytesTotal

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1076,6 +1076,7 @@ class Uppy {
       const currentProgress = this.getFile(file.id).progress
       this.setFileState(file.id, {
         progress: Object.assign({}, currentProgress, {
+          postprocess: this.postProcessors.length > 0,
           uploadComplete: true,
           percentage: 100,
           bytesUploaded: currentProgress.bytesTotal


### PR DESCRIPTION
A fix for this [issue](https://github.com/transloadit/uppy/issues/2534). I don't know if this is the best way to solve the bug but It works in my case. The `postprocess` property should be set up if there is any postprocessor, that way the success icon is not going to appear at the end of `upload-success`. That is possible because there is an existing [validation in a dashboard component](https://github.com/transloadit/uppy/blob/master/packages/%40uppy/dashboard/src/components/FileItem/index.js#L31) that checks for that property.


![postprocessor2](https://user-images.githubusercontent.com/4699893/93378951-c1124d00-f822-11ea-8e74-3180d89d312b.gif)


Question: Are the packages of this PR deployed somewhere? I need to use my forked version but it is becoming complicated since uppy uses mono repo and can't just simple do `yarn add https://github.com/myaccount/forked-repo` since I only need @uppy/core from my forked version.