### PR TITLE
@uppy/transloadit: upgrade `socket.io-client` version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -167,6 +167,7 @@ module.exports = {
       files: [
         'test/endtoend/**/*.js',
         'website/*.js',
+        'website/**/*.js',
       ],
       rules: {
         'import/no-extraneous-dependencies': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -165,20 +165,11 @@ module.exports = {
 
     {
       files: [
-        'test/endtoend/**/*.js',
-        'website/*.js',
-        'website/**/*.js',
-      ],
-      rules: {
-        'import/no-extraneous-dependencies': 'off',
-      },
-    },
-
-    {
-      files: [
         'bin/**.js',
         'postcss.config.js',
         '.eslintrc.js',
+        'website/*.js',
+        'website/**/*.js',
       ],
       rules: {
         'no-console': ['off'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -165,6 +165,16 @@ module.exports = {
 
     {
       files: [
+        'test/endtoend/**/*.js',
+        'website/*.js',
+      ],
+      rules: {
+        'import/no-extraneous-dependencies': 'off',
+      },
+    },
+
+    {
+      files: [
         'bin/**.js',
         'postcss.config.js',
         '.eslintrc.js',

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -32,7 +32,7 @@
     "@uppy/tus": "file:../tus",
     "@uppy/utils": "file:../utils",
     "component-emitter": "^1.2.1",
-    "socket.io-client": "~2.2.0"
+    "socket.io-client": "^4.1.3"
   },
   "peerDependencies": {
     "@uppy/core": "^1.0.0"

--- a/packages/@uppy/transloadit/src/Assembly.js
+++ b/packages/@uppy/transloadit/src/Assembly.js
@@ -83,7 +83,7 @@ class TransloaditAssembly extends Emitter {
       this.socket = null
     })
 
-    socket.on('error', () => {
+    socket.on('connect_error', () => {
       socket.disconnect()
       this.socket = null
     })

--- a/test/endtoend/create-react-app/src/App.js
+++ b/test/endtoend/create-react-app/src/App.js
@@ -1,14 +1,12 @@
 import React, { Component } from 'react'
 // These are resolved from the root instead of from the local package.json in
 // the create-react-app e2e test code.
-/* eslint-disable import/no-extraneous-dependencies */
 import Uppy from '@uppy/core'
 import Tus from '@uppy/tus'
 import GoogleDrive from '@uppy/google-drive'
 import { Dashboard, DashboardModal } from '@uppy/react'
 import '@uppy/core/dist/style.css'
 import '@uppy/dashboard/dist/style.css'
-/* eslint-enable import/no-extraneous-dependencies */
 
 const isOnTravis = process.env.REACT_APP_ON_TRAVIS
 const endpoint = isOnTravis ? 'http://companion.test:1080' : 'http://localhost:1080'

--- a/test/endtoend/create-react-app/src/App.js
+++ b/test/endtoend/create-react-app/src/App.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react'
 // These are resolved from the root instead of from the local package.json in
 // the create-react-app e2e test code.
+/* eslint-disable import/no-extraneous-dependencies */
 import Uppy from '@uppy/core'
 import Tus from '@uppy/tus'
 import GoogleDrive from '@uppy/google-drive'
 import { Dashboard, DashboardModal } from '@uppy/react'
 import '@uppy/core/dist/style.css'
 import '@uppy/dashboard/dist/style.css'
+/* eslint-enable import/no-extraneous-dependencies */
 
 const isOnTravis = process.env.REACT_APP_ON_TRAVIS
 const endpoint = isOnTravis ? 'http://companion.test:1080' : 'http://localhost:1080'

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "hexo": {
     "version": "4.2.1"
   },
-  "dependencies": {
+  "devDependencies": {
     "@babel/core": "^7.4.4",
     "@goto-bus-stop/hexo-renderer-postcss": "^2.0.0",
     "@octokit/rest": "16.43.1",


### PR DESCRIPTION
The "unsafe" version of `engine.io-client` is still used for the website, but is no longer a dependency of any of the `@uppy` packages. I've marked the website deps as `devDependencies` so this version is marked `dev: true` in the `package-lock.json`.

Fixes: https://github.com/transloadit/uppy/issues/2875