### PR TITLE
Remove double-slash from require path

### DIFF
--- a/packages/@uppy/dashboard/src/utils/trapFocus.js
+++ b/packages/@uppy/dashboard/src/utils/trapFocus.js
@@ -1,6 +1,6 @@
 const toArray = require('@uppy/utils/lib/toArray')
 const getActiveOverlayEl = require('./getActiveOverlayEl')
-const FOCUSABLE_ELEMENTS = require('@uppy/utils/lib//FOCUSABLE_ELEMENTS')
+const FOCUSABLE_ELEMENTS = require('@uppy/utils/lib/FOCUSABLE_ELEMENTS')
 
 function focusOnFirstNode (event, nodes) {
   const node = nodes[0]


### PR DESCRIPTION
This seems to just be a typo, and I'm not sure why it's working at all, but it breaks when building with snowpack.