### PR TITLE
deps: remove url-parse to use global `URL` instead

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,3 @@
-IE 10
 last 2 Safari versions
 last 2 Chrome versions
 last 2 ChromeAndroid versions

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -26,8 +26,7 @@
     "@uppy/utils": "file:../utils",
     "@uppy/xhr-upload": "file:../xhr-upload",
     "cuid": "^2.1.1",
-    "qs-stringify": "^1.1.0",
-    "url-parse": "^1.4.7"
+    "qs-stringify": "^1.1.0"
   },
   "devDependencies": {
     "whatwg-fetch": "3.6.2"

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -25,8 +25,6 @@
  * the XHRUpload code, but at least it's not horrifically broken :)
  */
 
-// If global `URL` constructor is available, use it
-const URL_ = typeof URL === 'function' ? URL : require('url-parse')
 const { Plugin } = require('@uppy/core')
 const Translator = require('@uppy/utils/lib/Translator')
 const RateLimitedQueue = require('@uppy/utils/lib/RateLimitedQueue')
@@ -38,9 +36,7 @@ const MiniXHRUpload = require('./MiniXHRUpload')
 const isXml = require('./isXml')
 
 function resolveUrl (origin, link) {
-  return origin
-    ? new URL_(link, origin).toString()
-    : new URL_(link).toString()
+  return new URL(link, origin || undefined).toString()
 }
 
 /**

--- a/packages/@uppy/companion-client/package.json
+++ b/packages/@uppy/companion-client/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@uppy/utils": "file:../utils",
     "namespace-emitter": "^2.0.1",
-    "qs-stringify": "^1.1.0",
-    "url-parse": "^1.4.7"
+    "qs-stringify": "^1.1.0"
   }
 }

--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const qsStringify = require('qs-stringify')
-const URL = require('url-parse')
 const RequestClient = require('./RequestClient')
 const tokenStorage = require('./tokenStorage')
 

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -32,8 +32,7 @@
     "@uppy/tus": "file:../tus",
     "@uppy/utils": "file:../utils",
     "component-emitter": "^1.2.1",
-    "socket.io-client": "~2.2.0",
-    "url-parse": "^1.4.7"
+    "socket.io-client": "~2.2.0"
   },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"

--- a/packages/@uppy/transloadit/src/Client.js
+++ b/packages/@uppy/transloadit/src/Client.js
@@ -1,5 +1,4 @@
 const fetchWithNetworkError = require('@uppy/utils/lib/fetchWithNetworkError')
-const URL = require('url-parse')
 
 /**
  * A Barebones HTTP API client for Transloadit.


### PR DESCRIPTION
IE users will need to use a polyfill (e.g., https://github.com/lifaon74/url-polyfill).