### PR TITLE
Add comments around empty setState calls

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -326,6 +326,7 @@ class Uppy {
       })
     }
 
+    // Note: this is not the preact `setState`, it's an internal function that has the same name.
     this.setState() // so that UI re-renders with new options
   }
 

--- a/packages/@uppy/store-redux/src/index.js
+++ b/packages/@uppy/store-redux/src/index.js
@@ -23,7 +23,8 @@ class ReduxStore {
     this._id = opts.id || cuid()
     this._selector = opts.selector || defaultSelector(this._id)
 
-    // Initialise the `uppy[id]` state key.
+    // Calling `setState` to dispatch an action to the Redux store.
+    // The intent is to make sure that the reducer has run once.
     this.setState({})
   }
 


### PR DESCRIPTION
~Using `forceUpdate` is closer to the intent than an empty `setState` call is IMHO.~
~Calling `setState` in the constructor is not useful, we can simply assign a `state` property to the object.~

nevermind it's not the preact `setState` but the uppy one. Instead, I'm adding comments to emphasise it's not the preact `setState` method.