### PR TITLE
Typescript Typed events

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -209,10 +209,10 @@ export type FileRemovedCallback<TMeta> = (file: UppyFile<TMeta>, reason: 'remove
 export type UploadCallback = (data: {id: string, fileIDs: string[]}) => void;
 export type ProgressCallback = (progress: number) => void;
 export type UploadProgressCallback<TMeta> = (file: UppyFile<TMeta>, progress: FileProgress) => void;
-export type UploadSuccessCallback<TMeta> = (file: UppyFile<TMeta>, body: any, uploadURL: string) => void
+export type UploadSuccessCallback<TMeta> = (file: UploadedUppyFile<TMeta, unknown>, body: unknown, uploadURL: string) => void
 export type UploadCompleteCallback<TMeta> = (result: UploadResult<TMeta>) => void
 export type ErrorCallback = (error: Error) => void;
-export type UploadErrorCallback<TMeta> = (file: UppyFile<TMeta>, error: Error, response: unknown) => void;
+export type UploadErrorCallback<TMeta> = (file: FailedUppyFile<TMeta, unknown>, error: Error, response: unknown) => void;
 export type UploadRetryCallback = (fileID: string) => void;
 export type RestrictionFailedCallback<TMeta> = (file: UppyFile<TMeta>, error: Error) => void;
 

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -30,28 +30,6 @@ type LocaleStrings<TNames extends string> = {
 
 type LogLevel = 'info' | 'warning' | 'error'
 
-// This hack accepts _any_ string for `Event`, but also tricks VSCode and friends into providing autocompletions
-// for the names listed. https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
-// eslint-disable-next-line no-use-before-define
-type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>)
-
-type Event = LiteralUnion<
-  | 'file-added'
-  | 'file-removed'
-  | 'upload'
-  | 'upload-progress'
-  | 'upload-success'
-  | 'complete'
-  | 'error'
-  | 'upload-error'
-  | 'upload-retry'
-  | 'info-visible'
-  | 'info-hidden'
-  | 'cancel-all'
-  | 'restriction-failed'
-  | 'reset-progress'
->
-
 export type Store = UppyUtils.Store
 
 export type InternalMetadata = UppyUtils.InternalMetadata
@@ -242,22 +220,16 @@ export class Uppy {
 
   on<TMeta extends IndexedObject<any>, K extends keyof UppyEventMap>(event: K, callback: UppyEventMap<TMeta>[K]): this
 
-  on(event: Event, callback: (...args: any[]) => void): this
-
   once<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
 
   once<TMeta extends IndexedObject<any>, K extends keyof UppyEventMap>(event: K, callback: UppyEventMap<TMeta>[K]): this
 
-  once(event: Event, callback: (...args: any[]) => void): this
-
   off<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
-
-  off(event: Event, callback: (...args: any[]) => void): this
 
   /**
    * For use by plugins only.
    */
-  emit(event: Event, ...args: any[]): void
+  emit(event: string, ...args: any[]): void
 
   updateAll(state: Record<string, unknown>): void
 

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -202,7 +202,7 @@ export interface State<
   totalProgress: number
 }
 
-export type GenericEventHandler = () => void;
+export type GenericEventCallback = () => void;
 export type FileAddedCallback<TMeta> = (file: UppyFile<TMeta>) => void;
 export type FilesAddedCallback<TMeta> = (files: UppyFile<TMeta>[]) => void;
 export type FileRemovedCallback<TMeta> = (file: UppyFile<TMeta>, reason: 'removed-by-user' | 'cancel-all') => void;
@@ -228,11 +228,11 @@ export interface UppyEventMap<TMeta = Record<string, unknown>> {
   'error': ErrorCallback
   'upload-error': UploadErrorCallback<TMeta>
   'upload-retry': UploadRetryCallback
-  'info-visible': GenericEventHandler
-  'info-hidden': GenericEventHandler
-  'cancel-all': GenericEventHandler
+  'info-visible': GenericEventCallback
+  'info-hidden': GenericEventCallback
+  'cancel-all': GenericEventCallback
   'restriction-failed': RestrictionFailedCallback<TMeta>
-  'reset-progress': GenericEventHandler
+  'reset-progress': GenericEventCallback
 }
 
 export class Uppy {

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -218,11 +218,11 @@ export class Uppy {
 
   on<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
 
-  on<TMeta extends IndexedObject<any>, K extends keyof UppyEventMap>(event: K, callback: UppyEventMap<TMeta>[K]): this
+  on<K extends keyof UppyEventMap, TMeta extends IndexedObject<any>>(event: K, callback: UppyEventMap<TMeta>[K]): this
 
   once<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
 
-  once<TMeta extends IndexedObject<any>, K extends keyof UppyEventMap>(event: K, callback: UppyEventMap<TMeta>[K]): this
+  once<K extends keyof UppyEventMap, TMeta extends IndexedObject<any>>(event: K, callback: UppyEventMap<TMeta>[K]): this
 
   off<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
 

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import DefaultStore from '@uppy/store-default'
-import Uppy, { UIPlugin } from '..'
+import Uppy, { UIPlugin, UploadCompleteCallback } from '..'
 import type { UploadedUppyFile, FailedUppyFile, PluginOptions } from '..'
 
 type anyObject = Record<string, unknown>
@@ -92,6 +92,25 @@ type anyObject = Record<string, unknown>
   uppy.on('dashboard:modal-closed', () => {})
   uppy.once('dashboard:modal-closed', () => {})
   /* eslint-enable @typescript-eslint/no-empty-function */
+
+  // Normal event signature
+  uppy.on('complete', (result) => {
+    const success = result.successful
+  })
+
+  // Meta signature
+  type Meta = Record<string, string>
+  uppy.on<Meta, 'complete'>('complete', (result) => {
+    const success = result.successful
+  })
+
+  // Alternative: Users that wish to have custom meta can split out the callback
+  // This could be made the recommended method of passing metadata into the file type within events
+  // and expanded to support the body generic
+  const completeHandler: UploadCompleteCallback<Meta> = (result) => {
+    const success = result.successful
+  }
+  uppy.on('complete', completeHandler)
 }
 
 {

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -95,20 +95,20 @@ type anyObject = Record<string, unknown>
 
   // Normal event signature
   uppy.on('complete', (result) => {
-    const success = result.successful
+    const successResults = result.successful
   })
 
   // Meta signature
-  type Meta = Record<string, string>
+  type Meta = {myCustomMetadata: string}
   uppy.on<Meta, 'complete'>('complete', (result) => {
-    const success = result.successful
+    const meta = result.successful[0].meta.myCustomMetadata
   })
 
   // Alternative: Users that wish to have custom meta can split out the callback
   // This could be made the recommended method of passing metadata into the file type within events
   // and expanded to support the body generic
   const completeHandler: UploadCompleteCallback<Meta> = (result) => {
-    const success = result.successful
+    const meta = result.successful[0].meta.myCustomMetadata
   }
   uppy.on('complete', completeHandler)
 }

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -100,7 +100,7 @@ type anyObject = Record<string, unknown>
 
   // Meta signature
   type Meta = {myCustomMetadata: string}
-  uppy.on<Meta, 'complete'>('complete', (result) => {
+  uppy.on<'complete', Meta>('complete', (result) => {
     const meta = result.successful[0].meta.myCustomMetadata
   })
 }

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -103,14 +103,6 @@ type anyObject = Record<string, unknown>
   uppy.on<Meta, 'complete'>('complete', (result) => {
     const meta = result.successful[0].meta.myCustomMetadata
   })
-
-  // Alternative: Users that wish to have custom meta can split out the callback
-  // This could be made the recommended method of passing metadata into the file type within events
-  // and expanded to support the body generic
-  const completeHandler: UploadCompleteCallback<Meta> = (result) => {
-    const meta = result.successful[0].meta.myCustomMetadata
-  }
-  uppy.on('complete', completeHandler)
 }
 
 {

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -87,10 +87,6 @@ type anyObject = Record<string, unknown>
   uppy.once('upload', () => {})
   uppy.once('complete', () => {})
   uppy.once('error', () => {})
-
-  // can register listeners on custom events
-  uppy.on('dashboard:modal-closed', () => {})
-  uppy.once('dashboard:modal-closed', () => {})
   /* eslint-enable @typescript-eslint/no-empty-function */
 
   // Normal event signature

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import DefaultStore from '@uppy/store-default'
-import Uppy, { UIPlugin, UploadCompleteCallback } from '..'
+import Uppy, { UIPlugin } from '..'
 import type { UploadedUppyFile, FailedUppyFile, PluginOptions } from '..'
 
 type anyObject = Record<string, unknown>

--- a/packages/@uppy/dashboard/types/index.d.ts
+++ b/packages/@uppy/dashboard/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { PluginOptions, UIPlugin, PluginTarget, UppyFile } from '@uppy/core'
+import type { PluginOptions, UIPlugin, PluginTarget, UppyFile, GenericEventCallback } from '@uppy/core'
 import type { StatusBarLocale } from '@uppy/status-bar'
 import DashboardLocale from './generatedLocale'
 
@@ -75,3 +75,16 @@ declare class Dashboard extends UIPlugin<DashboardOptions> {
 }
 
 export default Dashboard
+
+// Events
+
+export type DashboardFileEditStartCallback<TMeta> = (file: UppyFile<TMeta>) => void;
+export type DashboardFileEditCompleteCallback<TMeta> = (file: UppyFile<TMeta>) => void;
+declare module '@uppy/core' {
+  export interface UppyEventMap<TMeta> {
+    'dashboard:modal-open': GenericEventCallback
+    'dashboard:modal-closed': GenericEventCallback
+    'dashboard:file-edit-state': DashboardFileEditStartCallback<TMeta>
+    'dashboard:file-edit-complete': DashboardFileEditCompleteCallback<TMeta>
+  }
+}

--- a/packages/@uppy/dashboard/types/index.test-d.ts
+++ b/packages/@uppy/dashboard/types/index.test-d.ts
@@ -48,6 +48,10 @@ import Dashboard from '..'
       },
     ],
   })
+
+  uppy.on('dashboard:file-edit-state', (file) => {
+    const fileName = file.name
+  })
 }
 
 {

--- a/packages/@uppy/drag-drop/types/index.d.ts
+++ b/packages/@uppy/drag-drop/types/index.d.ts
@@ -9,9 +9,9 @@ export interface DragDropOptions extends PluginOptions {
   height?: string | number
   note?: string
   locale?: DragDropLocale
-  onDragOver?: (event: MouseEvent) => void
-  onDragLeave?: (event: MouseEvent) => void
-  onDrop?: (event: MouseEvent) => void
+  onDragOver?: (event: DragEvent) => void
+  onDragLeave?: (event: DragEvent) => void
+  onDrop?: (event: DragEvent) => void
 }
 
 declare class DragDrop extends UIPlugin<DragDropOptions> {}

--- a/packages/@uppy/image-editor/types/index.d.ts
+++ b/packages/@uppy/image-editor/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
+import type { PluginOptions, UIPlugin, PluginTarget, UppyFile } from '@uppy/core'
 import type Cropper from 'cropperjs'
 import ImageEditorLocale from './generatedLocale'
 
@@ -29,3 +29,15 @@ export interface ImageEditorOptions extends PluginOptions {
 declare class ImageEditor extends UIPlugin<ImageEditorOptions> {}
 
 export default ImageEditor
+
+// Events
+
+export type FileEditorStartCallback<TMeta> = (file: UppyFile<TMeta>) => void;
+export type FileEditorCompleteCallback<TMeta> = (updatedFile: UppyFile<TMeta>) => void;
+
+declare module '@uppy/core' {
+  export interface UppyEventMap<TMeta> {
+    'file-editor:start' : FileEditorStartCallback<TMeta>
+    'file-editor:complete': FileEditorCompleteCallback<TMeta>
+  }
+}

--- a/packages/@uppy/image-editor/types/index.test-d.ts
+++ b/packages/@uppy/image-editor/types/index.test-d.ts
@@ -1,2 +1,17 @@
-// import ImageEditor from '..'
 // TODO implement
+
+import Uppy from '@uppy/core'
+import ImageEditor from '..'
+
+{
+  const uppy = new Uppy()
+
+  uppy.use(ImageEditor)
+
+  uppy.on('file-editor:start', (file) => {
+    const fileName = file.name
+  })
+  uppy.on('file-editor:complete', (file) => {
+    const fileName = file.name
+  })
+}

--- a/packages/@uppy/thumbnail-generator/types/index.d.ts
+++ b/packages/@uppy/thumbnail-generator/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { PluginOptions, UIPlugin } from '@uppy/core'
+import type { PluginOptions, UIPlugin, UppyFile } from '@uppy/core'
 
 import ThumbnailGeneratorLocale from './generatedLocale'
 
@@ -11,6 +11,16 @@ interface ThumbnailGeneratorOptions extends PluginOptions {
     locale?: ThumbnailGeneratorLocale,
 }
 
-declare class ThumbnailGenerator extends UIPlugin<ThumbnailGeneratorOptions> {}
+declare class ThumbnailGenerator extends UIPlugin<ThumbnailGeneratorOptions> { }
 
 export default ThumbnailGenerator
+
+// Events
+
+export type ThumbnailGeneratedCallback<TMeta> = (file: UppyFile<TMeta>, preview: string) => void;
+
+declare module '@uppy/core' {
+    export interface UppyEventMap<TMeta> {
+        'thumbnail:generated' : ThumbnailGeneratedCallback<TMeta>
+    }
+}

--- a/packages/@uppy/thumbnail-generator/types/index.test-d.ts
+++ b/packages/@uppy/thumbnail-generator/types/index.test-d.ts
@@ -15,4 +15,11 @@ import ThumbnailGenerator from '..'
       },
     },
   })
+
+  uppy.on('thumbnail:generated', (file, preview) => {
+    const img = document.createElement('img')
+    img.src = preview
+    img.width = 100
+    document.body.appendChild(img)
+  })
 }

--- a/packages/@uppy/transloadit/types/index.d.ts
+++ b/packages/@uppy/transloadit/types/index.d.ts
@@ -1,7 +1,7 @@
 import type { PluginOptions, UppyFile, BasePlugin } from '@uppy/core'
 import TransloaditLocale from './generatedLocale'
 
-  interface FileInfo {
+export interface FileInfo {
     id: string,
     name: string,
     basename: string,
@@ -27,7 +27,8 @@ export interface Result extends FileInfo {
     cost: number,
     execTime: number,
     queue: string,
-    queueTime: number
+    queueTime: number,
+    localId: string | null
   }
 
 export interface Assembly {
@@ -127,3 +128,21 @@ declare class Transloadit extends BasePlugin<TransloaditOptions> {
 }
 
 export default Transloadit
+
+// Events
+
+export type TransloaditAssemblyCreatedCallback = (assembly: Assembly, fileIDs: string[]) => void;
+export type TransloaditUploadedCallback = (file: FileInfo, assembly: Assembly) => void;
+export type TransloaditAssemblyExecutingCallback = (assembly: Assembly) => void;
+export type TransloaditResultCallback = (stepName: string, result: Result, assembly: Assembly) => void;
+export type TransloaditCompleteCallback = (assembly: Assembly) => void;
+
+declare module '@uppy/core' {
+  export interface UppyEventMap {
+    'transloadit:assembly-created': TransloaditAssemblyCreatedCallback
+    'transloadit:upload': TransloaditUploadedCallback
+    'transloadit:assembly-executing': TransloaditAssemblyExecutingCallback
+    'transloadit:result': TransloaditResultCallback
+    'transloadit:complete': TransloaditCompleteCallback
+  }
+}

--- a/packages/@uppy/transloadit/types/index.test-d.ts
+++ b/packages/@uppy/transloadit/types/index.test-d.ts
@@ -25,6 +25,14 @@ const validParams = {
       steps: {},
     },
   })
+  // Access to both transloadit events and core events
+  uppy.on('transloadit:assembly-created', (assembly, fileIDs) => {
+    const status = assembly.ok
+  })
+
+  uppy.on('complete', (result) => {
+    const success = result.successful
+  })
 }
 
 {

--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -250,6 +250,13 @@ declare module '@uppy/utils' {
     [key: number]: T
   }
   export type InternalMetadata = { name: string; type?: string }
+  export interface FileProgress  {
+    uploadStarted: number | null
+    uploadComplete: boolean
+    percentage: number
+    bytesUploaded: number
+    bytesTotal: number
+  }
   export interface UppyFile<
     TMeta = IndexedObject<any>,
     TBody = IndexedObject<any>
@@ -262,13 +269,7 @@ declare module '@uppy/utils' {
     meta: InternalMetadata & TMeta
     name: string
     preview?: string
-    progress?: {
-      uploadStarted: number | null
-      uploadComplete: boolean
-      percentage: number
-      bytesUploaded: number
-      bytesTotal: number
-    }
+    progress?: FileProgress
     remote?: {
       host: string
       url: string


### PR DESCRIPTION
Closes #2922 

Utilizing declaration/interface merging, all events can be typed across all packages. ~~I'm opening this as a draft to collect feedback before I spend time finishing this off.~~

Positives: 

- Event names are autocompleted within VSCode with no hacks required
- Merging is additive for any `@uppy` package the user installs.
- Easy to add & maintain

Negatives:

- Unavoidable breaking change for people passing in a metadata structure as part of the generic, as Typescript does not support partial generic inference. I'm unsure if this is an issue, as it was only previously implemented for two events.