### PR TITLE
image-editor: show “edit” icon even when metaFields are not specified

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
@@ -5,12 +5,13 @@ function EditButton ({
   file,
   uploadInProgressOrComplete,
   metaFields,
+  canEditFile,
   i18n,
   onClick
 }) {
-  if (!uploadInProgressOrComplete &&
+  if ((!uploadInProgressOrComplete &&
       metaFields &&
-      metaFields.length > 0) {
+      metaFields.length > 0) || canEditFile(file)) {
     return (
       <button
         class="uppy-u-reset uppy-Dashboard-Item-action uppy-Dashboard-Item-action--edit"
@@ -80,15 +81,27 @@ module.exports = function Buttons (props) {
   const {
     file,
     uploadInProgressOrComplete,
+    canEditFile,
     metaFields,
     showLinkToFileUploadResult,
     showRemoveButton,
     i18n,
     removeFile,
     toggleFileCard,
+    openFileEditor,
     log,
     info
   } = props
+
+  const editAction = () => {
+    if (metaFields && metaFields.length > 0) {
+      console.log('TOGGLE FILE CARD')
+      toggleFileCard(file.id)
+    } else {
+      console.log('OPEN FILE EDITOR')
+      openFileEditor(file)
+    }
+  }
 
   return (
     <div className="uppy-Dashboard-Item-actionWrapper">
@@ -96,8 +109,9 @@ module.exports = function Buttons (props) {
         i18n={i18n}
         file={file}
         uploadInProgressOrComplete={uploadInProgressOrComplete}
+        canEditFile={canEditFile}
         metaFields={metaFields}
-        onClick={() => toggleFileCard(file.id)}
+        onClick={editAction}
       />
       {showLinkToFileUploadResult && file.uploadURL ? (
         <CopyLinkButton

--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
@@ -95,10 +95,8 @@ module.exports = function Buttons (props) {
 
   const editAction = () => {
     if (metaFields && metaFields.length > 0) {
-      console.log('TOGGLE FILE CARD')
       toggleFileCard(file.id)
     } else {
-      console.log('OPEN FILE EDITOR')
       openFileEditor(file)
     }
   }

--- a/packages/@uppy/dashboard/src/components/FileItem/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.js
@@ -98,10 +98,12 @@ module.exports = class FileItem extends Component {
 
             showLinkToFileUploadResult={this.props.showLinkToFileUploadResult}
             showRemoveButton={showRemoveButton}
+            canEditFile={this.props.canEditFile}
 
             uploadInProgressOrComplete={uploadInProgressOrComplete}
             removeFile={this.props.removeFile}
             toggleFileCard={this.props.toggleFileCard}
+            openFileEditor={this.props.openFileEditor}
 
             i18n={this.props.i18n}
             log={this.props.log}

--- a/packages/@uppy/dashboard/src/components/FileList.js
+++ b/packages/@uppy/dashboard/src/components/FileList.js
@@ -75,6 +75,8 @@ module.exports = (props) => {
             key={fileID}
             {...fileProps}
             role="listitem"
+            openFileEditor={props.openFileEditor}
+            canEditFile={props.canEditFile}
             file={props.files[fileID]}
           />
         ))}

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -256,6 +256,7 @@ module.exports = class Dashboard extends Plugin {
 
     this.setPluginState({
       showFileEditor: true,
+      fileCardFor: file.id || null,
       activeOverlayType: 'FileEditor'
     })
 


### PR DESCRIPTION
If Dashboard isn’t passed `metaFields`, but the Image Editor is used, the edit icon that usually opens the meta field editor will now take you straight to the image editor.

Fixes #2604