### PR TITLE
angular: Fix broken packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "build:companion": "npm run --prefix ./packages/@uppy/companion build",
     "build:css": "node ./bin/build-css.js",
     "build:svelte": "npm run --prefix ./packages/@uppy/svelte build",
-    "build:angular": "npm run --prefix ./packages/@uppy/angular build",
+    "build:angular": "npm run --prefix ./packages/@uppy/angular build:release",
     "build:js": "npm-run-all build:lib build:companion build:locale-pack build:svelte build:angular build:bundle",
     "build:lib": "node ./bin/build-lib.js",
     "build:locale-pack": "node ./bin/locale-packs.js build",

--- a/packages/@uppy/angular/package.json
+++ b/packages/@uppy/angular/package.json
@@ -7,7 +7,7 @@
     "ng": "ng",
     "start": "start-storybook -p 6006",
     "build": "ng build",
-    "release": "ng build --prod",
+    "build:release": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
@@ -66,5 +66,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "/dist"
+  ]
 }


### PR DESCRIPTION
A rogue `.gitignore` file was preventing the `dist` folder from shipping with the Angular integration. It's been... *taken care of*.

I added a `files` section to the `package.json` file for `@uppy/angular`, so it should, you know, actually be usable. Thanks to some Uppy folks for helping me track down the source of the issue.

Note: I also made Angular build for production instead of dev mode, when you run the NPM build script.

Closes #2987