### PR TITLE
build: fix legacy bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/jasminewd2": "file:./private/@types/jasmine",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
-    "abortcontroller-polyfill": "^1.7.3",
     "adm-zip": "^0.5.5",
     "aliasify": "^2.1.0",
     "autoprefixer": "^10.2.6",
@@ -91,7 +90,6 @@
     "last-commit-message": "^1.0.0",
     "lerna": "^4.0.0",
     "lint-staged": "^11.0.0",
-    "md-gum-polyfill": "^1.0.0",
     "mime-types": "^2.1.26",
     "minify-stream": "^2.0.1",
     "multi-glob": "^1.0.2",
@@ -109,7 +107,6 @@
     "remark-cli": "^9.0.0",
     "remark-lint-uppy": "file:private/remark-lint-uppy",
     "replacestream": "^4.0.3",
-    "resize-observer-polyfill": "^1.5.1",
     "resolve": "^1.17.0",
     "sass": "^1.29.0",
     "size-limit": "4.5.6",
@@ -122,8 +119,7 @@
     "tsify": "^5.0.1",
     "typescript": "~4.3",
     "verdaccio": "^5.1.1",
-    "watchify": "^4.0.0",
-    "whatwg-fetch": "^3.6.2"
+    "watchify": "^4.0.0"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",

--- a/packages/@uppy/robodog/package.json
+++ b/packages/@uppy/robodog/package.json
@@ -43,7 +43,10 @@
     "@uppy/webcam": "file:../webcam"
   },
   "devDependencies": {
-    "core-js": "^3.15.2",
+    "abortcontroller-polyfill": "^1.7.3",
+    "core-js": "~3.15.2",
+    "md-gum-polyfill": "^1.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "whatwg-fetch": "^3.6.2"
   }
 }

--- a/packages/uppy/bundle.js
+++ b/packages/uppy/bundle.js
@@ -8,4 +8,7 @@ const ResizeObserver = require('resize-observer-polyfill')
 
 if (typeof window.ResizeObserver !== 'function') window.ResizeObserver = ResizeObserver
 
-module.exports = require('.')
+// Needed for Babel
+require("regenerator-runtime/runtime");
+
+globalThis.Uppy = module.exports = require('.')

--- a/packages/uppy/package.json
+++ b/packages/uppy/package.json
@@ -63,5 +63,13 @@
     "@uppy/url": "file:../@uppy/url",
     "@uppy/webcam": "file:../@uppy/webcam",
     "@uppy/xhr-upload": "file:../@uppy/xhr-upload"
+  },
+  "devDependencies": {
+    "abortcontroller-polyfill": "^1.7.3",
+    "core-js": "~3.15.2",
+    "md-gum-polyfill": "^1.0.0",
+    "regenerator-runtime": "0.13.9",
+    "resize-observer-polyfill": "^1.5.1",
+    "whatwg-fetch": "^3.6.2"
   }
 }


### PR DESCRIPTION
The legacy bundle was missing `regenerator-runtime` dependency and was not defining `Uppy` global.