### PR TITLE
silence or fix lint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
   "rules": {
     "jsx-quotes": ["error", "prefer-double"],
     "compat/compat": ["error"],
-    "react/jsx-handler-names": ["warn"], // maybe we want to do this in the future?
+    "react/jsx-handler-names": ["off"],
     "react/react-in-jsx-scope": ["error"],
 
     "jsdoc/check-alignment": ["warn"],
@@ -30,6 +30,9 @@
   "settings": {
     "react": {
       "pragma": "h"
+    },
+    "jsdoc": {
+      "mode": "typescript"
     },
     "polyfills": [
       "Promise",

--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
@@ -146,7 +146,6 @@ module.exports = class ProviderView {
    * Fetches new folder
    *
    * @param  {object} folder
-   * @param  {string} title Folder title
    */
   getNextFolder (folder) {
     this.getFolder(folder.requestPath, folder.name)

--- a/packages/@uppy/transloadit/src/Client.js
+++ b/packages/@uppy/transloadit/src/Client.js
@@ -18,9 +18,12 @@ module.exports = class Client {
    * Create a new assembly.
    *
    * @param {object} options
+   * @param {string|object} options.params
+   * @param {object} options.fields
+   * @param {string} options.signature
+   * @param {number} options.expectedFiles
    */
   createAssembly ({
-    templateId,
     params,
     fields,
     signature,

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -256,7 +256,7 @@ module.exports = class Tus extends Plugin {
         }
       }
 
-      /** @type {{ [name: string]: string }} */
+      /** @type {Record<string, string>} */
       const meta = {}
       const metaFields = Array.isArray(opts.metaFields)
         ? opts.metaFields

--- a/website/build-examples.js
+++ b/website/build-examples.js
@@ -112,8 +112,7 @@ glob(srcPattern, (err, files) => {
      * Creates bundle and writes it to static and public folders.
      * Changes to
      *
-     * @param  {[type]} ids [description]
-     * @returns {[type]}     [description]
+     * @param  {string[]} ids
      */
     function bundle (ids = []) {
       ids.forEach((id) => {


### PR DESCRIPTION
Since the Github Actions switch, lint warnings show up in the PR UI, so things will be less cluttered if we just fix all existing ones.