### PR TITLE
Include meeting name in file name, and include meeting data in response object so it is available in later uppy lifecycle methods when interacting with file object

### DIFF
--- a/packages/@uppy/companion/src/server/provider/zoom/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/adapter.js
@@ -72,7 +72,7 @@ exports.getItemName = (item, userResponse) => {
   if (item.file_type) {
     const ext = EXT[item.file_type] ? `.${EXT[item.file_type]}` : ''
     const itemType = item.recording_type ? ` - ${item.recording_type.split('_').join(' ')}` : ''
-    return `${start}${itemType} (${item.file_type.toLowerCase()})${ext}`
+    return `${item.topic}${itemType} (${start})${ext}`
   }
 
   return `${item.topic} (${start})`
@@ -126,4 +126,8 @@ exports.getSize = (item) => {
     return item.file_size
   }
   return item.total_size
+}
+
+exports.getItemTopic = (item) => {
+  return item.topic
 }

--- a/packages/@uppy/companion/src/server/provider/zoom/index.js
+++ b/packages/@uppy/companion/src/server/provider/zoom/index.js
@@ -227,7 +227,8 @@ class Zoom extends Provider {
         .filter(item => moment.utc(item.start_time).isAfter(utcFrom) && moment.utc(item.start_time).isBefore(utcTo))
     } else {
       items = results.recording_files
-        .map(item => item).filter(file => file.file_type !== 'TIMELINE')
+        .map(item => { return { ...item, topic: results.topic } })
+        .filter(file => file.file_type !== 'TIMELINE')
     }
 
     items.forEach(item => {
@@ -240,7 +241,10 @@ class Zoom extends Provider {
         thumbnail: null,
         requestPath: adapter.getRequestPath(item),
         modifiedDate: adapter.getStartDate(item),
-        size: adapter.getSize(item)
+        size: adapter.getSize(item),
+        custom: {
+          topic: adapter.getItemTopic(item)
+        }
       })
     })
     return data


### PR DESCRIPTION
Hi again! We received user feedback that it's confusing trying to figure out which files are associated with which meeting because this information gets omitted after the file upload is complete (ie the file name doesn't include this data).

This PR aims to address that user feedback by:
- updating the file name to include the zoom meeting (i.e. the zoom topic, please see sample response in https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingget) 
- making the meeting topic available as customData on the file object, so that when we interact the file later via uppy events such as `onBeforeFileAdded` this information is available 