### PR TITLE
@uppy/core: fix required metafields UX

### DIFF
--- a/packages/@uppy/core/src/index.js
+++ b/packages/@uppy/core/src/index.js
@@ -25,7 +25,7 @@ class RestrictionError extends Error {
 if (typeof AggregateError === 'undefined') {
   // eslint-disable-next-line no-global-assign
   globalThis.AggregateError = class AggregateError extends Error {
-    constructor (message, errors) {
+    constructor (errors, message) {
       super(message)
       this.errors = errors
     }
@@ -571,7 +571,7 @@ class Uppy {
     }
 
     if (errors.length) {
-      throw new AggregateRestrictionError(`${this.i18n('missingRequiredMetaField')}`, errors)
+      throw new AggregateRestrictionError(errors, `${this.i18n('missingRequiredMetaField')}`)
     }
   }
 


### PR DESCRIPTION
PR to improve the UX when upload fails because of missing required metafields. The idea is to shorten the error message and give a visual clue on the failing file card.
This should probably be backported to v1.x.