### PR TITLE
companion-client: rethrow original error objects

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -138,7 +138,9 @@ module.exports = class RequestClient {
       .then(this._getPostResponseFunc(skipPostResponse))
       .then((res) => this._json(res))
       .catch((err) => {
-        err = err.isAuthError ? err : new Error(`Could not get ${this._getUrl(path)}. ${err}`)
+        if (!err.isAuthError) {
+          err.message = `Could not get ${this._getUrl(path)}. ${err.message}`
+        }
         return Promise.reject(err)
       })
   }
@@ -155,7 +157,9 @@ module.exports = class RequestClient {
       .then(this._getPostResponseFunc(skipPostResponse))
       .then((res) => this._json(res))
       .catch((err) => {
-        err = err.isAuthError ? err : new Error(`Could not post ${this._getUrl(path)}. ${err}`)
+        if (!err.isAuthError) {
+          err.message = `Could not post ${this._getUrl(path)}. ${err.message}`
+        }
         return Promise.reject(err)
       })
   }
@@ -172,7 +176,9 @@ module.exports = class RequestClient {
       .then(this._getPostResponseFunc(skipPostResponse))
       .then((res) => this._json(res))
       .catch((err) => {
-        err = err.isAuthError ? err : new Error(`Could not delete ${this._getUrl(path)}. ${err}`)
+        if (!err.isAuthError) {
+          err.message = `Could not delete ${this._getUrl(path)}. ${err.message}`
+        }
         return Promise.reject(err)
       })
   }


### PR DESCRIPTION
Changes the HTTP request error handling logic to only replace the
message inside an Error object, instead of creating a new Error. This
should keep stack traces intact and prevents us from obscuring any
potential additional properties on the original Error.

Hopefully this improves debugability. someone in Transloadit support
is running into issues _somewhere_ between the S3 plugin and Companion,
but the error message is missing. I think `${err}` in this code _should_
show the error, but it's even better if we can keep the stack trace and
stuff.