### PR TITLE
website: set background color on root element

### DIFF
--- a/website/themes/uppy/source/css/_common.scss
+++ b/website/themes/uppy/source/css/_common.scss
@@ -1,7 +1,10 @@
 html { box-sizing: border-box; }
 *, *:after, *:before { box-sizing: inherit; }
 
-html, body { height: 100%; }
+html, body {
+  height: 100%;
+  background-color: $color-primary;
+}
 
 body {
   font-family: $fontFamily-body;
@@ -10,7 +13,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
   color: $color-dark;
   margin: 0;
-  background-color: $color-primary;
 
   @media #{$screen-medium} {
     font-size: $fontSize-body;


### PR DESCRIPTION
I don't recall where I get the info from, but I remember that setting the bg-color to the root element improves the experience on mobile when the user scrolls over the top or the bottom of the document.