### PR TITLE
Add support for uploading nested folders

### DIFF
--- a/packages/@uppy/provider-views/src/index.js
+++ b/packages/@uppy/provider-views/src/index.js
@@ -528,6 +528,8 @@ module.exports = class ProviderView {
         res.items.forEach((item) => {
           if (!item.isFolder) {
             files.push(item)
+          } else {
+            this.addFolder(item)
           }
         })
         const moreFiles = res.nextPagePath || null


### PR DESCRIPTION
This change updates the uppy provider views to allow for nested folders to be added when a user selects a folder (described in https://github.com/transloadit/uppy/issues/2551).
Right now, when I try to select a folder with only subfolders, I get an error that no files are present.   The intent of this pr is to support nested folder structures like shown below:

No files in top level folder, but files present in subfolders 
<img width="199" alt="Screen Shot 2020-09-25 at 2 11 02 PM" src="https://user-images.githubusercontent.com/65177495/94301661-f6ace980-ff38-11ea-9f79-69eb9ef7d18c.png">

Files present in top level folder and subfolders
<img width="186" alt="Screen Shot 2020-09-25 at 2 06 48 PM" src="https://user-images.githubusercontent.com/65177495/94301359-6bcbef00-ff38-11ea-94b5-1ba6a18f798b.png">

As far as I could tell, this was the only spot that needed to be updated, as `addFolder` seems to handle syncing the uppy state for folders, and add `listAllFiles` already seems to handle infinite scroll, and  file vs folder support.


I'm not sure if this was intentionally not supported because of rate limit or other issues (though I don't anticipate this is a very common use cases), please let me know if this seems problematic otherwise. 