### PR TITLE
tools: lint JS code snippets inside blog posts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,4 +12,11 @@ website/themes/uppy/source/uppy/**
 test/endtoend/*/build
 examples/dev/output
 bundle.js
-website/src/_posts/*.md
+website/src/_posts/201*.md
+website/src/_posts/2020-*.md
+website/src/_posts/2021-01-*.md
+website/src/_posts/2021-02-*.md
+website/src/_posts/2021-03-*.md
+website/src/_posts/2021-04-*.md
+website/src/_posts/2021-05-*.md
+website/src/_posts/2021-06-*.md

--- a/website/src/_posts/2021-XX-XX.md
+++ b/website/src/_posts/2021-XX-XX.md
@@ -26,22 +26,22 @@ to make it work:
 If you're using a bundler, you need import them before Uppy:
 
 ```js
-import "es6-promise/auto";
-import "whatwg-fetch";
-import "abortcontroller-polyfill/dist/polyfill-patch-fetch";
+import 'es6-promise/auto'
+import 'whatwg-fetch'
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 // Order matters: AbortController needs fetch which needs Promise.
 
-import mathLog2 from "math-log2";
-import "md-gum-polyfill";
-import ResizeObserver from "resize-observer-polyfill";
-import "symbol-es6";
-import "url-polyfill";
+import mathLog2 from 'math-log2'
+import 'md-gum-polyfill'
+import ResizeObserver from 'resize-observer-polyfill'
+import 'symbol-es6'
+import 'url-polyfill'
 
-Math.log2 ??= mathLog2;
-window.ResizeObserver ??= ResizeObserver;
+Math.log2 ??= mathLog2
+window.ResizeObserver ??= ResizeObserver
 
-export { default } from "@uppy/core";
-export * from "@uppy/core";
+export { default } from '@uppy/core'
+export * from '@uppy/core'
 ```
 
 If you're using Uppy from CDN, we now provide two bundles, one for up-to-date


### PR DESCRIPTION
Enable linter on future blog posts (enabling the linter on existing blog posts would require some major refactors, auto-fixable errors are being suggested in #2991).