### PR TITLE
Fix npm package name for drop-target

### DIFF
--- a/website/src/docs/drop-target.md
+++ b/website/src/docs/drop-target.md
@@ -30,7 +30,7 @@ This plugin is published as the `@uppy/drop-target` package.
 Install from NPM:
 
 ```shell
-npm install @uppy/drag-drop
+npm install @uppy/drop-target
 ```
 
 In the [CDN package](/docs/#With-a-script-tag), it is available on the `Uppy` global object:


### PR DESCRIPTION
On the Drop Target page the npm installation instructions say to install `drag-drop` instead of `drop-target`. This fixes.