### PR TITLE
Dashboard: fix individual progress by renaming camelCased svg properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,10 @@
 
 'use strict'
 
+const svgPresentationAttributes = [
+  'alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule', 'color', 'color-interpolatio', 'color-interpolatio-filters', 'color-profile', 'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'image-rendering', 'kerning', 'letter-spacing', 'lighting-color', 'marker-end', 'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'text-anchor', 'text-decoration', 'text-rendering', 'transform', 'transform-origin', 'unicode-bidi', 'vector-effect', 'visibility', 'word-spacing', 'writing-mod',
+]
+
 module.exports = {
   extends: ['transloadit'],
   env: {
@@ -99,6 +103,9 @@ module.exports = {
     'react/prefer-stateless-function': ['warn'],
     'react/sort-comp': ['warn'],
     'react/style-prop-object': ['warn'],
+    'react/no-unknown-property': ['warn', {
+      ignore: svgPresentationAttributes,
+    }],
     'vars-on-top': ['warn'],
     'import/no-extraneous-dependencies': ['error'],
 

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
@@ -71,7 +71,6 @@ function ProgressCircle ({ progress }) {
   // circle length equals 2 * PI * R
   const circleLength = 2 * Math.PI * 15
 
-  /* eslint-disable react/no-unknown-property */
   return (
     <g>
       <circle
@@ -95,7 +94,6 @@ function ProgressCircle ({ progress }) {
       />
     </g>
   )
-  /* eslint-enable react/no-unknown-property */
 }
 
 module.exports = function FileProgress (props) {

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.js
@@ -71,22 +71,31 @@ function ProgressCircle ({ progress }) {
   // circle length equals 2 * PI * R
   const circleLength = 2 * Math.PI * 15
 
+  /* eslint-disable react/no-unknown-property */
   return (
     <g>
-      <circle className="uppy-Dashboard-Item-progressIcon--bg" r="15" cx="18" cy="18" strokeWidth="2" fill="none" />
+      <circle
+        className="uppy-Dashboard-Item-progressIcon--bg"
+        r="15"
+        cx="18"
+        cy="18"
+        stroke-width="2"
+        fill="none"
+      />
       <circle
         className="uppy-Dashboard-Item-progressIcon--progress"
         r="15"
         cx="18"
         cy="18"
         transform="rotate(-90, 18, 18)"
-        strokeWidth="2"
         fill="none"
-        strokeDasharray={circleLength}
-        strokeDashoffset={circleLength - (circleLength / 100 * progress)}
+        stroke-width="2"
+        stroke-dasharray={circleLength}
+        stroke-dashoffset={circleLength - ((circleLength / 100) * progress)}
       />
     </g>
   )
+  /* eslint-enable react/no-unknown-property */
 }
 
 module.exports = function FileProgress (props) {


### PR DESCRIPTION
In recent Big Linting Update™️ https://github.com/transloadit/uppy/pull/2796 autofix changed `stroke-width="2"` to `strokeWidth="2"` due to this rule https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md. Preact doesn’t play nice with camelCased html properties.

What do you think @goto-bus-stop @kvz, should we remove the rule?

https://preactjs.com/guide/v10/differences-to-react/#svg-inside-jsx:

> SVG is pretty interesting when it comes to the names of its properties and attributes. Some properties (and their attributes) on SVG objects are camelCased (e.g. clipPathUnits on a clipPath element), some attributes are kebab-case (e.g. clip-path on many SVG elements), and other attributes (usually ones inherited from the DOM, e.g. oninput) are all lowercase.
> 
> **Preact forwards SVG-Attributes as is**. This allows you to copy and paste unmodified SVG snippets right into your code and have them work out of the box. This allows greater interoperability with tools designers tend to use to generate icons or SVG illustrations.