### PR TITLE
Remove fs stat and use bytesWritten as content length

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -490,19 +490,10 @@ class Uploader {
         this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     } else {
-      fs.stat(this.path, (err, stats) => {
-        if (err) {
-          logger.error(err, 'upload.multipart.size.error')
-          this.emitError(err)
-          return
-        }
-
-        const fileSizeInBytes = stats.size
-        reqOptions.headers['content-length'] = fileSizeInBytes
-        reqOptions.body = file
-        httpRequest(reqOptions, (error, response, body) => {
-          this._onMultipartComplete(error, response, body, bytesUploaded)
-        })
+      reqOptions.headers['content-length'] = this.bytesWritten
+      reqOptions.body = file
+      httpRequest(reqOptions, (error, response, body) => {
+        this._onMultipartComplete(error, response, body, bytesUploaded)
       })
     }
   }


### PR DESCRIPTION
Hi, as described in this [issue](https://github.com/transloadit/uppy/issues/2682). I want to avoid any potential `fs.stat` delay which can be caused by infrastructure such as EFS. The best way to do it is to remove any potential delay between the creation of the `readStream` and the HTTP request to the destination.

I found that `this.bytesWritten` contains the number of bytes of the file downloaded from a provider(google drive, one drive, etc.). And, because companion uploads that same file it is safe to use it as `content-length` when uploading. In fact, the code already [uses this.bytesWritten as a synonym of `bytesTotal`](https://github.com/transloadit/uppy/blob/master/packages/%40uppy/companion/src/server/Uploader.js#L331)


please let me know if there is anything that I didn't clearly explain.



 cc @kvz this is a better solution than fs.statSync which I brought up on a [previous PR](https://github.com/transloadit/uppy/pull/2660) that I closed.