### PR TITLE
Default allow headers

### DIFF
--- a/examples/custom-provider/server/index.js
+++ b/examples/custom-provider/server/index.js
@@ -14,18 +14,6 @@ app.use(session({
   saveUninitialized: true,
 }))
 
-app.use((req, res, next) => {
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    'GET, POST, OPTIONS, PUT, PATCH, DELETE'
-  )
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Authorization, Origin, Content-Type, Accept'
-  )
-  next()
-})
-
 // Routes
 app.get('/', (req, res) => {
   res.setHeader('Content-Type', 'text/plain')

--- a/examples/uppy-with-companion/server/index.js
+++ b/examples/uppy-with-companion/server/index.js
@@ -14,14 +14,6 @@ app.use(session({
 
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*')
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    'GET, POST, OPTIONS, PUT, PATCH, DELETE'
-  )
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Authorization, Origin, Content-Type, Accept'
-  )
   next()
 })
 

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -81,7 +81,7 @@ exports.loadSearchProviderToken = (req, res, next) => {
 exports.cors = (options = {}) => (req, res, next) => {
   // TODO: Move to optional chaining when we drop Node.js v12.x support
   const existingExposeHeaders = res.get('Access-Control-Expose-Headers')
-  const exposeHeadersMap = new Set(existingExposeHeaders && existingExposeHeaders.split(',').map(method => method.trim().toLowerCase()))
+  const exposeHeadersSet = new Set(existingExposeHeaders && existingExposeHeaders.split(',').map(method => method.trim().toLowerCase()))
   // exposed so it can be accessed for our custom uppy client preflight
   exposeHeadersMap.add('access-control-allow-headers')
   if (options.sendSelfEndpoint) exposeHeadersMap.add('i-am')

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -86,10 +86,24 @@ exports.cors = (options = {}) => (req, res, next) => {
   exposeHeadersMap.add('access-control-allow-headers')
   if (options.sendSelfEndpoint) exposeHeadersMap.add('i-am')
 
-  const existingAllowHeaders = res.get('Access-Control-Allow-Headers')
-  const allowHeadersMap = new Set(existingAllowHeaders && existingAllowHeaders.split(',').map(method => method.trim().toLowerCase()))
   // Needed for basic operation: https://github.com/transloadit/uppy/issues/3021
-  allowHeadersMap.add('uppy-auth-token').add('uppy-versions').add('uppy-credentials-params').add('authorization').add('origin').add('content-type').add('accept')
+  const allowedHeaders = [
+    'uppy-auth-token',
+    'uppy-versions',
+    'uppy-credentials-params',
+    'authorization',
+    'origin',
+    'content-type',
+    'accept',
+  ];
+  const existingAllowHeaders = res.get('Access-Control-Allow-Headers');
+  const allowHeadersMap = new Set(existingAllowHeaders ?
+    existingAllowHeaders
+      .split(',')
+      .map((method) => method.trim().toLowerCase())
+      .concat(allowedHeaders)
+    : allowedHeaders
+  );
 
   const existingAllowMethods = res.get('Access-Control-Allow-Methods')
   const allowMethodsMap = new Set(existingAllowMethods && existingAllowMethods.split(',').map(method => method.trim().toUpperCase()))

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -88,8 +88,8 @@ exports.cors = (options = {}) => (req, res, next) => {
 
   const existingAllowHeaders = res.get('Access-Control-Allow-Headers')
   const allowHeadersMap = new Set(existingAllowHeaders && existingAllowHeaders.split(',').map(method => method.trim().toLowerCase()))
-  // Needed for basic operation:
-  allowHeadersMap.add('uppy-auth-token').add('uppy-versions').add('uppy-credentials-params')
+  // Needed for basic operation: https://github.com/transloadit/uppy/issues/3021
+  allowHeadersMap.add('uppy-auth-token').add('uppy-versions').add('uppy-credentials-params').add('authorization').add('origin').add('content-type').add('accept')
 
   const existingAllowMethods = res.get('Access-Control-Allow-Methods')
   const allowMethodsMap = new Set(existingAllowMethods && existingAllowMethods.split(',').map(method => method.trim().toUpperCase()))

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -79,12 +79,16 @@ exports.loadSearchProviderToken = (req, res, next) => {
 }
 
 exports.cors = (options = {}) => (req, res, next) => {
+  // HTTP headers are not case sensitive, and express always handles them in lower case, so that's why we lower case them.
+  // I believe that HTTP verbs are case sensitive, and should be uppercase.
+
   // TODO: Move to optional chaining when we drop Node.js v12.x support
   const existingExposeHeaders = res.get('Access-Control-Expose-Headers')
   const exposeHeadersSet = new Set(existingExposeHeaders && existingExposeHeaders.split(',').map(method => method.trim().toLowerCase()))
+
   // exposed so it can be accessed for our custom uppy client preflight
-  exposeHeadersMap.add('access-control-allow-headers')
-  if (options.sendSelfEndpoint) exposeHeadersMap.add('i-am')
+  exposeHeadersSet.add('access-control-allow-headers')
+  if (options.sendSelfEndpoint) exposeHeadersSet.add('i-am')
 
   // Needed for basic operation: https://github.com/transloadit/uppy/issues/3021
   const allowedHeaders = [
@@ -95,20 +99,19 @@ exports.cors = (options = {}) => (req, res, next) => {
     'origin',
     'content-type',
     'accept',
-  ];
-  const existingAllowHeaders = res.get('Access-Control-Allow-Headers');
-  const allowHeadersMap = new Set(existingAllowHeaders ?
-    existingAllowHeaders
+  ]
+  const existingAllowHeaders = res.get('Access-Control-Allow-Headers')
+  const allowHeadersSet = new Set(existingAllowHeaders
+    ? existingAllowHeaders
       .split(',')
       .map((method) => method.trim().toLowerCase())
       .concat(allowedHeaders)
-    : allowedHeaders
-  );
+    : allowedHeaders)
 
   const existingAllowMethods = res.get('Access-Control-Allow-Methods')
-  const allowMethodsMap = new Set(existingAllowMethods && existingAllowMethods.split(',').map(method => method.trim().toUpperCase()))
+  const allowMethodsSet = new Set(existingAllowMethods && existingAllowMethods.split(',').map(method => method.trim().toUpperCase()))
   // Needed for basic operation:
-  allowMethodsMap.add('GET').add('POST').add('OPTIONS').add('DELETE')
+  allowMethodsSet.add('GET').add('POST').add('OPTIONS').add('DELETE')
 
   // If endpoint urls are specified, then we only allow those endpoints.
   // Otherwise, we allow any client url to access companion.
@@ -121,9 +124,9 @@ exports.cors = (options = {}) => (req, res, next) => {
   return cors({
     credentials: true,
     origin,
-    methods: Array.from(allowMethodsMap),
-    allowedHeaders: Array.from(allowHeadersMap).join(','),
-    exposedHeaders: Array.from(exposeHeadersMap).join(','),
+    methods: Array.from(allowMethodsSet),
+    allowedHeaders: Array.from(allowHeadersSet).join(','),
+    exposedHeaders: Array.from(exposeHeadersSet).join(','),
   })(req, res, next)
 }
 

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -133,14 +133,6 @@ module.exports = function server (inputCompanionOptions = {}) {
 
   app.use(session(sessionOptions))
 
-  app.use((req, res, next) => {
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Authorization, Origin, Content-Type, Accept'
-    )
-    next()
-  })
-
   // Routes
   if (process.env.COMPANION_HIDE_WELCOME !== 'true') {
     app.get('/', (req, res) => {

--- a/packages/@uppy/companion/test/__tests__/cors.js
+++ b/packages/@uppy/companion/test/__tests__/cors.js
@@ -41,8 +41,8 @@ describe('cors', () => {
       ['Vary', 'Origin'],
       ['Access-Control-Allow-Credentials', 'true'],
       ['Access-Control-Allow-Methods', 'PATCH,OPTIONS,POST,GET,DELETE'],
-      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params,test-allow-header'],
-      ['Access-Control-Expose-Headers', 'Access-Control-Allow-Headers,i-am,test'],
+      ['Access-Control-Allow-Headers', 'test-allow-header,uppy-auth-token,uppy-versions,uppy-credentials-params,authorization,origin,content-type,accept'],
+      ['Access-Control-Expose-Headers', 'test,access-control-allow-headers,i-am'],
       ['Content-Length', '0'],
     ])
     // expect(next).toHaveBeenCalled()
@@ -55,8 +55,8 @@ describe('cors', () => {
       ['Vary', 'Origin'],
       ['Access-Control-Allow-Credentials', 'true'],
       ['Access-Control-Allow-Methods', 'GET,POST,OPTIONS,DELETE'],
-      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params'],
-      ['Access-Control-Expose-Headers', 'Access-Control-Allow-Headers'],
+      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params,authorization,origin,content-type,accept'],
+      ['Access-Control-Expose-Headers', 'access-control-allow-headers'],
       ['Content-Length', '0'],
     ])
   })
@@ -72,8 +72,8 @@ describe('cors', () => {
       ['Vary', 'Origin'],
       ['Access-Control-Allow-Credentials', 'true'],
       ['Access-Control-Allow-Methods', 'GET,POST,OPTIONS,DELETE'],
-      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params'],
-      ['Access-Control-Expose-Headers', 'Access-Control-Allow-Headers'],
+      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params,authorization,origin,content-type,accept'],
+      ['Access-Control-Expose-Headers', 'access-control-allow-headers'],
       ['Content-Length', '0'],
     ])
   })
@@ -85,8 +85,8 @@ describe('cors', () => {
       ['Vary', 'Origin'],
       ['Access-Control-Allow-Credentials', 'true'],
       ['Access-Control-Allow-Methods', 'GET,POST,OPTIONS,DELETE'],
-      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params'],
-      ['Access-Control-Expose-Headers', 'Access-Control-Allow-Headers'],
+      ['Access-Control-Allow-Headers', 'uppy-auth-token,uppy-versions,uppy-credentials-params,authorization,origin,content-type,accept'],
+      ['Access-Control-Expose-Headers', 'access-control-allow-headers'],
       ['Content-Length', '0'],
     ])
   })

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -150,20 +150,28 @@ The default implementation calls out to Companion's S3 signing endpoints.
 
 ## S3 Bucket Configuration
 
-S3 buckets do not allow public uploads by default.  In order to allow Uppy to upload to a bucket directly, its CORS permissions need to be configured.
+S3 buckets do not allow public uploads by default.  In order to allow Uppy to upload to a bucket directly, its CORS permissions need to be configured. This process is described in the [AwsS3 documentation](/docs/aws-s3/#S3-Bucket-configuration).
 
-This process is described in the [AwsS3 documentation](/docs/aws-s3/#S3-Bucket-configuration).
+While the Uppy AWS S3 plugin uses `POST` requests when uploading files to an S3 bucket, the AWS S3 Multipart plugin uses `PUT` requests when uploading file parts. Additionally, the `ETag` header must also be exposed (in the response):
 
-While the Uppy AWS S3 plugin uses `POST` requests while uploading files to an S3 bucket, the AWS S3 Multipart plugin uses `PUT` requests when uploading file parts. Additionally, the `ETag` header must also be whitelisted:
-
-```xml
-<CORSRule>
-  <!-- Change from POST to PUT if you followed the docs for the AWS S3 plugin ... -->
-  <AllowedMethod>PUT</AllowedMethod>
-
-  <!-- ... keep the existing MaxAgeSeconds and AllowedHeader lines and your other stuff ... -->
-
-  <!-- ... and don't forget to add this tag. -->
-  <ExposeHeader>ETag</ExposeHeader>
-</CORSRule>
+```json
+[
+  {
+    "AllowedOrigins": ["https://my-app.com"],
+    "AllowedMethods": ["GET", "PUT"],
+    "MaxAgeSeconds": 3000,
+    "AllowedHeaders": [
+      "Authorization",
+      "x-amz-date",
+      "x-amz-content-sha256",
+      "content-type"
+    ]
+    "ExposedHeaders": ["ETag"]
+  },
+  {
+    "AllowedOrigins": ["*"],
+    "AllowedMethods": ["GET"],
+    "MaxAgeSeconds": 3000
+  }
+]
 ```


### PR DESCRIPTION
Add the following headers to `access-control-allow-headers` by default:
- Authorization
- Origin
- Content-Type
- Accept
I believe they are always needed for basic operation of companion, and if the developers forget to add them I believe they will get cryptic errors. See #3021

Let me know if anyone knows any reason why these headers cannot be default added.

Also:
- Remove custom middlewares `setHeader` in examples and standalone
- Update outdated readme for S3: AWS now requires JSON instead of XML format
- refactor cors middleware to avoid duplicates

If this PR can not be merged, we need to update all example code to include the custom `setHeader` middleware.