### PR TITLE
Fix webcam mirror option

### DIFF
--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -54,6 +54,10 @@ module.exports = class Webcam extends UIPlugin {
   // eslint-disable-next-line global-require
   static VERSION = require('../package.json').version
 
+  // enableMirror is used to toggle mirroring, for instance when discarding the video,
+  // while `opts.mirror` is used to remember the initial user setting
+  #enableMirror = this.opts?.mirror ?? true
+
   constructor (uppy, opts) {
     super(uppy, opts)
     this.mediaDevices = getMediaDevices()
@@ -63,9 +67,6 @@ module.exports = class Webcam extends UIPlugin {
     this.id = this.opts.id || 'Webcam'
     this.type = 'acquirer'
     this.capturedMediaFile = null
-    // enableMirror is used to toggle mirroring, for instance when discarding the video,
-    // while `opts.mirror` is used to remember the initial user setting
-    this.enableMirror = opts?.mirror ?? true
     this.icon = () => (
       <svg aria-hidden="true" focusable="false" width="32" height="32" viewBox="0 0 32 32">
         <g fill="none" fillRule="evenodd">
@@ -202,7 +203,7 @@ module.exports = class Webcam extends UIPlugin {
     this.webcamActive = true
 
     if (this.opts.mirror) {
-      this.enableMirror = true
+      this.#enableMirror = true
     }
 
     const constraints = this.getConstraints(options && options.deviceId ? options.deviceId : null)
@@ -350,7 +351,7 @@ module.exports = class Webcam extends UIPlugin {
           // eslint-disable-next-line compat/compat
           recordedVideo: URL.createObjectURL(file.data),
         })
-        this.enableMirror = false
+        this.#enableMirror = false
       } catch (err) {
         // Logging the error, exept restrictions, which is handled in Core
         if (!err.isRestriction) {
@@ -371,7 +372,7 @@ module.exports = class Webcam extends UIPlugin {
     this.setPluginState({ recordedVideo: null })
 
     if (this.opts.mirror) {
-      this.enableMirror = true
+      this.#enableMirror = true
     }
 
     this.capturedMediaFile = null
@@ -577,7 +578,7 @@ module.exports = class Webcam extends UIPlugin {
         showVideoSourceDropdown={this.opts.showVideoSourceDropdown}
         supportsRecording={supportsMediaRecorder()}
         recording={webcamState.isRecording}
-        mirror={this.enableMirror}
+        mirror={this.#enableMirror}
         src={this.stream}
       />
     )

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -65,7 +65,7 @@ module.exports = class Webcam extends UIPlugin {
     this.capturedMediaFile = null
     // enableMirror is used to toggle mirroring, for instance when discarding the video,
     // while `opts.mirror` is used to remember the initial user setting
-    this.enableMirror = 'mirror' in opts ? opts.mirror : true
+    this.enableMirror = opts?.mirror ?? true
     this.icon = () => (
       <svg aria-hidden="true" focusable="false" width="32" height="32" viewBox="0 0 32 32">
         <g fill="none" fillRule="evenodd">

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -63,6 +63,9 @@ module.exports = class Webcam extends UIPlugin {
     this.id = this.opts.id || 'Webcam'
     this.type = 'acquirer'
     this.capturedMediaFile = null
+    // enableMirror is used to toggle mirroring, for instance when discarding the video,
+    // while `opts.mirror` is used to remember the initial user setting
+    this.enableMirror = 'mirror' in opts ? opts.mirror : true
     this.icon = () => (
       <svg aria-hidden="true" focusable="false" width="32" height="32" viewBox="0 0 32 32">
         <g fill="none" fillRule="evenodd">
@@ -197,7 +200,10 @@ module.exports = class Webcam extends UIPlugin {
     }
 
     this.webcamActive = true
-    this.opts.mirror = true
+
+    if (this.opts.mirror) {
+      this.enableMirror = true
+    }
 
     const constraints = this.getConstraints(options && options.deviceId ? options.deviceId : null)
 
@@ -344,7 +350,7 @@ module.exports = class Webcam extends UIPlugin {
           // eslint-disable-next-line compat/compat
           recordedVideo: URL.createObjectURL(file.data),
         })
-        this.opts.mirror = false
+        this.enableMirror = false
       } catch (err) {
         // Logging the error, exept restrictions, which is handled in Core
         if (!err.isRestriction) {
@@ -363,7 +369,11 @@ module.exports = class Webcam extends UIPlugin {
 
   discardRecordedVideo () {
     this.setPluginState({ recordedVideo: null })
-    this.opts.mirror = true
+
+    if (this.opts.mirror) {
+      this.enableMirror = true
+    }
+
     this.capturedMediaFile = null
   }
 
@@ -567,7 +577,7 @@ module.exports = class Webcam extends UIPlugin {
         showVideoSourceDropdown={this.opts.showVideoSourceDropdown}
         supportsRecording={supportsMediaRecorder()}
         recording={webcamState.isRecording}
-        mirror={this.opts.mirror}
+        mirror={this.enableMirror}
         src={this.stream}
       />
     )

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -76,8 +76,6 @@ module.exports = class Webcam extends UIPlugin {
       </svg>
     )
 
-    this.#enableMirror = opts?.mirror ?? true
-
     this.defaultLocale = {
       strings: {
         pluginNameCamera: 'Camera',
@@ -117,6 +115,8 @@ module.exports = class Webcam extends UIPlugin {
     this.opts = { ...defaultOptions, ...opts }
     this.i18nInit()
     this.title = this.i18n('pluginNameCamera')
+
+    this.#enableMirror = this.opts.mirror
 
     this.install = this.install.bind(this)
     this.setPluginState = this.setPluginState.bind(this)

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -56,7 +56,7 @@ module.exports = class Webcam extends UIPlugin {
 
   // enableMirror is used to toggle mirroring, for instance when discarding the video,
   // while `opts.mirror` is used to remember the initial user setting
-  #enableMirror = this.opts?.mirror ?? true
+  #enableMirror
 
   constructor (uppy, opts) {
     super(uppy, opts)
@@ -75,6 +75,8 @@ module.exports = class Webcam extends UIPlugin {
         </g>
       </svg>
     )
+
+    this.#enableMirror = opts?.mirror ?? true
 
     this.defaultLocale = {
       strings: {


### PR DESCRIPTION
Closes #3068 

Before webcam previews we only needed `opts.mirror` to know whether we needed to mirror because the image/video would be instantly added, and re-opening would reset the state. But when that feature was introduced, we needed to toggle the mirror option without re-opening, otherwise you would see the video preview and its video controls flipped. But this caused the video start function to always enable mirroring. This PR fixes that by using `opts.mirror` as the initial setting and adding `shouldMirror` to toggle mirroring.