### PR TITLE
S3 validate parameters: display correct error for wrong method

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -134,7 +134,7 @@ module.exports = class AwsS3 extends Plugin {
   validateParameters (file, params) {
     const valid = typeof params === 'object' && params &&
       typeof params.url === 'string' &&
-      (typeof params.fields === 'object' || params.fields == null) &&
+      (typeof params.fields === 'object' || params.fields == null)
 
     if (!valid) {
       const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields, headers }' but got '${JSON.stringify(params)}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -143,7 +143,7 @@ module.exports = class AwsS3 extends Plugin {
       throw err
     }
 
-    const methodIsValid = /^(put|post)$/i.test(params.method);
+    const methodIsValid = params.method == null || /^(put|post)$/i.test(params.method)
 
     if (!methodIsValid) {
       const err = new TypeError(`AwsS3: got incorrect method from 'getUploadParameters()' for file '${file.name}', expected  'put,post' but got '${params.method}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -135,7 +135,6 @@ module.exports = class AwsS3 extends Plugin {
     const valid = typeof params === 'object' && params &&
       typeof params.url === 'string' &&
       (typeof params.fields === 'object' || params.fields == null) &&
-      params.method == null;
 
     if (!valid) {
       const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields, headers }' but got '${JSON.stringify(params)}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
@@ -146,11 +145,10 @@ module.exports = class AwsS3 extends Plugin {
     const methodIsValid = params.method == null || /^(put|post)$/i.test(params.method)
 
     if (!methodIsValid) {
-      const err = new TypeError(`AwsS3: got incorrect method from 'getUploadParameters()' for file '${file.name}', expected  'put,post' but got '${params.method}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+      const err = new TypeError(`AwsS3: got incorrect method from 'getUploadParameters()' for file '${file.name}', expected  'put' or 'post' but got '${params.method}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
       console.error(err)
       throw err
     }
-
 
   }
 

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -135,13 +135,23 @@ module.exports = class AwsS3 extends Plugin {
     const valid = typeof params === 'object' && params &&
       typeof params.url === 'string' &&
       (typeof params.fields === 'object' || params.fields == null) &&
-      (params.method == null || /^(put|post)$/i.test(params.method))
+      params.method == null;
 
     if (!valid) {
       const err = new TypeError(`AwsS3: got incorrect result from 'getUploadParameters()' for file '${file.name}', expected an object '{ url, method, fields, headers }' but got '${JSON.stringify(params)}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
       console.error(err)
       throw err
     }
+
+    const methodIsValid = /^(put|post)$/i.test(params.method);
+
+    if (!methodIsValid) {
+      const err = new TypeError(`AwsS3: got incorrect method from 'getUploadParameters()' for file '${file.name}', expected  'put,post' but got '${params.method}' instead.\nSee https://uppy.io/docs/aws-s3/#getUploadParameters-file for more on the expected format.`)
+      console.error(err)
+      throw err
+    }
+
+
   }
 
   handleUpload (fileIDs) {

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -149,7 +149,6 @@ module.exports = class AwsS3 extends Plugin {
       console.error(err)
       throw err
     }
-
   }
 
   handleUpload (fileIDs) {


### PR DESCRIPTION
I had quite a hard time figuring my backend pre-sign function was returning the wrong method, because the displayed error was pointing me in the wrong direction. Added this for the sake of clarity.