### PR TITLE
meta: fix `package.json` imports to be inlined by Babel

### DIFF
--- a/packages/@uppy/drag-drop/src/index.js
+++ b/packages/@uppy/drag-drop/src/index.js
@@ -5,14 +5,13 @@ const isDragDropSupported = require('@uppy/utils/lib/isDragDropSupported')
 const getDroppedFiles = require('@uppy/utils/lib/getDroppedFiles')
 const { h } = require('preact')
 
-const { version } = require('../package.json')
-
 /**
  * Drag & Drop plugin
  *
  */
 module.exports = class DragDrop extends UIPlugin {
-  static VERSION = version
+  // eslint-disable-next-line global-require
+  static VERSION = require('../package.json').version
 
   constructor (uppy, opts) {
     super(uppy, opts)

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -8,7 +8,6 @@ const supportsMediaRecorder = require('./supportsMediaRecorder')
 const CameraIcon = require('./CameraIcon')
 const CameraScreen = require('./CameraScreen')
 const PermissionsScreen = require('./PermissionsScreen')
-const packageJsonVersion = require('../package.json').version
 
 /**
  * Normalize a MIME type or file extension into a MIME type.
@@ -52,7 +51,8 @@ function getMediaDevices () {
  * Webcam
  */
 module.exports = class Webcam extends UIPlugin {
-  static VERSION = packageJsonVersion
+  // eslint-disable-next-line global-require
+  static VERSION = require('../package.json').version
 
   constructor (uppy, opts) {
     super(uppy, opts)


### PR DESCRIPTION
Using `babel-plugin-inline-package-json` (when building with `IS_RELEASE_BUILD=true npm run build`).