### PR TITLE
test: fix end2end test suite

### DIFF
--- a/examples/angular-example/package.json
+++ b/examples/angular-example/package.json
@@ -25,7 +25,7 @@
     "@uppy/progress-bar": "file:../../packages/@uppy/progress-bar",
     "@uppy/tus": "file:../../packages/@uppy/tus",
     "@uppy/webcam": "file:../../packages/@uppy/webcam",
-    "rxjs": "^7.2.0",
+    "rxjs": "^6.5.3",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"
   },

--- a/examples/dev/package.json
+++ b/examples/dev/package.json
@@ -13,8 +13,12 @@
     "watchify": "^3.11.0",
     "whatwg-fetch": "^3.0.0"
   },
+  "devDependencies": {
+    "browser-sync": "^2.27.4"
+  },
   "private": true,
   "scripts": {
+    "start": "browser-sync start --no-open --no-ghost-mode false --server . --index Dashboard.html --port 3452 --serveStatic ../../packages/uppy/dist --files \"./output/*.js, ../../packages/uppy/dist/uppy.min.css, ../../packages/uppy/lib/**/*\"",
     "watch:sandbox": "watchify -vd -t [ babelify --cwd ../../ ] -g aliasify index.js -o output/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "babel-plugin-inline-package-json": "^2.0.0",
     "babelify": "^10.0.0",
     "brake": "^1.0.1",
-    "browser-sync": "^2.26.7",
     "browserify": "^17.0.0",
     "chai": "^4.2.0",
     "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "build:locale-pack": "node ./bin/locale-packs.js build",
     "build": "npm-run-all --parallel build:js build:css --serial size",
     "contributors:save": "node ./bin/update-contributors.mjs",
-    "dev:browsersync": "browser-sync start --no-open --no-ghost-mode false --server examples/dev --index Dashboard.html --port 3452 --serveStatic packages/uppy/dist --files \"examples/dev/output/*.js, packages/uppy/dist/uppy.min.css, packages/uppy/lib/**/*\"",
+    "dev:browsersync": "npm run --prefix examples/dev start",
     "dev:watch-sandbox": "npm run --prefix examples/dev watch:sandbox",
     "dev:with-companion": "npm-run-all --parallel start:companion dev:watch-sandbox watch:js:lib watch:css dev:browsersync",
     "dev": "npm-run-all --parallel dev:watch-sandbox watch:js:lib watch:css dev:browsersync",

--- a/packages/@uppy/angular/package.json
+++ b/packages/@uppy/angular/package.json
@@ -28,7 +28,7 @@
     "@uppy/progress-bar": "1.3.30",
     "@uppy/status-bar": "1.9.6",
     "prop-types": "^15.7.2",
-    "rxjs": "^7.2.0",
+    "rxjs": "^6.5.3",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"
   },

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -104,7 +104,7 @@
     ]
   },
   "scripts": {
-    "build": "tsc --skipLibCheck -p .",
+    "build": "tsc -p .",
     "deploy": "kubectl apply -f infra/kube/companion-kube.yml",
     "prepublishOnly": "npm run build",
     "start": "node ./lib/standalone/start-server.js",

--- a/packages/uppy/types/index.d.ts
+++ b/packages/uppy/types/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: taoqf <https://github.com/taoqf>
 
 // Core
-export * as Core from '@uppy/core'
+export { default as Core } from '@uppy/core'
 
 // Stores
 export { default as DefaultStore } from '@uppy/store-default'

--- a/test/endtoend/typescript/main.ts
+++ b/test/endtoend/typescript/main.ts
@@ -10,6 +10,8 @@ import {
   Form,
 } from 'uppy'
 
+declare let process: { env: Record<string, string> }
+
 const isOnTravis = !!(process.env.TRAVIS && process.env.CI)
 const TUS_ENDPOINT = `http://${isOnTravis ? 'companion.test' : 'localhost'}:1080/files/`
 


### PR DESCRIPTION
Angular depends on `rxjs` v6, I think it makes sense to use this instead. Also moving `browser-sync` to the `examples/dev` package and fixing other e2e test failures.