### PR TITLE
dashboard: add autoopen for file editors (image-editor)

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -698,7 +698,7 @@ class Uppy {
     })
 
     this.emit('file-added', newFile)
-    this.emit('final-file-added', newFile)
+    this.emit('files-added', [newFile])
     this.log(`Added file: ${newFile.name}, ${newFile.id}, mime type: ${newFile.type}`)
 
     this._startIfAutoProceed()
@@ -734,13 +734,11 @@ class Uppy {
 
     this.setState({ files })
 
-    newFiles.forEach((newFile, i) => {
+    newFiles.forEach((newFile) => {
       this.emit('file-added', newFile)
-
-      if (i + 1 === newFiles.length) {
-        this.emit('final-file-added', newFile)
-      }
     })
+
+    this.emit('files-added', newFiles)
 
     if (newFiles.length > 5) {
       this.log(`Added batch of ${newFiles.length} files`)

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -698,6 +698,7 @@ class Uppy {
     })
 
     this.emit('file-added', newFile)
+    this.emit('final-file-added', newFile)
     this.log(`Added file: ${newFile.name}, ${newFile.id}, mime type: ${newFile.type}`)
 
     this._startIfAutoProceed()
@@ -733,8 +734,12 @@ class Uppy {
 
     this.setState({ files })
 
-    newFiles.forEach((newFile) => {
+    newFiles.forEach((newFile, i) => {
       this.emit('file-added', newFile)
+
+      if (i + 1 === newFiles.length) {
+        this.emit('final-file-added', newFile)
+      }
     })
 
     if (newFiles.length > 5) {

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -659,9 +659,10 @@ module.exports = class Dashboard extends Plugin {
     }
   }
 
-  _openFileEditorWhenSingleFileAdded = (file) => {
-    if (this.canEditFile(file)) {
-      this.openFileEditor(file)
+  _openFileEditorWhenFilesAdded = (files) => {
+    const firstFile = files[0]
+    if (this.canEditFile(firstFile)) {
+      this.openFileEditor(firstFile)
     }
   }
 
@@ -695,7 +696,7 @@ module.exports = class Dashboard extends Plugin {
     }
 
     if (this.opts.autoOpenFileEditor) {
-      this.uppy.on('final-file-added', this._openFileEditorWhenSingleFileAdded)
+      this.uppy.on('files-added', this._openFileEditorWhenFilesAdded)
     }
   }
 
@@ -722,7 +723,7 @@ module.exports = class Dashboard extends Plugin {
     }
 
     if (this.opts.autoOpenFileEditor) {
-      this.uppy.off('final-file-added', this._openFileEditorWhenSingleFileAdded)
+      this.uppy.off('files-added', this._openFileEditorWhenFilesAdded)
     }
   }
 

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -143,7 +143,8 @@ module.exports = class Dashboard extends Plugin {
       showSelectedFiles: true,
       showRemoveButtonAfterComplete: false,
       browserBackButtonClose: false,
-      theme: 'light'
+      theme: 'light',
+      autoOpenFileEditor: false
     }
 
     // merge default options with the ones set by user
@@ -651,10 +652,16 @@ module.exports = class Dashboard extends Plugin {
     }
   }
 
-  handleComplete = ({ failed, uploadID }) => {
+  handleComplete = ({ failed }) => {
     if (this.opts.closeAfterFinish && failed.length === 0) {
       // All uploads are done
       this.requestCloseModal()
+    }
+  }
+
+  _openFileEditorWhenSingleFileAdded = (file) => {
+    if (this.canEditFile(file)) {
+      this.openFileEditor(file)
     }
   }
 
@@ -686,6 +693,10 @@ module.exports = class Dashboard extends Plugin {
     if (this.opts.inline) {
       this.el.addEventListener('keydown', this.handleKeyDownInInline)
     }
+
+    if (this.opts.autoOpenFileEditor) {
+      this.uppy.on('final-file-added', this._openFileEditorWhenSingleFileAdded)
+    }
   }
 
   removeEvents = () => {
@@ -708,6 +719,10 @@ module.exports = class Dashboard extends Plugin {
 
     if (this.opts.inline) {
       this.el.removeEventListener('keydown', this.handleKeyDownInInline)
+    }
+
+    if (this.opts.autoOpenFileEditor) {
+      this.uppy.off('final-file-added', this._openFileEditorWhenSingleFileAdded)
     }
   }
 

--- a/packages/@uppy/image-editor/src/style.scss
+++ b/packages/@uppy/image-editor/src/style.scss
@@ -56,3 +56,14 @@
     background-color: rgba($blue, 0.8);
   }
 }
+
+// Cropper overrides
+
+.uppy-ImageCropper .cropper-point {
+  width: 8px;
+  height: 8px;
+}
+
+.uppy-ImageCropper .cropper-view-box {
+  outline: 2px solid #39f;
+}

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -99,7 +99,8 @@ uppy.use(Dashboard, {
   showRemoveButtonAfterComplete: false,
   locale: defaultLocale,
   browserBackButtonClose: false,
-  theme: 'light'
+  theme: 'light',
+  autoOpenFileEditor: false
 })
 ```
 
@@ -415,6 +416,12 @@ There are three options:
 - `auto` — will respect the user’s system settings and switch automatically
 
 ![Uppy dark mode screenshot](/images/uppy-dashboard-dark-mar-2020.png)
+
+### `autoOpenFileEditor: false`
+
+Automatically open file editor (see [`@uppy/image-editor`](/docs/image-editor/)) for the last file that has been added in a batch.
+
+Most common use case: user adds an image — Uppy opens Image Editor right away — user crops / adjusts the image — upload.
 
 ## Methods
 

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -411,6 +411,7 @@ Remove all children of the `target` element before mounting the Dashboard. By de
 Uppy Dashboard supports “Dark Mode”. You can try it live on [the Dashboard example page](https://uppy.io/examples/dashboard/).
 
 There are three options:
+
 - `light` — the default
 - `dark`
 - `auto` — will respect the user’s system settings and switch automatically
@@ -419,9 +420,9 @@ There are three options:
 
 ### `autoOpenFileEditor: false`
 
-Automatically open file editor (see [`@uppy/image-editor`](/docs/image-editor/)) for the last file that has been added in a batch.
+Automatically open file editor (see [`@uppy/image-editor`](/docs/image-editor/)) for the first file in a batch. If one file is added, editor opens for that file, if 10 files are added — editor opens for the first file.
 
-Most common use case: user adds an image — Uppy opens Image Editor right away — user crops / adjusts the image — upload.
+Use case: user adds an image — Uppy opens Image Editor right away — user crops / adjusts the image — upload.
 
 ## Methods
 

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -754,6 +754,13 @@ uppy.on('file-removed', (file, reason) => {
 })
 ```
 
+### `final-file-added`
+
+**Parameters**
+- `file` - The [File Object][File Objects] representing the last file that was added in one batch.
+
+Fired when the last file from a batch has been added. If you drag and drop files `a`, `b`, `bob` and `tom`, `tom` will be passed. If you only add `bob`, `bob` will be past.
+
 ### `upload`
 
 Fired when upload starts.

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -728,6 +728,13 @@ uppy.on('file-added', (file) => {
 })
 ```
 
+### `files-added`
+
+**Parameters**
+- `files` - An array of [File Objects][File Objects] representing all files that were added at once, in a batch.
+
+Fired each time when one or multiple files are added — one event, for all files
+
 ### `file-removed`
 
 Fired each time a file is removed.
@@ -753,13 +760,6 @@ uppy.on('file-removed', (file, reason) => {
   }
 })
 ```
-
-### `final-file-added`
-
-**Parameters**
-- `file` - The [File Object][File Objects] representing the last file that was added in one batch.
-
-Fired when the last file from a batch has been added. If you drag and drop files `a`, `b`, `bob` and `tom`, `tom` will be passed. If you only add `bob`, `bob` will be past.
 
 ### `upload`
 


### PR DESCRIPTION
Changes:
- New `@uppy/core` event: `final-file-added`
- New Dashboard option: `autoOpenFileEditor` — if `true`, Dashboard will open the image editor once `final-file-added` is fired
- More visible crop area for the Image Editor

- [x] docs