### PR TITLE
transloadit: fix unhandled promise rejections

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1094,7 +1094,7 @@ class Uppy {
 
       this.setState({ error: errorMsg })
 
-      if (file != null) {
+      if (file != null && file.id in this.getState().files) {
         this.setFileState(file.id, {
           error: errorMsg,
           response,
@@ -1552,14 +1552,13 @@ class Uppy {
       ...this.uploaders,
       ...this.postProcessors,
     ]
-    let lastStep = Promise.resolve()
-    steps.forEach((fn, step) => {
+    const lastStep = steps.reduce((lastStep, fn, step) => {
       // Skip this step if we are restoring and have already completed this step before.
       if (step < restoreStep) {
-        return
+        return lastStep
       }
 
-      lastStep = lastStep.then(() => {
+      return lastStep.then(() => {
         const { currentUploads } = this.getState()
         const currentUpload = currentUploads[uploadID]
         if (!currentUpload) {
@@ -1582,16 +1581,11 @@ class Uppy {
         // Otherwise when more metadata may be added to the upload this would keep getting more parameters
         // eslint-disable-next-line consistent-return
         return fn(updatedUpload.fileIDs, uploadID)
-      }).then(() => {
-        return null
-      })
-    })
-
-    // Not returning the `catch`ed promise, because we still want to return a rejected
-    // promise from this method if the upload failed.
-    lastStep.catch((err) => {
+      }).then(() => null)
+    }, Promise.resolve()).catch((err) => {
       this.emit('error', err, uploadID)
       this.removeUpload(uploadID)
+      throw err
     })
 
     return lastStep.then(() => {
@@ -1599,6 +1593,7 @@ class Uppy {
       const { currentUploads } = this.getState()
       const currentUpload = currentUploads[uploadID]
       if (!currentUpload) {
+        this.log(`Not setting result for an upload that has been removed: ${uploadID}`)
         return
       }
 
@@ -1623,24 +1618,16 @@ class Uppy {
       const successful = files.filter((file) => !file.error)
       const failed = files.filter((file) => file.error)
       this.addResultData(uploadID, { successful, failed, uploadID })
-    }).then(() => {
+
       // Emit completion events.
       // This is in a separate function so that the `currentUploads` variable
       // always refers to the latest state. In the handler right above it refers
       // to an outdated object without the `.result` property.
-      const { currentUploads } = this.getState()
-      if (!currentUploads[uploadID]) {
-        return
-      }
-      const currentUpload = currentUploads[uploadID]
       const { result } = currentUpload
       this.emit('complete', result)
 
       this.removeUpload(uploadID)
 
-      // eslint-disable-next-line consistent-return
-      return result
-    }).then((result) => {
       if (result == null) {
         this.log(`Not setting result for an upload that has been removed: ${uploadID}`)
       }

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -659,25 +659,23 @@ module.exports = class Transloadit extends Plugin {
     const files = fileIDs.map((id) => this.uppy.getFile(id))
     const assemblyOptions = new AssemblyOptions(files, this.opts)
 
-    return assemblyOptions.build().then(
-      (assemblies) => Promise.all(
-        assemblies.map(createAssembly)
-      ).then((createdAssemblies) => {
+    return assemblyOptions.build()
+      .then((assemblies) => Promise.all(assemblies.map(createAssembly)))
+      .then((createdAssemblies) => {
         const assemblyIDs = createdAssemblies.map(assembly => assembly.status.assembly_id)
         this._createAssemblyWatcher(assemblyIDs, fileIDs, uploadID)
-        createdAssemblies.map(assembly => this._connectAssembly(assembly))
-      }),
+        return Promise.all(createdAssemblies.map(assembly => this._connectAssembly(assembly)))
+      })
       // If something went wrong before any Assemblies could be created,
       // clear all processing state.
-      (err) => {
+      .catch((err) => {
         fileIDs.forEach((fileID) => {
           const file = this.uppy.getFile(fileID)
           this.uppy.emit('preprocess-complete', file)
           this.uppy.emit('upload-error', file, err)
         })
         throw err
-      }
-    )
+      })
   }
 
   _afterUpload (fileIDs, uploadID) {


### PR DESCRIPTION
Targeting conservatively in case this is a breaking change. Node.js v15+ defaults to crashing if there are unhandled promises rejections at runtime (https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode).

It's indeed quite tricky to spot and to find where the rejected promise comes from, after investigation it looks like it this error that is being thrown from the `errorHandler`: https://github.com/transloadit/uppy/blob/57eae08e9d1c0fdc12bd487ad8d777e389d43ec4/packages/@uppy/core/src/index.js#L290-L293