### PR TITLE
Include required CSS import

### DIFF
--- a/website/src/docs/image-editor.md
+++ b/website/src/docs/image-editor.md
@@ -41,6 +41,16 @@ npm install @uppy/image-editor
 
 The `@uppy/image-editor` plugin is in beta and is not yet available in the [CDN package](/docs/#With-a-script-tag).
 
+## CSS
+
+The `@Uppy/image-editor` plugin requires the following CSS for styling:
+
+```js
+import '@uppy/image-editor/dist/style.css'
+```
+
+A minified version is also available as `style.min.css` at the same path.  Include this import after your import of the core stylesheet and the dashboard stylesheet.
+
 ## Options
 
 The `@uppy/image-editor` plugin has the following configurable options:


### PR DESCRIPTION
The editor is unusable if you're importing stylesheets individually and leave this one out.  In line with the documentation of other plugins, I added a note to import the relevant CSS file.