### PR TITLE
FEATURE: AWS S3 multipart presigned URL batching

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "semi": false
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 120,
-  "singleQuote": true,
-  "semi": false
-}

--- a/packages/@uppy/aws-s3-multipart/package.json
+++ b/packages/@uppy/aws-s3-multipart/package.json
@@ -26,6 +26,9 @@
     "@uppy/companion-client": "file:../companion-client",
     "@uppy/utils": "file:../utils"
   },
+  "devDependencies": {
+    "whatwg-fetch": "3.6.2"
+  },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"
   }

--- a/packages/@uppy/aws-s3-multipart/package.json
+++ b/packages/@uppy/aws-s3-multipart/package.json
@@ -27,7 +27,8 @@
     "@uppy/utils": "file:../utils"
   },
   "devDependencies": {
-    "whatwg-fetch": "3.6.2"
+    "whatwg-fetch": "3.6.2",
+    "nock": "9.6.1"
   },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -205,15 +205,7 @@ class MultipartUploader {
             this._onError(err)
           })
         })
-      });
-      // this._batchPrepareUploadParts(candidates).then((result) => {
-      //   let partPromises = candidates.map((index) => this._uploadPartRetryable(index, result.presignedUrls[index + 1]))
-      //   Promise.all(partPromises).then(() => {
-      //     this._uploadParts()
-      //   }).catch((err) => {
-      //     this._onError(err)
-      //   })
-      // })
+      })
     } else {
       candidates.forEach((index) => {
         this._uploadPartRetryable(index).then(() => {
@@ -263,15 +255,13 @@ class MultipartUploader {
 
   _batchPrepareUploadParts (candidates) {
     this.lockedCandidatesForBatch.push(...candidates)
-    return Promise.resolve().then(() =>
-      this.options.batchPrepareUploadParts(
-        {
-          key: this.key,
-          uploadId: this.uploadId,
-          partNumbers: candidates.map((index) => index + 1)
-        }
-      )
-    ).then((result) => {
+    return Promise.resolve().then(() => {
+      return this.options.batchPrepareUploadParts({
+        key: this.key,
+        uploadId: this.uploadId,
+        partNumbers: candidates.map((index) => index + 1),
+      })
+    }).then((result) => {
       const valid = typeof result === 'object' && result
         && typeof result.presignedUrls === 'object'
       if (!valid) {

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -239,12 +239,15 @@ class MultipartUploader {
     this.chunkState[index].busy = true
 
     return Promise.resolve().then(() =>
-      this.options.prepareUploadPart({
-        key: this.key,
-        uploadId: this.uploadId,
-        body,
-        number: index + 1,
-      })).then((result) => {
+      this.options.prepareUploadPart(
+        {
+          key: this.key,
+          uploadId: this.uploadId,
+          body,
+          number: index + 1,
+        }
+      )
+    ).then((result) => {
       const valid = typeof result === 'object' && result
         && typeof result.url === 'string'
       if (!valid) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -29,9 +29,11 @@ module.exports = class AwsS3Multipart extends Plugin {
       timeout: 30 * 1000,
       limit: 0,
       retryDelays: [0, 1000, 3000, 5000],
+      batchPartPresign: false,
       createMultipartUpload: this.createMultipartUpload.bind(this),
       listParts: this.listParts.bind(this),
       prepareUploadPart: this.prepareUploadPart.bind(this),
+      batchPrepareUploadParts: this.batchPrepareUploadParts.bind(this),
       abortMultipartUpload: this.abortMultipartUpload.bind(this),
       completeMultipartUpload: this.completeMultipartUpload.bind(this),
     }
@@ -106,6 +108,14 @@ module.exports = class AwsS3Multipart extends Plugin {
 
     const filename = encodeURIComponent(key)
     return this.client.get(`s3/multipart/${uploadId}/${number}?key=${filename}`)
+      .then(assertServerError)
+  }
+
+  batchPrepareUploadParts (file, { key, uploadId, partNumbers }) {
+    this.assertHost('batchPrepareUploadParts')
+
+    const filename = encodeURIComponent(key)
+    return this.client.get(`s3/multipart/${uploadId}/batch?key=${filename}?partNumbers=${partNumbers.join(',')}`)
       .then(assertServerError)
   }
 
@@ -192,9 +202,11 @@ module.exports = class AwsS3Multipart extends Plugin {
         createMultipartUpload: this.opts.createMultipartUpload.bind(this, file),
         listParts: this.opts.listParts.bind(this, file),
         prepareUploadPart: this.opts.prepareUploadPart.bind(this, file),
+        batchPrepareUploadParts: this.opts.batchPrepareUploadParts.bind(this, file),
         completeMultipartUpload: this.opts.completeMultipartUpload.bind(this, file),
         abortMultipartUpload: this.opts.abortMultipartUpload.bind(this, file),
         getChunkSize: this.opts.getChunkSize ? this.opts.getChunkSize.bind(this) : null,
+        batchPartPresign: this.opts.batchPartPresign,
 
         onStart,
         onProgress,

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -207,6 +207,7 @@ module.exports = class AwsS3Multipart extends Plugin {
         abortMultipartUpload: this.opts.abortMultipartUpload.bind(this, file),
         getChunkSize: this.opts.getChunkSize ? this.opts.getChunkSize.bind(this) : null,
         batchPartPresign: this.opts.batchPartPresign,
+        minNeededForPresignBatch: this.opts.minNeededForPresignBatch || this.opts.limit || 5,
 
         onStart,
         onProgress,

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -179,6 +179,35 @@ describe('AwsS3Multipart', () => {
           done()
         })
       })
+
+      it('Does not allow for a minNeededForPresignBatch to be > limit', done => {
+        awsS3Multipart.opts.minNeededForPresignBatch = 200
+        const scope = nock('https://bucket.s3.us-east-2.amazonaws.com').defaultReplyHeaders({
+          'access-control-allow-method': 'PUT',
+          'access-control-allow-origin': '*',
+          'access-control-expose-headers': 'ETag',
+        })
+        scope.options((uri) => uri.includes('test/upload/multitest.bat')).reply(200, '')
+        scope.put((uri) => uri.includes('test/upload/multitest.bat')).reply(200, '', { ETag: 'test' })
+        scope.persist()
+
+        // 32MB file will give us 7 chunks, so there will be 7 PUT and 7 OPTIONS
+        // calls to the presigned URL from 2 batchPrepareUploadParts calls (need 5
+        // based on limit then need 5 again based on limit but only actually doing 2,
+        // because we are not using minNeededForPresignBatch if it exceeds limit)
+        const fileSize = 30 * MB + 2 * MB
+        core.addFile({
+          source: 'jest',
+          name: 'multitest.dat',
+          type: 'application/octet-stream',
+          data: new File([Buffer.alloc(fileSize)], { type: 'application/octet-stream' }),
+        })
+        core.upload().then(() => {
+          expect(awsS3Multipart.opts.batchPrepareUploadParts.mock.calls.length).toEqual(2)
+          expect(awsS3Multipart.opts.prepareUploadPart.mock.calls.length).toEqual(0)
+          done()
+        })
+      })
     })
   })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -36,27 +36,28 @@ describe('AwsS3Multipart', () => {
   })
 
   describe('without companionUrl (custom main functions)', () => {
-    const core = new Core()
-    core.use(AwsS3Multipart, {
-      createMultipartUpload: jest.fn(() => {
-        return {
-          uploadId: '6aeb1980f3fc7ce0b5454d25b71992',
-          key: 'test/upload/multitest.bat',
-        }
-      }),
-      completeMultipartUpload: jest.fn(() => Promise.resolve({ location: 'test' })),
-      abortMultipartUpload: jest.fn(),
-      // TOOD (martin) Use a proper presigned URL for a part number here
-      prepareUploadPart: jest.fn(() => {
-        return {
-          url: 'https://bucket.s3.us-east-2.amazonaws.com/test/upload/multitest.bat',
-        }
-      }),
-    })
-    const awsS3Multipart = core.getPlugin('AwsS3Multipart')
+    let core
+    let awsS3Multipart
 
-    afterEach(() => {
-      core.reset()
+    beforeEach(() => {
+      core = new Core()
+      core.use(AwsS3Multipart, {
+        createMultipartUpload: jest.fn(() => {
+          return {
+            uploadId: '6aeb1980f3fc7ce0b5454d25b71992',
+            key: 'test/upload/multitest.bat',
+          }
+        }),
+        completeMultipartUpload: jest.fn(() => Promise.resolve({ location: 'test' })),
+        abortMultipartUpload: jest.fn(),
+        // TOOD (martin) Use a proper presigned URL for a part number here
+        prepareUploadPart: jest.fn(() => {
+          return {
+            url: 'https://bucket.s3.us-east-2.amazonaws.com/test/upload/multitest.bat',
+          }
+        }),
+      })
+      awsS3Multipart = core.getPlugin('AwsS3Multipart')
     })
 
     it('Calls prepareUploadPart N times, where N is fileSize / getChunkSize()', (done) => {
@@ -104,30 +105,6 @@ describe('AwsS3Multipart', () => {
           awsS3Multipart.opts.prepareUploadPart = originalPrepareFn
           done()
         })
-    })
-
-    it('Emits an s3-multipart:part-uploaded event for each part', (done) => {
-      const scope = nock('https://bucket.s3.us-east-2.amazonaws.com').defaultReplyHeaders({
-        'access-control-allow-method': 'PUT',
-        'access-control-allow-origin': '*',
-        'access-control-expose-headers': 'ETag',
-      })
-      scope.options((uri) => uri.includes('test/upload/multitest.bat')).reply(200, '')
-      scope.put((uri) => uri.includes('test/upload/multitest.bat')).reply(200, '', { ETag: 'test' })
-      scope.persist()
-      const fileSize = 5 * MB + 1 * MB
-      core.addFile({
-        source: 'jest',
-        name: 'multitest.dat',
-        type: 'application/octet-stream',
-        data: new File([Buffer.alloc(fileSize)], { type: 'application/octet-stream' }),
-      })
-      const eventHandler = jest.fn()
-      core.on('s3-multipart:part-uploaded', eventHandler)
-      core.upload().then(() => {
-        expect(eventHandler.mock.calls.length).toEqual(2)
-        done()
-      })
     })
   })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -1,0 +1,13 @@
+require('whatwg-fetch')
+const Core = require('@uppy/core')
+const AwsS3Multipart = require('.')
+
+describe('AwsS3Multipart', () => {
+  it('Registers AwsS3Multipart upload plugin', () => {
+    const core = new Core()
+    core.use(AwsS3Multipart)
+
+    const pluginNames = core.plugins.uploader.map((plugin) => plugin.constructor.name)
+    expect(pluginNames).toContain('AwsS3Multipart')
+  })
+})

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -1,8 +1,11 @@
 require('whatwg-fetch')
+const nock = require('nock')
 const Core = require('@uppy/core')
 const AwsS3Multipart = require('.')
 
 describe('AwsS3Multipart', () => {
+  beforeEach(() => nock.disableNetConnect())
+
   it('Registers AwsS3Multipart upload plugin', () => {
     const core = new Core()
     core.use(AwsS3Multipart)
@@ -26,6 +29,71 @@ describe('AwsS3Multipart', () => {
       expect(() => awsS3Multipart.opts.prepareUploadPart(file, opts)).toThrow(err)
       expect(() => awsS3Multipart.opts.completeMultipartUpload(file, opts)).toThrow(err)
       expect(() => awsS3Multipart.opts.abortMultipartUpload(file, opts)).toThrow(err)
+    })
+  })
+
+  describe('without companionUrl (custom main functions)', () => {
+    const core = new Core()
+    core.use(AwsS3Multipart, {
+      createMultipartUpload: jest.fn(() => {
+        return {
+          uploadId: '6aeb1980f3fc7ce0b5454d25b71992',
+          key: 'test/upload/file3.jpg',
+        }
+      }),
+      completeMultipartUpload: jest.fn(() => Promise.resolve({ location: 'test' })),
+      abortMultipartUpload: jest.fn(),
+      prepareUploadPart: jest.fn((file, { key, uploadId, number }) => {
+        return {
+          url: 'https://bucket.s3.us-east-2.amazonaws.com/test/upload/file3.jpg',
+        }
+      }),
+    })
+    const awsS3Multipart = core.getPlugin('AwsS3Multipart')
+
+    afterEach(() => {
+      core.reset()
+    })
+
+    it('Calls prepareUploadPart N times, where N is fileSize / getChunkSize()', (done) => {
+      const scope = nock('https://bucket.s3.us-east-2.amazonaws.com')
+        .defaultReplyHeaders({
+          'access-control-allow-method': 'PUT',
+          'access-control-allow-origin': '*',
+          'access-control-expose-headers': 'ETag'
+        })
+      scope.options(uri => uri.includes('test'))
+        .reply(200, "", { ETag: "test" })
+      scope.put(uri => uri.includes('test/upload/file3.jpg'))
+        .reply(200, "", { ETag: "test" })
+
+      core.addFile({
+        source: 'jest',
+        name: 'multitest.dat',
+        type: 'application/octet-stream',
+        data: new File([Buffer.alloc(20971520)], { type: 'application/octet-stream' }),
+      })
+      core.upload().then(() => {
+        expect(awsS3Multipart.opts.prepareUploadPart.mock.calls.length).toEqual(4)
+        done()
+      })
+    })
+
+    it('Throws an error if prepareUploadPart does not return an object with a url', (done) => {
+      awsS3Multipart.opts.prepareUploadPart = jest.fn(() => null)
+      core.addFile({
+        source: 'jest',
+        name: 'multitest.dat',
+        type: 'application/octet-stream',
+        data: new File([Buffer.alloc(5242880)], { type: 'application/octet-stream' }),
+      })
+      core
+        .upload()
+        .then(() => {})
+        .catch((err) => {
+          expect(err.message).toEqual("AwsS3/Multipart: Got incorrect result from `prepareUploadPart()`, expected an object `{ url }`.")
+          done()
+        })
     })
   })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -10,4 +10,14 @@ describe('AwsS3Multipart', () => {
     const pluginNames = core.plugins.uploader.map((plugin) => plugin.constructor.name)
     expect(pluginNames).toContain('AwsS3Multipart')
   })
+
+  describe('prepareUploadPart', () => {
+    it('Throws an error if configured without companionUrl', () => {
+      const core = new Core()
+      core.use(AwsS3Multipart)
+      const awsS3Multipart = core.getPlugin('AwsS3Multipart')
+
+      expect(awsS3Multipart.opts.prepareUploadPart).toThrow()
+    })
+  })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -11,13 +11,21 @@ describe('AwsS3Multipart', () => {
     expect(pluginNames).toContain('AwsS3Multipart')
   })
 
-  describe('prepareUploadPart', () => {
-    it('Throws an error if configured without companionUrl', () => {
+  describe('companionUrl assertion', () => {
+    it('Throws an error for main functions if configured without companionUrl', () => {
       const core = new Core()
       core.use(AwsS3Multipart)
       const awsS3Multipart = core.getPlugin('AwsS3Multipart')
 
-      expect(awsS3Multipart.opts.prepareUploadPart).toThrow()
+      const err = 'Expected a `companionUrl` option'
+      const file = {}
+      const opts = {}
+
+      expect(() => awsS3Multipart.opts.createMultipartUpload(file)).toThrow(err)
+      expect(() => awsS3Multipart.opts.listParts(file, opts)).toThrow(err)
+      expect(() => awsS3Multipart.opts.prepareUploadPart(file, opts)).toThrow(err)
+      expect(() => awsS3Multipart.opts.completeMultipartUpload(file, opts)).toThrow(err)
+      expect(() => awsS3Multipart.opts.abortMultipartUpload(file, opts)).toThrow(err)
     })
   })
 })

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -20,7 +20,7 @@ describe('AwsS3', () => {
       expect(awsS3.opts.getUploadParameters).toThrow()
     })
 
-    it('Does not throw an error with campanionUrl configured', () => {
+    it('Does not throw an error with companionUrl configured', () => {
       const core = new Core()
       core.use(AwsS3, { companionUrl: 'https://uppy-companion.myapp.com/' })
       const awsS3 = core.getPlugin('AwsS3')

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -251,7 +251,7 @@ module.exports = function s3 (config) {
       })
     ).then((urls) => {
       const presignedUrls = {}
-      partNumbersArray.each((partNumber, index) => {
+      partNumbersArray.forEach((partNumber, index) => {
         presignedUrls[partNumber] = urls[index]
       })
       res.json({ presignedUrls })

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -205,6 +205,23 @@ module.exports = function s3 (config) {
   }
 
   /**
+   * Get parameters for uploading a batch of parts.
+   *
+   * Expected URL parameters:
+   *  - uploadId - The uploadId returned from `createMultipartUpload`.
+   *  - partNumbers - A comma separated list of part numbers representing
+   *                  indecies in the file (1-10000).
+   * Expected query parameters:
+   *  - key - The object key in the S3 bucket.
+   * Response JSON:
+   *  - presignedUrls - The URLs to upload to, including signed query parameters,
+   *                    in an object mapped to part numbers.
+   */
+  batchSignPartsUpload (req, res, next) {
+
+  }
+ 
+  /**
    * Abort a multipart upload, deleting already uploaded parts.
    *
    * Expected URL parameters:
@@ -287,6 +304,7 @@ module.exports = function s3 (config) {
     .get('/multipart/:uploadId', getUploadedParts)
     .get('/multipart/:uploadId/:partNumber', signPartUpload)
     .post('/multipart/:uploadId/complete', completeMultipartUpload)
+    .get(`/multipart/:uploadId/batch`, batchSignPartsUpload)
     .delete('/multipart/:uploadId', abortMultipartUpload)
 }
 

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -217,10 +217,10 @@ module.exports = function s3 (config) {
    *  - presignedUrls - The URLs to upload to, including signed query parameters,
    *                    in an object mapped to part numbers.
    */
-  batchSignPartsUpload (req, res, next) {
+  function batchSignPartsUpload (req, res, next) {
 
   }
- 
+
   /**
    * Abort a multipart upload, deleting already uploaded parts.
    *

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -209,16 +209,55 @@ module.exports = function s3 (config) {
    *
    * Expected URL parameters:
    *  - uploadId - The uploadId returned from `createMultipartUpload`.
-   *  - partNumbers - A comma separated list of part numbers representing
-   *                  indecies in the file (1-10000).
    * Expected query parameters:
    *  - key - The object key in the S3 bucket.
+   *  - partNumbers - A comma separated list of part numbers representing
+   *                  indecies in the file (1-10000).
    * Response JSON:
    *  - presignedUrls - The URLs to upload to, including signed query parameters,
    *                    in an object mapped to part numbers.
    */
   function batchSignPartsUpload (req, res, next) {
+    // @ts-ignore The `companion` property is added by middleware before reaching here.
+    const client = req.companion.s3Client
+    const { uploadId } = req.params
+    const { key, partNumbers } = req.query
 
+    if (typeof key !== 'string') {
+      return res.status(400).json({ error: 's3: the object key must be passed as a query parameter. For example: "?key=abc.jpg"' })
+    }
+
+    if (typeof partNumbers !== 'string') {
+      return res.status(400).json({ error: 's3: the part numbers must be passed as a comma separated query parameter. For example: "?partNumbers=4,6,7,21"' })
+    }
+
+    const partNumbersArray = partNumbers.split(',')
+    partNumbersArray.forEach((partNumber) => {
+      if (!parseInt(partNumber, 10)) {
+        return res.status(400).json({ error: 's3: the part numbers must be a number between 1 and 10000.' })
+      }
+    })
+
+    Promise.all(
+      partNumbersArray.map((partNumber) => {
+        return client.getSignedUrlPromise('uploadPart', {
+          Bucket: config.bucket,
+          Key: key,
+          UploadId: uploadId,
+          PartNumber: partNumber,
+          Body: '',
+          Expires: config.expires,
+        })
+      })
+    ).then((urls) => {
+      const presignedUrls = {}
+      partNumbersArray.each((partNumber, index) => {
+        presignedUrls[partNumber] = urls[index]
+      })
+      res.json({ presignedUrls })
+    }).catch((err) => {
+      next(err)
+    })
   }
 
   /**


### PR DESCRIPTION
I'm opening this PR after discussing this on the forum, see https://community.transloadit.com/t/presigning-urls-in-batches-for-aws-s3-multipart-upload/15774

-----

This PR introduces batch presigning part URLs when using the AWS S3 multipart plugin. I've put this behind a new option; by default the existing flow using `prepareUploadPart` is used. The new option is `batchPartPresign`.

When `batchPartPresign` is true, instead of calling `prepareUploadPart` for each chunk we call the new function `batchPrepareUploadParts`, which must be filled in via an option if companion is not being used. That function takes an array of part numbers, and needs to return an object with the part numbers as the keys and the presigned URLs as the values. I've added the corresponding companion endpoint for this batch presigning too.

Additionally, I added the `minNeededForPresignBatch` option. This is the minimum number of part candidates required before attemtping to batch presign some chunk URLs. This is used so that after the initial batch of `limit` presigned URLs are requested, smaller requests for one or two URLs at a time are not done.

I've also done my best to add a fair amount of unit tests for the AWS S3 multipart plugin as it did not have any previously, though I haven't added tests for the companion controller because there aren't any for any of the companion routes.