### PR TITLE
core: remove outdated comment

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -704,8 +704,6 @@ class Uppy {
   /**
    * Add multiple files to `state.files`. See the `addFile()` documentation.
    *
-   * This cuts some corners for performance, so should typically only be used in cases where there may be a lot of files.
-   *
    * If an error occurs while adding a file, it is logged and the user is notified. This is good for UI plugins, but not for programmatic use. Programmatic users should usually still use `addFile()` on individual files.
    */
   addFiles (fileDescriptors) {


### PR DESCRIPTION
AKAICT, `addFiles` doesn't cut any corner (anymore?), I think it should be used as soon as there is more than one file to add. This PR is removing the comment suggesting to use that method only with lots of files.

Fixes: https://github.com/transloadit/uppy/issues/2787