### PR TITLE
types: Corrected StatusBar types

### DIFF
--- a/packages/@uppy/status-bar/types/index.d.ts
+++ b/packages/@uppy/status-bar/types/index.d.ts
@@ -13,7 +13,7 @@ declare module StatusBar {
     hideRetryButton?: boolean,
     hidePauseResumeButton?: boolean,
     hideCancelButton?: boolean,
-    doneButtonHandler: Function | null,
+    doneButtonHandler?: () => void,
     locale?: StatusBarLocale
   }
 }

--- a/packages/@uppy/status-bar/types/index.d.ts
+++ b/packages/@uppy/status-bar/types/index.d.ts
@@ -10,6 +10,10 @@ declare module StatusBar {
     showProgressDetails?: boolean
     hideUploadButton?: boolean
     hideAfterFinish?: boolean
+    hideRetryButton?: boolean,
+    hidePauseResumeButton?: boolean,
+    hideCancelButton?: boolean,
+    doneButtonHandler: Function | null,
     locale?: StatusBarLocale
   }
 }


### PR DESCRIPTION
Not all of the documented options were in the types file, this fixes that. Added types:
- `hideRetryButton`
- `hidePauseResumeButton`
- `hideCancelButton`
- `doneButtonHandler`

Closes #2694