### PR TITLE
Add file metadata overload for `off` type.

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -234,6 +234,8 @@ export class Uppy {
 
   off<K extends keyof UppyEventMap>(event: K, callback: UppyEventMap[K]): this
 
+  off<K extends keyof UppyEventMap, TMeta extends IndexedObject<any>>(event: K, callback: UppyEventMap<TMeta>[K]): this
+
   /**
    * For use by plugins only.
    */

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -101,6 +101,13 @@ type anyObject = Record<string, unknown>
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const meta = result.successful[0].meta.myCustomMetadata
   })
+
+  // Separate event handlers
+  const handleUpload = (file: UploadedUppyFile<Meta, unknown>) => {
+    const meta = file.meta.myCustomMetadata
+  }
+
+  uppy.off<'upload-success', Meta>('upload-success', handleUpload)
 }
 
 {


### PR DESCRIPTION
The missing overload was raised here:
https://github.com/transloadit/uppy/pull/3085#pullrequestreview-738482514

