### PR TITLE
ignore ts errors

### DIFF
--- a/packages/@uppy/companion/src/server/emitter/redis-emitter.js
+++ b/packages/@uppy/companion/src/server/emitter/redis-emitter.js
@@ -6,6 +6,7 @@ const NRP = require('node-redis-pubsub')
  * This is useful for when companion is running on multiple instances and events need
  * to be distributed across.
  */
+// @ts-ignore
 class RedisEmitter extends NRP {
   /**
    *
@@ -23,6 +24,7 @@ class RedisEmitter extends NRP {
    * @param {Function} handler the handler of the event
    */
   once (eventName, handler) {
+    // @ts-ignore
     const removeListener = this.on(eventName, (message) => {
       handler(message)
       removeListener()
@@ -46,7 +48,9 @@ class RedisEmitter extends NRP {
    * @param {Function} handler the handler of the event to remove
    */
   removeListener (eventName, handler) {
+    // @ts-ignore
     this.receiver.removeListener(eventName, handler)
+    // @ts-ignore
     this.receiver.punsubscribe(this.prefix + eventName)
   }
 
@@ -56,7 +60,9 @@ class RedisEmitter extends NRP {
    * @param {string} eventName name of the event
    */
   removeAllListeners (eventName) {
+    // @ts-ignore
     this.receiver.removeAllListeners(eventName)
+    // @ts-ignore
     this.receiver.punsubscribe(this.prefix + eventName)
   }
 }


### PR DESCRIPTION
i couldn't get the @types/node-redis-pubsub to work
It seems they are incorrect (they have a namespace NRP around teh class) (NRP.NodeRedisPubSub)
See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-redis-pubsub/index.d.ts
I'm, not so good with TS but this seems wrong. If we change the code to match the TS definititions, I think it's gonna break