### PR TITLE
#2920 fixed standalone server to initiate itself on explicit function…

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -93,6 +93,7 @@
   ],
   "jest": {
     "testEnvironment": "node",
+    "testTimeout": 10000,
     "automock": false,
     "collectCoverage": true,
     "collectCoverageFrom": [

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -18,7 +18,7 @@ const middlewares = require('../server/middlewares')
  *
  * @returns {object}
  */
-function server (inputCompanionOptions = {}) {
+module.exports = function server (inputCompanionOptions = {}) {
   const app = express()
 
   // Query string keys whose values should not end up in logging output.
@@ -203,5 +203,3 @@ function server (inputCompanionOptions = {}) {
 
   return { app, companionOptions }
 }
-
-module.exports = { server }

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -204,5 +204,4 @@ function server (inputCompanionOptions = {}) {
   return { app, companionOptions }
 }
 
-const { app, companionOptions } = server()
-module.exports = { app, companionOptions, server }
+module.exports = { server }

--- a/packages/@uppy/companion/src/standalone/start-server.js
+++ b/packages/@uppy/companion/src/standalone/start-server.js
@@ -2,9 +2,11 @@
 const companion = require('../companion')
 // @ts-ignore
 const { version } = require('../../package.json')
-const { app } = require('.')
+const standalone = require('.')
 
 const port = process.env.COMPANION_PORT || 3020
+
+const { app, companionOptions } = standalone.server()
 
 companion.socket(app.listen(port))
 

--- a/packages/@uppy/companion/src/standalone/start-server.js
+++ b/packages/@uppy/companion/src/standalone/start-server.js
@@ -6,7 +6,7 @@ const standalone = require('.')
 
 const port = process.env.COMPANION_PORT || 3020
 
-const { app, companionOptions } = standalone.server()
+const { app } = standalone()
 
 companion.socket(app.listen(port))
 

--- a/packages/@uppy/companion/test/__tests__/uploader.js
+++ b/packages/@uppy/companion/test/__tests__/uploader.js
@@ -5,11 +5,12 @@ jest.mock('tus-js-client')
 const fs = require('fs')
 const Uploader = require('../../src/server/Uploader')
 const socketClient = require('../mocksocket')
-const { companionOptions } = require('../../src/standalone')
+const standalone = require('../../src/standalone')
 
 describe('uploader with tus protocol', () => {
   test('upload functions with tus protocol', () => {
     const fileContent = Buffer.from('Some file content')
+    const { companionOptions } = standalone()
     const opts = {
       companionOptions,
       endpoint: 'http://url.myendpoint.com/files',

--- a/packages/@uppy/companion/test/mockserver.js
+++ b/packages/@uppy/companion/test/mockserver.js
@@ -11,7 +11,7 @@ module.exports.getServer = (env) => {
 
   // delete from cache to force the server to reload companionOptions from the new env vars
   jest.resetModules()
-  const { app } = require('../src/standalone')
+  const standalone = require('../src/standalone')
   const authServer = express()
 
   authServer.use(session({ secret: 'grant', resave: true, saveUninitialized: true }))
@@ -26,6 +26,7 @@ module.exports.getServer = (env) => {
     next()
   })
 
+  const { app } = standalone()
   authServer.use(app)
   return authServer
 }


### PR DESCRIPTION
The changes will change the way the standalone server is starting, now using an explicit function call. This will enable users to use the standalone server with a custom `start-server.js` script to add additional options to the companion server. This is useful in cases you have to modify the options of a companion server which aren't set by the environment variables, e.g. `s3getKey` (see issue #2902).

Now you can call the `server()` function from the standalone module with the already existing parameter for additional options.

Closes #2920