### PR TITLE
Upgrade TypeScript

### DIFF
--- a/examples/svelte-example/package.json
+++ b/examples/svelte-example/package.json
@@ -24,7 +24,7 @@
     "svelte-check": "^1.0.0",
     "svelte-preprocess": "^4.6.1",
     "tslib": "^2.0.0",
-    "typescript": "^3.9.3"
+    "typescript": "~4.1"
   },
   "dependencies": {
     "@uppy/core": "file:../../packages/@uppy/core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "tsd": "^0.11.0",
         "tsify": "5.0.1",
         "tus-node-server": "0.3.2",
-        "typescript": "3.9.3",
+        "typescript": "~4.1",
         "verdaccio": "^4.8.0",
         "watchify": "3.11.1",
         "webdriverio": "5.18.6",
@@ -740,7 +740,7 @@
         "svelte-check": "^1.0.0",
         "svelte-preprocess": "^4.6.1",
         "tslib": "^2.0.0",
-        "typescript": "^3.9.3"
+        "typescript": "~4.1"
       }
     },
     "examples/svelte-example/node_modules/postcss": {
@@ -51326,9 +51326,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -56935,7 +56935,7 @@
         "@types/uuid": "3.4.7",
         "@types/ws": "6.0.4",
         "supertest": "3.4.2",
-        "typescript": "3.7.5"
+        "typescript": "~4.1"
       },
       "engines": {
         "node": ">=10.20.1",
@@ -63445,7 +63445,7 @@
         "svelte-check": "^1.0.0",
         "svelte-preprocess": "^4.6.1",
         "tslib": "^2.0.0",
-        "typescript": "^3.9.3"
+        "typescript": "~4.1"
       },
       "dependencies": {
         "postcss": {
@@ -63655,7 +63655,7 @@
         "serialize-error": "^2.1.0",
         "supertest": "3.4.2",
         "tus-js-client": "2.1.1",
-        "typescript": "3.7.5",
+        "typescript": "~4.1",
         "uuid": "8.1.0",
         "validator": "^12.1.0",
         "ws": "6.2.1"
@@ -63719,8 +63719,7 @@
           "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
         },
         "typescript": {
-          "version": "3.7.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+          "version": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
           "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
           "dev": true
         },
@@ -99694,9 +99693,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "tsd": "^0.11.0",
     "tsify": "5.0.1",
     "tus-node-server": "0.3.2",
-    "typescript": "3.9.3",
+    "typescript": "~4.1",
     "verdaccio": "^4.8.0",
     "watchify": "3.11.1",
     "webdriverio": "5.18.6",

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -85,7 +85,7 @@
     "@types/uuid": "3.4.7",
     "@types/ws": "6.0.4",
     "supertest": "3.4.2",
-    "typescript": "3.7.5"
+    "typescript": "~4.1"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary

This PR updates TypeScript from version `3.7.3` to `~4.1`, in order to accommodate the upcoming Angular integration (#2381). This update does come with breaking changes, which can be read [here](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes).

## Why?

Well Angular straight up requires a TypeScript version `>= 4.0 < 4.2`, so basically either `4.1` or `4.0`. Since the former is newer, it seems like the better choice.

Unfortunately, due to the way npm 7 handles dependencies, we can't isolate this change to just one folder. The short explanation is that dependencies that only one package has are installed into root, and a different TypeScript version is installed into that package directory, so the other dependencies can't find it. There are of course solutions, but most are hacky, and we still can't be sure that they'll work

## Things to Check out

The only two packages that use TypeScript directly are Companion and Svelte. Here are a couple of places where things might break

- [ ] Running a build
- [ ] Svelte example
- [ ] Companion tests
- [ ] Type tests

If all of these work, then we can be somewhat certain that this doesn't have catastrophic side effects. Of course there may be more subtle bugs, but hopefully this gives some sort of indication.

It seems like most breaking changes are changes to the type system, but changes could also change the outputted JavaScript.

For example, TypeScript 3.9 came with a breaking change that made this snippet `foo?.bar!.baz` output `foo?.bar.baz` instead of `(foo?.bar).baz`. These kind of changes are few and far between, but they are something to be aware of.