### PR TITLE
dashboard: fix showing showProgressDetails on md and up

### DIFF
--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -605,6 +605,11 @@
   height: 100%;
 }
 
+// Do not show progress details in the StatusBar if we do not have space.
+.uppy-Dashboard:not(.uppy-size--md) .uppy-StatusBar-additionalInfo {
+  display: none;
+}
+
 .uppy-Dashboard-filesContainer {
   @include clearfix;
   position: relative;

--- a/packages/@uppy/status-bar/src/style.scss
+++ b/packages/@uppy/status-bar/src/style.scss
@@ -129,11 +129,6 @@
   padding-inline-end: 0.3em;
 }
 
-// Don't display elements with class .-additionalInfo if we're not at least on .md
-.uppy-Root:not(.uppy-size--md) .uppy-StatusBar-additionalInfo {
-  display: none;
-}
-
 .uppy-StatusBar-statusPrimary {
   font-weight: 500;
   line-height: 1;


### PR DESCRIPTION
The DOM changed to accomodate RTL scripts, but this CSS rule was not
changed accordingly.

The StatusBar does not know its own width, so a standalone StatusBar
would never have an `.uppy-size--md` parent element. You only get that
with the Dashboard. So I've moved the rule to the Dashboard plugin, and
the selector now checks for `.uppy-Dashboard`. That element also has the
size classes.

The standalone StatusBar does not auto-hide progress details on narrow
screens. I think that's probably fine, if you're using it directly and
explicitly asking for progress details you might want to always see
them…