### PR TITLE
Create `onUnmount` in `UIPlugin` for plugins that require clean up

### DIFF
--- a/packages/@uppy/core/src/BasePlugin.js
+++ b/packages/@uppy/core/src/BasePlugin.js
@@ -76,12 +76,6 @@ module.exports = class BasePlugin {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  onMount () {}
-
-  // eslint-disable-next-line class-methods-use-this
-  onUnmount () {}
-
-  // eslint-disable-next-line class-methods-use-this
   update () {}
 
   // Called after every state update, after everything's mounted. Debounced.

--- a/packages/@uppy/core/src/BasePlugin.js
+++ b/packages/@uppy/core/src/BasePlugin.js
@@ -79,6 +79,9 @@ module.exports = class BasePlugin {
   onMount () {}
 
   // eslint-disable-next-line class-methods-use-this
+  onUnmount () {}
+
+  // eslint-disable-next-line class-methods-use-this
   update () {}
 
   // Called after every state update, after everything's mounted. Debounced.

--- a/packages/@uppy/core/src/UIPlugin.js
+++ b/packages/@uppy/core/src/UIPlugin.js
@@ -134,7 +134,14 @@ class UIPlugin extends BasePlugin {
     if (this.isTargetDOMEl) {
       this.el?.remove()
     }
+    this.onUnmount()
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  onMount () {}
+
+  // eslint-disable-next-line class-methods-use-this
+  onUnmount () {}
 }
 
 module.exports = UIPlugin

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -99,6 +99,10 @@ export class BasePlugin<TOptions extends PluginOptions = DefaultPluginOptions> {
   install(): void
 
   uninstall(): void
+
+  onMount(): void
+
+  onUnmount(): void
 }
 
 export class UIPlugin<TOptions extends PluginOptions = DefaultPluginOptions> extends BasePlugin<TOptions> {

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -99,10 +99,6 @@ export class BasePlugin<TOptions extends PluginOptions = DefaultPluginOptions> {
   install(): void
 
   uninstall(): void
-
-  onMount(): void
-
-  onUnmount(): void
 }
 
 export class UIPlugin<TOptions extends PluginOptions = DefaultPluginOptions> extends BasePlugin<TOptions> {
@@ -126,6 +122,10 @@ export class UIPlugin<TOptions extends PluginOptions = DefaultPluginOptions> ext
   addTarget<TPlugin extends UIPlugin>(plugin: TPlugin): void
 
   unmount(): void
+
+  onMount(): void
+
+  onUnmount(): void
 }
 
 export type PluginTarget =

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -205,8 +205,7 @@ module.exports = class Dashboard extends UIPlugin {
   }
 
   hideAllPanels = () => {
-    const dashboardState = this.getPluginState()
-    const activePlugin = this.uppy.getPlugin(dashboardState.activePickerPanel.id)
+    const state = this.getPluginState()
     const update = {
       activePickerPanel: false,
       showAddFilesPanel: false,
@@ -215,17 +214,13 @@ module.exports = class Dashboard extends UIPlugin {
       showFileEditor: false,
     }
 
-    if (dashboardState.activePickerPanel === update.activePickerPanel
-        && dashboardState.showAddFilesPanel === update.showAddFilesPanel
-        && dashboardState.showFileEditor === update.showFileEditor
-        && dashboardState.activeOverlayType === update.activeOverlayType) {
+    if (state.activePickerPanel === update.activePickerPanel
+        && state.showAddFilesPanel === update.showAddFilesPanel
+        && state.showFileEditor === update.showFileEditor
+        && state.activeOverlayType === update.activeOverlayType) {
       // avoid doing a state update if nothing changed
       return
     }
-
-    // Dashboard plugins can define a `onUnmount` method to perform
-    // any clean up that may be required when the user clicked cancel.
-    activePlugin?.onUnmount()
 
     this.setPluginState(update)
   }

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -222,6 +222,8 @@ module.exports = class Dashboard extends UIPlugin {
       return
     }
 
+    this.uppy.getPlugin(current.activePickerPanel.id).uninstall()
+
     this.setPluginState(update)
   }
 

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -205,6 +205,8 @@ module.exports = class Dashboard extends UIPlugin {
   }
 
   hideAllPanels = () => {
+    const dashboardState = this.getPluginState()
+    const activePlugin = this.uppy.getPlugin(dashboardState.activePickerPanel.id)
     const update = {
       activePickerPanel: false,
       showAddFilesPanel: false,
@@ -213,16 +215,17 @@ module.exports = class Dashboard extends UIPlugin {
       showFileEditor: false,
     }
 
-    const current = this.getPluginState()
-    if (current.activePickerPanel === update.activePickerPanel
-        && current.showAddFilesPanel === update.showAddFilesPanel
-        && current.showFileEditor === update.showFileEditor
-        && current.activeOverlayType === update.activeOverlayType) {
+    if (dashboardState.activePickerPanel === update.activePickerPanel
+        && dashboardState.showAddFilesPanel === update.showAddFilesPanel
+        && dashboardState.showFileEditor === update.showFileEditor
+        && dashboardState.activeOverlayType === update.activeOverlayType) {
       // avoid doing a state update if nothing changed
       return
     }
 
-    this.uppy.getPlugin(current.activePickerPanel.id).uninstall()
+    // Dashboard plugins can define a `onClose` method to perform
+    // any clean up that may be required when the user clicked cancel.
+    activePlugin?.onClose()
 
     this.setPluginState(update)
   }

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -223,9 +223,9 @@ module.exports = class Dashboard extends UIPlugin {
       return
     }
 
-    // Dashboard plugins can define a `onClose` method to perform
+    // Dashboard plugins can define a `onUnmount` method to perform
     // any clean up that may be required when the user clicked cancel.
-    activePlugin?.onClose()
+    activePlugin?.onUnmount()
 
     this.setPluginState(update)
   }

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -1,6 +1,5 @@
 const { h } = require('preact')
 const { UIPlugin } = require('@uppy/core')
-const Translator = require('@uppy/utils/lib/Translator')
 const getFileTypeExtension = require('@uppy/utils/lib/getFileTypeExtension')
 const mimeTypes = require('@uppy/utils/lib/mimeTypes')
 const canvasToBlob = require('@uppy/utils/lib/canvasToBlob')
@@ -136,6 +135,8 @@ module.exports = class Webcam extends UIPlugin {
 
     this.webcamActive = false
 
+    this.onClose = this.stop
+
     if (this.opts.countdown) {
       this.opts.onBeforeSnapshot = this.oneTwoThreeSmile
     }
@@ -147,6 +148,7 @@ module.exports = class Webcam extends UIPlugin {
       recordingLengthSeconds: 0,
       videoSources: [],
       currentDeviceId: null,
+      onClose: this.stop,
     })
   }
 

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -394,13 +394,15 @@ module.exports = class Webcam extends UIPlugin {
 
   async stop () {
     if (this.stream) {
-      this.stream.getAudioTracks().forEach((track) => track.stop())
-      this.stream.getVideoTracks().forEach((track) => track.stop())
+      const audioTracks = this.stream.getAudioTracks()
+      const videoTracks = this.stream.getVideoTracks()
+
+      audioTracks.concat(videoTracks).forEach((track) => track.stop())
     }
 
     if (this.recorder) {
       await new Promise((resolve) => {
-        this.recorder.addEventListener('stop', () => resolve())
+        this.recorder.addEventListener('stop', resolve, { once: true })
         this.recorder.stop()
 
         if (this.opts.showRecordingLength) {

--- a/packages/@uppy/webcam/src/index.js
+++ b/packages/@uppy/webcam/src/index.js
@@ -135,8 +135,6 @@ module.exports = class Webcam extends UIPlugin {
 
     this.webcamActive = false
 
-    this.onClose = this.stop
-
     if (this.opts.countdown) {
       this.opts.onBeforeSnapshot = this.oneTwoThreeSmile
     }
@@ -148,7 +146,6 @@ module.exports = class Webcam extends UIPlugin {
       recordingLengthSeconds: 0,
       videoSources: [],
       currentDeviceId: null,
-      onClose: this.stop,
     })
   }
 
@@ -641,5 +638,9 @@ module.exports = class Webcam extends UIPlugin {
   uninstall () {
     this.stop()
     this.unmount()
+  }
+
+  onUnmount () {
+    this.stop()
   }
 }

--- a/website/src/docs/writing-plugins.md
+++ b/website/src/docs/writing-plugins.md
@@ -17,14 +17,18 @@ See a [full example of a plugin](#Example-of-a-custom-plugin) below.
 
 ## Creating A Plugin
 
-Plugins are classes that extend from Uppy's `Plugin` class. Each plugin has an `id` and a `type`. `id`s are used to uniquely identify plugins. A `type` can be anything—some plugins use `type`s to determine whether to do something to some other plugin. For example, when targeting plugins at the built-in `Dashboard` plugin, the Dashboard uses the `type` to figure out where to mount different UI elements. `'acquirer'`-type plugins are mounted into the tab bar, while `'progressindicator'`-type plugins are mounted into the progress bar area.
+Uppy has two classes to create plugins with. `BasePlugin` for plugins that don't require an user interface, and `UIPlugin` for onces that do.
+Each plugin has an `id` and a `type`. `id`s are used to uniquely identify plugins.
+A `type` can be anything—some plugins use `type`s to determine whether to do something to some other plugin.
+For example, when targeting plugins at the built-in `Dashboard` plugin, the Dashboard uses the `type` to figure out where to mount different UI elements.
+`'acquirer'`-type plugins are mounted into the tab bar, while `'progressindicator'`-type plugins are mounted into the progress bar area.
 
 The plugin constructor receives the Uppy instance in the first parameter, and any options passed to `uppy.use()` in the second parameter.
 
 ```js
-import { UIPlugin } from '@uppy/core'
+import { BasePlugin } from '@uppy/core'
 
-export default class MyPlugin extends UIPlugin {
+export default class MyPlugin extends BasePlugin {
   constructor (uppy, opts) {
     super(uppy, opts)
     this.id = opts.id || 'MyPlugin'
@@ -39,7 +43,9 @@ Plugins can implement methods in order to execute certain tasks. The most import
 
 All of the below methods are optional! Only implement the methods you need.
 
-### `install()`
+### `BasePlugin`
+
+#### `install()`
 
 Called when the plugin is `.use`d. Do any setup work here, like attaching events or adding [upload hooks](#Upload-Hooks).
 
@@ -53,7 +59,7 @@ export default class MyPlugin extends UIPlugin {
 }
 ```
 
-### `uninstall()`
+#### `uninstall()`
 
 Called when the plugin is removed, or the Uppy instance is closed. This should undo all of the work done in the `install()` method.
 
@@ -67,9 +73,40 @@ export default class MyPlugin extends UIPlugin {
 }
 ```
 
-### `update(state)`
+#### `afterUpdate()`
+
+Called after every state update with a debounce, after everything has mounted.
+
+#### `addTarget()`
+
+Use this to add your plugin to another plugin's target. This is what `@uppy/dashboard` uses to add other plugins to its UI.
+
+### `UIPlugin`
+
+`UIPlugin` extends the `BasePlugin` class so it will also contain all the above methods.
+
+#### `mount(target)`
+
+Mount this plugin to the `target` element. `target` can be a CSS query selector, a DOM element, or another Plugin. If `target` is a Plugin, the source (current) plugin will register with the target plugin, and the latter can decide how and where to render the source plugin.
+
+This method can be overridden to support for different render engines.
+
+#### `render()`
+
+Render this plugin's UI. Uppy uses [Preact](https://preactjs.com) as its view engine, so `render()` should return a Preact element.
+`render` is automatically called by Uppy on each state change.
+
+#### `onMount()`
+
+Called after Preact has rendered the components of the plugin. Can be used to perform additional side-effects.
+
+#### `update(state)`
 
 Called on each state update. You will rarely need to use this, it is mostly handy if you want to build a UI plugin using something other than Preact.
+
+#### `onUnmount()`
+
+Called after the elements have been removed from the DOM. Can be used to perform additional (clean up) side-effects.
 
 ## Upload Hooks
 
@@ -82,7 +119,7 @@ Additionally, upload hooks can fire events to signal progress.
 When adding hooks, make sure to bind the hook `fn` beforehand! Otherwise, it will be impossible to remove. For example:
 
 ```js
-class MyPlugin extends UIPlugin {
+class MyPlugin extends BasePlugin {
   constructor (uppy, opts) {
     super(uppy, opts)
     this.id = opts.id || 'MyPlugin'
@@ -164,35 +201,11 @@ When `mode` is `'determinate'`, also add the `value` property:
 
  `err` is an `Error` object. `fileID` can optionally which file fails to inform the user.
 
-## UI Plugins
-
-UI Plugins can be used to show a user interface. Uppy plugins use [preact](https://preactjs.com) v8.2.9 for rendering. preact is a very small React-like library that works really well with Uppy's state architecture. Uppy implements preact rendering in the `mount(target)` and `update()` plugin methods, so if you want to write a custom UI plugin using some other library, you can override those methods.
-
-> **Only** `preact@8.2.9` can be used for Uppy plugins. In Uppy 2.0, the restriction will be changed to a newer range of preact versions. For now, specify the dependency with a fixed version number:
-> ```json
-> "dependencies": {
->   "preact": "8.2.9"
-> }
-> ```
-
-Plugins can implement certain methods to do so, that will be called by Uppy when necessary:
-
-### `mount(target)`
-
-Mount this plugin to the `target` element. `target` can be a CSS query selector, a DOM element, or another Plugin. If `target` is a Plugin, the source (current) plugin will register with the target plugin, and the latter can decide how and where to render the source plugin.
-
-This method can be overridden to support for different render engines.
-
-### `render()`
-
-Render this plugin's UI. Uppy uses [Preact](https://preactjs.com) as its view engine, so `render()` should return a Preact element.
-`render` is automatically called by Uppy on each state change.
-
-Note that we are looking into ways to make Uppy's render engine agnostic, so that plugins can choose their own favourite library—whether it's Preact, Choo, jQuery, or anything else. This means that the `render()` API may change in the future, but we will detail exactly what you need to do on the [blog](https://uppy.io/blog) if and when that happens.
 
 ### JSX
 
-Since Uppy uses Preact and not React, the default Babel configuration for JSX elements does not work. You have to import the Preact `h` function and tell Babel to use it by adding a `/** @jsx h */` comment at the top of the file.
+Since Uppy uses Preact and not React, the default Babel configuration for JSX elements does not work.
+You have to import the Preact `h` function and tell Babel to use it by adding a `/** @jsx h */` comment at the top of the file.
 
 See the Preact [Getting Started Guide](https://preactjs.com/guide/getting-started) for more on Babel and JSX.
 


### PR DESCRIPTION
Fixes #3092 

- Create and call `onUnmount` in `UIPlugin` for plugins that require clean up
- Update webcam `stop` to clean up when already recording
- Update "Writing plugins" docs
- Move `onMount` and `onUnmount` from `BasePlugin` into `UIPlugin`
- Update types