### PR TITLE
@uppy/core: mark `state` as deprecated

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -279,8 +279,10 @@ class Uppy {
 
   /**
    * Back compat for when uppy.state is used instead of uppy.getState().
+   * @deprecated
    */
   get state () {
+    // Here, state is a non-enumerable property.
     return this.getState()
   }
 

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -167,6 +167,7 @@ declare module Uppy {
     setOptions(update: Partial<UppyOptions>): void
     setState(patch: object): void
     getState<TMeta extends IndexedObject<any> = {}>(): State<TMeta>
+    /** @deprecated use `getState()` instead. */
     readonly state: State
     setFileState(fileID: string, state: object): void
     resetProgress(): void


### PR DESCRIPTION
~Doesn't break user code that still uses `.state` instead of `.getState`, and limits the possibility of users discovering the deprecated property.~
Mark the property as deprecated in the TypeScript definitions to nudge users to move away from it so it can be removed in a future semver-major release (`2.0.0`? `3.0.0`?).