### PR TITLE
svelte: Fix Svelte example

### DIFF
--- a/examples/svelte-example/rollup.config.js
+++ b/examples/svelte-example/rollup.config.js
@@ -6,6 +6,7 @@ import { terser } from 'rollup-plugin-terser'
 import sveltePreprocess from 'svelte-preprocess'
 import typescript from '@rollup/plugin-typescript'
 import css from 'rollup-plugin-css-only'
+import json from '@rollup/plugin-json'
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -19,10 +20,14 @@ function serve () {
   return {
     writeBundle () {
       if (server) return
-      server = require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
-        stdio: ['ignore', 'inherit', 'inherit'],
-        shell: true,
-      })
+      server = require('child_process').spawn(
+        'npm',
+        ['run', 'start', '--', '--dev'],
+        {
+          stdio: ['ignore', 'inherit', 'inherit'],
+          shell: true,
+        }
+      )
 
       process.on('SIGTERM', toExit)
       process.on('exit', toExit)
@@ -62,6 +67,7 @@ export default {
       dedupe: ['svelte', '@uppy/core'],
     }),
     commonjs(),
+    json(),
     typescript({
       sourceMap: !production,
       inlineSources: !production,

--- a/examples/svelte-example/src/App.svelte
+++ b/examples/svelte-example/src/App.svelte
@@ -1,71 +1,72 @@
 <script lang="ts">
-	import { Dashboard, DashboardModal, DragDrop, ProgressBar } from "@uppy/svelte"
-	import Uppy from "@uppy/core"
-	import Webcam from '@uppy/webcam'
-	import XHRUpload from '@uppy/xhr-upload'
+  import {
+    Dashboard,
+    DashboardModal,
+    DragDrop,
+    ProgressBar
+  } from "@uppy/svelte";
+  import Uppy from "@uppy/core";
+  import Webcam from "@uppy/webcam";
+  import XHRUpload from "@uppy/xhr-upload";
 
-	let createUppy = () => Uppy().use(Webcam).use(XHRUpload, {
-		bundle: true,
-		endpoint: 'http://localhost:9967/upload',
-		metaFields: ['something'],
-		fieldName: 'files'
-	})
+  let createUppy = () =>
+    Uppy()
+      .use(Webcam)
+      .use(XHRUpload, {
+        bundle: true,
+        endpoint: "http://localhost:9967/upload",
+        metaFields: ["something"],
+        fieldName: "files"
+      });
 
-	let uppy1 = createUppy()
-	let uppy2 = createUppy() 
+  let uppy1 = createUppy();
+  let uppy2 = createUppy();
 
-	let open = false;
-	let showInlineDashboard = true;
+  let open = false;
+  let showInlineDashboard = true;
 </script>
 
 <main>
-	<h1>Welcome to the <code>@uppy/svelte</code> demo!</h1>
-	<h2>Inline Dashboard</h2>
-	<label>
-      <input
-        type="checkbox"
-				bind:checked={showInlineDashboard}
-			/>
-      Show Dashboard
-	</label>
-	{#if showInlineDashboard}
-		<Dashboard 
-			uppy={uppy1}
-			plugins={['Webcam']}
-		/>
-	{/if}
-	<h2>Modal Dashboard</h2>
-	<div>
-		<button on:click={() => open = true}>Show Dashboard</button>
-		<DashboardModal 
-			uppy={uppy2} 
-			open={open} 
-			props={{
-				onRequestCloseModal: () => open = false,
-				plugins: ['Webcam']
-			}} 
-		/>
-	</div>
+  <h1>Welcome to the <code>@uppy/svelte</code> demo!</h1>
+  <h2>Inline Dashboard</h2>
+  <label>
+    <input type="checkbox" bind:checked={showInlineDashboard} />
+    Show Dashboard
+  </label>
+  {#if showInlineDashboard}
+    <Dashboard uppy={uppy1} plugins={["Webcam"]} />
+  {/if}
+  <h2>Modal Dashboard</h2>
+  <div>
+    <button on:click={() => (open = true)}>Show Dashboard</button>
+    <DashboardModal
+      uppy={uppy2}
+      {open}
+      props={{
+        onRequestCloseModal: () => (open = false),
+        plugins: ["Webcam"]
+      }}
+    />
+  </div>
 
-	<h2>Drag Drop Area</h2>
-	<DragDrop 
-		uppy={uppy1}
-	/>
+  <h2>Drag Drop Area</h2>
+  <DragDrop uppy={uppy1} />
 
-	<h2>Progress Bar</h2>
-	<ProgressBar 
-		uppy={uppy1}
-		props={{
-			hideAfterFinish: false
-		}}
-	/>
+  <h2>Progress Bar</h2>
+  <ProgressBar
+    uppy={uppy1}
+    props={{
+      hideAfterFinish: false
+    }}
+  />
 </main>
+
 <style global>
-	@import "@uppy/core/dist/style.min.css";
-	@import "@uppy/dashboard/dist/style.min.css";
-	@import "@uppy/drag-drop/dist/style.min.css";
-	@import "@uppy/progress-bar/dist/style.min.css";
-	input[type="checkbox"] {
-		user-select: none;
-	}
+  @import "@uppy/core/dist/style.min.css";
+  @import "@uppy/dashboard/dist/style.min.css";
+  @import "@uppy/drag-drop/dist/style.min.css";
+  @import "@uppy/progress-bar/dist/style.min.css";
+  input[type="checkbox"] {
+    user-select: none;
+  }
 </style>


### PR DESCRIPTION
There was a configuration error in the svelte example, and rollup did not appreciate it. This adds `@rollup/plugin-json` to the `rollup.config.js`, which fixes it

It's also marked as a significant rewrite to `App.svelte` in the example because it didn't have formatting applied to it for some reason

Closes #2819