### PR TITLE
tools: remove use of `promisify` where possible

### DIFF
--- a/bin/after-version-bump.js
+++ b/bin/after-version-bump.js
@@ -15,13 +15,9 @@
 
 const lastCommitMessage = require('last-commit-message')
 const { spawn } = require('child_process')
-const { promisify } = require('util')
+const { readFile, writeFile } = require('fs/promises')
 const once = require('events.once')
 const globby = require('globby')
-const fs = require('fs')
-
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
 
 async function replaceInFile (filename, replacements) {
   let content = await readFile(filename, 'utf8')

--- a/bin/upload-to-cdn.js
+++ b/bin/upload-to-cdn.js
@@ -22,16 +22,14 @@
 //  - Kevin van Zonneveld <kevin@transloadit.com>
 
 const path = require('path')
-const { pipeline } = require('stream/promises')
+const { pipeline, finished } = require('stream/promises')
+const { readFile } = require('fs/promises')
 const AWS = require('aws-sdk')
 const packlist = require('npm-packlist')
 const tar = require('tar')
 const pacote = require('pacote')
 const concat = require('concat-stream')
 const mime = require('mime-types')
-const { promisify } = require('util')
-const readFile = promisify(require('fs').readFile)
-const finished = promisify(require('stream').finished)
 const AdmZip = require('adm-zip')
 
 function delay (ms) {

--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
     "postcss-inline-svg": "^3.1.1",
     "prismjs": "^1.17.1",
     "sass": "^1.29.0",
+    "terser": "^5.7.0",
     "touch": "3.1.0",
     "watchify": "^4.0.0"
   },

--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -11,8 +11,6 @@ global.Prism = Prism
 // the / is needed to force it to resolve to the directory
 require('prismjs/components/')()
 
-delete global.Prism
-
 const unhighlightedCodeRx = /<pre><code class="([^"]*)?">([\s\S]*?)<\/code><\/pre>/igm
 
 function highlight (lang, code) {

--- a/website/scripts/highlight.js
+++ b/website/scripts/highlight.js
@@ -1,8 +1,7 @@
 /* global hexo */
 const Prism = require('prismjs')
 const entities = require('he')
-const { promisify } = require('util')
-const readFile = promisify(require('fs').readFile)
+const { readFile } = require('fs/promises')
 const path = require('path')
 
 // oof


### PR DESCRIPTION
Remove use of `promisify` when a native promise API is available.