### PR TITLE
transloadit: fix #2626

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -296,7 +296,7 @@ module.exports = class Transloadit extends Plugin {
   _reserveFiles (assembly, fileIDs) {
     return Promise.all(fileIDs.map((fileID) => {
       const file = this.uppy.getFile(fileID)
-      return this.client.reserveFile(assembly, file)
+      return this.client.reserveFile(assembly.status, file)
     }))
   }
 


### PR DESCRIPTION
Another small fix from the bottom of my assigned issues list!

This one is for functionality that was broken for apparently many months 😬 

The Transloadit plugin has an `importFromUploadURLs` option that lets you use a separate uploader plugin like AwsS3Multipart, and then import those files into transloadit. To do that we first tell Transloadit how many files to expect with this `reserveFile()` function. That function should receive an Assembly status object, but we were passing it a wrapper for that object. This patch unbreaks it.