### PR TITLE
companion: generate type declaration files

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "description": "OAuth helper and remote fetcher for Uppy's (https://uppy.io) extensible file upload widget with support for drag&drop, resumable uploads, previews, restrictions, file processing/encoding, remote providers like Dropbox and Google Drive, S3 and more :dog:",
   "main": "lib/companion.js",
-  "types": "types/index.d.ts",
+  "types": "lib/companion.d.ts",
   "author": "Transloadit.com",
   "license": "ISC",
   "homepage": "https://github.com/transloadit/uppy#readme",

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -47,6 +47,7 @@ module.exports.socket = require('./server/socket')
  * Entry point into initializing the Companion app.
  *
  * @param {object} options
+ * @returns {import('express').Express}
  */
 module.exports.app = (options = {}) => {
   validateConfig(options)

--- a/packages/@uppy/companion/src/server/provider/error.d.ts
+++ b/packages/@uppy/companion/src/server/provider/error.d.ts
@@ -1,0 +1,13 @@
+// We need explicit type declarations for `errors.js` because of a typescript bug when generating declaration files. I think it's this one:
+// https://github.com/microsoft/TypeScript/issues/37832
+//
+// We could try removing this file when we upgrade to 4.1 :)
+
+export class ProviderApiError extends Error {
+  constructor(message: string, statusCode: number)
+}
+export class ProviderAuthError extends ProviderApiError {
+  constructor()
+}
+
+export function errorToResponse(anyError: Error): { code: number, message: string }

--- a/packages/@uppy/companion/src/server/socket.js
+++ b/packages/@uppy/companion/src/server/socket.js
@@ -8,7 +8,7 @@ const { STORAGE_PREFIX, shortenToken } = require('./Uploader')
 /**
  * the socket is used to send progress events during an upload
  *
- * @param {object} server
+ * @param {import('http').Server | import('https').Server} server
  */
 module.exports = (server) => {
   const wss = new SocketServer({ server })

--- a/packages/@uppy/companion/tsconfig.json
+++ b/packages/@uppy/companion/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "./lib",
     "module": "commonjs",
+    "declaration": true,
     "target": "es6",
     "noImplicitAny": false,
     "sourceMap": false,


### PR DESCRIPTION
So folks can use it more easily in their server-side typescript projects.

We don't have precise types for the `options` objects yet. We should add
that too.

fixes #2738