### PR TITLE
[FIX] Webcam - improve MIME type detection to solve issue in iOS Safari 

### DIFF
--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -476,7 +476,11 @@ module.exports = class Webcam extends Plugin {
   }
 
   getVideo () {
-    const mimeType = this.recordingChunks[0].type
+    // Sometimes in iOS Safari, Blobs (especially the first Blob in the recordingChunks Array)
+    // have empty 'type' attributes (e.g. '') so we need to find a Blob that has a defined 'type'
+    // attribute in order to determine the correct MIME type.
+    const mimeType = this.recordingChunks.find(blob => blob.type?.length > 0).type
+
     const fileExtension = getFileTypeExtension(mimeType)
 
     if (!fileExtension) {


### PR DESCRIPTION
[FIX] - improve MIME type detection to solve issue in iOS Safari where the first Blob in the Array might not have a MIME type specified and so would crash the Webcam component when we try to determine the MIME type.