### PR TITLE
Fix AWS S3 upload on React Native

### DIFF
--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -237,7 +237,7 @@ module.exports = class MiniXHRUpload {
       xhr.open(opts.method.toUpperCase(), opts.endpoint, true)
       // IE10 does not allow setting `withCredentials` and `responseType`
       // before `open()` is called.
-      xhr.withCredentials = opts.withCredentials
+      xhr.withCredentials = opts.withCredentials || false
       if (opts.responseType !== '') {
         xhr.responseType = opts.responseType
       }


### PR DESCRIPTION
This took me hours to figure out, but React Native's XMLHttpRequest has a bug where setting `withCredentials` to `undefined` crashes the app silently.

This is more of a patch, because `withCredentials` can never be set (from what I can tell).