### PR TITLE
replace fingerprint.js link

### DIFF
--- a/website/src/_posts/2019-04-liftoff-08.md
+++ b/website/src/_posts/2019-04-liftoff-08.md
@@ -38,7 +38,7 @@ After:<br />
 
 - We are currently investigating an [issue](https://github.com/tus/tus-js-client/issues/146) with `tus-js-client`, which affects uploads where the file size is larger than 500MB. Artur is now trying to execute a 600MB upload and then see if it crashes. After that, he will set chunkSize, test the upload again, and report back his findings so we can evaluate our next steps.
 
-- We are also doing more research on `tus-js-client` fingerprints. Since these are identical for each file on React Native, the team is figuring out how to properly identify files on that platform, because [the standard file properties that tus-js-client relies on](https://github.com/tus/tus-js-client/blob/master/lib/fingerprint.js#L10) are not available.
+- We are also doing more research on `tus-js-client` fingerprints. Since these are identical for each file on React Native, the team is figuring out how to properly identify files on that platform, because [the standard file properties that tus-js-client relies on](https://github.com/tus/tus-js-client/blob/master/lib/node/fingerprint.js) are not available.
 
 - We have our first WIP screenshot for the React Native implementation:
 


### PR DESCRIPTION
https://app.intercom.com/a/apps/qiqpfgjg/inbox/inbox/all/conversations/26852700005169
No. 4i, found two possible links to replace the broken link and I replaced it with this link: https://github.com/tus/tus-js-client/blob/master/lib/node/fingerprint.js, but this is the other potential link I found: https://github.com/tus/tus-js-client/blob/master/lib/browser/fingerprint.js Would you like me to put the second link in or is the one I already used fine?