### PR TITLE
@uppy/core: reject empty string as valid value for required meta fields

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -555,14 +555,14 @@ class Uppy {
    */
   #checkRequiredMetaFields (files) {
     const { requiredMetaFields } = this.opts.restrictions
-    const { hasOwnProperty } = Object.prototype.hasOwnProperty
+    const { hasOwnProperty } = Object.prototype
 
     const errors = []
     const fileIDs = Object.keys(files)
     for (let i = 0; i < fileIDs.length; i++) {
       const file = this.getFile(fileIDs[i])
       for (let i = 0; i < requiredMetaFields.length; i++) {
-        if (!hasOwnProperty.call(file.meta, requiredMetaFields[i])) {
+        if (!hasOwnProperty.call(file.meta, requiredMetaFields[i]) || file.meta[requiredMetaFields[i]] === '') {
           const err = new RestrictionError(`${this.i18n('missingRequiredMetaFieldOnFile', { fileName: file.name })}`)
           errors.push(err)
           this.#showOrLogErrorAndThrow(err, { file, showInformer: false, throwErr: false })

--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -249,7 +249,7 @@ uppy.use(Dashboard, {
       id: 'public',
       name: 'Public',
       render ({ value, onChange, required, form }, h) {
-        return h('input', { type: 'checkbox', required, form, onChange: (ev) => onChange(ev.target.checked ? 'on' : 'off'), defaultChecked: value === 'on' })
+        return h('input', { type: 'checkbox', required, form, onChange: (ev) => onChange(ev.target.checked ? 'on' : ''), defaultChecked: value === 'on' })
       },
     },
   ],
@@ -272,7 +272,7 @@ uppy.use(Dashboard, {
         render: ({ value, onChange, required, form }, h) => {
           return h('input', {
             type: 'checkbox',
-            onChange: (ev) => onChange(ev.target.checked ? 'on' : 'off'),
+            onChange: (ev) => onChange(ev.target.checked ? 'on' : ''),
             defaultChecked: value === 'on',
             required,
             form,


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/input.html#attr-input-required

> Constraint validation: If the element is required, and its value IDL attribute applies and is in the mode value, and the element is mutable, and **the element's value is the empty string**, then the element is suffering from being missing.

This is important to align the pre-upload check with the form validation done by the browser (if the browser does have support for the `form` attribute). We should backport this to Uppy v1.x.