### PR TITLE
Send sameSite and secure for https cookies

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/jwt.js
+++ b/packages/@uppy/companion/src/server/helpers/jwt.js
@@ -55,6 +55,13 @@ const addToCookies = (res, token, companionOptions, authProvider, prefix) => {
     httpOnly: true,
   }
 
+  // Fix to show thumbnails on Chrome
+  // https://community.transloadit.com/t/dropbox-and-box-thumbnails-returning-401-unauthorized/15781/2
+  if (companionOptions.server && companionOptions.server.protocol === 'https') {
+    cookieOptions.sameSite = 'none'
+    cookieOptions.secure = true
+  }
+
   if (companionOptions.cookieDomain) {
     cookieOptions.domain = companionOptions.cookieDomain
   }


### PR DESCRIPTION
When companion server is running on a different domain than the frontend, Chrome (and probably other browsers) will error with `A cookie associated with a cross-site resource at http://xx.com/ was set without the `SameSite` attribute It has been blocked, as Chrome now only delivers cookies with cross-site requests if they are set with SameSite=None and Secure` when a thumbnail is loaded.

See also
- https://community.transloadit.com/t/dropbox-and-box-thumbnails-returning-401-unauthorized/15781
- https://community.transloadit.com/t/dropbox-image-thumbnail-issue-in-chrome/15418

This PR fixes that issue. I have verified the error and that this PR fixes the error.