### PR TITLE
transloadit: fix polling fallback bugs

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -724,6 +724,12 @@ module.exports = class Transloadit extends Plugin {
 
     const watcher = this.assemblyWatchers[uploadID]
     return watcher.promise.then(() => {
+      assemblyIDs.forEach((id) => {
+        const assembly = this.activeAssemblies[id]
+        assembly.close()
+        delete this.activeAssemblies[id]
+      })
+
       const assemblies = assemblyIDs.map((id) => this.getAssembly(id))
 
       // Remove the Assembly ID list for this upload,


### PR DESCRIPTION
When the Transloadit plugin can't connect to Transloadit's WebSocket endpoints, it falls back to polling the Assembly status endpoint.

The polling interval was only cleared if the *WebSocket* told us the Assembly finished. So if the WebSocket connection was never set up, we would keep polling the Assembly status endpoints after the upload had finished. Doesn't cause any crashes or bugs but it does waste a lot of bandwidth over time. Now the polling interval is always cleared by calling `assembly.stop()` after the Assembly has finished.

There was a case where the UI would show the postprocessing state while the upload had already completed. I've tried to explain the details in a code comment.