### PR TITLE
Finishing touches on Companion dynamic Oauth

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -37,6 +37,7 @@
     "connect-redis": "4.0.3",
     "cookie-parser": "1.4.6",
     "cors": "^2.8.5",
+    "escape-goat": "3.0.0",
     "escape-string-regexp": "2.0.0",
     "express": "4.17.1",
     "express-interceptor": "1.2.0",

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -56,7 +56,13 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
       if (credentials.redirect_uri) {
         res.locals.grant.dynamic.redirect_uri = credentials.redirect_uri
       }
-    }).finally(() => next())
+
+      next()
+    }).catch((err) => {
+      // TODO we should return an html page here that can communicate the error
+      // back to the Uppy client
+      next(err)
+    })
   }
 }
 

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -1,12 +1,65 @@
 const request = require('request')
 // @ts-ignore
 const atob = require('atob')
+const { htmlEscape } = require('escape-goat')
 const logger = require('../logger')
 const oAuthState = require('../helpers/oauth-state')
 const tokenService = require('../helpers/jwt')
-const { sanitizeHtml } = require('../helpers/utils')
 // eslint-disable-next-line
 const Provider = require('./Provider')
+
+/**
+ * @param {string} url
+ * @param {string} providerName
+ * @param {object} credentialRequestParams
+ */
+function fetchKeys (url, providerName, credentialRequestParams) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      body: {
+        provider: providerName,
+        parameters: credentialRequestParams,
+      },
+      json: true,
+    }
+    request.post(url, options, (requestErr, resp, body) => {
+      if (requestErr) {
+        logger.error(requestErr, 'credentials.fetch.fail')
+        return reject(requestErr)
+      }
+
+      if (resp.statusCode !== 200 || !body.credentials) {
+        const err = new Error(`received status: ${resp.statusCode} with no credentials`)
+        logger.error(err, 'credentials.fetch.fail')
+        return reject(err)
+      }
+
+      return resolve(body.credentials)
+    })
+  })
+}
+
+/**
+ * Fetches for a providers OAuth credentials. If the config for thtat provider allows fetching
+ * of the credentials via http, and the `credentialRequestParams` argument is provided, the oauth
+ * credentials will be fetched via http. Otherwise, the credentials provided via companion options
+ * will be used instead.
+ *
+ * @param {string} providerName the name of the provider whose oauth keys we want to fetch (e.g onedrive)
+ * @param {object} companionOptions the companion options object
+ * @param {object} credentialRequestParams the params that should be sent if an http request is required.
+ */
+async function fetchProviderKeys (providerName, companionOptions, credentialRequestParams) {
+  let providerConfig = companionOptions.providerOptions[providerName]
+  if (!providerConfig) {
+    providerConfig = (companionOptions.customProviders[providerName] || {}).config
+  }
+
+  if (providerConfig && providerConfig.credentialsURL && credentialRequestParams) {
+    return fetchKeys(providerConfig.credentialsURL, providerName, credentialRequestParams)
+  }
+  return providerConfig
+}
 
 /**
  * Returns a request middleware function that can be used to pre-fetch a provider's
@@ -21,11 +74,13 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
     const { authProvider, override } = req.params
     const [providerName] = Object.keys(providers).filter((name) => providers[name].authProvider === authProvider)
     if (!providerName) {
-      return next()
+      next()
+      return
     }
 
     if (!companionOptions.providerOptions[providerName].credentialsURL) {
-      return next()
+      next()
+      return
     }
 
     const dynamic = oAuthState.getDynamicStateFromRequest(req)
@@ -33,17 +88,20 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
     // override param indicates subsequent requests from the oauth flow
     const state = override ? dynamic : req.query.state
     if (!state) {
-      return next()
+      next()
+      return
     }
 
     const preAuthToken = oAuthState.getFromState(state, 'preAuthToken', companionOptions.secret)
     if (!preAuthToken) {
-      return next()
+      next()
+      return
     }
 
     const { err, payload } = tokenService.verifyEncryptedToken(preAuthToken, companionOptions.preAuthSecret)
     if (err || !payload) {
-      return next()
+      next()
+      return
     }
 
     fetchProviderKeys(providerName, companionOptions, payload).then((credentials) => {
@@ -59,7 +117,7 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
       }
 
       next()
-    }).catch((err) => {
+    }).catch((keyErr) => {
       // TODO we should return an html page here that can communicate the error
       // back to the Uppy client, just like /send-token does
       res.send(`
@@ -73,7 +131,7 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
           <p>
             This is probably an Uppy configuration issue. Check that your Transloadit key is correct, and that the configured <code>credentialsName</code> for this remote provider matches the name you gave it in the Template Credentials setup on the Transloadit side.
           </p>
-          <p>Internal error message: ${sanitizeHtml(err.message)}</p>
+          <p>Internal error message: ${htmlEscape(keyErr.message)}</p>
         </body>
         </html>
       `)
@@ -106,52 +164,4 @@ module.exports.getCredentialsResolver = (providerName, companionOptions, req) =>
   }
 
   return credentialsResolver
-}
-
-/**
- * Fetches for a providers OAuth credentials. If the config for thtat provider allows fetching
- * of the credentials via http, and the `credentialRequestParams` argument is provided, the oauth
- * credentials will be fetched via http. Otherwise, the credentials provided via companion options
- * will be used instead.
- *
- * @param {string} providerName the name of the provider whose oauth keys we want to fetch (e.g onedrive)
- * @param {object} companionOptions the companion options object
- * @param {object} credentialRequestParams the params that should be sent if an http request is required.
- */
-const fetchProviderKeys = (providerName, companionOptions, credentialRequestParams) => {
-  let providerConfig = companionOptions.providerOptions[providerName]
-  if (!providerConfig) {
-    providerConfig = (companionOptions.customProviders[providerName] || {}).config
-  }
-
-  if (providerConfig && providerConfig.credentialsURL && credentialRequestParams) {
-    return fetchKeys(providerConfig.credentialsURL, providerName, credentialRequestParams)
-  }
-  return Promise.resolve(providerConfig)
-}
-
-const fetchKeys = (url, providerName, credentialRequestParams) => {
-  return new Promise((resolve, reject) => {
-    const options = {
-      body: {
-        provider: providerName,
-        parameters: credentialRequestParams,
-      },
-      json: true,
-    }
-    request.post(url, options, (err, resp, body) => {
-      if (err) {
-        logger.error(err, 'credentials.fetch.fail')
-        return reject(err)
-      }
-
-      if (resp.statusCode !== 200 || !body.credentials) {
-        const err = new Error(`received status: ${resp.statusCode} with no credentials`)
-        logger.error(err, 'credentials.fetch.fail')
-        return reject(err)
-      }
-
-      return resolve(body.credentials)
-    })
-  })
 }

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -4,6 +4,7 @@ const atob = require('atob')
 const logger = require('../logger')
 const oAuthState = require('../helpers/oauth-state')
 const tokenService = require('../helpers/jwt')
+const { sanitizeHtml } = require('../helpers/utils')
 // eslint-disable-next-line
 const Provider = require('./Provider')
 
@@ -60,8 +61,22 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
       next()
     }).catch((err) => {
       // TODO we should return an html page here that can communicate the error
-      // back to the Uppy client
-      next(err)
+      // back to the Uppy client, just like /send-token does
+      res.send(`
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+        </head>
+        <body>
+          <h1>Could not fetch credentials</h1>
+          <p>
+            This is probably an Uppy configuration issue. Check that your Transloadit key is correct, and that the configured <code>credentialsName</code> for this remote provider matches the name you gave it in the Template Credentials setup on the Transloadit side.
+          </p>
+          <p>Internal error message: ${sanitizeHtml(err.message)}</p>
+        </body>
+        </html>
+      `)
     })
   }
 }

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -11,7 +11,7 @@ const Provider = require('./Provider')
 /**
  * @param {string} url
  * @param {string} providerName
- * @param {object} credentialRequestParams
+ * @param {object|null} credentialRequestParams - null asks for default credentials.
  */
 function fetchKeys (url, providerName, credentialRequestParams) {
   return new Promise((resolve, reject) => {
@@ -55,10 +55,22 @@ async function fetchProviderKeys (providerName, companionOptions, credentialRequ
     providerConfig = (companionOptions.customProviders[providerName] || {}).config
   }
 
-  if (providerConfig && providerConfig.credentialsURL && credentialRequestParams) {
-    return fetchKeys(providerConfig.credentialsURL, providerName, credentialRequestParams)
+  if (!providerConfig) {
+    return null
   }
-  return providerConfig
+
+  if (!providerConfig.credentialsURL) {
+    return providerConfig
+  }
+
+  // If a default key is configured, do not ask the credentials endpoint for it.
+  // In a future version we could make this an XOR thing, providing either an endpoint or global keys,
+  // but not both.
+  if (!credentialRequestParams && providerConfig.key) {
+    return providerConfig
+  }
+
+  return fetchKeys(providerConfig.credentialsURL, providerName, credentialRequestParams || null)
 }
 
 /**

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -11,9 +11,9 @@ const Provider = require('./Provider')
  * Returns a request middleware function that can be used to pre-fetch a provider's
  * Oauth credentials before the request is passed to the Oauth handler (https://github.com/simov/grant in this case).
  *
- * @param {Object.<string, (typeof Provider)>} providers provider classes enabled for this server
+ * @param {Record<string, typeof Provider>} providers provider classes enabled for this server
  * @param {object} companionOptions companion options object
- * @returns {(req: object, res: object, next: Function) => void}
+ * @returns {import('express').RequestHandler}
  */
 exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
   return (req, res, next) => {

--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.js
@@ -218,7 +218,9 @@ module.exports = class ProviderView extends View {
     })
   }
 
-  handleAuth () {
+  async handleAuth () {
+    await this.provider.ensurePreAuth()
+
     const authState = btoa(JSON.stringify({ origin: getOrigin() }))
     const clientVersion = `@uppy/provider-views=${ProviderView.VERSION}`
     const link = this.provider.authUrl({ state: authState, uppyVersions: clientVersion })

--- a/packages/@uppy/robodog/src/addProviders.js
+++ b/packages/@uppy/robodog/src/addProviders.js
@@ -49,7 +49,7 @@ function addRemoteProvider (uppy, name, opts) {
       const { key } = opts.params.auth
       overrides.companionKeysParams = {
         key,
-        credentialsName: overrides.credentialsName
+        credentialsName: overrides.credentialsName,
       }
       delete overrides.credentialsName
     }

--- a/packages/@uppy/robodog/src/addProviders.js
+++ b/packages/@uppy/robodog/src/addProviders.js
@@ -46,7 +46,7 @@ function addRemoteProvider (uppy, name, opts) {
     // Use the app's own oauth credentials instead of the shared
     // Transloadit ones.
     if (overrides.credentialsName) {
-      const { key } = opts.params
+      const { key } = opts.params.auth
       overrides.companionKeysParams = {
         key,
         credentialsName: overrides.credentialsName

--- a/packages/@uppy/robodog/src/addProviders.js
+++ b/packages/@uppy/robodog/src/addProviders.js
@@ -1,6 +1,7 @@
 const Transloadit = require('@uppy/transloadit')
 const has = require('@uppy/utils/lib/hasProperty')
 
+// We add providers to Robodog when they hit version 1.0.
 const remoteProviders = {
   dropbox: require('@uppy/dropbox'),
   'google-drive': require('@uppy/google-drive'),
@@ -37,9 +38,23 @@ function addRemoteProvider (uppy, name, opts) {
   remoteProviderOptionNames.forEach((name) => {
     if (has(opts, name)) providerOptions[name] = opts[name]
   })
+
   // Apply overrides for a specific provider plugin.
   if (typeof opts[name] === 'object') {
-    Object.assign(providerOptions, opts[name])
+    const overrides = { ...opts[name] }
+
+    // Use the app's own oauth credentials instead of the shared
+    // Transloadit ones.
+    if (overrides.credentialsName) {
+      const { key } = opts.params
+      overrides.companionKeysParams = {
+        key,
+        credentialsName: overrides.credentialsName
+      }
+      delete overrides.credentialsName
+    }
+
+    Object.assign(providerOptions, overrides)
   }
 
   uppy.use(Provider, providerOptions)

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -135,7 +135,7 @@ export default () => {
       })
       uppyDashboard.use(XHRUpload, {
         method: 'POST',
-        endpoint: 'https://api2.transloadit.com/assemblies',
+        endpoint: `${TRANSLOADIT_SERVICE_URL}/assemblies`,
         metaFields: ['params'],
         bundle: true,
       })

--- a/website/src/docs/robodog-dashboard.md
+++ b/website/src/docs/robodog-dashboard.md
@@ -71,8 +71,27 @@ Array of mime type wildcards `image/*`, exact mime types `image/jpeg`, or file e
 
 If provided, the [`<input accept>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types) attribute will be added to `<input type="file">` fields, so only acceptable files can be selected in the system file dialog.
 
+## Using your own OAuth applications when importing files
+
+When importing files from remote providers, Transloadit’s OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust. You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
+
+You can use your own OAuth keys with Transloadit’s hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select “Companion OAuth” for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to that provider:
+
+```js
+Robodog.dashboard({
+  providers: ['dropbox'],
+  dropbox: {
+    credentialsName: 'my_companion_dropbox_creds',
+  },
+})
+```
+
+Users will now be asked to allow _your_ application access, and they’re probably already familiar with that!
+
 [dashboard]: /docs/dashboard
 
 [transloadit]: /docs/transloadit
 
 [file picker]: /docs/robodog/picker
+
+[template-credentials]: https://transloadit.com/docs/#how-to-create-template-credentials

--- a/website/src/docs/robodog-dashboard.md
+++ b/website/src/docs/robodog-dashboard.md
@@ -7,7 +7,7 @@ order: 4
 category: "File Processing"
 ---
 
-Add the [Dashboard UI][dashboard] to your page, all wired up and ready to go! This is a wrapper around the [Transloadit][transloadit] and [Dashboard][dashboard] plugins. Unlike the [File Picker][file picker] API, this Dashboard is embedded directly into the page. Users can upload multiple files after another.
+Add the [Dashboard UI][dashboard] to your page, all wired up and ready to go! This is a wrapper around the [Transloadit][transloadit] and [Dashboard][dashboard] plugins. Unlike the [File Picker][file picker] API, this Dashboard is embedded directly into the page. Users can upload many files after another.
 
 ```html
 <div id="dashboard"></div>
@@ -69,7 +69,7 @@ The minimum number of files that must be selected before the upload. The upload 
 
 Array of mime type wildcards `image/*`, exact mime types `image/jpeg`, or file extensions `.jpg`: `['image/*', '.jpg', '.jpeg', '.png', '.gif']`.
 
-If provided, the [`<input accept>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting\_accepted\_file\_types) attribute will be added to `<input type="file">` fields, so only acceptable files can be selected in the system file dialog.
+If provided, the [`<input accept>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types) attribute will be added to `<input type="file">` fields, so only acceptable files can be selected in the system file dialog.
 
 [dashboard]: /docs/dashboard
 

--- a/website/src/docs/robodog-dashboard.md
+++ b/website/src/docs/robodog-dashboard.md
@@ -7,7 +7,7 @@ order: 4
 category: "File Processing"
 ---
 
-Add the [Dashboard UI][dashboard] to your page, all wired up and ready to go! This is a basic wrapper around the [Transloadit][transloadit] and [Dashboard][dashboard] plugins. Unlike the [File Picker][file picker] API, this Dashboard is embedded directly into the page. Users can upload many files after another.
+Add the [Dashboard UI][dashboard] to your page, all wired up and ready to go! This is a wrapper around the [Transloadit][transloadit] and [Dashboard][dashboard] plugins. Unlike the [File Picker][file picker] API, this Dashboard is embedded directly into the page. Users can upload multiple files after another.
 
 ```html
 <div id="dashboard"></div>

--- a/website/src/docs/robodog-picker.md
+++ b/website/src/docs/robodog-picker.md
@@ -123,7 +123,7 @@ Specific options for the [Webcam](/docs/webcam) provider.
 
 ## Using your own OAuth applications when importing files
 
-When importing files from remote providers, Transloadit's OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust.
+When importing files from remote providers, Transloadit's OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust. You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
 
 You can use your own OAuth keys with Transloadit's hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select "Companion OAuth" for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to the appropriate provider:
 

--- a/website/src/docs/robodog-picker.md
+++ b/website/src/docs/robodog-picker.md
@@ -87,7 +87,7 @@ Array of providers to use. Each entry is the name of a provider. The available o
 
 ### `companionUrl: Transloadit.COMPANION`
 
-The URL to a [Uppy Companion][companion] server to use.
+The URL to a [Uppy Companion][companion] server to use. By default, Transloadit's hosted servers are used. These servers are restricted to importing files from remote providers into Transloadit Assemblies.
 
 ### `companionAllowedHosts: Transloadit.COMPANION_PATTERN`
 
@@ -95,7 +95,7 @@ The valid and authorised URL(s) from which OAuth responses should be accepted.
 
 This value can be a `String`, a `Regex` pattern, or an `Array` of both.
 
-This is useful when you have your [Uppy Companion][companion] running on several hosts. Otherwise, the default value should do fine.
+This is useful when you have your own [Uppy Companion][companion] running on multiple hosts. Otherwise, the default value should do just fine.
 
 ### `companionHeaders: {}`
 
@@ -121,10 +121,27 @@ Specific options for the [URL](/docs/url) provider.
 
 Specific options for the [Webcam](/docs/webcam) provider.
 
+## Using your own OAuth applications when importing files
+
+When importing files from remote providers, Transloadit's OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust.
+
+You can use your own OAuth keys with Transloadit's hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select "Companion OAuth" for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to the appropriate provider:
+
+```js
+Robodog.pick({
+  providers: ['dropbox'],
+  dropbox: {
+    credentialsName: 'my_companion_dropbox_creds',
+  },
+})
+```
+
+Users will now be asked to allow _your_ application access, and they're probably already familiar with that!
+
 [companion]: /docs/companion
 
 [transloadit]: /docs/transloadit#options
 
 [assembly-status]: https://transloadit.com/docs/api/#assembly-status-response
-
+[template-credentials]: https://transloadit.com/docs/#how-to-create-template-credentials
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise

--- a/website/src/docs/robodog-picker.md
+++ b/website/src/docs/robodog-picker.md
@@ -67,7 +67,7 @@ The minimum number of files that must be selected before the upload.
 
 Array of mime type wildcards `image/*`, exact mime types `image/jpeg`, or file extensions `.jpg`: `['image/*', '.jpg', '.jpeg', '.png', '.gif']`.
 
-If provided, the [`<input accept>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting\_accepted\_file\_types) attribute will be used for the internal file input field, so only acceptable files can be selected in the system file dialog.
+If provided, the [`<input accept>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types) attribute will be used for the internal file input field, so only acceptable files can be selected in the system file dialog.
 
 ## Providers
 
@@ -87,7 +87,7 @@ Array of providers to use. Each entry is the name of a provider. The available o
 
 ### `companionUrl: Transloadit.COMPANION`
 
-The URL to a [Uppy Companion][companion] server to use. By default, Transloadit's hosted servers are used. These servers are restricted to importing files from remote providers into Transloadit Assemblies.
+The URL to a [Uppy Companion][companion] server to use. By default, Transloadit’s hosted servers are used. These servers are restricted to importing files from remote providers into Transloadit Assemblies.
 
 ### `companionAllowedHosts: Transloadit.COMPANION_PATTERN`
 
@@ -95,7 +95,7 @@ The valid and authorised URL(s) from which OAuth responses should be accepted.
 
 This value can be a `String`, a `Regex` pattern, or an `Array` of both.
 
-This is useful when you have your own [Uppy Companion][companion] running on multiple hosts. Otherwise, the default value should do just fine.
+This is useful when you have your own [Uppy Companion][companion] instances running on many hostnames.
 
 ### `companionHeaders: {}`
 
@@ -123,9 +123,9 @@ Specific options for the [Webcam](/docs/webcam) provider.
 
 ## Using your own OAuth applications when importing files
 
-When importing files from remote providers, Transloadit's OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust. You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
+When importing files from remote providers, Transloadit’s OAuth applications are used by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust. You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
 
-You can use your own OAuth keys with Transloadit's hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select "Companion OAuth" for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to the appropriate provider:
+You can use your own OAuth keys with Transloadit’s hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select “Companion OAuth” for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to that provider:
 
 ```js
 Robodog.pick({
@@ -136,12 +136,14 @@ Robodog.pick({
 })
 ```
 
-Users will now be asked to allow _your_ application access, and they're probably already familiar with that!
+Users will now be asked to allow _your_ application access, and they’re probably already familiar with that!
 
 [companion]: /docs/companion
 
 [transloadit]: /docs/transloadit#options
 
 [assembly-status]: https://transloadit.com/docs/api/#assembly-status-response
+
 [template-credentials]: https://transloadit.com/docs/#how-to-create-template-credentials
+
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -50,6 +50,33 @@ In the [CDN package](/docs/#With-a-script-tag), the plugin class is available on
 const { Transloadit } = Uppy
 ```
 
+## Hosted Companion Service
+
+You can use this plugin together with Transloadit’s hosted Companion service to let your users import files from third party sources across the web.
+To do so each provider plugin must be configured with Transloadit’s Companion URLs:
+
+```js
+uppy.use(Dropbox, {
+  companionUrl: Transloadit.COMPANION,
+  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+})
+```
+
+This will already work. Transloadit’s OAuth applications are used to authenticate your users by default. Your users will be asked to provide Transloadit access to their files. Since your users are probably not aware of Transloadit, this may be confusing or decrease trust. You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
+
+To solve that, you can use your own OAuth keys with Transloadit’s hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select “Companion OAuth” for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to that provider:
+
+```js
+uppy.use(Dropbox, {
+  companionUrl: Transloadit.COMPANION,
+  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+  companionKeysParams: {
+    key: 'YOUR_TRANSLOADIT_API_KEY',
+    credentialsName: 'my_companion_dropbox_creds',
+  },
+})
+```
+
 ## Properties
 
 ### `Transloadit.COMPANION`
@@ -383,3 +410,5 @@ uppy.on('transloadit:complete', (assembly) => {
 ```
 
 [assembly-status]: https://transloadit.com/docs/api/#assembly-status-response
+
+[template-credentials]: https://transloadit.com/docs/#how-to-create-template-credentials

--- a/yarn.lock
+++ b/yarn.lock
@@ -8951,6 +8951,7 @@ __metadata:
     connect-redis: 4.0.3
     cookie-parser: 1.4.6
     cors: ^2.8.5
+    escape-goat: 3.0.0
     escape-string-regexp: 2.0.0
     express: 4.17.1
     express-interceptor: 1.2.0
@@ -18241,6 +18242,13 @@ __metadata:
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
+  languageName: node
+  linkType: hard
+
+"escape-goat@npm:3.0.0":
+  version: 3.0.0
+  resolution: "escape-goat@npm:3.0.0"
+  checksum: 6719196d073cc72d0bbe079646d6fa32f226f24fd7d00c1a71fa375bd4c5b8999050021d9e62c232a8874230328ebf89a5c8bd76fb72f7ccd6229efbe5abd04e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR will contain the final bits we need to start using Companion's dynamic oauth feature on transloadit.com. May add a few more things here as I work on the transloadit.com side…

So far this:
- fails loudly if requested third-party credentials do not exist, instead of silently falling back to the preconfigured one. There was no way for developers to see what went wrong before
- adds options to Robodog so you don't have to remember how `companionKeysParams` works and don't have to duplicate your transloadit API key. Now you can do:
  ```js
  robodog.dashboard({
    params: {
      auth: { key: 'your transloadit api key' }
    },
    providers: ['instagram'],
    instagram: {
      credentialsName: 'your instagram credentials name on transloadit.com'
    }
  })
  ```

To do:
- when requested third-party credentials can't be found, error out with an HTML page that can communicate back to the Uppy client, instead of a JSON error. – leaving this for a followup PR
- [x] docs for the new robodog options
- [x] Seems to lose preauth state when the initial authentication attempt fails; then falls back to default credentials, which is bad