### PR TITLE
Add missing option types to XHRUploadOptions

### DIFF
--- a/packages/@uppy/xhr-upload/types/index.d.ts
+++ b/packages/@uppy/xhr-upload/types/index.d.ts
@@ -14,6 +14,8 @@ declare module XHRUpload {
     endpoint: string
     method?: 'GET' | 'POST' | 'PUT' | 'HEAD' | 'get' | 'post' | 'put' | 'head'
     locale?: XHRUploadLocale
+    responseType?: string
+    withCredentials?: boolean    
   }
 }
 


### PR DESCRIPTION
`withCredentials` and `responseType` are available options when using `XHRUpload`, but they are not included in the type signature of `XHRUploadOptions`.