### PR TITLE
fix: jwt helper optional parameters

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/jwt.js
+++ b/packages/@uppy/companion/src/server/helpers/jwt.js
@@ -29,7 +29,6 @@ module.exports.verifyToken = (token, secret) => {
  * @param {object} res
  * @param {string} token
  * @param {object} companionOptions
- * @param {string=} companionOptions.cookieDomain
  * @param {string} providerName
  */
 module.exports.addToCookies = (res, token, companionOptions, providerName) => {
@@ -49,7 +48,6 @@ module.exports.addToCookies = (res, token, companionOptions, providerName) => {
  *
  * @param {object} res
  * @param {object} companionOptions
- * @param {string=} companionOptions.cookieDomain
  * @param {string} providerName
  */
 module.exports.removeFromCookies = (res, companionOptions, providerName) => {

--- a/packages/@uppy/companion/src/server/helpers/jwt.js
+++ b/packages/@uppy/companion/src/server/helpers/jwt.js
@@ -28,8 +28,9 @@ module.exports.verifyToken = (token, secret) => {
  *
  * @param {object} res
  * @param {string} token
- * @param {object=} companionOptions
- * @param {string=} providerName
+ * @param {object} companionOptions
+ * @param {string=} companionOptions.cookieDomain
+ * @param {string} providerName
  */
 module.exports.addToCookies = (res, token, companionOptions, providerName) => {
   const cookieOptions = {
@@ -47,8 +48,9 @@ module.exports.addToCookies = (res, token, companionOptions, providerName) => {
 /**
  *
  * @param {object} res
- * @param {object=} companionOptions
- * @param {string=} providerName
+ * @param {object} companionOptions
+ * @param {string=} companionOptions.cookieDomain
+ * @param {string} providerName
  */
 module.exports.removeFromCookies = (res, companionOptions, providerName) => {
   const cookieOptions = {

--- a/packages/@uppy/companion/src/server/helpers/jwt.js
+++ b/packages/@uppy/companion/src/server/helpers/jwt.js
@@ -29,7 +29,7 @@ module.exports.verifyToken = (token, secret) => {
  * @param {object} res
  * @param {string} token
  * @param {object=} companionOptions
- * @param {string} providerName
+ * @param {string=} providerName
  */
 module.exports.addToCookies = (res, token, companionOptions, providerName) => {
   const cookieOptions = {
@@ -48,7 +48,7 @@ module.exports.addToCookies = (res, token, companionOptions, providerName) => {
  *
  * @param {object} res
  * @param {object=} companionOptions
- * @param {string} providerName
+ * @param {string=} providerName
  */
 module.exports.removeFromCookies = (res, companionOptions, providerName) => {
   const cookieOptions = {


### PR DESCRIPTION
Now it is not possible to build companion locally, because required parameters can't follow optional ones