### PR TITLE
Switch to statSync for amazon EFS temp directory support

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -490,19 +490,18 @@ class Uploader {
         this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     } else {
-      fs.stat(this.path, (err, stats) => {
-        if (err) {
-          logger.error(err, 'upload.multipart.size.error')
-          this.emitError(err)
-          return
-        }
-
+      try {
+        const stats = fs.statSync(this.path)
         const fileSizeInBytes = stats.size
         reqOptions.headers['content-length'] = fileSizeInBytes
-        reqOptions.body = file
-        httpRequest(reqOptions, (error, response, body) => {
-          this._onMultipartComplete(error, response, body, bytesUploaded)
-        })
+      } catch (err) {
+        logger.error(err, 'upload.multipart.size.error')
+        this.emitError(err)
+        return
+      }
+      reqOptions.body = file
+      httpRequest(reqOptions, (error, response, body) => {
+        this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     }
   }

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -486,6 +486,7 @@ class Uploader {
         }
       )
 
+      logger.debug(JSON.stringify(reqOptions), 'upload.multipart.request')
       httpRequest(reqOptions, (error, response, body) => {
         this._onMultipartComplete(error, response, body, bytesUploaded)
       })
@@ -500,6 +501,7 @@ class Uploader {
         return
       }
       reqOptions.body = file
+      logger.debug(JSON.stringify(reqOptions), 'upload.multipart.request')
       httpRequest(reqOptions, (error, response, body) => {
         this._onMultipartComplete(error, response, body, bytesUploaded)
       })
@@ -524,6 +526,7 @@ class Uploader {
       headers
     }
 
+    logger.debug(JSON.stringify(respObj), 'upload.multipart.response')
     if (response.statusCode >= 400) {
       logger.error(`upload failed with status: ${response.statusCode}`, 'upload.multipart.error')
       this.emitError(new Error(response.statusMessage), respObj)


### PR DESCRIPTION
Hi guys, we are working on our production companion. Unfortunately, we encountered an issue. We cannot upload files bigger than 2KB from companion, any file bigger than that returns the following error from aws s3:

```xml
<Error>
<Code>RequestTimeout</Code>
<Message>Your socket connection to the server was not read from or written to within the timeout period.
Idle connections will be closed.</Message>
```
One thing to consider is that we run the temp file directory on [Amazon EFS](https://aws.amazon.com/efs/)

After trying many things everything pointed to a possible file read related issue. I modified the code that calculates the size of the file in the PUT scenario and used `fs.statSync()` instead of `fs.stat()` and that solved the issue in our case. It appears to us that fs.stat doesn't work well with EFS it might be related to [callbacks](https://github.com/nodejs/node/blob/master/doc/api/fs.md#ordering-of-callback-and-promise-based-operations) and any EFS delay