### PR TITLE
Allow Stream to be used with Uppy and Tus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8349,7 +8349,7 @@
         "ip-address": "6.2.0",
         "isobject": "3.0.1",
         "jsonwebtoken": "8.5.1",
-        "lodash.merge": "4.6.2",
+        "lodash": "^4.17.20",
         "mime-types": "2.1.25",
         "moment-timezone": "^0.5.31",
         "morgan": "1.10.0",

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -26,10 +26,7 @@ declare module Uppy {
     error: string
   }
 
- /* interface UppyReadableStream extends ReadableStreamDefaultReader
-  {
-    size:number;
-  }*/
+ 
   // Replace the `meta` property type with one that allows omitting internal metadata; addFile() will add that
   type UppyFileWithoutMeta<TMeta, TBody> = OmitKey<
     UppyFile<TMeta, TBody>,

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -1,3 +1,4 @@
+import { UppyReadableStream } from '@uppy/utils'
 import UppyUtils = require('@uppy/utils')
 
 declare module Uppy {
@@ -25,6 +26,10 @@ declare module Uppy {
     error: string
   }
 
+ /* interface UppyReadableStream extends ReadableStreamDefaultReader
+  {
+    size:number;
+  }*/
   // Replace the `meta` property type with one that allows omitting internal metadata; addFile() will add that
   type UppyFileWithoutMeta<TMeta, TBody> = OmitKey<
     UppyFile<TMeta, TBody>,
@@ -35,7 +40,7 @@ declare module Uppy {
     TBody = IndexedObject<any>
   > extends Partial<UppyFileWithoutMeta<TMeta, TBody>> {
     // `.data` is the only required property here.
-    data: Blob | File
+    data: Blob | File |UppyReadableStream
     meta?: Partial<InternalMetadata> & TMeta
   }
 

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -271,7 +271,7 @@ module.exports = class Tus extends Plugin {
       copyProp(meta, 'name', 'filename')
 
       uploadOptions.metadata = meta
-
+      uploadOptions.uploadSize = file.data.size
       const upload = new tus.Upload(file.data, uploadOptions)
       this.uploaders[file.id] = upload
       this.uploaderEvents[file.id] = new EventTracker(this.uppy)

--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -240,11 +240,15 @@ declare module '@uppy/utils' {
     [key: number]: T
   }
   export type InternalMetadata = { name: string; type?: string }
+ export interface UppyReadableStream extends ReadableStreamDefaultReader<Blob>
+  {
+    size:number;
+  }
   export interface UppyFile<
     TMeta = IndexedObject<any>,
     TBody = IndexedObject<any>
   > {
-    data: Blob | File
+    data: Blob | File | UppyReadableStream
     extension: string
     id: string
     isPaused?: boolean


### PR DESCRIPTION
Mainly Tus allow streamreader to be used with Uppy.
This patch allow Uppy to take Stream with TypeScript