### PR TITLE
Revert "deps: replace `cuid` with `nanoid` (#3053)"

### DIFF
--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -25,7 +25,7 @@
     "@uppy/companion-client": "file:../companion-client",
     "@uppy/utils": "file:../utils",
     "@uppy/xhr-upload": "file:../xhr-upload",
-    "nanoid": "^3.1.23"
+    "cuid": "^2.1.1"
   },
   "devDependencies": {
     "whatwg-fetch": "3.6.2"

--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid')
+const cuid = require('cuid')
 const { Provider, RequestClient, Socket } = require('@uppy/companion-client')
 const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')
 const getSocketHost = require('@uppy/utils/lib/getSocketHost')
@@ -161,7 +161,7 @@ module.exports = class MiniXHRUpload {
         reject(error)
       })
 
-      const id = nanoid()
+      const id = cuid()
 
       xhr.upload.addEventListener('loadstart', (ev) => {
         this.uppy.log(`[AwsS3/XHRUpload] ${id} started`)

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -23,10 +23,10 @@
     "@transloadit/prettier-bytes": "0.0.7",
     "@uppy/store-default": "file:../store-default",
     "@uppy/utils": "file:../utils",
+    "cuid": "^2.1.1",
     "lodash.throttle": "^4.1.1",
     "mime-match": "^1.0.2",
     "namespace-emitter": "^2.0.1",
-    "nanoid": "^3.1.23",
     "preact": "^10.5.13"
   }
 }

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -1,7 +1,7 @@
 /* global AggregateError */
 const Translator = require('@uppy/utils/lib/Translator')
 const ee = require('namespace-emitter')
-const { nanoid } = require('nanoid')
+const cuid = require('cuid')
 const throttle = require('lodash.throttle')
 const prettierBytes = require('@transloadit/prettier-bytes')
 const match = require('mime-match')
@@ -1512,7 +1512,7 @@ class Uppy {
       throw new Error('Cannot create a new upload: already uploading.')
     }
 
-    const uploadID = nanoid()
+    const uploadID = cuid()
 
     this.emit('upload', {
       id: uploadID,

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -11,8 +11,8 @@ const InvalidPluginWithoutId = require('../../../../test/mocks/invalidPluginWith
 const InvalidPluginWithoutType = require('../../../../test/mocks/invalidPluginWithoutType')
 const DeepFrozenStore = require('../../../../test/resources/DeepFrozenStore.js')
 
-jest.mock('nanoid', () => {
-  return { nanoid: () => 'cjd09qwxb000dlql4tp4doz8h' }
+jest.mock('cuid', () => {
+  return () => 'cjd09qwxb000dlql4tp4doz8h'
 })
 jest.mock('@uppy/utils/lib/findDOMElement', () => {
   return () => null

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -29,10 +29,10 @@
     "@uppy/thumbnail-generator": "file:../thumbnail-generator",
     "@uppy/utils": "file:../utils",
     "classnames": "^2.2.6",
+    "cuid": "^2.1.1",
     "is-shallow-equal": "^1.0.1",
     "lodash.debounce": "^4.0.8",
     "memoize-one": "^5.0.4",
-    "nanoid": "^3.1.23",
     "preact": "^10.5.13"
   },
   "devDependencies": {

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -8,7 +8,7 @@ const findAllDOMElements = require('@uppy/utils/lib/findAllDOMElements')
 const toArray = require('@uppy/utils/lib/toArray')
 const getDroppedFiles = require('@uppy/utils/lib/getDroppedFiles')
 const getTextDirection = require('@uppy/utils/lib/getTextDirection')
-const { nanoid } = require('nanoid')
+const cuid = require('cuid')
 const trapFocus = require('./utils/trapFocus')
 const createSuperFocus = require('./utils/createSuperFocus')
 const memoize = require('memoize-one').default || require('memoize-one')
@@ -46,7 +46,7 @@ module.exports = class Dashboard extends UIPlugin {
     this.id = this.opts.id || 'Dashboard'
     this.title = 'Dashboard'
     this.type = 'orchestrator'
-    this.modalName = `uppy-Dashboard-${nanoid()}`
+    this.modalName = `uppy-Dashboard-${cuid()}`
 
     this.defaultLocale = {
       strings: {

--- a/packages/@uppy/store-redux/package.json
+++ b/packages/@uppy/store-redux/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "nanoid": "^3.1.23"
+    "cuid": "^2.1.1"
   },
   "devDependencies": {
     "redux": "4.0.5"

--- a/packages/@uppy/store-redux/src/index.js
+++ b/packages/@uppy/store-redux/src/index.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid')
+const cuid = require('cuid')
 
 // Redux action name.
 const STATE_UPDATE = 'uppy/STATE_UPDATE'
@@ -20,7 +20,7 @@ class ReduxStore {
 
   constructor (opts) {
     this._store = opts.store
-    this._id = opts.id || nanoid()
+    this._id = opts.id || cuid()
     this._selector = opts.selector || defaultSelector(this._id)
 
     // Calling `setState` to dispatch an action to the Redux store.

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@uppy/companion-client": "file:../companion-client",
     "@uppy/utils": "file:../utils",
-    "nanoid": "^3.1.23"
+    "cuid": "^2.1.1"
   },
   "devDependencies": {
     "nock": "^13.1.0"

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -1,5 +1,5 @@
 const { BasePlugin } = require('@uppy/core')
-const { nanoid } = require('nanoid')
+const cuid = require('cuid')
 const Translator = require('@uppy/utils/lib/Translator')
 const { Provider, RequestClient, Socket } = require('@uppy/companion-client')
 const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')
@@ -237,7 +237,7 @@ module.exports = class XHRUpload extends BasePlugin {
         reject(error)
       })
 
-      const id = nanoid()
+      const id = cuid()
 
       xhr.upload.addEventListener('loadstart', () => {
         this.uppy.log(`[XHRUpload] ${id} started`)


### PR DESCRIPTION
Our tooling is not compatible with `nanoid` for the time being, I suggest we revert to using `cuid` and we can "revert revert"  when we switch to ESM.

This reverts commit defc7b40f85b1382f7773a323edf0cc13b67b6f4.