### PR TITLE
companion: remove incorrect `Expires` option

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -92,8 +92,7 @@ module.exports = function s3 (config) {
       Key: key,
       ACL: config.acl,
       ContentType: type,
-      Metadata: metadata,
-      Expires: config.expires
+      Metadata: metadata
     }, (err, data) => {
       if (err) {
         next(err)


### PR DESCRIPTION
I assumed `Expires` had to do with signed URL expiration, but in the
case of `createMultipartUpload`, it affects the _uploaded file itself_.

Those files are not automatically removed but no longer cacheable after
the expiration time, which is still bad.

Thanks to @Dock1100 for raising this! Fixes #2483.