### PR TITLE
unsplash: unsplash needs uppy/core to be 1.13.3 or higher

### DIFF
--- a/packages/@uppy/unsplash/package.json
+++ b/packages/@uppy/unsplash/package.json
@@ -26,7 +26,7 @@
     "preact": "8.2.9"
   },
   "peerDependencies": {
-    "@uppy/core": "^1.0.0"
+    "@uppy/core": "^1.13.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This is because we added some new i18n keys to core when we implemented unsplash