### PR TITLE
return fileId or error in plugin.addFile

### DIFF
--- a/packages/@uppy/url/src/index.js
+++ b/packages/@uppy/url/src/index.js
@@ -150,11 +150,12 @@ module.exports = class Url extends Plugin {
       .then((tagFile) => {
         this.uppy.log('[Url] Adding remote file')
         try {
-          this.uppy.addFile(tagFile)
+          return this.uppy.addFile(tagFile)
         } catch (err) {
           if (!err.isRestriction) {
             this.uppy.log(err)
           }
+          return err
         }
       })
       .catch((err) => {
@@ -163,6 +164,7 @@ module.exports = class Url extends Plugin {
           message: this.i18n('failedToFetch'),
           details: err,
         }, 'error', 4000)
+        return err
       })
   }
 


### PR DESCRIPTION
In the case of an invalid URL, this is no proper way to handle an error. `uppy.state.info` only show the error without any info that due to which URL error was thrown. 
So returning the error or file so it can be handled as need. throwing the error will not be backward compatible