### PR TITLE
Add missing camera translations to de_DE

### DIFF
--- a/packages/@uppy/locales/src/de_DE.js
+++ b/packages/@uppy/locales/src/de_DE.js
@@ -63,6 +63,8 @@ de_DE.strings = {
   loading: 'Laden...',
   logOut: 'Ausloggen',
   myDevice: 'Mein Gerät',
+  noCameraDescription: 'Bitte Kamera anschließen, um Bilder oder Videos aufzunehmen',
+  noCameraTitle: 'Kamera nicht verfügbar',
   noDuplicates: 'Datei \'%{fileName}\' existiert bereits und kann nicht erneut hinzugefügt werden',
   noFilesFound: 'Sie haben keine Dateien oder Ordner hier',
   noInternetConnection: 'Keine Internetverbindung',


### PR DESCRIPTION
Translations seem to be missing in all languages except en_US & zh_CN.

This pull requests adds these missing translations for camera texts in German.