### PR TITLE
Add Robodog Types

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -285,7 +285,7 @@ The most important part about this is that `@uppy/core` is a peer dependency. If
 
 ### Adding TypeScript Support
 
-This section won't be too in-depth, because TypeScript depends on your framework. As general advice, prefer using `d.ts` files and vanilla JavaScript over TypeScript files. This is of course circumstantial, but it makes handling the build system a lot easier when TypeScript doesn't have to transpiled. The version of typescript in the monorepo is `3.7.5`, so features like `import type` will not work at build time. For upcoming integrations, like Angular, this may be updated.
+This section won't be too in-depth, because TypeScript depends on your framework. As general advice, prefer using `d.ts` files and vanilla JavaScript over TypeScript files. This is of course circumstantial, but it makes handling the build system a lot easier when TypeScript doesn't have to transpiled. The version of typescript in the monorepo is `4.1`.
 
 ### Writing docs
 

--- a/packages/@uppy/robodog/types/index.d.ts
+++ b/packages/@uppy/robodog/types/index.d.ts
@@ -1,0 +1,55 @@
+import Uppy = require('@uppy/core');
+import Transloadit = require('@uppy/transloadit')
+import Dashboard = require('@uppy/dashboard')
+import Dropbox = require('@uppy/dropbox')
+import GoogleDrive = require('@uppy/google-drive')
+import Instagram = require('@uppy/instagram');
+import Url = require('@uppy/url')
+import Webcam = require('@uppy/webcam')
+import Onedrive = require('@uppy/onedrive')
+import Facebook = require('@uppy/facebook');
+import Form = require('@uppy/form')
+
+declare module Robodog {
+    type Provider = 'dropbox' | 'google-drive' | 'instagram' | 'url' | 'webcam' | 'onedrive' | 'facebook'
+
+    interface RobodogOptionsBase extends Uppy.UppyOptions {
+        providers?: Provider[]
+        companionUrl?: string,
+        companionAllowedHosts?: string | RegExp | Array<string | RegExp>
+        companionHeaders?: object,
+        dropbox?: Dropbox.DropboxOptions
+        googleDrive?: GoogleDrive.GoogleDriveOptions
+        instagram?: Instagram.InstagramOptions
+        url?: Url.UrlOptions
+        webcam?: Webcam.WebcamOptions,
+        onedrive?: Onedrive.OneDriveOptions,
+        facebook?: Facebook.FacebookOptions
+    }
+
+    type RobodogOptions = RobodogOptionsBase & Transloadit.TransloaditOptions & Dashboard.DashboardOptions
+
+    interface RobodogTransloaditResult extends Transloadit.Result {
+        assemblyId: string,
+        stepName: string
+    }
+
+    interface RobodogResult extends Uppy.UploadResult {
+        transloadit: Transloadit.Assembly[],
+        results?: RobodogTransloaditResult[]
+    }
+    type RobodogPickOptions = RobodogOptions & { target?: string }
+
+    function pick(opts: RobodogPickOptions): Promise<RobodogResult>;
+
+    type RobodogFormOptions = RobodogOptions & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'> & {modal: boolean}
+
+    function form(target: string, opts: RobodogFormOptions): Uppy.Uppy
+
+    function upload(files: (File | Blob & { name: string })[], opts: RobodogOptions): Promise<RobodogResult>;
+
+    function dashboard(target: string, opts: RobodogOptions): Uppy.Uppy;
+}
+
+
+export = Robodog;

--- a/packages/@uppy/robodog/types/index.d.ts
+++ b/packages/@uppy/robodog/types/index.d.ts
@@ -42,7 +42,10 @@ declare module Robodog {
 
     function pick(opts: RobodogPickOptions): Promise<RobodogResult>;
 
-    type RobodogFormOptions = RobodogOptions & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'> & { modal: boolean }
+    type RobodogFormOptions = RobodogOptions
+        & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'>
+        & { modal?: boolean, statusbar?: string }
+
 
     function form(target: string, opts: RobodogFormOptions): Uppy.Uppy
 

--- a/packages/@uppy/robodog/types/index.d.ts
+++ b/packages/@uppy/robodog/types/index.d.ts
@@ -42,7 +42,7 @@ declare module Robodog {
 
     function pick(opts: RobodogPickOptions): Promise<RobodogResult>;
 
-    type RobodogFormOptions = RobodogOptions & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'> & {modal: boolean}
+    type RobodogFormOptions = RobodogOptions & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'> & { modal: boolean }
 
     function form(target: string, opts: RobodogFormOptions): Uppy.Uppy
 

--- a/packages/@uppy/robodog/types/index.d.ts
+++ b/packages/@uppy/robodog/types/index.d.ts
@@ -38,14 +38,12 @@ declare module Robodog {
         transloadit: Transloadit.Assembly[],
         results?: RobodogTransloaditResult[]
     }
-    type RobodogPickOptions = RobodogOptions & { target?: string }
 
-    function pick(opts: RobodogPickOptions): Promise<RobodogResult>;
+    function pick(opts: RobodogOptions): Promise<RobodogResult>;
 
     type RobodogFormOptions = RobodogOptions
         & Pick<Form.FormOptions, 'submitOnSuccess' | 'triggerUploadOnSubmit'>
         & { modal?: boolean, statusbar?: string }
-
 
     function form(target: string, opts: RobodogFormOptions): Uppy.Uppy
 

--- a/packages/@uppy/robodog/types/index.test-d.ts
+++ b/packages/@uppy/robodog/types/index.test-d.ts
@@ -1,4 +1,5 @@
 import { Transloadit } from 'uppy'
+import {expectError} from 'tsd'
 import Robodog from '.'
 async function performPick() {
     const { successful, failed, transloadit, results } = await Robodog.pick({
@@ -30,6 +31,8 @@ async function performPick() {
 }
 
 
+
+
 const instance = Robodog.form('string', {
     submitOnSuccess: true,
     triggerUploadOnSubmit: false,
@@ -42,6 +45,16 @@ const instance = Robodog.form('string', {
     statusbar: "target"
 })
 
+//should not have access to omitted form settings
+expectError(Robodog.form('string', {
+    addResultToForm: false
+}))
+
+// target is required
+expectError(Robodog.form({
+    addResultToForm: false
+}))
+
 const files: File[] = []
 
 const upload = Robodog.upload(files, {
@@ -52,6 +65,9 @@ const upload = Robodog.upload(files, {
         template_id: ''
     }
 })
+
+// Files array is required
+expectError(Robodog.upload({debug: true}))
 
 const dashboard = Robodog.dashboard("selector", {
     debug: true,
@@ -65,4 +81,5 @@ const dashboard = Robodog.dashboard("selector", {
         console.log(result)
     })
 
-
+// selector is required
+expectError(Robodog.dashboard({ }))

--- a/packages/@uppy/robodog/types/index.test-d.ts
+++ b/packages/@uppy/robodog/types/index.test-d.ts
@@ -1,0 +1,67 @@
+import { Transloadit } from 'uppy'
+import Robodog from '.'
+async function performPick() {
+    const { successful, failed, transloadit, results } = await Robodog.pick({
+        target: "test",
+        errorReporting: true,
+        waitForEncoding: false,
+        waitForMetadata: false,
+        animateOpenClose: true,
+        inline: false,
+        params: {
+            auth: { key: '' },
+            template_id: ''
+        },
+        providers: ['webcam', 'url'],
+        webcam: {
+            countdown: false,
+            modes: [
+                'video-audio',
+                'video-only',
+                'audio-only',
+                'picture'
+            ],
+            mirror: true,
+        },
+        url: {
+            companionUrl: Transloadit.COMPANION
+        }
+    })
+}
+
+
+const instance = Robodog.form('string', {
+    submitOnSuccess: true,
+    triggerUploadOnSubmit: false,
+    params: {
+        auth: { key: '' },
+        template_id: ''
+    },
+    modal: true,
+    closeAfterFinish: true
+})
+
+const files: File[] = []
+
+const upload = Robodog.upload(files, {
+    debug: true,
+    errorReporting: true,
+    params: {
+        auth: { key: '' },
+        template_id: ''
+    }
+})
+
+const dashboard = Robodog.dashboard("selector", {
+    debug: true,
+    errorReporting: true,
+    params: {
+        auth: { key: '' },
+        template_id: ''
+    }
+})
+    .on('transloadit:result', (result) => {
+        console.log(result)
+    })
+
+

--- a/packages/@uppy/robodog/types/index.test-d.ts
+++ b/packages/@uppy/robodog/types/index.test-d.ts
@@ -38,7 +38,8 @@ const instance = Robodog.form('string', {
         template_id: ''
     },
     modal: true,
-    closeAfterFinish: true
+    closeAfterFinish: true,
+    statusbar: "target"
 })
 
 const files: File[] = []

--- a/packages/@uppy/transloadit/types/index.d.ts
+++ b/packages/@uppy/transloadit/types/index.d.ts
@@ -1,7 +1,91 @@
 import Uppy = require('@uppy/core')
 import TransloaditLocale = require('./generatedLocale')
 
-declare module Transloadit {
+declare module Transloadit { 
+
+  interface FileInfo {
+    id: string,
+    name: string,
+    basename: string,
+    ext: string,
+    size: number,
+    mime: string,
+    type: string,
+    field: string, 
+    md5hash: string,
+    is_tus_file: boolean,
+    original_md5hash: string,
+    original_id: string,
+    original_name: string
+    original_basename: string,
+    original_path: string,
+    url: string,
+    ssl_url: string,
+    tus_upload_url: string,
+    meta: Record<string, any>
+  }
+
+  interface Result extends FileInfo {
+    cost: number,
+    execTime: number,
+    queue: string,
+    queueTime: number
+  }
+
+  interface Assembly {
+    ok?: string,
+    message?: string,
+    assembly_id: string,
+    parent_id?: string,
+    account_id: string,
+    template_id?: string,
+    instance: string,
+    assembly_url: string,
+    assembly_ssl_url: string,
+    uppyserver_url: string,
+    companion_url: string,
+    websocket_url: string,
+    tus_url: string,
+    bytes_received: number,
+    bytes_expected: number,
+    upload_duration: number,
+    client_agent?: string,
+    client_ip?: string,
+    client_referer?: string,
+    transloadit_client: string,
+    start_date: string,
+    upload_meta_data_extracted: boolean,
+    warnings: any[],
+    is_infinite: boolean,
+    has_dupe_jobs: boolean,
+    execution_start: string,
+    execution_duration: number,
+    queue_duration: number,
+    jobs_queue_duration: number,
+    notify_start?: any,
+    notify_url?: string,
+    notify_status?: any,
+    notify_response_code?: any,
+    notify_duration?: any,
+    last_job_completed?: string,
+    fields: Record<string, any>,
+    running_jobs: any[],
+    bytes_usage: number,
+    executing_jobs: any[],
+    started_jobs: string[],
+    parent_assembly_status: any,
+    params: string,
+    template?: any,
+    merged_params: string,
+    uploads: FileInfo[],
+    results: Record<string, Result[]>,
+    build_id: string,
+    error?: string,
+    stderr?: string,
+    stdout?: string,
+    reason?: string,
+  }
+
   interface AssemblyParameters {
     auth: {
       key: string,


### PR DESCRIPTION
Have been interested in using Robodog for a while but the lack of types was a no-go for me. I also added the transloadit assembly type (ported from transloadit node.js) as well as inner result/file types.

There's still some inaccuracy here due to `addDashboardPlugin.js` and its exclusion of different dashboard settings based on `inline`, however I think this is close enough for the time being.

Fixes #2447