### PR TITLE
updated naming conventions link

### DIFF
--- a/website/src/_template/contributing.md
+++ b/website/src/_template/contributing.md
@@ -190,7 +190,7 @@ The CSS standards followed in this project closely resemble those from [Mediumâ€
 ### Naming conventions
 
 This project uses naming conventions adopted from the SUIT CSS framework.
-[Read about them here](https://github.com/suitcss/suit/blob/main/doc/naming-conventions.md).
+[Read about them here](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).
 
 To quickly summarize:
 


### PR DESCRIPTION
https://app.intercom.com/a/apps/qiqpfgjg/inbox/inbox/5079389/conversations/26852700005063, the original naming conventions link had been changed, so updated it with the new one.