### PR TITLE
onedrive: fix OneDrive for Business

### DIFF
--- a/packages/@uppy/companion/src/server/provider/onedrive/index.js
+++ b/packages/@uppy/companion/src/server/provider/onedrive/index.js
@@ -36,7 +36,7 @@ class OneDrive extends Provider {
    */
   list ({ directory, query, token }, done) {
     const path = directory ? `items/${directory}` : 'root'
-    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/drive'
+    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/me/drive'
     const qs = { $expand: 'thumbnails' }
     if (query.cursor) {
       qs.$skiptoken = query.cursor
@@ -65,7 +65,7 @@ class OneDrive extends Provider {
   }
 
   download ({ id, token, query }, onData) {
-    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/drive'
+    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/me/drive'
     return this.client
       .get(`${rootPath}/items/${id}/content`)
       .auth(token)
@@ -92,7 +92,7 @@ class OneDrive extends Provider {
   }
 
   size ({ id, query, token }, done) {
-    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/drive'
+    const rootPath = query.driveId ? `/drives/${query.driveId}` : '/me/drive'
     return this.client
       .get(`${rootPath}/items/${id}`)
       .auth(token)


### PR DESCRIPTION
Was using org's default Sharepoint site, instead of user's OneDrive.

You can see the difference in [MS Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer) by comparing the requests "https://graph.microsoft.com/v1.0/drive/" and "https://graph.microsoft.com/v1.0/me/drive"

I'm also working on a separate PR to show all drives available to the user, which would allow them to select from either their OneDrive or from any of their org's sharepoint drives.