### PR TITLE
Add uppy.logout() that logs user out of all cloud providers

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -953,6 +953,14 @@ class Uppy {
     this.cancelAll()
   }
 
+  logout () {
+    this.iteratePlugins(plugin => {
+      if (plugin.provider && plugin.provider.logout) {
+        plugin.provider.logout()
+      }
+    })
+  }
+
   _calculateProgress (file, data) {
     if (!this.getFile(file.id)) {
       this.log(`Not setting progress for a file that has been removed: ${file.id}`)

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -665,6 +665,10 @@ Stop all uploads in progress and clear file selection, set progress to 0. Basica
 
 Uninstall all plugins and close down this Uppy instance. Also runs `uppy.reset()` before uninstalling.
 
+### `uppy.logout()`
+
+Calls `provider.logout()` on each remote provider plugin (Google Drive, Instagram, etc). Useful, for example, after your users log out of their account in your app — this will clean things up with Uppy cloud providers as well, for extra security.
+
 ### `uppy.log()`
 
 #### Parameters


### PR DESCRIPTION
Should we call it something more distinct, `logoutAll` or `signout`? `logout` could be confused with `log`, but maybe not. It is consistent with `this.provider.logout` that it calls internally.