### PR TITLE
[FIX] Safari 14.0 on Mac records audio using audio/mp4 MIME type which isn't currently recognised by Uppy

### DIFF
--- a/packages/@uppy/utils/src/getFileTypeExtension.js
+++ b/packages/@uppy/utils/src/getFileTypeExtension.js
@@ -4,6 +4,7 @@
 // most of which will go unused, so not sure if that's worth it.
 const mimeToExtensions = {
   'audio/mp3': 'mp3',
+  'audio/mp4': 'mp4',
   'audio/ogg': 'ogg',
   'audio/webm': 'webm',
   'image/gif': 'gif',

--- a/packages/@uppy/utils/src/getFileTypeExtension.test.js
+++ b/packages/@uppy/utils/src/getFileTypeExtension.test.js
@@ -4,6 +4,7 @@ describe('getFileTypeExtension', () => {
   it('should return the filetype based on the specified mime type', () => {
     expect(getFileTypeExtension('video/ogg')).toEqual('ogv')
     expect(getFileTypeExtension('audio/ogg')).toEqual('ogg')
+    expect(getFileTypeExtension('audio/mp4')).toEqual('mp4')
     expect(getFileTypeExtension('video/webm')).toEqual('webm')
     // Supports mime types with additional data
     expect(getFileTypeExtension('video/webm;codecs=vp8,opus')).toEqual('webm')


### PR DESCRIPTION
Safari 14.0 on Mac records audio (using the Webcam Uppy component) with MIME type ‘audio/mp4’, which isn't a recognised MIME type in Uppy. 

This fix updates the file extensions checker to add this MIME type, as otherwise audio cannot be recorded with Safari.