### PR TITLE
build: add zoom to "remove-accidental-tags" script

### DIFF
--- a/bin/remove-accidental-git-tags.sh
+++ b/bin/remove-accidental-git-tags.sh
@@ -5,7 +5,7 @@
 # usage: ./remove-tags.sh VERSION_NUMBER
 # where VERSION_NUMBER is something like 0.30.0
 
-Packages=(aws-s3 file-input react transloadit aws-s3-multipart form redux-dev-tools tus companion golden-retriever robodog url companion-client google-drive server-utils utils core informer status-bar webcam dashboard instagram store-default xhr-upload drag-drop progress-bar store-redux dropbox box provider-views thumbnail-generator)
+Packages=(aws-s3 file-input react transloadit aws-s3-multipart form redux-dev-tools tus companion golden-retriever robodog url companion-client google-drive server-utils utils core informer status-bar webcam dashboard instagram store-default xhr-upload drag-drop progress-bar store-redux dropbox box provider-views thumbnail-generator zoom)
 Version = $*
 
 for i in "${Packages[@]}"


### PR DESCRIPTION
I noticed this while reviewing the [Box PR](https://github.com/transloadit/uppy/pull/2549/files#diff-2897b0f6ed6ab54d616e19406de98703f303bc91e913a8cb64d1efc2ba1444ecR8)