### PR TITLE
core: remove use of `Array.prototype.reduce` where possible

### DIFF
--- a/examples/transloadit-textarea/main.js
+++ b/examples/transloadit-textarea/main.js
@@ -94,12 +94,10 @@ class MarkdownTextarea {
       }
     })
 
-    return Object.keys(filesById).reduce((acc, key) => {
-      const file = filesById[key]
-      const thumb = thumbsById[key]
-      acc.push({ file, thumb })
-      return acc
-    }, [])
+    return Object.keys(filesById).map((key) => ({
+      file : filesById[key],
+      thumb : thumbsById[key],
+    }))
   }
 
   uploadFiles (files) {

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -216,7 +216,13 @@ const maskLogger = (companionOptions) => {
 const validateConfig = (companionOptions) => {
   const mandatoryOptions = ['secret', 'filePath', 'server.host']
   /** @type {string[]} */
-  const unspecified = mandatoryOptions.filter((i) => i.split('.').reduce((prev, curr) => prev?.[curr], companionOptions) == null).map((i) => JSON.stringify(i))
+  const unspecified = []
+
+  mandatoryOptions.forEach((i) => {
+    const value = i.split('.').reduce((prev, curr) => (prev ? prev[curr] : undefined), companionOptions)
+
+    if (!value) unspecified.push(`"${i}"`)
+  })
 
   // vaidate that all required config is specified
   if (unspecified.length) {

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -216,13 +216,7 @@ const maskLogger = (companionOptions) => {
 const validateConfig = (companionOptions) => {
   const mandatoryOptions = ['secret', 'filePath', 'server.host']
   /** @type {string[]} */
-  const unspecified = []
-
-  mandatoryOptions.forEach((i) => {
-    const value = i.split('.').reduce((prev, curr) => (prev ? prev[curr] : undefined), companionOptions)
-
-    if (!value) unspecified.push(`"${i}"`)
-  })
+  const unspecified = mandatoryOptions.filter((i) => i.split('.').reduce((prev, curr) => prev?.[curr], companionOptions) == null).map((i) => JSON.stringify(i))
 
   // vaidate that all required config is specified
   if (unspecified.length) {

--- a/packages/@uppy/provider-views/src/SharedHandler.js
+++ b/packages/@uppy/provider-views/src/SharedHandler.js
@@ -36,29 +36,28 @@ module.exports = class SharedHandler {
     // Shift-clicking selects a single consecutive list of items
     // starting at the previous click and deselects everything else.
     if (this.lastCheckbox && e.shiftKey) {
-      let currentSelection
       const prevIndex = items.indexOf(this.lastCheckbox)
       const currentIndex = items.indexOf(file)
-      if (prevIndex < currentIndex) {
-        currentSelection = items.slice(prevIndex, currentIndex + 1)
-      } else {
-        currentSelection = items.slice(currentIndex, prevIndex + 1)
-      }
+      const currentSelection = (prevIndex < currentIndex)
+        ? items.slice(prevIndex, currentIndex + 1)
+        : items.slice(currentIndex, prevIndex + 1)
+      const reducedCurrentSelection = []
+
       // Check restrictions on each file in currentSelection,
       // reduce it to only contain files that pass restrictions
-      currentSelection = currentSelection.reduce((reducedCurrentSelection, item) => {
-        const uppy = this.plugin.uppy
+      for (const item of currentSelection) {
+        const { uppy } = this.plugin
         const validatedRestrictions = uppy.validateRestrictions(
           remoteFileObjToLocal(item),
           [...uppy.getFiles(), ...reducedCurrentSelection]
         )
-        if (!validatedRestrictions.result) {
+        if (validatedRestrictions.result) {
+          reducedCurrentSelection.push(item)
+        } else {
           uppy.info({ message: validatedRestrictions.reason }, 'error', uppy.opts.infoTimeout)
-          return reducedCurrentSelection
         }
-        return [...reducedCurrentSelection, item]
-      })
-      this.plugin.setPluginState({ currentSelection })
+      }
+      this.plugin.setPluginState({ currentSelection: reducedCurrentSelection })
       return
     }
 

--- a/website/src/examples/markdown-snippets/app.es6
+++ b/website/src/examples/markdown-snippets/app.es6
@@ -98,12 +98,10 @@ class MarkdownTextarea {
       }
     })
 
-    return Object.keys(filesById).reduce((acc, key) => {
-      const file = filesById[key]
-      const thumb = thumbsById[key]
-      acc.push({ file, thumb })
-      return acc
-    }, [])
+    return Object.keys(filesById).map((key) => ({
+      file : filesById[key],
+      thumb : thumbsById[key],
+    }))
   }
 
   uploadFiles (files) {


### PR DESCRIPTION
Targeting `2.0` because I believe `for..of` loops are not supported there, could be easily backported to 1.0 though.