### PR TITLE
Don’t show double error info message for required metafields

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -565,7 +565,7 @@ class Uppy {
         if (!hasOwnProperty.call(file.meta, requiredMetaFields[i])) {
           const err = new RestrictionError(`${this.i18n('missingRequiredMetaFieldOnFile', { fileName: file.name })}`)
           errors.push(err)
-          this.#showOrLogErrorAndThrow(err, { file, throwErr: false })
+          this.#showOrLogErrorAndThrow(err, { file, showInformer: false, throwErr: false })
         }
       }
     }


### PR DESCRIPTION
Just one with all the errors before upload.