### PR TITLE
thumbnail-generator: upgrade exifr to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8645,8 +8645,15 @@
       "version": "file:packages/@uppy/thumbnail-generator",
       "requires": {
         "@uppy/utils": "file:packages/@uppy/utils",
-        "exifr": "^5.0.2",
+        "exifr": "^6.0.0",
         "math-log2": "^1.0.1"
+      },
+      "dependencies": {
+        "exifr": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/exifr/-/exifr-6.0.0.tgz",
+          "integrity": "sha512-a8n3SVIyuI5NP5VJCb/rJHsqXnofgYL1ZXcJdKBXOmCNIrj+pSExaBFHcbdEF5xp5GQrK4kpOabLJ+wBfUGYuA=="
+        }
       }
     },
     "@uppy/transloadit": {
@@ -18508,11 +18515,6 @@
           }
         }
       }
-    },
-    "exifr": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/exifr/-/exifr-5.0.6.tgz",
-      "integrity": "sha512-iDB4IhKoKVF+uDDrHRlyNxWqGaTxYluVWqvBWVG54HkQZe8qkFYl9eQrjEP3d8Q4UMBZ9rWu3Pa+mfC+o4CZuw=="
     },
     "exit": {
       "version": "0.1.2",

--- a/packages/@uppy/thumbnail-generator/package.json
+++ b/packages/@uppy/thumbnail-generator/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@uppy/utils": "file:../utils",
-    "exifr": "^5.0.2",
+    "exifr": "^6.0.0",
     "math-log2": "^1.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
I think the thumbnail rotation issue mentioned in #2309 was already fixed in exifr 5.0.5, which is within our accepted version range, but which may not be auto installed for users who have a lockfile with an older version.

So this version bump is not necessary to fix anything, but will opt us in to future improvements to the exifr library.