### PR TITLE
companion: upgrade express-prom-bundle to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8038,6 +8038,8 @@
           "integrity": "sha512-cRQ5Qw87SNS4b2v+UfjUW5uAVx4nv6pj9I0cu6ys8x+t7NjVo3cOjaT4Bns1/xxy6xzWv/4WT0LbG5h+NNGNMA==",
           "requires": {
             "@types/tus-js-client": "^1.8.0",
+            "@uppy/companion-client": "^1.5.0",
+            "@uppy/utils": "^3.1.0",
             "tus-js-client": "^1.8.0"
           }
         },
@@ -8251,7 +8253,7 @@
         "escape-string-regexp": "2.0.0",
         "express": "4.17.1",
         "express-interceptor": "1.2.0",
-        "express-prom-bundle": "5.0.0",
+        "express-prom-bundle": "6.3.0",
         "express-request-id": "1.4.1",
         "express-session": "1.17.1",
         "grant": "4.7.0",
@@ -8325,15 +8327,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-        },
-        "express-prom-bundle": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-5.0.0.tgz",
-          "integrity": "sha512-QrpylXBXmf5dKADYC41YU+Ox4vGZrKUcTKkjNGDtBcAQFAFhI2pdtwGD+sy5hyt5ZaYnMf5FK0IWQxAwr4UhpQ==",
-          "requires": {
-            "on-finished": "^2.3.0",
-            "url-value-parser": "^2.0.0"
-          }
         },
         "grant": {
           "version": "4.7.0",
@@ -8412,11 +8405,6 @@
             "punycode": "1.3.2",
             "querystring": "0.2.0"
           }
-        },
-        "url-value-parser": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
-          "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
         },
         "uuid": {
           "version": "8.1.0",
@@ -19228,6 +19216,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "express-prom-bundle": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.3.0.tgz",
+      "integrity": "sha512-XeA9pzG+07X5JhR4SV0szQnb2pWBaeNMBb1jBox/d70204jPlcLPoNuCpaQs5kOEedoXJtJEbVJ2esivED1WyA==",
+      "requires": {
+        "on-finished": "^2.3.0",
+        "url-value-parser": "^2.0.0"
       }
     },
     "express-request-id": {
@@ -41775,6 +41772,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-trim/-/url-trim-1.0.0.tgz",
       "integrity": "sha1-QAV+LxZLiOXaynJp2kfm0d2Detw="
+    },
+    "url-value-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
+      "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8328,6 +8328,15 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         },
+        "express-prom-bundle": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.3.0.tgz",
+          "integrity": "sha512-XeA9pzG+07X5JhR4SV0szQnb2pWBaeNMBb1jBox/d70204jPlcLPoNuCpaQs5kOEedoXJtJEbVJ2esivED1WyA==",
+          "requires": {
+            "on-finished": "^2.3.0",
+            "url-value-parser": "^2.0.0"
+          }
+        },
         "grant": {
           "version": "4.7.0",
           "resolved": "https://registry.npmjs.org/grant/-/grant-4.7.0.tgz",
@@ -19216,15 +19225,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "express-prom-bundle": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.3.0.tgz",
-      "integrity": "sha512-XeA9pzG+07X5JhR4SV0szQnb2pWBaeNMBb1jBox/d70204jPlcLPoNuCpaQs5kOEedoXJtJEbVJ2esivED1WyA==",
-      "requires": {
-        "on-finished": "^2.3.0",
-        "url-value-parser": "^2.0.0"
       }
     },
     "express-request-id": {

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -41,7 +41,7 @@
     "escape-string-regexp": "2.0.0",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",
-    "express-prom-bundle": "5.0.0",
+    "express-prom-bundle": "6.3.0",
     "express-request-id": "1.4.1",
     "express-session": "1.17.1",
     "grant": "4.7.0",

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -28,6 +28,7 @@ function server (moreCompanionOptions = {}) {
   let metricsMiddleware
   if (process.env.COMPANION_HIDE_METRICS !== 'true') {
     metricsMiddleware = promBundle({ includeMethod: true })
+    // @ts-ignore Not in the typings, but it does exist
     const promClient = metricsMiddleware.promClient
     const collectDefaultMetrics = promClient.collectDefaultMetrics
     collectDefaultMetrics({ register: promClient.register })


### PR DESCRIPTION
express-prom-bundle 5 requires prom-client 11, but we had already upgraded to prom-client 12. For prom-client 12, we must also upgrade to express-prom-bundle 6.

should fix
```
npm ERR! peer dep missing: prom-client@^11.1.2, required by express-prom-bundle@5.0.0
```

This is blocking dockerhub releases and causing invalid install trees for users, so it would be good to get this change published ASAP 😄 