### PR TITLE
build: fix building on Node.js v14.x LTS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,8 +19,9 @@ module.exports = {
     browser: true,
   },
   globals: {
-    window: true,
+    globalThis: true,
     hexo: true,
+    window: true,
   },
   plugins: [
     '@babel/eslint-plugin',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "pre-commit": "lint:staged",
   "license": "MIT",
   "engines": {
-    "npm": "7.x"
+    "npm": "7.x",
+    "node": "^v14.17.0 || >=v16.0.0"
   },
   "workspaces": [
     "examples/*",
@@ -133,7 +134,7 @@
     "build:angular": "npm run --prefix ./packages/@uppy/angular build:release",
     "build:js": "npm-run-all build:lib build:companion build:locale-pack build:svelte build:angular build:bundle",
     "build:lib": "node ./bin/build-lib.js",
-    "build:locale-pack": "node ./bin/locale-packs.js build",
+    "build:locale-pack": "node --experimental-abortcontroller ./bin/locale-packs.js build",
     "build": "npm-run-all --parallel build:js build:css --serial size",
     "contributors:save": "node ./bin/update-contributors.mjs",
     "dev:browsersync": "npm run --prefix examples/dev start",

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -24,7 +24,7 @@ class RestrictionError extends Error {
 }
 if (typeof AggregateError === 'undefined') {
   // eslint-disable-next-line no-global-assign
-  AggregateError = class AggregateError extends Error {
+  globalThis.AggregateError = class AggregateError extends Error {
     constructor (message, errors) {
       super(message)
       this.errors = errors

--- a/packages/@uppy/dashboard/src/index.test.js
+++ b/packages/@uppy/dashboard/src/index.test.js
@@ -1,4 +1,3 @@
-/* global globalThis */
 const Core = require('@uppy/core')
 const StatusBarPlugin = require('@uppy/status-bar')
 const GoogleDrivePlugin = require('@uppy/google-drive') // eslint-disable-line


### PR DESCRIPTION
`AbortControler` is available globally as of Node.js v15.0.0, v14.x needs a CLI flag and it's not available at all on v12.x.