### PR TITLE
UIPlugin fix: prevent Preact replacing contents of body element by using createDocumentFragment

### DIFF
--- a/examples/bundled/index.js
+++ b/examples/bundled/index.js
@@ -24,7 +24,6 @@ const uppy = new Uppy({
     trigger: '#pick-files',
     target: '#upload-form',
     inline: true,
-    replaceTargetContent: true,
     metaFields: [
       { id: 'license', name: 'License', placeholder: 'specify license' },
       { id: 'caption', name: 'Caption', placeholder: 'add caption' },

--- a/packages/@uppy/box/types/index.d.ts
+++ b/packages/@uppy/box/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, PluginTarget, UIPlugin } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 interface BoxOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/box/types/index.test-d.ts
+++ b/packages/@uppy/box/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Box from '..'
   uppy.use(Box, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -46,7 +46,6 @@ export interface DashboardOptions extends PluginOptions {
   showProgressDetails?: boolean
   showSelectedFiles?: boolean
   showRemoveButtonAfterComplete?: boolean
-  replaceTargetContent?: boolean
   target?: PluginTarget
   theme?: 'auto' | 'dark' | 'light'
   thumbnailWidth?: number

--- a/packages/@uppy/drag-drop/types/index.d.ts
+++ b/packages/@uppy/drag-drop/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import DragDropLocale from './generatedLocale'
 
 export interface DragDropOptions extends PluginOptions {
-  replaceTargetContent?: boolean
   target?: PluginTarget
   inputName?: string
   allowMultipleFiles?: boolean

--- a/packages/@uppy/drag-drop/types/index.test-d.ts
+++ b/packages/@uppy/drag-drop/types/index.test-d.ts
@@ -6,7 +6,6 @@ import DragDrop from '..'
   const uppy = new Uppy()
 
   uppy.use(DragDrop, {
-    replaceTargetContent: true,
     target: 'body',
     inputName: 'test',
     allowMultipleFiles: true,

--- a/packages/@uppy/dropbox/types/index.d.ts
+++ b/packages/@uppy/dropbox/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 export interface DropboxOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/dropbox/types/index.test-d.ts
+++ b/packages/@uppy/dropbox/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Dropbox from '..'
   uppy.use(Dropbox, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/facebook/types/index.d.ts
+++ b/packages/@uppy/facebook/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 export interface FacebookOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/facebook/types/index.test-d.ts
+++ b/packages/@uppy/facebook/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Facebook from '..'
   uppy.use(Facebook, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/file-input/types/index.d.ts
+++ b/packages/@uppy/file-input/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import FileInputLocale from './generatedLocale'
 
 export interface FileInputOptions extends PluginOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     pretty?: boolean
     inputName?: string

--- a/packages/@uppy/form/types/index.d.ts
+++ b/packages/@uppy/form/types/index.d.ts
@@ -1,7 +1,6 @@
 import type { PluginOptions, PluginTarget, BasePlugin } from '@uppy/core'
 
 export interface FormOptions extends PluginOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     resultName?: string
     getMetaFromForm?: boolean

--- a/packages/@uppy/google-drive/types/index.d.ts
+++ b/packages/@uppy/google-drive/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 export interface GoogleDriveOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/informer/types/index.d.ts
+++ b/packages/@uppy/informer/types/index.d.ts
@@ -1,7 +1,6 @@
 import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 
 interface InformerOptions extends PluginOptions {
-  replaceTargetContent?: boolean
   target?: PluginTarget
 }
 

--- a/packages/@uppy/instagram/types/index.d.ts
+++ b/packages/@uppy/instagram/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 export interface InstagramOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/instagram/types/index.test-d.ts
+++ b/packages/@uppy/instagram/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Instagram from '..'
   uppy.use(Instagram, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/onedrive/types/index.d.ts
+++ b/packages/@uppy/onedrive/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { PublicProviderOptions, TokenStorage } from '@uppy/companion-client'
 
 export interface OneDriveOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/onedrive/types/index.test-d.ts
+++ b/packages/@uppy/onedrive/types/index.test-d.ts
@@ -6,7 +6,6 @@ import OneDrive from '..'
   uppy.use(OneDrive, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -17,7 +17,6 @@ module.exports = class ProgressBar extends UIPlugin {
     // set default options
     const defaultOptions = {
       target: 'body',
-      replaceTargetContent: false,
       fixed: false,
       hideAfterFinish: true,
     }

--- a/packages/@uppy/progress-bar/types/index.d.ts
+++ b/packages/@uppy/progress-bar/types/index.d.ts
@@ -1,7 +1,6 @@
 import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 
 export interface ProgressBarOptions extends PluginOptions {
-  replaceTargetContent?: boolean
   target?: PluginTarget
   hideAfterFinish?: boolean
   fixed?: boolean

--- a/packages/@uppy/progress-bar/types/index.test-d.ts
+++ b/packages/@uppy/progress-bar/types/index.test-d.ts
@@ -4,7 +4,6 @@ import ProgressBar from '..'
 {
   const uppy = new Uppy()
   uppy.use(ProgressBar, {
-    replaceTargetContent: true,
     target: 'body',
     hideAfterFinish: true,
     fixed: true,

--- a/packages/@uppy/react/src/CommonTypes.d.ts
+++ b/packages/@uppy/react/src/CommonTypes.d.ts
@@ -5,6 +5,6 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 // If I use the helper it doesn't work, I think because 'target' is not a `keyof T` while
 // the generic T is unknown, so will just use the expansion here
-type OmitTarget<T> = Pick<T, Exclude<keyof T, 'target' | 'replaceTargetContent'>>
+type OmitTarget<T> = Pick<T, Exclude<keyof T, 'target'>>
 type WithBaseUppyProps<T> = T & { uppy: Uppy }
 export type ToUppyProps<T> = WithBaseUppyProps<OmitTarget<T>>

--- a/packages/@uppy/react/types/index.test-d.tsx
+++ b/packages/@uppy/react/types/index.test-d.tsx
@@ -20,7 +20,6 @@ const uppy = new Uppy()
 {
   expectError(<components.Dashboard inline />)
   expectError(<components.DashboardModal inline />)
-  expectError(<components.DashboardModal replaceTargetContent />)
 }
 
 {

--- a/packages/@uppy/status-bar/types/index.d.ts
+++ b/packages/@uppy/status-bar/types/index.d.ts
@@ -4,7 +4,6 @@ import GeneratedLocale from './generatedLocale'
 export type StatusBarLocale = GeneratedLocale
 
 export interface StatusBarOptions extends PluginOptions {
-  replaceTargetContent?: boolean
   target?: PluginTarget
   showProgressDetails?: boolean
   hideUploadButton?: boolean

--- a/packages/@uppy/status-bar/types/index.test-d.ts
+++ b/packages/@uppy/status-bar/types/index.test-d.ts
@@ -4,7 +4,6 @@ import StatusBar from '..'
 {
   const uppy = new Uppy()
   uppy.use(StatusBar, {
-    replaceTargetContent: false,
     target: 'body',
     showProgressDetails: true,
     hideUploadButton: false,

--- a/packages/@uppy/unsplash/types/index.d.ts
+++ b/packages/@uppy/unsplash/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { RequestClientOptions } from '@uppy/companion-client'
 
 interface UnsplashOptions extends PluginOptions, RequestClientOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
 }

--- a/packages/@uppy/unsplash/types/index.test-d.ts
+++ b/packages/@uppy/unsplash/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Unsplash from '..'
   uppy.use(Unsplash, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/packages/@uppy/url/types/index.d.ts
+++ b/packages/@uppy/url/types/index.d.ts
@@ -3,7 +3,6 @@ import type { RequestClientOptions } from '@uppy/companion-client'
 import UrlLocale from './generatedLocale'
 
 export interface UrlOptions extends PluginOptions, RequestClientOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     locale?: UrlLocale

--- a/packages/@uppy/url/types/index.test-d.ts
+++ b/packages/@uppy/url/types/index.test-d.ts
@@ -7,7 +7,6 @@ import Url from '..'
   uppy.use(Url, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
     locale: {

--- a/packages/@uppy/webcam/types/index.d.ts
+++ b/packages/@uppy/webcam/types/index.d.ts
@@ -8,7 +8,6 @@ export type WebcamMode =
     | 'picture'
 
 export interface WebcamOptions extends PluginOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     onBeforeSnapshot?: () => Promise<void>
     countdown?: number | boolean

--- a/packages/@uppy/zoom/types/index.d.ts
+++ b/packages/@uppy/zoom/types/index.d.ts
@@ -2,7 +2,6 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { TokenStorage, PublicProviderOptions } from '@uppy/companion-client'
 
 interface ZoomOptions extends PluginOptions, PublicProviderOptions {
-    replaceTargetContent?: boolean
     target?: PluginTarget
     title?: string
     storage?: TokenStorage

--- a/packages/@uppy/zoom/types/index.test-d.ts
+++ b/packages/@uppy/zoom/types/index.test-d.ts
@@ -6,7 +6,6 @@ import Zoom from '..'
   uppy.use(Zoom, {
     companionUrl: '',
     companionCookiesRule: 'same-origin',
-    replaceTargetContent: false,
     target: 'body',
     title: 'title',
   })

--- a/website/src/_template/contributing.md
+++ b/website/src/_template/contributing.md
@@ -12,11 +12,11 @@ cd uppy
 npm install
 ```
 
-Our website's examples section is also our playground, please read the [Local Previews](#Local-previews) section to get up and running.
+Our website’s examples section is also our playground, please read the [Local Previews](#Local-previews) section to get up and running.
 
 ### Requiring files
 
-*   If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (e.g. to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).
+*   If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (for example to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).
 *   But if we want to `require()` some file from another subpackage - we should use global @uppy requires, and they should always be in the form of `@uppy/:packageName/(lib instead of src)/(same path).js`
 
 ## Tests
@@ -60,7 +60,7 @@ You can run in several browsers by passing several `-b` flags:
 npm run test:endtoend:local -- -b chrome -b firefox
 ```
 
-When trying to get a specific integration test to pass, it’s not that helpful to continuously run _all_ tests. You can use the `--suite` flag to run tests from a single `./test/endtoend` folder. For example, `--suite thumbnails` will only run the tests from `./test/endtoend/thumbnails`. It can also be joint with one or more `-b` flags.
+When trying to get a specific integration test to pass, it’s not that helpful to continuously run _all_ tests. You can use the `--suite` flag to run tests from a single `./test/endtoend` folder. For example, `--suite thumbnails` will only run the tests from `./test/endtoend/thumbnails`. It can also be used in conjunction with one or more `-b` flags.
 
 ```bash
 npm run test:endtoend:local -- -b chrome --suite thumbnails
@@ -89,8 +89,8 @@ Run
 ngrok http 3020
 ```
 
-Note the ngrok https base URL, e.g. `https://e0c7de09808d.ngrok.io` and
-append `/instagram/redirect` to it, e.g.:
+Note the ngrok https base URL, for example `https://e0c7de09808d.ngrok.io` and
+append `/instagram/redirect` to it, such as:
 
     https://e0c7de09808d.ngrok.io/instagram/redirect
 
@@ -162,7 +162,7 @@ If you don’t have access to the transloadit.com source code ping @arturi or @g
 
 We keep the [uppy.io](http://uppy.io) website in `./website` to keep docs and code in sync as we are still iterating at high velocity.
 
-The site is built with [Hexo](http://hexo.io/), and Travis automatically deploys this onto GitHub Pages (it overwrites the `gh-pages` branch with Hexo’s build at every change to `master`). The content is written in Markdown and located in `./website/src`. Feel free to fork & hack!
+The site is built with [Hexo](http://hexo.io/), and Travis automatically deploys this onto GitHub Pages (it overwrites the `gh-pages` branch with Hexo’s build at every change to `main`). The content is written in Markdown and located in `./website/src`. Feel free to fork & hack!
 
 Even though bundled in this repo, the website is regarded as a separate project. As such, it has its own `package.json` and we aim to keep the surface where the two projects interface as small as possible. `./website/update.js` is called during website builds to inject the Uppy knowledge into the site.
 
@@ -190,7 +190,7 @@ The CSS standards followed in this project closely resemble those from [Medium�
 ### Naming conventions
 
 This project uses naming conventions adopted from the SUIT CSS framework.
-[Read about them here](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).
+[Read about them here](https://github.com/suitcss/suit/blob/main/doc/naming-conventions.md).
 
 To quickly summarize:
 
@@ -364,7 +364,7 @@ This data is used to generate Uppy’s website. Refer to [the section about runn
 
 ### Adding an example
 
-You can likely use whatever code generation tool for your framework (ex. `create-react-app`) to create this example. Make sure you add the same version of `@uppy/core` to this as your peer dependency required, or you may run into strange issues. Try to include all the components are some of their functionality. [The React example](https://github.com/transloadit/uppy/blob/master/examples/react-example/App.js) is a great... well example of how to do this well.
+You can likely use whatever code generation tool for your framework (ex. `create-react-app`) to create this example. Make sure you add the same version of `@uppy/core` to this as your peer dependency required, or you may run into strange issues. Try to include all the components are some of their functionality. [The React example](https://github.com/transloadit/uppy/blob/main/examples/react-example/App.js) is a great... well example of how to do this well.
 
 ### Integrating the build system
 

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -432,10 +432,6 @@ const strings = {
 }
 ```
 
-### `replaceTargetContent: false`
-
-Remove all children of the `target` element before mounting the Dashboard. By default, Uppy will append any UI to the `target` DOM element. This is the least dangerous option. However, there might be cases when you would want to clear the container element before placing Uppy UI in there (for example, to provide a fallback `<form>` that will be shown if Uppy or JavaScript is not available). Set `replaceTargetContent: true` to clear the `target` before appending.
-
 ### `theme: 'light'`
 
 Uppy Dashboard supports “Dark Mode”. You can try it live on [the Dashboard example page](https://uppy.io/examples/dashboard/).

--- a/website/src/docs/informer.md
+++ b/website/src/docs/informer.md
@@ -66,7 +66,3 @@ A unique identifier for this plugin. It defaults to `'Informer'`. Use this if yo
 ### `target: null`
 
 DOM element, CSS selector, or plugin to mount the Informer into.
-
-### `replaceTargetContent: false`
-
-Remove all children of the `target` element before mounting the Informer. By default, Uppy will append any UI to the `target` DOM element. This is the least dangerous option. However, you may have some fallback HTML inside the `target` element in case JavaScript or Uppy is not available. In that case, you can set `replaceTargetContent: true` to clear the `target` before appending.

--- a/website/src/docs/progressbar.md
+++ b/website/src/docs/progressbar.md
@@ -86,7 +86,3 @@ uppy.use(ProgressBar, {
 ### `hideAfterFinish: true`
 
 When set to true, hides the progress bar after the upload has finished. If set to false, it remains visible.
-
-### `replaceTargetContent: false`
-
-Remove all children of the `target` element before mounting the Progress Bar. By default, Uppy will append any UI to the `target` DOM element. This is the least dangerous option. However, you may have some fallback HTML inside the `target` element in case JavaScript or Uppy is not available. In that case, you can set `replaceTargetContent: true` to clear the `target` before appending.

--- a/website/src/docs/statusbar.md
+++ b/website/src/docs/statusbar.md
@@ -165,9 +165,5 @@ const strings = {
 }
 ```
 
-### `replaceTargetContent: false`
-
-Remove all children of the `target` element before mounting the Status Bar. By default, Uppy will append any UI to the `target` DOM element. This is the least dangerous option. However, you may have some fallback HTML inside the `target` element in case JavaScript or Uppy is not available. In that case, you can set `replaceTargetContent: true` to clear the `target` before appending.
-
 [`@uppy/file-input`]: /docs/file-input
 [`@uppy/drag-drop`]: /docs/drag-drop

--- a/website/src/examples/dashboard/app.es6
+++ b/website/src/examples/dashboard/app.es6
@@ -50,7 +50,6 @@ function uppyInit () {
     trigger: '.UppyModalOpenerBtn',
     target: opts.DashboardInline ? '.DashboardContainer' : 'body',
     inline: opts.DashboardInline,
-    replaceTargetContent: opts.DashboardInline,
     height: 470,
     showProgressDetails: true,
     metaFields: [

--- a/website/src/examples/dashboard/index.ejs
+++ b/website/src/examples/dashboard/index.ejs
@@ -53,7 +53,6 @@ const uppy = new Uppy({
   trigger: '.UppyModalOpenerBtn',
   inline: true,
   target: '.DashboardContainer',
-  replaceTargetContent: true,
   showProgressDetails: true,
   note: 'Images and video only, 2–3 files, up to 1 MB',
   height: 470,

--- a/website/src/examples/xhrupload/app.es6
+++ b/website/src/examples/xhrupload/app.es6
@@ -6,7 +6,6 @@ const ProgressBar = require('@uppy/progress-bar')
 const uppy = new Uppy({ debug: true, autoProceed: true })
 uppy.use(FileInput, {
   target: '.UppyForm',
-  replaceTargetContent: true
 })
 uppy.use(ProgressBar, {
   target: '.UppyProgressBar',

--- a/website/themes/uppy/layout/index.ejs
+++ b/website/themes/uppy/layout/index.ejs
@@ -201,7 +201,6 @@
     .use(Uppy.Dashboard, {
       target: '#demo',
       inline: true,
-      replaceTargetContent: true,
       metaFields: [
         { id: 'license', name: 'License', placeholder: 'specify license' },
         { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }


### PR DESCRIPTION
**This PR changes the UIPlugin’s `mount` method to pass `createDocumentFragment` instead of the `targetElement` to Preact, so it doesn’t destroy the contents of `targetElement`.**

Bug after [upgrading to Preact X](https://github.com/transloadit/uppy/pull/2926):

If `target: body` is set, instead of appending `<div class="uppy-Root">` to `body`, Preact replaced `<div class="page">` in `body` with said Uppy root node. If `<main>`, `<article>` or tags other than `<div>` were used, Preact would correctly append Uppy root.

This PR fixes that.

It also fixes the `replaceTargetContent` — rendering empty stuff into `target` didn’t work, as Preact doesn’t replace, but instead appends to `target`.

We could get rid of the `replaceTargetContent` option — the reason it is here was for progressive enchancement: you have a `<form>` on the page, and if JS didn’t load or an error occured — users will still see the form and be able to submit files. If Uppy loads successfully, it would replace the `<form>` with its own UI. However this could be done by the user/developer, before loading Uppy? `document.querySelector('form').innerHTML = ''`?