### PR TITLE
@uppy/aws-s3: refactor to use private fields

### DIFF
--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -12,6 +12,8 @@ const { internalRateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
 function buildResponseError (xhr, error) {
   if (isNetworkError(xhr)) return new NetworkError(error, xhr)
 
+  // TODO: when we drop support for browsers that do not support this syntax, use:
+  // return new Error('Upload error', { cause: error, request: xhr })
   const err = new Error('Upload error')
   err.cause = error
   err.request = xhr

--- a/packages/@uppy/utils/src/NetworkError.js
+++ b/packages/@uppy/utils/src/NetworkError.js
@@ -1,7 +1,8 @@
 class NetworkError extends Error {
   constructor (error, xhr = null) {
-    super(`This looks like a network error, the endpoint might be blocked by an internet provider or a firewall.\n\nSource error: [${error}]`)
+    super(`This looks like a network error, the endpoint might be blocked by an internet provider or a firewall.`)
 
+    this.cause = error
     this.isNetworkError = true
     this.request = xhr
   }


### PR DESCRIPTION
Also fixes other linter warnings in this file, and migrating `NetworkError` to use the [Error Cause stage 3 proposal](https://github.com/tc39/proposal-error-cause).