### PR TITLE
companion: catch errors when fetching dropbox user email

### DIFF
--- a/packages/@uppy/companion/src/server/provider/dropbox/index.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/index.js
@@ -57,10 +57,9 @@ class DropBox extends Provider {
     let stats
     let reqErr
     const finishReq = () => {
-      if (reqErr || stats.statusCode !== 200) {
-        const err = this._error(reqErr, stats)
-        logger.error(err, 'provider.dropbox.list.error')
-        done(err)
+      if (reqErr) {
+        logger.error(reqErr, 'provider.dropbox.list.error')
+        done(reqErr)
       } else {
         stats.body.user_email = userInfo.body.email
         done(null, this.adaptData(stats.body, options.companion))
@@ -70,6 +69,9 @@ class DropBox extends Provider {
     this.stats(options, (err, resp) => {
       statsDone = true
       stats = resp
+      if (err || resp.statusCode !== 200) {
+        err = this._error(err, resp)
+      }
       reqErr = reqErr || err
       if (userInfoDone) {
         finishReq()
@@ -79,6 +81,10 @@ class DropBox extends Provider {
     this._userInfo(options, (err, resp) => {
       userInfoDone = true
       userInfo = resp
+      if (err || resp.statusCode !== 200) {
+        err = this._error(err, resp)
+      }
+
       reqErr = reqErr || err
       if (statsDone) {
         finishReq()


### PR DESCRIPTION
sometimes fetching a dropbox user's details may return a failed status code, we should be catching that too.