### PR TITLE
Add methods to type definition for XHRUploadOptions

### DIFF
--- a/packages/@uppy/xhr-upload/types/index.d.ts
+++ b/packages/@uppy/xhr-upload/types/index.d.ts
@@ -19,6 +19,9 @@ export interface XHRUploadOptions extends PluginOptions {
     locale?: XHRUploadLocale
     responseType?: string
     withCredentials?: boolean
+    validateStatus?: (statusCode: number, responseText: string, response: unknown) => boolean
+    getResponseData?: (responseText: string, response: unknown) => any
+    getResponseError?: (responseText: string, xhr: unknown) => Error
 }
 
 declare class XHRUpload extends BasePlugin<XHRUploadOptions> {}


### PR DESCRIPTION
Should resolve issue #3144.
Running `npm run lint` I get lots of warnings from files I did not touch;
running `npm run test`I get warnings about 'locale has missing string', even after I run `npm run build:lib`.
Maybe this is a result of my working environment (it is a windows system).