### PR TITLE
url: Add missing companionCookiesRule option

### DIFF
--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -61,6 +61,7 @@ module.exports = class Url extends Plugin {
     this.client = new RequestClient(uppy, {
       companionUrl: this.opts.companionUrl,
       companionHeaders: this.opts.companionHeaders || this.opts.serverHeaders,
+      companionCookiesRule: this.opts.companionCookiesRule,
     })
   }
 


### PR DESCRIPTION
Only `@uppy/url` plugin is missing `companionCookiesRule` option.

[The documentation](https://github.com/transloadit/uppy/blob/f4e99fa7bf8ac085d4215215aa1d2b3342ef9fef/website/src/docs/url.md#companioncookiesrule-same-origin)