### PR TITLE
companion: smaller heroku deployment

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Deploy to heroku
-        uses: akhileshns/heroku-deploy@v3.5.6
+        uses: akhileshns/heroku-deploy@v3.12.12
         with:
+          appdir: packages/@uppy/companion
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: companion-demo
           heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ./bin/companion-heroku

--- a/bin/companion-heroku
+++ b/bin/companion-heroku
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-env \
-  COMPANION_PORT=$PORT \
-node ./packages/@uppy/companion/src/standalone/start-server.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -56938,7 +56938,8 @@
         "typescript": "3.7.5"
       },
       "engines": {
-        "node": ">=10.20.1"
+        "node": ">=10.20.1",
+        "npm": "7.x"
       }
     },
     "packages/@uppy/companion-client": {

--- a/packages/@uppy/companion/Procfile
+++ b/packages/@uppy/companion/Procfile
@@ -1,0 +1,1 @@
+web: COMPANION_PORT=$PORT node ./src/standalone/start-server

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -109,6 +109,7 @@
     "test:watch": "npm test -- --watch"
   },
   "engines": {
-    "node": ">=10.20.1"
+    "node": ">=10.20.1",
+    "npm": "7.x"
   }
 }


### PR DESCRIPTION
Currently we push the entire repo to heroku and it installs the whole dependency tree, leading to 400MB+ image sizes. Companion is actually self contained so we can only push that folder to Heroku and reduce our image sizes by 90%, and increase deploy performance by a similar margin.