### PR TITLE
xhr: use symbol for internal options

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -3,7 +3,7 @@ const { Socket, Provider, RequestClient } = require('@uppy/companion-client')
 const EventTracker = require('@uppy/utils/lib/EventTracker')
 const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')
 const getSocketHost = require('@uppy/utils/lib/getSocketHost')
-const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
+const { RateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
 const Uploader = require('./MultipartUploader')
 
 function assertServerError (res) {

--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -6,6 +6,7 @@ const EventTracker = require('@uppy/utils/lib/EventTracker')
 const ProgressTimeout = require('@uppy/utils/lib/ProgressTimeout')
 const NetworkError = require('@uppy/utils/lib/NetworkError')
 const isNetworkError = require('@uppy/utils/lib/isNetworkError')
+const { internalRateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
 
 // See XHRUpload
 function buildResponseError (xhr, error) {
@@ -43,7 +44,7 @@ module.exports = class MiniXHRUpload {
       ...opts,
     }
 
-    this.requests = opts.__queue
+    this.requests = opts[internalRateLimitedQueue]
     this.uploaderEvents = Object.create(null)
     this.i18n = opts.i18n
   }

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -29,7 +29,7 @@
 const URL_ = typeof URL === 'function' ? URL : require('url-parse')
 const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
-const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
+const { RateLimitedQueue, internalRateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
 const settle = require('@uppy/utils/lib/settle')
 const hasProperty = require('@uppy/utils/lib/hasProperty')
 const { RequestClient } = require('@uppy/companion-client')
@@ -283,7 +283,7 @@ module.exports = class AwsS3 extends Plugin {
       responseUrlFieldName: 'location',
       timeout: this.opts.timeout,
       // Share the rate limiting queue with XHRUpload.
-      __queue: this.requests,
+      [internalRateLimitedQueue]: this.requests,
       responseType: 'text',
       getResponseData: this.opts.getResponseData || defaultGetResponseData,
       getResponseError: defaultGetResponseError,

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -7,7 +7,7 @@ const settle = require('@uppy/utils/lib/settle')
 const EventTracker = require('@uppy/utils/lib/EventTracker')
 const NetworkError = require('@uppy/utils/lib/NetworkError')
 const isNetworkError = require('@uppy/utils/lib/isNetworkError')
-const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
+const { RateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
 const hasProperty = require('@uppy/utils/lib/hasProperty')
 const getFingerprint = require('./getFingerprint')
 

--- a/packages/@uppy/utils/src/RateLimitedQueue.js
+++ b/packages/@uppy/utils/src/RateLimitedQueue.js
@@ -4,7 +4,7 @@ function createCancelError () {
   return new Error('Cancelled')
 }
 
-module.exports = class RateLimitedQueue {
+class RateLimitedQueue {
   constructor (limit) {
     if (typeof limit !== 'number' || limit === 0) {
       this.limit = Infinity
@@ -152,4 +152,9 @@ module.exports = class RateLimitedQueue {
       return outerPromise
     }
   }
+}
+
+module.exports = {
+  RateLimitedQueue,
+  internalRateLimitedQueue: Symbol('__queue'),
 }

--- a/packages/@uppy/utils/src/RateLimitedQueue.test.js
+++ b/packages/@uppy/utils/src/RateLimitedQueue.test.js
@@ -1,4 +1,4 @@
-const RateLimitedQueue = require('./RateLimitedQueue')
+const { RateLimitedQueue } = require('./RateLimitedQueue')
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 

--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -57,7 +57,7 @@ declare module '@uppy/utils/lib/RateLimitedQueue' {
     }
   }
 
-  class RateLimitedQueue {
+  export class RateLimitedQueue {
     constructor(limit: number)
     run(
       fn: () => RateLimitedQueue.AbortFunction,
@@ -69,7 +69,7 @@ declare module '@uppy/utils/lib/RateLimitedQueue' {
     ): RateLimitedQueue.PromiseFunction
   }
 
-  export = RateLimitedQueue
+  export const internalRateLimitedQueue: symbol
 }
 
 declare module '@uppy/utils/lib/canvasToBlob' {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -7,7 +7,7 @@ const getSocketHost = require('@uppy/utils/lib/getSocketHost')
 const settle = require('@uppy/utils/lib/settle')
 const EventTracker = require('@uppy/utils/lib/EventTracker')
 const ProgressTimeout = require('@uppy/utils/lib/ProgressTimeout')
-const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
+const { RateLimitedQueue, internalRateLimitedQueue } = require('@uppy/utils/src/RateLimitedQueue')
 const NetworkError = require('@uppy/utils/lib/NetworkError')
 const isNetworkError = require('@uppy/utils/lib/isNetworkError')
 
@@ -124,9 +124,8 @@ module.exports = class XHRUpload extends Plugin {
     this.handleUpload = this.handleUpload.bind(this)
 
     // Simultaneous upload limiting is shared across all uploads with this plugin.
-    // __queue is for internal Uppy use only!
-    if (this.opts.__queue instanceof RateLimitedQueue) {
-      this.requests = this.opts.__queue
+    if (internalRateLimitedQueue in this.opts) {
+      this.requests = this.opts[internalRateLimitedQueue]
     } else {
       this.requests = new RateLimitedQueue(this.opts.limit)
     }
@@ -617,8 +616,8 @@ module.exports = class XHRUpload extends Plugin {
       return Promise.resolve()
     }
 
-    // no limit configured by the user, and no RateLimitedQueue passed in by a "parent" plugin (basically just AwsS3) using the top secret `__queue` option
-    if (this.opts.limit === 0 && !this.opts.__queue) {
+    // no limit configured by the user, and no RateLimitedQueue passed in by a "parent" plugin (basically just AwsS3) using the internal symbol
+    if (this.opts.limit === 0 && !this.opts[internalRateLimitedQueue]) {
       this.uppy.log(
         '[XHRUpload] When uploading multiple files at once, consider setting the `limit` option (to `10` for example), to limit the number of concurrent uploads, which helps prevent memory and network issues: https://uppy.io/docs/xhr-upload/#limit-0',
         'warning'


### PR DESCRIPTION
IE users will need a polyfill for `Symbol` (e.g., https://github.com/rousan/symbol-es6).