### PR TITLE
Fix React `DashboardModal`'s `target` type

### DIFF
--- a/packages/@uppy/react/src/CommonTypes.d.ts
+++ b/packages/@uppy/react/src/CommonTypes.d.ts
@@ -6,5 +6,6 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 // If I use the helper it doesn't work, I think because 'target' is not a `keyof T` while
 // the generic T is unknown, so will just use the expansion here
 type OmitTarget<T> = Pick<T, Exclude<keyof T, 'target'>>
-type WithBaseUppyProps<T> = T & { uppy: Uppy }
+
+export type WithBaseUppyProps<T> = T & { uppy: Uppy }
 export type ToUppyProps<T> = WithBaseUppyProps<OmitTarget<T>>

--- a/packages/@uppy/react/src/Dashboard.d.ts
+++ b/packages/@uppy/react/src/Dashboard.d.ts
@@ -1,17 +1,22 @@
 import * as React from 'react'
 import type { DashboardOptions } from '@uppy/dashboard'
-import { Omit, ToUppyProps } from './CommonTypes'
+import { Omit, WithBaseUppyProps } from './CommonTypes'
 
 // This type is mapped into `DashboardProps` below so IntelliSense doesn't display this big mess of nested types
 type DashboardPropsInner = Omit<
-  ToUppyProps<DashboardOptions>,
+  WithBaseUppyProps<DashboardOptions>,
   // Remove the modal-only props
-  'animateOpenClose' | 'browserBackButtonClose' | 'inline' | 'onRequestCloseModal' | 'trigger'
-> & React.BaseHTMLAttributes<HTMLDivElement>
+  | 'animateOpenClose'
+  | 'browserBackButtonClose'
+  | 'inline'
+  | 'onRequestCloseModal'
+  | 'trigger'
+> &
+  React.BaseHTMLAttributes<HTMLDivElement>;
 
 export type DashboardProps = {
-   [K in keyof DashboardPropsInner]: DashboardPropsInner[K]
-}
+  [K in keyof DashboardPropsInner]: DashboardPropsInner[K];
+};
 
 /**
  * React Component that renders a Dashboard for an Uppy instance. This component

--- a/packages/@uppy/react/src/Dashboard.d.ts
+++ b/packages/@uppy/react/src/Dashboard.d.ts
@@ -12,11 +12,11 @@ type DashboardPropsInner = Omit<
   | 'onRequestCloseModal'
   | 'trigger'
 > &
-  React.BaseHTMLAttributes<HTMLDivElement>;
+  React.BaseHTMLAttributes<HTMLDivElement>
 
 export type DashboardProps = {
-  [K in keyof DashboardPropsInner]: DashboardPropsInner[K];
-};
+  [K in keyof DashboardPropsInner]: DashboardPropsInner[K]
+}
 
 /**
  * React Component that renders a Dashboard for an Uppy instance. This component

--- a/packages/@uppy/react/src/DashboardModal.js
+++ b/packages/@uppy/react/src/DashboardModal.js
@@ -74,8 +74,8 @@ class DashboardModal extends React.Component {
   }
 }
 
-DashboardModal.propTypes = { // Only check this prop type in the browser.
-  target: typeof window !== 'undefined' ? PropTypes.instanceOf(window.HTMLElement) : PropTypes.any,
+DashboardModal.propTypes = {
+  target: PropTypes.instanceOf(HTMLElement),
   open: PropTypes.bool,
   onRequestClose: PropTypes.func,
   closeModalOnClickOutside: PropTypes.bool,

--- a/packages/@uppy/react/src/DashboardModal.js
+++ b/packages/@uppy/react/src/DashboardModal.js
@@ -75,15 +75,12 @@ class DashboardModal extends React.Component {
 }
 
 DashboardModal.propTypes = {
-  target: PropTypes.instanceOf(HTMLElement),
+  target: PropTypes.oneOf([PropTypes.elementType, PropTypes.string]),
   open: PropTypes.bool,
   onRequestClose: PropTypes.func,
   closeModalOnClickOutside: PropTypes.bool,
   disablePageScrollWhenModalOpen: PropTypes.bool,
   ...basePropTypes,
-}
-
-DashboardModal.defaultProps = {
 }
 
 module.exports = DashboardModal

--- a/packages/@uppy/react/src/DashboardModal.js
+++ b/packages/@uppy/react/src/DashboardModal.js
@@ -75,7 +75,7 @@ class DashboardModal extends React.Component {
 }
 
 DashboardModal.propTypes = {
-  target: PropTypes.oneOf([PropTypes.elementType, PropTypes.string]),
+  target: typeof window !== 'undefined' ? PropTypes.instanceOf(window.HTMLElement) : PropTypes.any,
   open: PropTypes.bool,
   onRequestClose: PropTypes.func,
   closeModalOnClickOutside: PropTypes.bool,

--- a/packages/@uppy/react/types/index.test-d.tsx
+++ b/packages/@uppy/react/types/index.test-d.tsx
@@ -15,6 +15,10 @@ const uppy = new Uppy()
   }
 }
 
+{
+  expectError(<components.Dashboard target="body"/>)
+}
+
 // inline option should be removed from proptypes because it is always overridden
 // by the component
 {
@@ -45,6 +49,7 @@ const uppy = new Uppy()
 {
   const el = (
     <components.DashboardModal
+      target="body"
       uppy={uppy}
       open
       animateOpenClose


### PR DESCRIPTION
Fixes #2972

- `OmitTarget` was incorrectly also added to `DashboardModal`, which can in fact have a `target`.