### PR TITLE
remove google drive link

### DIFF
--- a/website/src/_posts/2016-08-0.9.0.md
+++ b/website/src/_posts/2016-08-0.9.0.md
@@ -39,7 +39,7 @@ Or when Uppy has successfully uploaded your files:
 The Webcam plugin can now take snapshots and add them to the file dashboard in Uppy's modal.  We have also added Flash support for Safari/IE users.  The UI has also been cleaned up in the dashboard.  We have temporarily disabled video recording in order to focus on rolling out the snapshot feature.
 
 ## Under the hood: UI refactors
-Under the hood, we have made some changes to how the UI is structured.  We are taking a more componentized approach.  For example, the rendering of Google Drive's UI has been separated into multiple smaller components that can be found in the [`plugins/GoogleDrive` folder](https://github.com/transloadit/uppy/tree/master/src/plugins/GoogleDrive).
+Under the hood, we have made some changes to how the UI is structured.  We are taking a more componentized approach.  For example, the rendering of Google Drive's UI has been separated into multiple smaller components that can be found in the `plugins/GoogleDrive` folder.
 
 ## Release Notes
 


### PR DESCRIPTION
https://app.intercom.com/a/apps/qiqpfgjg/inbox/inbox/all/conversations/26852700005169 
No. 3i, removed the link as I couldn't find a replacement. The only link I could find that seemed to be about the same thing as the original link is: https://github.com/transloadit/uppy/blob/main/website/src/docs/google-drive.md, but this is already available on the website for users to see.