### PR TITLE
fix username not updating when switching OneDrive accounts

### DIFF
--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -147,7 +147,7 @@ module.exports = class ProviderView {
           updatedDirectories = state.directories.concat([{ id, title: name }])
         }
 
-        this.username = this.username ? this.username : res.username
+        this.username = res.username || this.username
         this._updateFilesAndFolders(res, files, folders)
         this.plugin.setPluginState({ directories: updatedDirectories })
       },


### PR DESCRIPTION
Continues to use cached username instead of using the updated one sent from the companion server.
To reproduce: Connect to OneDrive, then click Log out and reconnect with another account.