### PR TITLE
companion: support relative redirect URLs in responses

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -86,16 +86,14 @@ module.exports.getRedirectEvaluator = (rawRequestURL, blockPrivateIPs) => {
       return true
     }
 
-    const redirectURL = res.headers.location
-    let shouldRedirect = false
-    if (redirectURL) {
-      try {
-        shouldRedirect = new URL(redirectURL, requestURL).protocol === requestURL.protocol
-      } catch (e) {
-        // `redirectURL` is invalid
-      }
+    let redirectURL = null
+    try {
+      redirectURL = new URL(res.headers.location, requestURL)
+    } catch (err) {
+      return false
     }
 
+    const shouldRedirect = redirectURL.protocol === requestURL.protocol
     if (!shouldRedirect) {
       logger.info(
         `blocking redirect from ${requestURL} to ${redirectURL}`, 'redirect.protection'


### PR DESCRIPTION
When a URL import attempt responds with a redirect, we tried to naively
parse the URL with `new URL()`. This is a problem when the URL is
invalid, because that constructor will throw an error.

Redirect URLs are also allowed to be relative URLs, which was not
supported by us.

With this change, invalid URLs will cause a redirect to be blocked,
and relative redirects will work.