### PR TITLE
core: pass files array to _checkRestrictions

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -653,7 +653,8 @@ class Uppy {
     }
 
     try {
-      this._checkRestrictions(newFile)
+      const filesArray = Object.keys(files).map(i => files[i])
+      this._checkRestrictions(newFile, filesArray)
     } catch (err) {
       this._showOrLogErrorAndThrow(err, { file: newFile })
     }


### PR DESCRIPTION
Fixes #2647

Without this, `restrictions.maxNumberOfFiles` were ignored when bulk-adding files via `uppy.addFiles`. Thanks so much @NermienBarakat for reporting!

@goto-bus-stop can we use `Object.values`? Not supported in IE10-11, got confused, seems like we’d need core-js, so overkill? https://babeljs.io/docs/en/babel-preset-env#usebuiltins