### PR TITLE
Dashboard: emit fileId on both file-edit-start and file-edit-complete events

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -45,7 +45,7 @@ class FileCard extends Component {
   }
 
   handleCancel = () => {
-    this.props.toggleFileCard()
+    this.props.toggleFileCard(false)
   }
 
   renderMetaFields = () => {

--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.js
@@ -96,7 +96,7 @@ module.exports = function Buttons (props) {
 
   const editAction = () => {
     if (metaFields && metaFields.length > 0) {
-      toggleFileCard(file.id)
+      toggleFileCard(true, file.id)
     } else {
       openFileEditor(file)
     }

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -399,16 +399,16 @@ module.exports = class Dashboard extends Plugin {
     this.setDarkModeCapability(isDarkModeOnNow)
   }
 
-  toggleFileCard = (fileId) => {
-    if (fileId) {
-      this.uppy.emit('dashboard:file-edit-start')
+  toggleFileCard = (show, fileId) => {
+    if (show) {
+      this.uppy.emit('dashboard:file-edit-start', fileId)
     } else {
-      this.uppy.emit('dashboard:file-edit-complete')
+      this.uppy.emit('dashboard:file-edit-complete', fileId)
     }
 
     this.setPluginState({
-      fileCardFor: fileId || null,
-      activeOverlayType: fileId ? 'FileCard' : null
+      fileCardFor: show ? fileId : null,
+      activeOverlayType: show ? 'FileCard' : null
     })
   }
 
@@ -765,7 +765,7 @@ module.exports = class Dashboard extends Plugin {
 
   saveFileCard = (meta, fileID) => {
     this.uppy.setFileMeta(fileID, meta)
-    this.toggleFileCard()
+    this.toggleFileCard(false, fileID)
   }
 
   _attachRenderFunctionToTarget = (target) => {

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -399,15 +399,15 @@ module.exports = class Dashboard extends Plugin {
     this.setDarkModeCapability(isDarkModeOnNow)
   }
 
-  toggleFileCard = (show, fileId) => {
+  toggleFileCard = (show, fileID) => {
     if (show) {
-      this.uppy.emit('dashboard:file-edit-start', fileId)
+      this.uppy.emit('dashboard:file-edit-start', fileID)
     } else {
-      this.uppy.emit('dashboard:file-edit-complete', fileId)
+      this.uppy.emit('dashboard:file-edit-complete', fileID)
     }
 
     this.setPluginState({
-      fileCardFor: show ? fileId : null,
+      fileCardFor: show ? fileID : null,
       activeOverlayType: show ? 'FileCard' : null
     })
   }

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -400,10 +400,11 @@ module.exports = class Dashboard extends Plugin {
   }
 
   toggleFileCard = (show, fileID) => {
+    const file = this.uppy.getFile(fileID)
     if (show) {
-      this.uppy.emit('dashboard:file-edit-start', fileID)
+      this.uppy.emit('dashboard:file-edit-start', file)
     } else {
-      this.uppy.emit('dashboard:file-edit-complete', fileID)
+      this.uppy.emit('dashboard:file-edit-complete', file)
     }
 
     this.setPluginState({

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -469,7 +469,7 @@ Fired when the Dashboard modal is closed.
 
 **Parameters:**
 
-- `fileId` — the fileId of the file that was opened for editing
+- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects) representing the file that was opened for editing.
 
 Fired when the user clicks “edit” icon next to a file in the Dashboard. The FileCard panel is then open with file metadata available for editing.
 
@@ -477,6 +477,6 @@ Fired when the user clicks “edit” icon next to a file in the Dashboard. The 
 
 **Parameters:**
 
-- `fileId` — the fileId of the file that was edited
+- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects) representing the file that was edited.
 
 Fired when the user finished editing the file metadata.

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -467,8 +467,16 @@ Fired when the Dashboard modal is closed.
 
 ### `dashboard:file-edit-start`
 
+**Parameters:**
+
+- `fileId` — the fileId of the file that was opened for editing
+
 Fired when the user clicks “edit” icon next to a file in the Dashboard. The FileCard panel is then open with file metadata available for editing.
 
 ### `dashboard:file-edit-complete`
+
+**Parameters:**
+
+- `fileId` — the fileId of the file that was edited
 
 Fired when the user finished editing the file metadata.


### PR DESCRIPTION
Builds on what @lacieri started in https://github.com/transloadit/uppy/pull/2728, following the conversation in https://github.com/transloadit/uppy/issues/2340.