### PR TITLE
fix: Aws-s3-multipart sends outdated file info to upload-success event

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -168,7 +168,8 @@ module.exports = class AwsS3Multipart extends Plugin {
         queuedRequest.done()
         this.resetUploaderReferences(file.id)
 
-        this.uppy.emit('upload-success', file, uploadResp)
+        const cFile = this.uppy.getFile(file.id)
+        this.uppy.emit('upload-success', cFile || file, uploadResp)
 
         if (result.location) {
           this.uppy.log(`Download ${upload.file.name} from ${result.location}`)


### PR DESCRIPTION
Fixes #2825 