### PR TITLE
Revert "dashboard: mostly restore backwards compatibility for the `browse` strings

### DIFF
--- a/packages/@uppy/dashboard/src/components/AddFiles.js
+++ b/packages/@uppy/dashboard/src/components/AddFiles.js
@@ -107,69 +107,24 @@ class AddFiles extends Component {
     )
   }
 
-  // TODO(2.x) remove all the backwards compatibility garbage here
   renderDropPasteBrowseTagline = () => {
     const numberOfAcquirers = this.props.acquirers.length
+    const browseFiles = this.renderBrowseButton(this.props.i18n('browseFiles'), this.triggerFileInputClick)
+    const browseFolders = this.renderBrowseButton(this.props.i18n('browseFolders'), this.triggerFolderInputClick)
+
     // in order to keep the i18n CamelCase and options lower (as are defaults) we will want to transform a lower
     // to Camel
     const lowerFMSelectionType = this.props.fileManagerSelectionType
     const camelFMSelectionType = lowerFMSelectionType.charAt(0).toUpperCase() + lowerFMSelectionType.slice(1)
 
-    // For backwards compatibility, we need to support both 'browse' and 'browseFiles'/'browseFolders' as strings here.
-    let browseText = 'browse'
-    let browseFilesText = 'browse'
-    let browseFoldersText = 'browse'
-    if (lowerFMSelectionType === 'files') {
-      try {
-        browseText = this.props.i18n('browse')
-        browseFilesText = this.props.i18n('browse')
-        browseFoldersText = this.props.i18n('browse')
-      } catch {
-        // Ignore, hopefully we can use the 'browseFiles' / 'browseFolders' strings
-      }
-    }
-    try {
-      browseFilesText = this.props.i18n('browseFiles')
-      browseFoldersText = this.props.i18n('browseFolders')
-    } catch {
-      // Ignore, use the 'browse' string
-    }
-
-    const browse = this.renderBrowseButton(browseText, this.triggerFileInputClick)
-    const browseFiles = this.renderBrowseButton(browseFilesText, this.triggerFileInputClick)
-    const browseFolders = this.renderBrowseButton(browseFoldersText, this.triggerFolderInputClick)
-
-    // Before the `fileManagerSelectionType` feature existed, we had two possible
-    // strings here, but now we have six. We use the new-style strings by default:
-    let titleText
-    if (numberOfAcquirers > 0) {
-      titleText = this.props.i18nArray(`dropPasteImport${camelFMSelectionType}`, { browseFiles, browseFolders, browse })
-    } else {
-      titleText = this.props.i18nArray(`dropPaste${camelFMSelectionType}`, { browseFiles, browseFolders, browse })
-    }
-
-    // We use the old-style strings if available: this implies that the user has
-    // manually specified them, so they should take precedence over the new-style
-    // defaults.
-    if (lowerFMSelectionType === 'files') {
-      try {
-        if (numberOfAcquirers > 0) {
-          titleText = this.props.i18nArray('dropPasteImport', { browse })
-        } else {
-          titleText = this.props.i18nArray('dropPaste', { browse })
-        }
-      } catch {
-        // Ignore, the new-style strings will be used.
-      }
-    }
-
-    if (this.props.disableLocalFiles) {
-      titleText = this.props.i18n('importFiles')
-    }
-
     return (
-      <div className="uppy-Dashboard-AddFiles-title">
-        {titleText}
+      <div class="uppy-Dashboard-AddFiles-title">
+        {
+          this.props.disableLocalFiles ? this.props.i18n('importFiles')
+            : numberOfAcquirers > 0
+              ? this.props.i18nArray(`dropPasteImport${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
+              : this.props.i18nArray(`dropPaste${camelFMSelectionType}`, { browseFiles, browseFolders, browse: browseFiles })
+        }
       </div>
     )
   }


### PR DESCRIPTION
This mostly reverts commit 72965029f24a5edaa5cca7a2ae6e5020c9e73e2b.

Refs: https://github.com/transloadit/uppy/pull/2397