### PR TITLE
Add check for 'uploadComplete' before uploading

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1657,8 +1657,8 @@ class Uppy {
         const waitingFileIDs = []
         Object.keys(files).forEach((fileID) => {
           const file = this.getFile(fileID)
-          // if the file hasn't started uploading and hasn't already been assigned to an upload..
-          if ((!file.progress.uploadStarted) && (currentlyUploadingFiles.indexOf(fileID) === -1)) {
+          // if the file hasn't started or finished uploading, and hasn't already been assigned to an upload
+          if ((!file.progress.uploadStarted) && (!file.progress.uploadComplete) && (currentlyUploadingFiles.indexOf(fileID) === -1)) {
             waitingFileIDs.push(file.id)
           }
         })


### PR DESCRIPTION
I was reading issue #1112  and was trying to replicate the solution suggested by @arturi, however it fails in the newer versions. I successfully managed to solve it by adding a check to see if the file is already uploaded before adding it to the array of `fileIDs` to be uploaded.

NB: Would be great with some seasoned eyes on this though, since I am unsure of the side-effects :)

