### PR TITLE
Make url concatenation more robust

### DIFF
--- a/packages/@uppy/transloadit/src/Client.js
+++ b/packages/@uppy/transloadit/src/Client.js
@@ -42,7 +42,7 @@ module.exports = class Client {
     })
     data.append('num_expected_upload_files', expectedFiles)
 
-    const url = `${this.opts.service}/assemblies`
+    const url = new URL('/assemblies', `${this.opts.service}`).href
     return fetchWithNetworkError(url, {
       method: 'post',
       headers: this._headers,

--- a/packages/@uppy/transloadit/src/Client.js
+++ b/packages/@uppy/transloadit/src/Client.js
@@ -1,4 +1,5 @@
 const fetchWithNetworkError = require('@uppy/utils/lib/fetchWithNetworkError')
+const URL = require('url-parse')
 
 /**
  * A Barebones HTTP API client for Transloadit.


### PR DESCRIPTION
Currently if you provide the following service URLs for the `Transloadit` plugin, any uploads will fail. 

1. https://api2-ap-southeast-1.transloadit.com/
2. https://api2-eu-west-1.transloadit.com/
3. https://api2-us-east-1.transloadit.com/

This is because our concatenation introduces a double //. A user could get these URLs from https://transloaditstatus.com/ by doing the following:

![image](https://user-images.githubusercontent.com/182492/108778718-6ac0dd00-752b-11eb-9c44-94fb72141eec.png)
