### PR TITLE
Use Array.findIndex instead of Array.indexOf in uppy.removePlugin

### DIFF
--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
@@ -5,19 +5,10 @@ const Browser = require('../Browser')
 const LoaderView = require('../Loader')
 const generateFileID = require('@uppy/utils/lib/generateFileID')
 const getFileType = require('@uppy/utils/lib/getFileType')
+const findIndex = require('@uppy/utils/lib/findIndex')
 const isPreviewSupported = require('@uppy/utils/lib/isPreviewSupported')
 const SharedHandler = require('../SharedHandler')
 const CloseWrapper = require('../CloseWrapper')
-
-/**
- * Array.prototype.findIndex ponyfill for old browsers.
- */
-function findIndex (array, predicate) {
-  for (let i = 0; i < array.length; i++) {
-    if (predicate(array[i])) return i
-  }
-  return -1
-}
 
 // location.origin does not exist in IE
 function getOrigin () {

--- a/packages/@uppy/utils/src/RateLimitedQueue.js
+++ b/packages/@uppy/utils/src/RateLimitedQueue.js
@@ -1,12 +1,4 @@
-/**
- * Array.prototype.findIndex ponyfill for old browsers.
- */
-function findIndex (array, predicate) {
-  for (let i = 0; i < array.length; i++) {
-    if (predicate(array[i])) return i
-  }
-  return -1
-}
+const findIndex = require('@uppy/utils/lib/findIndex')
 
 function createCancelError () {
   return new Error('Cancelled')

--- a/packages/@uppy/utils/src/findIndex.js
+++ b/packages/@uppy/utils/src/findIndex.js
@@ -1,0 +1,13 @@
+/**
+ * Array.prototype.findIndex ponyfill for old browsers.
+ *
+ * @param {Array} array
+ * @param {Function} predicate
+ * @returns {number}
+ */
+module.exports = function findIndex (array, predicate) {
+  for (let i = 0; i < array.length; i++) {
+    if (predicate(array[i])) return i
+  }
+  return -1
+}

--- a/packages/@uppy/utils/src/findIndex.test.js
+++ b/packages/@uppy/utils/src/findIndex.test.js
@@ -1,0 +1,23 @@
+const findIndex = require('./findIndex')
+
+describe('findIndex', () => {
+  it('should return index of an object in an array, that matches a predicate', () => {
+    const arr = [
+      { name: 'foo' },
+      { name: 'bar' },
+      { name: '123' }
+    ]
+    const index = findIndex(arr, item => item.name === 'bar')
+    expect(index).toEqual(1)
+  })
+
+  it('should return -1 when no object in an array matches a predicate', () => {
+    const arr = [
+      { name: 'foo' },
+      { name: 'bar' },
+      { name: '123' }
+    ]
+    const index = findIndex(arr, item => item.name === 'hello')
+    expect(index).toEqual(-1)
+  })
+})


### PR DESCRIPTION
`uppy.removePlugin()` started failing to do its job when used in a Vue3 component https://github.com/transloadit/uppy/pull/2755, because [Vue3 started using](https://v3.vuejs.org/guide/reactivity.html#how-vue-tracks-these-changes) [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy):

> When you pass a plain JavaScript object to an application or component instance as its data option, Vue will walk through all of its properties and convert them to Proxies using a handler with getters and setters. 

So when we did `const index = list.indexOf(instance)` it would always return `-1`, because `Obj !== ObjProxy`, and the plugin was not removed from Uppy, and its `render` was being called even when its `pluginState` was emptied out, resulting in:

```
vue.js:9738 Uncaught (in promise) TypeError: Cannot read property 'filter' of undefined
    at Dashboard$1.<anonymous> (vue.js:9738)
    at Dashboard$1.memoized [as _getAcquirers] (vue.js:8908)
    at Dashboard$1._this.render (vue.js:9790)
    at rerender (index-0d20f3f3.js:2529)
    at index-0d20f3f3.js:2431
```