### PR TITLE
Update xhrupload.md

### DIFF
--- a/website/src/docs/xhrupload.md
+++ b/website/src/docs/xhrupload.md
@@ -285,7 +285,7 @@ uppy.use(XHRUpload, {
 $my_file = $_FILES['my_file'];
 $file_path = $my_file['tmp_name']; // temporary upload path of the file
 $file_name = $_POST['name']; // desired name of the file
-move_uploaded_file($file_path, './img/' . basename($file_name)); // save the file at `img/FILE_NAME`
+move_uploaded_file($file_path, $_SERVER['DOCUMENT_ROOT'] . '/img/' . basename($file_name)); // save the file at `img/FILE_NAME`
 ```
 
 [FormData]: https://developer.mozilla.org/en-US/docs/Web/API/FormData


### PR DESCRIPTION
explicitly use "document_root" variable (instead of '.') to define base path to move uploaded file...gleaned from personal experience this week 😅