### PR TITLE
Companion improve logging

### DIFF
--- a/packages/@uppy/companion/src/server/logger.js
+++ b/packages/@uppy/companion/src/server/logger.js
@@ -35,31 +35,36 @@ function maskMessage (msg) {
 /**
  * message log
  *
- * @param {string | Error} msgIn the message to log
+ * @param {string | Error} msg the message to log
  * @param {string} tag a unique tag to easily search for this message
  * @param {string} level error | info | debug
  * @param {string=} id a unique id to easily trace logs tied to a request
  * @param {Function=} color function to display the log in appropriate color
  * @param {boolean=} shouldLogStackTrace when set to true, errors will be logged with their stack trace
  */
-const log = (msgIn, tag = '', level, id = '', color = (message) => message, shouldLogStackTrace) => {
+const log = (msg, tag = '', level, id = '', color = (message) => message, shouldLogStackTrace) => {
   const time = new Date().toISOString()
   const whitespace = tag && id ? ' ' : ''
-  let msg = msgIn
-  if (typeof msg === 'string') {
-    msg = maskMessage(msg)
-  } else if (msg && typeof msg.message === 'string') {
-    msg.message = maskMessage(msg.message)
+
+  function logMsg (msg2) {
+    let msgString = typeof msg2 === 'string' ? msg2 : util.inspect(msg2)
+    msgString = maskMessage(msgString)
+    // eslint-disable-next-line no-console
+    console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msgString))
   }
 
-  // eslint-disable-next-line no-console
-  const logMsg = (msg2) => console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(util.inspect(msg2)))
+  if (msg instanceof Error) {
+    // Not sure why it only logs the stack without the message, but this is how the code was originally
+    if (shouldLogStackTrace && typeof msg.stack === 'string') {
+      logMsg(msg.stack)
+      return
+    }
 
-  if (shouldLogStackTrace && msg instanceof Error && typeof msg.stack === 'string') {
-    msg.stack = maskMessage(msg.stack)
-    logMsg(msg.stack)
+    // We don't want to log stack trace (this is how the code was originally)
+    logMsg(String(msg))
     return
   }
+
   logMsg(msg)
 }
 

--- a/packages/@uppy/companion/src/server/logger.js
+++ b/packages/@uppy/companion/src/server/logger.js
@@ -17,6 +17,55 @@ exports.setMaskables = (maskables) => {
 }
 
 /**
+ * Mask the secret content of a message
+ *
+ * @param {string} msg the message whose content should be masked
+ * @returns {string}
+ */
+const maskMessage = (msg) => {
+  for (const toBeMasked of valuesToMask) {
+    const toBeReplaced = new RegExp(toBeMasked, 'gi')
+    msg = msg.replace(toBeReplaced, '******')
+  }
+  return msg
+}
+
+/**
+ * message log
+ *
+ * @param {string | Error} msg the message to log
+ * @param {string} tag a unique tag to easily search for this message
+ * @param {string} level error | info | debug
+ * @param {Function=} color function to display the log in appropriate color
+ * @param {string=} id a unique id to easily trace logs tied to a request
+ * @param {boolean=} shouldLogStackTrace when set to true, errors will be logged with their stack trace
+ */
+const log = (msg, tag, level, id, color, shouldLogStackTrace) => {
+  const time = new Date().toISOString()
+  tag = tag || ''
+  id = id || ''
+  const whitespace = tag && id ? ' ' : ''
+  color = color || ((message) => message)
+  if (typeof msg === 'string') {
+    msg = maskMessage(msg)
+  } else if (msg && typeof msg.message === 'string') {
+    msg.message = maskMessage(msg.message)
+  }
+
+  if (shouldLogStackTrace && msg instanceof Error && typeof msg.stack === 'string') {
+    msg.stack = maskMessage(msg.stack)
+    // exclude msg from template string so values such as error objects
+    // can be well formatted
+    console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg.stack))
+    return
+  }
+
+  // exclude msg from template string so values such as error objects
+  // can be well formatted
+  console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg))
+}
+
+/**
  * INFO level log
  *
  * @param {string} msg the message to log
@@ -65,53 +114,4 @@ exports.debug = (msg, tag, traceId) => {
     // @ts-ignore
     log(msg, tag, 'debug', traceId, chalk.bold.blue)
   }
-}
-
-/**
- * message log
- *
- * @param {string | Error} msg the message to log
- * @param {string} tag a unique tag to easily search for this message
- * @param {string} level error | info | debug
- * @param {Function=} color function to display the log in appropriate color
- * @param {string=} id a unique id to easily trace logs tied to a request
- * @param {boolean=} shouldLogStackTrace when set to true, errors will be logged with their stack trace
- */
-const log = (msg, tag, level, id, color, shouldLogStackTrace) => {
-  const time = new Date().toISOString()
-  tag = tag || ''
-  id = id || ''
-  const whitespace = tag && id ? ' ' : ''
-  color = color || ((message) => message)
-  if (typeof msg === 'string') {
-    msg = maskMessage(msg)
-  } else if (msg && typeof msg.message === 'string') {
-    msg.message = maskMessage(msg.message)
-  }
-
-  if (shouldLogStackTrace && msg instanceof Error && typeof msg.stack === 'string') {
-    msg.stack = maskMessage(msg.stack)
-    // exclude msg from template string so values such as error objects
-    // can be well formatted
-    console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg.stack))
-    return
-  }
-
-  // exclude msg from template string so values such as error objects
-  // can be well formatted
-  console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg))
-}
-
-/**
- * Mask the secret content of a message
- *
- * @param {string} msg the message whose content should be masked
- * @returns {string}
- */
-const maskMessage = (msg) => {
-  for (const toBeMasked of valuesToMask) {
-    const toBeReplaced = new RegExp(toBeMasked, 'gi')
-    msg = msg.replace(toBeReplaced, '******')
-  }
-  return msg
 }

--- a/packages/@uppy/companion/src/server/logger.js
+++ b/packages/@uppy/companion/src/server/logger.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk')
 const escapeStringRegexp = require('escape-string-regexp')
+const util = require('util')
 
 const valuesToMask = []
 /**
@@ -22,47 +23,44 @@ exports.setMaskables = (maskables) => {
  * @param {string} msg the message whose content should be masked
  * @returns {string}
  */
-const maskMessage = (msg) => {
+function maskMessage (msg) {
+  let out = msg
   for (const toBeMasked of valuesToMask) {
     const toBeReplaced = new RegExp(toBeMasked, 'gi')
-    msg = msg.replace(toBeReplaced, '******')
+    out = out.replace(toBeReplaced, '******')
   }
-  return msg
+  return out
 }
 
 /**
  * message log
  *
- * @param {string | Error} msg the message to log
+ * @param {string | Error} msgIn the message to log
  * @param {string} tag a unique tag to easily search for this message
  * @param {string} level error | info | debug
- * @param {Function=} color function to display the log in appropriate color
  * @param {string=} id a unique id to easily trace logs tied to a request
+ * @param {Function=} color function to display the log in appropriate color
  * @param {boolean=} shouldLogStackTrace when set to true, errors will be logged with their stack trace
  */
-const log = (msg, tag, level, id, color, shouldLogStackTrace) => {
+const log = (msgIn, tag = '', level, id = '', color = (message) => message, shouldLogStackTrace) => {
   const time = new Date().toISOString()
-  tag = tag || ''
-  id = id || ''
   const whitespace = tag && id ? ' ' : ''
-  color = color || ((message) => message)
+  let msg = msgIn
   if (typeof msg === 'string') {
     msg = maskMessage(msg)
   } else if (msg && typeof msg.message === 'string') {
     msg.message = maskMessage(msg.message)
   }
 
+  // eslint-disable-next-line no-console
+  const logMsg = (msg2) => console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(util.inspect(msg2)))
+
   if (shouldLogStackTrace && msg instanceof Error && typeof msg.stack === 'string') {
     msg.stack = maskMessage(msg.stack)
-    // exclude msg from template string so values such as error objects
-    // can be well formatted
-    console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg.stack))
+    logMsg(msg.stack)
     return
   }
-
-  // exclude msg from template string so values such as error objects
-  // can be well formatted
-  console.log(color(`companion: ${time} [${level}] ${id}${whitespace}${tag}`), color(msg))
+  logMsg(msg)
 }
 
 /**


### PR DESCRIPTION
When logging an object it would print `[object Object]` if `color` was set.
e.g.: google drive callback: `callback.oauth.resp [object Object]`
Now we will instead use util.inspect before calling color so it can log the object structure.
Also fix some linting warnings by reordering code. See second commit for easier to read changes