### PR TITLE
Core: rename allowMultipleUploads to allowMultipleUploadBatches

### DIFF
--- a/examples/dev/Dashboard.js
+++ b/examples/dev/Dashboard.js
@@ -59,6 +59,7 @@ module.exports = () => {
       license: 'Creative Commons',
     },
     allowMultipleUploadBatches: false,
+    // restrictions: { requiredMetaFields: ['caption'] },
   })
     .use(Dashboard, {
       trigger: '#pick-files',

--- a/examples/dev/Dashboard.js
+++ b/examples/dev/Dashboard.js
@@ -58,7 +58,7 @@ module.exports = () => {
       username: 'John',
       license: 'Creative Commons',
     },
-    restrictions: { requiredMetaFields: ['caption'] },
+    allowMultipleUploadBatches: false,
   })
     .use(Dashboard, {
       trigger: '#pick-files',

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -85,7 +85,7 @@ class Uppy {
         missingRequiredMetaFieldOnFile: 'Missing required meta fields in %{fileName}',
         inferiorSize: 'This file is smaller than the allowed size of %{size}',
         youCanOnlyUploadFileTypes: 'You can only upload: %{types}',
-        noNewAlreadyUploading: 'Cannot add new files: already uploading',
+        noMoreFilesAllowed: 'Cannot add more files',
         noDuplicates: 'Cannot add the duplicate file \'%{fileName}\', it already exists',
         companionError: 'Connection with Companion failed',
         companionUnauthorizeHint: 'To unauthorize to your %{provider} account, please go to %{url}',
@@ -622,7 +622,7 @@ class Uppy {
     const { allowNewUpload } = this.getState()
 
     if (allowNewUpload === false) {
-      this.#showOrLogErrorAndThrow(new RestrictionError(this.i18n('noNewAlreadyUploading')), { file })
+      this.#showOrLogErrorAndThrow(new RestrictionError(this.i18n('noMoreFilesAllowed')), { file })
     }
   }
 

--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -122,7 +122,11 @@ class Uppy {
     const defaultOptions = {
       id: 'uppy',
       autoProceed: false,
+      /**
+       * @deprecated The method should not be used
+       */
       allowMultipleUploads: true,
+      allowMultipleUploadBatches: true,
       debug: false,
       restrictions: {
         maxFileSize: null,
@@ -1520,7 +1524,7 @@ class Uppy {
     })
 
     this.setState({
-      allowNewUpload: this.opts.allowMultipleUploads !== false,
+      allowNewUpload: this.opts.allowMultipleUploadBatches !== false && this.opts.allowMultipleUploads !== false,
 
       currentUploads: {
         ...currentUploads,

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -722,8 +722,31 @@ describe('src/Core', () => {
       expect(core.getFiles().length).toEqual(0)
     })
 
-    describe('with allowMultipleUploads: false', () => {
+    describe('with allowMultipleUploadBatches: false', () => {
       it('allows no new files after upload', async () => {
+        const core = new Core({ allowMultipleUploadBatches: false })
+        core.addFile({
+          source: 'jest',
+          name: 'foo.jpg',
+          type: 'image/jpeg',
+          data: new File([sampleImage], { type: 'image/jpeg' }),
+        })
+
+        await core.upload()
+
+        expect(() => {
+          core.addFile({
+            source: 'jest',
+            name: '123.foo',
+            type: 'image/jpeg',
+            data: new File([sampleImage], { type: 'image/jpeg' }),
+          })
+        }).toThrow(
+          /Cannot add new files: already uploading/
+        )
+      })
+
+      it('allows no new files after upload with legacy allowMultipleUploads option', async () => {
         const core = new Core({ allowMultipleUploads: false })
         core.addFile({
           source: 'jest',
@@ -747,7 +770,7 @@ describe('src/Core', () => {
       })
 
       it('does not allow new files after the removeFile() if some file is still present', async () => {
-        const core = new Core({ allowMultipleUploads: false })
+        const core = new Core({ allowMultipleUploadBatches: false })
 
         // adding 2 files
         const fileId1 = core.addFile({
@@ -770,7 +793,7 @@ describe('src/Core', () => {
       })
 
       it('allows new files after the last removeFile()', async () => {
-        const core = new Core({ allowMultipleUploads: false })
+        const core = new Core({ allowMultipleUploadBatches: false })
 
         // adding 2 files
         const fileId1 = core.addFile({
@@ -916,8 +939,8 @@ describe('src/Core', () => {
       })
     })
 
-    it('only allows a single upload() batch when allowMultipleUploads: false', async () => {
-      const core = new Core({ allowMultipleUploads: false })
+    it('only allows a single upload() batch when allowMultipleUploadBatches: false', async () => {
+      const core = new Core({ allowMultipleUploadBatches: false })
       core.addFile({
         source: 'jest',
         name: 'foo.jpg',
@@ -937,8 +960,8 @@ describe('src/Core', () => {
       )
     })
 
-    it('allows new files again with allowMultipleUploads: false after reset() was called', async () => {
-      const core = new Core({ allowMultipleUploads: false })
+    it('allows new files again with allowMultipleUploadBatches: false after reset() was called', async () => {
+      const core = new Core({ allowMultipleUploadBatches: false })
 
       core.addFile({
         source: 'jest',
@@ -1089,12 +1112,12 @@ describe('src/Core', () => {
       core.setOptions({
         id: 'lolUppy',
         autoProceed: true,
-        allowMultipleUploads: true,
+        allowMultipleUploadBatches: true,
       })
 
       expect(core.opts.id).toEqual('lolUppy')
       expect(core.opts.autoProceed).toEqual(true)
-      expect(core.opts.allowMultipleUploads).toEqual(true)
+      expect(core.opts.allowMultipleUploadBatches).toEqual(true)
     })
 
     it('should change locale on the fly', () => {

--- a/packages/@uppy/core/src/index.test.js
+++ b/packages/@uppy/core/src/index.test.js
@@ -742,7 +742,7 @@ describe('src/Core', () => {
             data: new File([sampleImage], { type: 'image/jpeg' }),
           })
         }).toThrow(
-          /Cannot add new files: already uploading/
+          /Cannot add more files/
         )
       })
 
@@ -765,7 +765,7 @@ describe('src/Core', () => {
             data: new File([sampleImage], { type: 'image/jpeg' }),
           })
         }).toThrow(
-          /Cannot add new files: already uploading/
+          /Cannot add more files/
         )
       })
 

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -138,6 +138,7 @@ export interface UppyOptions<TMeta extends IndexedObject<any> = Record<string, u
   id?: string
   autoProceed?: boolean
   allowMultipleUploads?: boolean
+  allowMultipleUploadBatches?: boolean
   logger?: Logger
   debug?: boolean
   restrictions?: Restrictions

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -137,6 +137,9 @@ export interface Restrictions {
 export interface UppyOptions<TMeta extends IndexedObject<any> = Record<string, unknown>> {
   id?: string
   autoProceed?: boolean
+  /**
+   * @deprecated Use allowMultipleUploadBatches
+   */
   allowMultipleUploads?: boolean
   allowMultipleUploadBatches?: boolean
   logger?: Logger

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -1013,9 +1013,9 @@ module.exports = class Dashboard extends UIPlugin {
       throw new Error('[Dashboard] `closeAfterFinish: true` cannot be used on an inline Dashboard, because an inline Dashboard cannot be closed at all. Either set `inline: false`, or disable the `closeAfterFinish` option.')
     }
 
-    const { allowMultipleUploads } = this.uppy.opts
-    if (allowMultipleUploads && closeAfterFinish) {
-      this.uppy.log('[Dashboard] When using `closeAfterFinish`, we recommended setting the `allowMultipleUploads` option to `false` in the Uppy constructor. See https://uppy.io/docs/uppy/#allowMultipleUploads-true', 'warning')
+    const { allowMultipleUploads, allowMultipleUploadBatches } = this.uppy.opts
+    if ((allowMultipleUploads || allowMultipleUploadBatches) && closeAfterFinish) {
+      this.uppy.log('[Dashboard] When using `closeAfterFinish`, we recommended setting the `allowMultipleUploadBatches` option to `false` in the Uppy constructor. See https://uppy.io/docs/uppy/#allowMultipleUploads-true', 'warning')
     }
 
     const { target } = this.opts

--- a/packages/@uppy/dashboard/src/index.js
+++ b/packages/@uppy/dashboard/src/index.js
@@ -592,7 +592,9 @@ module.exports = class Dashboard extends UIPlugin {
     event.preventDefault()
     event.stopPropagation()
 
-    if (this.opts.disabled || this.opts.disableLocalFiles) {
+    if (this.opts.disabled
+      || this.opts.disableLocalFiles
+      || !this.uppy.getState().allowNewUpload) {
       return
     }
 
@@ -608,7 +610,9 @@ module.exports = class Dashboard extends UIPlugin {
     event.preventDefault()
     event.stopPropagation()
 
-    if (this.opts.disabled || this.opts.disableLocalFiles) {
+    if (this.opts.disabled
+      || this.opts.disableLocalFiles
+      || !this.uppy.getState().allowNewUpload) {
       return
     }
 
@@ -623,7 +627,9 @@ module.exports = class Dashboard extends UIPlugin {
     event.preventDefault()
     event.stopPropagation()
 
-    if (this.opts.disabled || this.opts.disableLocalFiles) {
+    if (this.opts.disabled
+        || this.opts.disableLocalFiles
+        || !this.uppy.getState().allowNewUpload) {
       return
     }
 

--- a/packages/@uppy/locales/src/bg_BG.js
+++ b/packages/@uppy/locales/src/bg_BG.js
@@ -70,7 +70,7 @@ bg_BG.strings = {
   noDuplicates: 'Файлът \'%{fileName}\' съществува. Не може да добавите дублиращи файлове',
   noFilesFound: 'Тук нямате файлове или директории',
   noInternetConnection: 'Няма връзка с интернет',
-  noNewAlreadyUploading: 'Не може да се добавят нови файлове: в процес на качване',
+  noMoreFilesAllowed: 'Не може да се добавят нови файлове: в процес на качване',
   openFolderNamed: 'Отваряне на директория %{name}',
   pause: 'Пауза',
   pauseUpload: 'Паузиране на качването',
@@ -143,7 +143,7 @@ bg_BG.strings = {
   },
 }
 
-bg_BG.pluralize = function (count) {
+bg_BG.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/de_DE.js
+++ b/packages/@uppy/locales/src/de_DE.js
@@ -85,7 +85,7 @@ de_DE.strings = {
   noDuplicates: 'Datei \'%{fileName}\' existiert bereits und kann nicht erneut hinzugefügt werden',
   noFilesFound: 'Sie haben hier keine Dateien oder Ordner',
   noInternetConnection: 'Keine Internetverbindung',
-  noNewAlreadyUploading: 'Während der Upload läuft, können keine weiteren Dateien hinzugefügt werden',
+  noMoreFilesAllowed: 'Während der Upload läuft, können keine weiteren Dateien hinzugefügt werden',
   openFolderNamed: 'Ordner %{name} öffnen',
   pause: 'Pausieren',
   paused: 'Pausiert',
@@ -177,7 +177,7 @@ de_DE.strings = {
   zoomOut: 'Verkleinern',
 }
 
-de_DE.pluralize = function (count) {
+de_DE.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/en_US.js
+++ b/packages/@uppy/locales/src/en_US.js
@@ -86,7 +86,7 @@ en_US.strings = {
   noDuplicates: 'Cannot add the duplicate file \'%{fileName}\', it already exists',
   noFilesFound: 'You have no files or folders here',
   noInternetConnection: 'No Internet connection',
-  noNewAlreadyUploading: 'Cannot add new files: already uploading',
+  noMoreFilesAllowed: 'Cannot add new files: already uploading',
   openFolderNamed: 'Open folder %{name}',
   pause: 'Pause',
   paused: 'Paused',
@@ -178,7 +178,7 @@ en_US.strings = {
   zoomOut: 'Zoom out',
 }
 
-en_US.pluralize = function (count) {
+en_US.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/en_US.js
+++ b/packages/@uppy/locales/src/en_US.js
@@ -86,7 +86,7 @@ en_US.strings = {
   noDuplicates: 'Cannot add the duplicate file \'%{fileName}\', it already exists',
   noFilesFound: 'You have no files or folders here',
   noInternetConnection: 'No Internet connection',
-  noMoreFilesAllowed: 'Cannot add new files: already uploading',
+  noMoreFilesAllowed: 'Cannot add more files',
   openFolderNamed: 'Open folder %{name}',
   pause: 'Pause',
   paused: 'Paused',

--- a/packages/@uppy/locales/src/fa_IR.js
+++ b/packages/@uppy/locales/src/fa_IR.js
@@ -82,7 +82,7 @@ fa_IR.strings = {
   noDuplicates: 'نمی‌توان فایل تکراری بارگذاری کرد،\'%{fileName}\' قبلا بارگذاری شده است.',
   noFilesFound: 'هیچ فایل یا پوشه‌ای اینجا ندارید',
   noInternetConnection: 'عدم اتصال به اینترنت',
-  noNewAlreadyUploading: 'نمی توان فایل جدید بارگذاری کرد: درحال بارگذاری است',
+  noMoreFilesAllowed: 'نمی توان فایل جدید بارگذاری کرد: درحال بارگذاری است',
   openFolderNamed: 'پوشه باز کنید %{name}',
   pause: 'توقف',
   pauseUpload: 'توقف بارگذاری',

--- a/packages/@uppy/locales/src/fr_FR.js
+++ b/packages/@uppy/locales/src/fr_FR.js
@@ -74,7 +74,7 @@ fr_FR.strings = {
   noDuplicates: 'Impossible d\'ajouter le fichier "%{fileName}", il existe déjà',
   noFilesFound: 'Vous n\'avez aucun fichier ou dossier ici',
   noInternetConnection: 'Pas de connexion à Internet',
-  noNewAlreadyUploading: 'Impossible d\'ajouter de nouveaux fichiers: en cours de chargement ',
+  noMoreFilesAllowed: 'Impossible d\'ajouter de nouveaux fichiers: en cours de chargement ',
   openFolderNamed: 'Ouvrir %{name}',
   pause: 'Pause',
   pauseUpload: 'Mettre en pause le téléchargement',

--- a/packages/@uppy/locales/src/nb_NO.js
+++ b/packages/@uppy/locales/src/nb_NO.js
@@ -79,7 +79,7 @@ nb_NO.strings = {
   noDuplicates: 'Kan ikke legge til \'%{fileName}\', da den allerede eksisterer',
   noFilesFound: 'Du har ingen filer eller mapper her',
   noInternetConnection: 'Ingen internettilgang',
-  noNewAlreadyUploading: 'Kan ikke legge til nye filer mens opplasting pågår',
+  noMoreFilesAllowed: 'Kan ikke legge til nye filer mens opplasting pågår',
   openFolderNamed: 'Åpne mappe %{name}',
   pause: 'Pause',
   pauseUpload: 'Stopp opplasting midlertidig',
@@ -158,7 +158,7 @@ nb_NO.strings = {
   zoomOut: 'Zoom ut',
 }
 
-nb_NO.pluralize = function (count) {
+nb_NO.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/pl_PL.js
+++ b/packages/@uppy/locales/src/pl_PL.js
@@ -71,7 +71,7 @@ pl_PL.strings = {
   noDuplicates: 'Nie można dodać i zduplikować pliku \'%{fileName}\', już istnieje',
   noFilesFound: 'W tym miejscu brakuje plików lub katalogów',
   noInternetConnection: 'Brak połączenia z Internetem',
-  noNewAlreadyUploading: 'Nie można dodać nowych plików: trwa wysyłka',
+  noMoreFilesAllowed: 'Nie można dodać nowych plików: trwa wysyłka',
   openFolderNamed: 'Otwórz folder %{name}',
   pause: 'Wstrzymaj',
   pauseUpload: 'Wstrzymaj wysyłkę',

--- a/packages/@uppy/locales/src/ro_RO.js
+++ b/packages/@uppy/locales/src/ro_RO.js
@@ -69,7 +69,7 @@ ro_RO.strings = {
   noDuplicates: 'Nu se poate adăuga fișierul \'%{fileName}\', acesta există deja',
   noFilesFound: 'Nu sunt fișiere sau directoare aici',
   noInternetConnection: 'Fără conexiune la internet',
-  noNewAlreadyUploading: 'Nu se pot adăuga fișiere noi: încărcare în curs',
+  noMoreFilesAllowed: 'Nu se pot adăuga fișiere noi: încărcare în curs',
   openFolderNamed: 'Deschide director %{name}',
   pause: 'Întrerupe',
   pauseUpload: 'Întrerupe încărcarea',
@@ -136,7 +136,7 @@ ro_RO.strings = {
   },
 }
 
-ro_RO.pluralize = function (count) {
+ro_RO.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/sk_SK.js
+++ b/packages/@uppy/locales/src/sk_SK.js
@@ -81,7 +81,7 @@ sk_SK.strings = {
   noDuplicates: 'Nemôžete pridať duplikátny súbor \'%{fileName}\', ktorý už existuje',
   noFilesFound: 'Nemáte pridané žiadne súbory ani zložky',
   noInternetConnection: 'Žiadne internetové pripojenie',
-  noNewAlreadyUploading: 'Počas nahrávania nemôžete pridať ďalšie súbory',
+  noMoreFilesAllowed: 'Počas nahrávania nemôžete pridať ďalšie súbory',
   openFolderNamed: 'Otvoriť zložku %{name}',
   pause: 'Pozastaviť',
   pauseUpload: 'Pozastaviť nahrávanie',
@@ -167,7 +167,7 @@ sk_SK.strings = {
   zoomOut: 'Oddialiť',
 }
 
-sk_SK.pluralize = function (count) {
+sk_SK.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/locales/src/th_TH.js
+++ b/packages/@uppy/locales/src/th_TH.js
@@ -78,7 +78,7 @@ th_TH.strings = {
   noDuplicates: 'ไม่สามารถเพิ่มไฟล์ซ้ำได้ ไฟล์ \'%{fileName}\', มีอยู่แล้ว',
   noFilesFound: 'คุณไม่มีไฟล์หรือโฟลเดอร์ที่นี่',
   noInternetConnection: 'ไม่มีการเชื่อมต่ออินเทอร์เน็ต',
-  noNewAlreadyUploading: 'ไม่สามารถเพิ่มไฟล์ใหม่: กำลังอยู่ระหว่างอัพโหลด',
+  noMoreFilesAllowed: 'ไม่สามารถเพิ่มไฟล์ใหม่: กำลังอยู่ระหว่างอัพโหลด',
   openFolderNamed: 'เปิดโฟลเดอร์ %{name}',
   pause: 'หยุดชั่วคราว',
   pauseUpload: 'หยุดการอัปโหลดชั่วคราว',

--- a/packages/@uppy/locales/src/zh_CN.js
+++ b/packages/@uppy/locales/src/zh_CN.js
@@ -63,7 +63,7 @@ zh_CN.strings = {
   noDuplicates: '无法添加重复文件 %{fileName}，该文件已存在',
   noFilesFound: '这里空空如也',
   noInternetConnection: '无法连接到网络',
-  noNewAlreadyUploading: '无法添加新文件：已正在上传文件',
+  noMoreFilesAllowed: '无法添加新文件：已正在上传文件',
   openFolderNamed: '打开文件夹 %{name}',
   pause: '暂停',
   pauseUpload: '暂停上传',

--- a/packages/@uppy/locales/src/zh_TW.js
+++ b/packages/@uppy/locales/src/zh_TW.js
@@ -71,7 +71,7 @@ zh_TW.strings = {
   noDuplicates: '無法新增重複檔案 \'%{fileName}\' 已存在',
   noFilesFound: '這裡空空如也',
   noInternetConnection: '無法連線到網絡',
-  noNewAlreadyUploading: '無法新增檔案: 已在上傳中',
+  noMoreFilesAllowed: '無法新增檔案: 已在上傳中',
   openFolderNamed: '開啟資料夾 %{name}',
   pause: '暫停',
   pauseUpload: '暫停上傳',

--- a/packages/@uppy/locales/template.js
+++ b/packages/@uppy/locales/template.js
@@ -2,7 +2,7 @@ const en_US = {}
 
 en_US.strings = {}
 
-en_US.pluralize = function (count) {
+en_US.pluralize = function pluralize (count) {
   if (count === 1) {
     return 0
   }

--- a/packages/@uppy/robodog/src/pick.js
+++ b/packages/@uppy/robodog/src/pick.js
@@ -10,7 +10,7 @@ function pick (opts = {}) {
 
   const pluginId = 'pick'
   const uppy = createUppy(opts, {
-    allowMultipleUploads: false,
+    allowMultipleUploadBatches: false,
   })
   addTransloaditPlugin(uppy, opts)
   addDashboardPlugin(uppy, opts, {

--- a/website/src/docs/uppy.md
+++ b/website/src/docs/uppy.md
@@ -38,7 +38,7 @@ The Uppy core module has the following configurable options:
 const uppy = new Uppy({
   id: 'uppy',
   autoProceed: false,
-  allowMultipleUploads: true,
+  allowMultipleUploadBatches: true,
   debug: false,
   restrictions: {
     maxFileSize: null,
@@ -77,7 +77,7 @@ const photoUploader = new Uppy({ id: 'post' })
 
 By default Uppy will wait for an upload button to be pressed in the UI, or an `.upload()` method to be called, before starting an upload. Setting this to `autoProceed: true` will start uploading automatically after the first file is selected.
 
-### `allowMultipleUploads: true`
+### `allowMultipleUploadBatches: true`
 
 Whether to allow multiple upload batches. This means multiple calls to `.upload()`, or a user adding more files after already uploading some. An upload batch is made up of the files that were added since the previous `.upload()` call.
 


### PR DESCRIPTION
- Renaming `allowMultipleUploads` to `allowMultipleUploadBatches`, keeping the old option as alias for now
- Change the “Can’t add new files: already uploading” string, because it also applies after the upload is complete
- Don’t allow drag-drop after initial upload, if `allowMultipleUploadBatches: false`

Related: https://github.com/transloadit/uppy/issues/2806, https://github.com/transloadit/uppy/issues/1575