### PR TITLE
Fix: uploadStarted should say true

### DIFF
--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -463,7 +463,7 @@ If `uppy.opts.autoProceed === true`, Uppy will begin uploading automatically whe
 
 > Sometimes you might need to add a remote file to Uppy. This can be achieved by [fetching the file, then creating a Blob object, or using the Url plugin with Companion](https://github.com/transloadit/uppy/issues/1006#issuecomment-413495493).
 >
-> Sometimes you might need to mark some files as “already uploaded”, so that the user sees them, but they won’t actually be uploaded by Uppy. This can be achieved by [looping through files and setting `uploadComplete: true, uploadStarted: false` on them](https://github.com/transloadit/uppy/issues/1112#issuecomment-432339569)
+> Sometimes you might need to mark some files as “already uploaded”, so that the user sees them, but they won’t actually be uploaded by Uppy. This can be achieved by [looping through files and setting `uploadComplete: true, uploadStarted: true` on them](https://github.com/transloadit/uppy/issues/1112#issuecomment-432339569)
 
 ### `uppy.removeFile(fileID)`
 


### PR DESCRIPTION
If the uploadStarted is set to false, and the autoProceed is on, it asks to retry the file and displays them as failures.

Example: https://github.com/transloadit/uppy/issues/1112#issuecomment-785160268