### PR TITLE
Updated website docs added total upload progress event

### DIFF
--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -767,6 +767,22 @@ uppy.on('upload', (data) => {
 })
 ```
 
+### `progress`
+
+Fired each time the total upload progress is updated:
+
+**Parameters**
+- `progress` - An integer representing the total upload progress.
+
+**Example**
+
+```javascript
+uppy.on('progress', (progress) => {
+  // progress: integer (total progress percentage)
+  console.log(progress)
+})
+```
+
 ### `upload-progress`
 
 Fired each time file upload progress is available:

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -772,7 +772,7 @@ uppy.on('upload', (data) => {
 Fired each time the total upload progress is updated:
 
 **Parameters**
-- `progress` - An integer representing the total upload progress.
+- `progress` - An integer (0-100) representing the total upload progress.
 
 **Example**
 

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -785,7 +785,7 @@ uppy.on('progress', (progress) => {
 
 ### `upload-progress`
 
-Fired each time file upload progress is available:
+Fired each time an individual file upload progress is available:
 
 **Parameters**
 - `file` - The [File Object][File Objects] for the file whose upload has progressed.


### PR DESCRIPTION
I recently posted https://github.com/transloadit/uppy/issues/2633 regarding total upload progress, asking for this feature. Turns total upload progress exists and is just undocumented. 

I have added the the progress event to the uppy website documentation in hopes that it could help another person in the future. 