### PR TITLE
Mobile issues fixes + compact Companion migration table

### DIFF
--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -493,7 +493,7 @@ to:
 
 `http(s)://$YOUR_COMPANION_HOST_NAME/$PROVIDER_NAME/redirect` in v2
 
-#### Old Redirect URIs vs New Redirect URIs
+#### New Redirect URIs
 
 <div class="table-responsive">
 

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -487,11 +487,11 @@ In v2 the `google` and `microsoft` [providerOptions](https://uppy.io/docs/compan
 
 On your Providers' respective developer platforms, the OAuth redirect URIs that you should supply has now changed from:
 
-`http(s)://$YOUR_COMPANION_HOST_NAME/connect/$AUTH_PROVIDER/callback` in v1
+`http(s)://$COMPANION_HOST_NAME/connect/$AUTH_PROVIDER/callback` in v1
 
 to:
 
-`http(s)://$YOUR_COMPANION_HOST_NAME/$PROVIDER_NAME/redirect` in v2
+`http(s)://$COMPANION_HOST_NAME/$PROVIDER_NAME/redirect` in v2
 
 #### New Redirect URIs
 
@@ -499,11 +499,11 @@ to:
 
 | Provider | New Redirect URI
 |-|-|
-| Dropbox | `https://$YOUR_COMPANION_HOST_NAME/dropbox/redirect` |
-| Google Drive | `https://$YOUR_COMPANION_HOST_NAME/drive/redirect` |
-| OneDrive | `https://$YOUR_COMPANION_HOST_NAME/onedrive/redirect` |
-| Facebook | `https://$YOUR_COMPANION_HOST_NAME/facebook/redirect` |
-| Instagram | `https://$YOUR_COMPANION_HOST_NAME/instagram/redirect` |
+| Dropbox | `https://$COMPANION_HOST_NAME/dropbox/redirect` |
+| Google Drive | `https://$COMPANION_HOST_NAME/drive/redirect` |
+| OneDrive | `https://$COMPANION_HOST_NAME/onedrive/redirect` |
+| Facebook | `https://$COMPANION_HOST_NAME/facebook/redirect` |
+| Instagram | `https://$COMPANION_HOST_NAME/instagram/redirect` |
 
 </div>
 

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -493,15 +493,19 @@ to:
 
 `http(s)://$YOUR_COMPANION_HOST_NAME/$PROVIDER_NAME/redirect` in v2
 
-Old Redirect URIs vs New Redirect URIs
+#### Old Redirect URIs vs New Redirect URIs
 
-| Provider | v1 Redirect URI | v2 Redirect URI |
-|-|-|-|
-| Dropbox | https://$YOUR_COMPANION_HOST_NAME/connect/dropbox/callback | https://$YOUR_COMPANION_HOST_NAME/dropbox/redirect |
-| Google drive | https://$YOUR_COMPANION_HOST_NAME/connect/google/callback | https://$YOUR_COMPANION_HOST_NAME/drive/redirect |
-| OneDrive | https://$YOUR_COMPANION_HOST_NAME/connect/microsoft/callback | https://$YOUR_COMPANION_HOST_NAME/onedrive/redirect |
-| Facebook | https://$YOUR_COMPANION_HOST_NAME/connect/facebook/callback | https://$YOUR_COMPANION_HOST_NAME/facebook/redirect |
-| Instagram | https://$YOUR_COMPANION_HOST_NAME/connect/instagram/callback | https://$YOUR_COMPANION_HOST_NAME/instagram/redirect |
+<div class="table-responsive">
+
+| Provider | New Redirect URI
+|-|-|
+| Dropbox | `https://$YOUR_COMPANION_HOST_NAME/dropbox/redirect` |
+| Google Drive | `https://$YOUR_COMPANION_HOST_NAME/drive/redirect` |
+| OneDrive | `https://$YOUR_COMPANION_HOST_NAME/onedrive/redirect` |
+| Facebook | `https://$YOUR_COMPANION_HOST_NAME/facebook/redirect` |
+| Instagram | `https://$YOUR_COMPANION_HOST_NAME/instagram/redirect` |
+
+</div>
 
 ## Development
 

--- a/website/themes/uppy/source/css/_page.scss
+++ b/website/themes/uppy/source/css/_page.scss
@@ -141,6 +141,7 @@
   max-width: 600px;
   margin: 0 auto;
   font-size: 18px;
+  word-wrap: break-word; // it prevents long code blocks from breaking the layout
 
   @media #{$screen-medium} {
     padding: 2.2em 0;
@@ -266,7 +267,7 @@
 
   .post h4,
   > h4 {
-    font-size: 0.8em;
+    font-size: 1em;
   }
 
   .post figure, .post ul, .post ol,

--- a/website/themes/uppy/source/css/_page.scss
+++ b/website/themes/uppy/source/css/_page.scss
@@ -196,14 +196,20 @@
     border-collapse: collapse;
   }
 
-  table th,
-  table td {
-    padding: 14px 8px;
+  table th {
+    padding: 8px 8px 4px;
   }
 
-  table td { 
+  table td {
+    padding: 14px 8px;
     vertical-align: top;
     border-bottom: 1px solid #eee;
+  }
+
+  // Don't set padding for the first column cells
+  table th:first-child,
+  table td:first-child {
+    padding-left: 0;
   }
 
   .light {
@@ -252,7 +258,7 @@
 
   .post h3,
   > h3 {
-    margin: 3em 0 1.2em;
+    margin: 3em 0 1em;
     position: relative;
     &:before {
       content: "#";
@@ -268,6 +274,7 @@
   .post h4,
   > h4 {
     font-size: 1em;
+    margin-bottom: 0.5em;
   }
 
   .post figure, .post ul, .post ol,

--- a/website/themes/uppy/source/css/_page.scss
+++ b/website/themes/uppy/source/css/_page.scss
@@ -206,6 +206,11 @@
     border-bottom: 1px solid #eee;
   }
 
+  // Remove the last row's border-bottom
+table tr:last-child td {
+  border-bottom: 0;
+}
+
   // Don't set padding for the first column cells
   table th:first-child,
   table td:first-child {


### PR DESCRIPTION
The Companion docs page is ~broken on mobile:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/375537/96843915-89b54280-1457-11eb-89cf-c3c642c4c004.png">

I added the **inline code blocks wrapping,** significantly simplified the **Redirect URIs table,** and tweaked **some small typographic thingies** as well.

### Table: before and after

> <img width="1033" alt="image" src="https://user-images.githubusercontent.com/375537/96844117-cc771a80-1457-11eb-8313-5c9952674c39.png">

↓ ↓ ↓

> <img width="1021" alt="image" src="https://user-images.githubusercontent.com/375537/96844198-e6b0f880-1457-11eb-9771-00447f479304.png">

### Mobile

The page has no horizontal scroll and isn't looking broken anymore. The table is a bit wider than the container (on my iPhone XR at least), but it's easily scrollable — and doesn't affects the page.

<img width="678" alt="image" src="https://user-images.githubusercontent.com/375537/96844481-38598300-1458-11eb-8989-fc894b82b6c9.png">

P.S. This should solve the `Google's Mobile Usability issues detected` problem. /cc @kvz