### PR TITLE
companion: fix crash when S3 is not configured

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -26,10 +26,15 @@ module.exports = function s3 (config) {
   function getUploadParameters (req, res, next) {
     // @ts-ignore The `companion` property is added by middleware before reaching here.
     const client = req.companion.s3Client
+
+    if (!client || typeof config.bucket !== 'string') {
+      return res.status(400).json({ error: 'This Companion server does not support uploading to S3' })
+    }
+
     const metadata = req.query.metadata || {}
     const key = config.getKey(req, req.query.filename, metadata)
     if (typeof key !== 'string') {
-      return res.status(500).json({ error: 's3: filename returned from `getKey` must be a string' })
+      return res.status(500).json({ error: 'S3 uploads are misconfigured: filename returned from `getKey` must be a string' })
     }
 
     const fields = {


### PR DESCRIPTION
I thought of this as a server-side issue when initially writing it, but
if you don't have S3 uploads configured, users can still target the
endpoint. So that endpoint should never crash the process.

With this change users get a 400 response when trying to start an S3 upload
of remote files if their Companion server does not support it.