### PR TITLE
Add multipart request and response debug logs

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -490,19 +490,10 @@ class Uploader {
         this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     } else {
-      fs.stat(this.path, (err, stats) => {
-        if (err) {
-          logger.error(err, 'upload.multipart.size.error')
-          this.emitError(err)
-          return
-        }
-
-        const fileSizeInBytes = stats.size
-        reqOptions.headers['content-length'] = fileSizeInBytes
-        reqOptions.body = file
-        httpRequest(reqOptions, (error, response, body) => {
-          this._onMultipartComplete(error, response, body, bytesUploaded)
-        })
+      reqOptions.headers['content-length'] = this.bytesWritten
+      reqOptions.body = file
+      httpRequest(reqOptions, (error, response, body) => {
+        this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     }
   }


### PR DESCRIPTION
Hi, While working on deploying companion I found that there is no multipart request and response logging. By adding these logs I was able to see the 400 error S3 was returning.

For some reason, I didn't get that error by WebSocket message in the browser. Do you guys think of something that can cause the message not being sent or received?

Here is an example of how the additional log looks like:
![Screen Shot 2020-12-04 at 12 20 49](https://user-images.githubusercontent.com/4699893/101197191-c916a780-362f-11eb-9910-72c85f04c2c2.png)
