### PR TITLE
core: tighten duck type check for file objects

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1592,7 +1592,7 @@ class Uppy {
     // Not returning the `catch`ed promise, because we still want to return a rejected
     // promise from this method if the upload failed.
     lastStep.catch((err) => {
-      this.emit('error', err, uploadID)
+      this.emit('error', err)
       this.removeUpload(uploadID)
     })
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1095,7 +1095,8 @@ class Uppy {
 
       this.setState({ error: errorMsg })
 
-      if (file != null) {
+      // When a file is also given, we store the error on the file object.
+      if (file != null && typeof file === 'object' && typeof file.id === 'string') {
         this.setFileState(file.id, {
           error: errorMsg,
           response,

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1096,7 +1096,7 @@ class Uppy {
       this.setState({ error: errorMsg })
 
       // When a file is also given, we store the error on the file object.
-      if (file != null && typeof file === 'object' && typeof file.id === 'string') {
+      if (file != null && typeof file.id === 'string') {
         this.setFileState(file.id, {
           error: errorMsg,
           response,


### PR DESCRIPTION
When the `'error'` event is emitted, the error is stored on the file
object if the second argument is a file.

I don't know if that is intentional behaviour or if it's a coincidental
effect of the implementation. We don't use it anywhere.

When an upload step fails, `Uppy#_runUpload()` may emit an 'error'
message with the upload ID in the second argument. So then `file` is the
upload ID in this event handler. A string is not null, but it also
doesn't have an `.id` property, so the `setFileState()` call would fail.

Now it checks to make sure that the second argument actually could be a
file.

The upload ID argument is actually also not used. So I removed it in the
second commit. It isn't documented anywhere and it is only available in
some situations if the plugin doesn't do its own error handling. It's
also pretty much useless. So I think there is very little risk that
anyone's relying on this, and we can pretend it is a bugfix.