### PR TITLE
tus: add `onBeforeRequest` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8053,7 +8053,8 @@
       "dependencies": {
         "@uppy/tus": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-1.6.0.tgz",
+          "integrity": "sha512-cRQ5Qw87SNS4b2v+UfjUW5uAVx4nv6pj9I0cu6ys8x+t7NjVo3cOjaT4Bns1/xxy6xzWv/4WT0LbG5h+NNGNMA==",
           "requires": {
             "@types/tus-js-client": "^1.8.0",
             "@uppy/companion-client": "^1.5.0",
@@ -8063,11 +8064,13 @@
         },
         "buffer-from": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
         },
         "react": {
           "version": "16.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/react/-/react-16.5.0.tgz",
+          "integrity": "sha512-nw/yB/L51kA9PsAy17T1JrzzGRk+BlFCJwFF7p+pwVxgqwPjYNeZEkkH7LXn9dmflolrYMXLWMTkQ77suKPTNQ==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -8077,7 +8080,8 @@
         },
         "tus-js-client": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.8.0.tgz",
+          "integrity": "sha512-qPX3TywqzxocTxUZtcS8X7Aik72SVMa0jKi4hWyfvRV+s9raVzzYGaP4MoJGaF0yOgm2+b6jXaVEHogxcJ8LGw==",
           "requires": {
             "buffer-from": "^0.1.1",
             "combine-errors": "^3.0.3",
@@ -8124,7 +8128,8 @@
       "dependencies": {
         "marked": {
           "version": "0.7.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
         }
       }
     },
@@ -8212,7 +8217,8 @@
       "dependencies": {
         "aws-sdk": {
           "version": "2.701.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.701.0.tgz",
+          "integrity": "sha512-95fWGr6gvyRH408VP5LQAycB8Wqw665ll7q6/soscGFD+2HuQ+gB5qpSlXJwOgSggKQCaExWoQnDABBoTSXM2w==",
           "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",
@@ -8227,13 +8233,15 @@
           "dependencies": {
             "uuid": {
               "version": "3.3.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
             }
           }
         },
         "buffer": {
           "version": "4.9.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
@@ -8242,15 +8250,18 @@
         },
         "buffer-from": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
         },
         "escape-string-regexp": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         },
         "express-prom-bundle": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-5.0.0.tgz",
+          "integrity": "sha512-QrpylXBXmf5dKADYC41YU+Ox4vGZrKUcTKkjNGDtBcAQFAFhI2pdtwGD+sy5hyt5ZaYnMf5FK0IWQxAwr4UhpQ==",
           "requires": {
             "on-finished": "^2.3.0",
             "url-value-parser": "^2.0.0"
@@ -8258,7 +8269,8 @@
         },
         "grant": {
           "version": "4.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/grant/-/grant-4.7.0.tgz",
+          "integrity": "sha512-QGPjCYDrBnb/OIiTRxbK3TnNOE6Ycgfc/GcgPzI4vyNIr+b7yisEexYp7VM74zj6bxr+mDTzfGONRLzzsVPJIA==",
           "requires": {
             "qs": "^6.9.1",
             "request-compose": "^1.2.1",
@@ -8267,45 +8279,54 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "mime-db": {
           "version": "1.42.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+          "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
         },
         "mime-types": {
           "version": "2.1.25",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+          "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
           "requires": {
             "mime-db": "1.42.0"
           }
         },
         "prom-client": {
           "version": "12.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+          "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
           "requires": {
             "tdigest": "^0.1.1"
           }
         },
         "punycode": {
           "version": "1.3.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         },
         "qs": {
           "version": "6.9.4",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
         },
         "sax": {
           "version": "1.2.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "semver": {
           "version": "6.3.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "tus-js-client": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.1.1.tgz",
+          "integrity": "sha512-ILpgHlR0nfKxmlkXfrZ2z61upkHEXhADOGbGyvXSPjp7bn1NhU50p/Mu59q577Xirayr9vlW4tmoFqUrHKcWeQ==",
           "requires": {
             "buffer-from": "^0.1.1",
             "combine-errors": "^3.0.3",
@@ -8317,7 +8338,8 @@
         },
         "url": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -8325,11 +8347,13 @@
         },
         "url-value-parser": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
+          "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
         },
         "uuid": {
           "version": "8.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
         }
       }
     },
@@ -8516,7 +8540,8 @@
       "dependencies": {
         "es6-promise": {
           "version": "4.2.5",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+          "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
         }
       }
     },
@@ -8567,14 +8592,16 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "engine.io-client": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+          "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
@@ -8591,13 +8618,15 @@
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
             }
           }
         },
         "engine.io-parser": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+          "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
           "requires": {
             "after": "0.8.2",
             "arraybuffer.slice": "~0.0.7",
@@ -8608,11 +8637,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "socket.io-client": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+          "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
           "requires": {
             "backo2": "1.0.2",
             "base64-arraybuffer": "0.1.5",
@@ -8632,13 +8663,15 @@
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
             }
           }
         },
         "ws": {
           "version": "6.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -18509,7 +18542,7 @@
         "qs": "^6.5.0",
         "react-native-branch": "2.2.5",
         "react-native-gesture-handler": "~1.0.14",
-        "react-native-maps": "github:expo/react-native-maps#e6f98ff7272e5d0a7fe974a41f28593af2d77bb2",
+        "react-native-maps": "github:expo/react-native-maps#v0.22.1-exp.0",
         "react-native-reanimated": "1.0.0-alpha.11",
         "react-native-screens": "1.0.0-alpha.22",
         "react-native-svg": "8.0.10",
@@ -40610,7 +40643,7 @@
         "hexo": "4.0.0",
         "hexo-browsersync": "^0.3.0",
         "hexo-cli": "3.1.0",
-        "hexo-filter-github-emojis": "github:arturi/hexo-filter-github-emojis#c0b188687b47669d0aa452d6f9adbb7487925baf",
+        "hexo-filter-github-emojis": "github:arturi/hexo-filter-github-emojis",
         "hexo-generator-alias": "^0.1.3",
         "hexo-generator-archive": "^1.0.0",
         "hexo-generator-category": "^1.0.0",
@@ -40638,25 +40671,29 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "braces": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
             "fill-range": "^7.0.1"
           }
         },
         "fill-range": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "requires": {
             "to-regex-range": "^5.0.1"
           }
         },
         "hexo": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hexo/-/hexo-4.0.0.tgz",
+          "integrity": "sha512-woVSeutGyFDLdE3UWJsZWw18KboFSsmmcxuivuLJPQ0pqLLz4zar07BG/YQXgVaXzR1jQ7Hurbx1gGZj5Z7y2w==",
           "requires": {
             "abbrev": "^1.1.1",
             "archy": "^1.0.0",
@@ -40689,15 +40726,18 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "marked": {
           "version": "0.7.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
         },
         "micromatch": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
@@ -40705,14 +40745,16 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "requires": {
             "is-number": "^7.0.0"
           }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -199,9 +199,11 @@ module.exports = class Tus extends Plugin {
       // the other in folder b.
       uploadOptions.fingerprint = getFingerprint(file)
 
-      uploadOptions.onBeforeRequest = (req) => {
-        const xhr = req.getUnderlyingObject()
-        xhr.withCredentials = !!opts.withCredentials
+      if (typeof uploadOptions.onBeforeRequest !== 'function') {
+        uploadOptions.onBeforeRequest = (req) => {
+          const xhr = req.getUnderlyingObject()
+          xhr.withCredentials = !!opts.withCredentials
+        }
       }
 
       uploadOptions.onError = (err) => {

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -199,10 +199,12 @@ module.exports = class Tus extends Plugin {
       // the other in folder b.
       uploadOptions.fingerprint = getFingerprint(file)
 
-      if (typeof uploadOptions.onBeforeRequest !== 'function') {
-        uploadOptions.onBeforeRequest = (req) => {
-          const xhr = req.getUnderlyingObject()
-          xhr.withCredentials = !!opts.withCredentials
+      uploadOptions.onBeforeRequest = (req) => {
+        const xhr = req.getUnderlyingObject()
+        xhr.withCredentials = !!opts.withCredentials
+
+        if (typeof opts.onBeforeRequest === 'function') {
+          opts.onBeforeRequest(req)
         }
       }
 


### PR DESCRIPTION
The onBeforeRequest callback cant be changed by Tus options after the changes on the issue #2518 

In this case, I think that we could skip the default callback definition if the callbacck was passed through Tus options