### PR TITLE
Lerna bootstrap without `package-lock.json` files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,10 @@
     "packages/*",
     "packages/@uppy/*",
     "private/*"
-  ]
+  ],
+  "command": {
+    "bootstrap": {
+      "npmClientArgs": ["--no-package-lock"]
+    }
+  }
 }


### PR DESCRIPTION
We always create them but never commit them so might as well not create them in the first place. 