### PR TITLE
Add missing doneButtonHandler type to dashboard

### DIFF
--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -26,6 +26,7 @@ declare module Dashboard {
     disablePageScrollWhenModalOpen?: boolean
     disableStatusBar?: boolean
     disableThumbnailGenerator?: boolean
+    doneButtonHandler?: () => void
     height?: string | number
     hideCancelButton?: boolean
     hidePauseResumeButton?: boolean


### PR DESCRIPTION
Added missing type to dashboard which is present in the documentation: https://uppy.io/docs/dashboard/#doneButtonHandler

`doneButtonHandler`