### PR TITLE
Fix `i18n` in aws-s3, thumbnail-generator, and xhr-upload

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -124,6 +124,9 @@ module.exports = class AwsS3 extends BasePlugin {
 
     this.setOptions({ ...defaultOptions, ...opts })
 
+    // TODO: remove i18n once we can depend on XHRUpload instead of MiniXHRUpload
+    this.i18nInit()
+
     this.#client = new RequestClient(uppy, opts)
     this.#requests = new RateLimitedQueue(this.opts.limit)
   }
@@ -269,7 +272,7 @@ module.exports = class AwsS3 extends BasePlugin {
       getResponseError: defaultGetResponseError,
     }
 
-    // Only for MiniXHRUpload, remove once we can depend on XHRUpload directly again
+    // TODO: remove i18n once we can depend on XHRUpload instead of MiniXHRUpload
     xhrOptions.i18n = this.i18n
 
     // Revert to `uppy.use(XHRUpload)` once the big comment block at the top of

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -122,7 +122,7 @@ module.exports = class AwsS3 extends BasePlugin {
       getUploadParameters: this.getUploadParameters.bind(this),
     }
 
-    this.setOptions({ ...defaultOptions, ...opts })
+    this.opts = { ...defaultOptions, ...opts }
 
     // TODO: remove i18n once we can depend on XHRUpload instead of MiniXHRUpload
     this.i18nInit()

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -122,7 +122,7 @@ module.exports = class AwsS3 extends BasePlugin {
       getUploadParameters: this.getUploadParameters.bind(this),
     }
 
-    this.opts = { ...defaultOptions, ...opts }
+    this.setOptions({ ...defaultOptions, ...opts })
 
     this.#client = new RequestClient(uppy, opts)
     this.#requests = new RateLimitedQueue(this.opts.limit)

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -35,6 +35,7 @@ module.exports = class ThumbnailGenerator extends UIPlugin {
     }
 
     this.opts = { ...defaultOptions, ...opts }
+    this.i18nInit()
 
     if (this.opts.lazy && this.opts.waitForThumbnailsBeforeUpload) {
       throw new Error('ThumbnailGenerator: The `lazy` and `waitForThumbnailsBeforeUpload` options are mutually exclusive. Please ensure at most one of them is set to `true`.')

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -117,6 +117,7 @@ module.exports = class XHRUpload extends BasePlugin {
     }
 
     this.opts = { ...defaultOptions, ...opts }
+    this.i18nInit()
 
     this.handleUpload = this.handleUpload.bind(this)
 


### PR DESCRIPTION
I got an error report to know the `this.i18n` is undefined ([@uppy/aws-s3/src/MiniXHRUpload.js#L139](https://github.com/transloadit/uppy/blob/main/packages/%40uppy/aws-s3/src/MiniXHRUpload.js#L139)), use `setOptions` from [BasePlugin](https://github.com/transloadit/uppy/blob/a3aac6ba4cd1322c59b030c2779ea64038e23b4c/packages/%40uppy/core/src/BasePlugin.js#L37-L48) will fix this issue.