### PR TITLE
Translator: refactor interpolate

### DIFF
--- a/packages/@uppy/utils/src/Translator.js
+++ b/packages/@uppy/utils/src/Translator.js
@@ -50,7 +50,7 @@ module.exports = class Translator {
    * @license https://github.com/airbnb/polyglot.js/blob/master/LICENSE
    * taken from https://github.com/airbnb/polyglot.js/blob/master/lib/polyglot.js#L299
    *
-   * @param {any} phrase that needs interpolation, with placeholders
+   * @param {string} phrase that needs interpolation, with placeholders
    * @param {object} options with values that will be used to replace placeholders
    * @returns {any[]} interpolated
    */

--- a/packages/@uppy/utils/src/Translator.js
+++ b/packages/@uppy/utils/src/Translator.js
@@ -50,12 +50,11 @@ module.exports = class Translator {
    * @license https://github.com/airbnb/polyglot.js/blob/master/LICENSE
    * taken from https://github.com/airbnb/polyglot.js/blob/master/lib/polyglot.js#L299
    *
-   * @param {string} phrase that needs interpolation, with placeholders
+   * @param {any} phrase that needs interpolation, with placeholders
    * @param {object} options with values that will be used to replace placeholders
-   * @returns {string} interpolated
+   * @returns {any[]} interpolated
    */
   interpolate (phrase, options) {
-    const { split, replace } = String.prototype
     const dollarRegex = /\$/g
     const dollarBillsYall = '$$$$'
     let interpolated = [phrase]
@@ -67,7 +66,7 @@ module.exports = class Translator {
         // be escaped with "$" itself, and we need two in the resulting output.
         var replacement = options[arg]
         if (typeof replacement === 'string') {
-          replacement = replace.call(options[arg], dollarRegex, dollarBillsYall)
+          replacement = dollarRegex[Symbol.replace](replacement, dollarBillsYall)
         }
         // We create a new `RegExp` each time instead of using a more-efficient
         // string replace so that the same argument can be replaced multiple times
@@ -89,7 +88,7 @@ module.exports = class Translator {
           return newParts.push(chunk)
         }
 
-        split.call(chunk, rx).forEach((raw, i, list) => {
+        rx[Symbol.split](chunk).forEach((raw, i, list) => {
           if (raw !== '') {
             newParts.push(raw)
           }

--- a/packages/@uppy/utils/src/Translator.js
+++ b/packages/@uppy/utils/src/Translator.js
@@ -55,6 +55,7 @@ module.exports = class Translator {
    * @returns {any[]} interpolated
    */
   interpolate (phrase, options) {
+    const { split, replace } = String.prototype
     const dollarRegex = /\$/g
     const dollarBillsYall = '$$$$'
     let interpolated = [phrase]
@@ -66,7 +67,7 @@ module.exports = class Translator {
         // be escaped with "$" itself, and we need two in the resulting output.
         var replacement = options[arg]
         if (typeof replacement === 'string') {
-          replacement = dollarRegex[Symbol.replace](replacement, dollarBillsYall)
+          replacement = replace.call(options[arg], dollarRegex, dollarBillsYall)
         }
         // We create a new `RegExp` each time instead of using a more-efficient
         // string replace so that the same argument can be replaced multiple times
@@ -88,7 +89,7 @@ module.exports = class Translator {
           return newParts.push(chunk)
         }
 
-        rx[Symbol.split](chunk).forEach((raw, i, list) => {
+        split.call(chunk, rx).forEach((raw, i, list) => {
           if (raw !== '') {
             newParts.push(raw)
           }


### PR DESCRIPTION
Fixes types and small code edits:
`<regex>[Symbol.split](<string>)` is equivalent to `String.prototype.split.call(<string>, <regex>)` and potentially more readable (the downside it's not compatible with IE, which may be why we currently use the latter). I'm not sure where we stand in term of IE compatibilty.

Refs: https://github.com/transloadit/uppy/pull/2899