### PR TITLE
Fix incorrect font in Chrome on the Dashboard

### DIFF
--- a/packages/@uppy/dashboard/src/components/AddFiles.js
+++ b/packages/@uppy/dashboard/src/components/AddFiles.js
@@ -77,7 +77,7 @@ class AddFiles extends Component {
       >
         <button
           type="button"
-          className="uppy-DashboardTab-btn"
+          className="uppy-u-reset uppy-c-btn uppy-DashboardTab-btn"
           role="tab"
           tabIndex={0}
           data-uppy-super-focusable
@@ -185,7 +185,7 @@ class AddFiles extends Component {
       >
         <button
           type="button"
-          className="uppy-DashboardTab-btn"
+          className="uppy-u-reset uppy-c-btn uppy-DashboardTab-btn"
           role="tab"
           tabIndex={0}
           aria-controls={`uppy-DashboardContent-panel--${acquirer.id}`}

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -391,7 +391,6 @@
   width: 100%;
   height: 100%;
   cursor: pointer;
-  border: 0;
   background-color: transparent;
   -webkit-appearance: none;
   appearance: none;
@@ -400,8 +399,6 @@
   flex-direction: row;
   align-items: center;
   padding: 12px 15px;
-  line-height: 1;
-  text-align: center;
 
   .uppy-size--md & {
     width: 86px;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -402,6 +402,7 @@
   padding: 12px 15px;
   line-height: 1;
   text-align: center;
+  font-family: inherit;
 
   .uppy-size--md & {
     width: 86px;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -402,7 +402,6 @@
   padding: 12px 15px;
   line-height: 1;
   text-align: center;
-  font-family: inherit;
 
   .uppy-size--md & {
     width: 86px;


### PR DESCRIPTION
I noticed that Chrome showed an incorrect font on the Dashboard buttons:

![CleanShot 2021-05-13 at 13 53 40@2x](https://user-images.githubusercontent.com/375537/118116781-6225c780-b3f3-11eb-9503-1038add3ece2.png)

Here, I've made a simple fix to resolve this — so everything looks as expected:

![CleanShot 2021-05-13 at 13 54 24@2x](https://user-images.githubusercontent.com/375537/118116998-aca74400-b3f3-11eb-9b8f-4888c282a246.png)
