### PR TITLE
Show all details on mobile when `showProgressDetails` is `true`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,7 +85,7 @@ module.exports = {
     'no-param-reassign': ['warn'],
     'no-redeclare': ['warn'],
     'no-shadow': ['warn'],
-    'no-use-before-define': ['warn'],
+    'no-use-before-define': ['warn', { 'functions': false }],
     'radix': ['warn'],
     'react/button-has-type': 'error',
     'react/destructuring-assignment': ['warn'],

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,7 +50,6 @@ PRs are welcome! Please do open an issue to discuss first if it's a big feature,
 - [ ] Display data like image resolution on file cards. should be done by thumbnail generator maybe #783
 - [ ] Possibility to edit/delete more than one file at once. example: add copyrigh info to 1000 files #118, #97
 - [ ] Possibility to work on already uploaded / in progress files. We'll just provide the `fileId` to the `file-edit-complete` event so that folks can more easily roll out custom code for this themselves #112, #113, #2063
-- [ ] Show upload speed too if `showProgressDetails: true`. Maybe have separate options for which things are displayed, or at least have css-classes that can be hidden with `display: none` #766
 - [ ] Focus jumps weirdly if you remove a file https://github.com/transloadit/uppy/pull/2161#issuecomment-613565486
 - [ ] A mini UI that features drop & progress (may involve a `mini: true` options for dashboard, may involve drop+progress or new plugin) (@arturi)
 - [ ] Add a Load More button so you don't have to TAB endlessly to get to the upload button (https://github.com/transloadit/uppy/issues/1419)

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -705,11 +705,6 @@
   height: 100%;
 }
 
-// Do not show progress details in the StatusBar if we do not have space.
-.uppy-Dashboard:not(.uppy-size--md) .uppy-StatusBar-additionalInfo {
-  display: none;
-}
-
 .uppy-Dashboard-filesContainer {
   @include clearfix;
 

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -1,0 +1,389 @@
+const classNames = require('classnames')
+const throttle = require('lodash.throttle')
+const prettierBytes = require('@transloadit/prettier-bytes')
+const prettyETA = require('@uppy/utils/lib/prettyETA')
+const { h } = require('preact')
+
+const statusBarStates = require('./StatusBarStates')
+
+const renderDot = () => ' \u00B7 '
+
+module.exports = {
+  UploadBtn,
+  RetryBtn,
+  CancelBtn,
+  PauseResumeButton,
+  DoneBtn,
+  LoadingSpinner,
+  ProgressDetails,
+  ProgressBarProcessing,
+  ProgressBarError,
+  ProgressBarUploading,
+  ProgressBarComplete,
+}
+
+function UploadBtn (props) {
+  const uploadBtnClassNames = classNames(
+    'uppy-u-reset',
+    'uppy-c-btn',
+    'uppy-StatusBar-actionBtn',
+    'uppy-StatusBar-actionBtn--upload',
+    {
+      'uppy-c-btn-primary': props.uploadState === statusBarStates.STATE_WAITING,
+    },
+    { 'uppy-StatusBar-actionBtn--disabled': props.isSomeGhost }
+  )
+
+  const uploadBtnText
+    = props.newFiles && props.isUploadStarted && !props.recoveredState
+      ? props.i18n('uploadXNewFiles', { smart_count: props.newFiles })
+      : props.i18n('uploadXFiles', { smart_count: props.newFiles })
+
+  return (
+    <button
+      type="button"
+      className={uploadBtnClassNames}
+      aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
+      onClick={props.startUpload}
+      disabled={props.isSomeGhost}
+      data-uppy-super-focusable
+    >
+      {uploadBtnText}
+    </button>
+  )
+}
+
+function RetryBtn (props) {
+  return (
+    <button
+      type="button"
+      className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--retry"
+      aria-label={props.i18n('retryUpload')}
+      onClick={() => props.uppy.retryAll()}
+      data-uppy-super-focusable
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="uppy-c-icon"
+        width="8"
+        height="10"
+        viewBox="0 0 8 10"
+      >
+        <path d="M4 2.408a2.75 2.75 0 1 0 2.75 2.75.626.626 0 0 1 1.25.018v.023a4 4 0 1 1-4-4.041V.25a.25.25 0 0 1 .389-.208l2.299 1.533a.25.25 0 0 1 0 .416l-2.3 1.533A.25.25 0 0 1 4 3.316v-.908z" />
+      </svg>
+      {props.i18n('retry')}
+    </button>
+  )
+}
+
+function CancelBtn (props) {
+  return (
+    <button
+      type="button"
+      className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
+      title={props.i18n('cancel')}
+      aria-label={props.i18n('cancel')}
+      onClick={() => props.uppy.cancelAll()}
+      data-uppy-super-focusable
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="uppy-c-icon"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+      >
+        <g fill="none" fillRule="evenodd">
+          <circle fill="#888" cx="8" cy="8" r="8" />
+          <path
+            fill="#FFF"
+            d="M9.283 8l2.567 2.567-1.283 1.283L8 9.283 5.433 11.85 4.15 10.567 6.717 8 4.15 5.433 5.433 4.15 8 6.717l2.567-2.567 1.283 1.283z"
+          />
+        </g>
+      </svg>
+    </button>
+  )
+}
+
+function PauseResumeButton (props) {
+  const { isAllPaused, i18n } = props
+  const title = isAllPaused ? i18n('resume') : i18n('pause')
+
+  function togglePauseResume () {
+    if (props.isAllComplete) return null
+
+    if (!props.resumableUploads) {
+      return props.uppy.cancelAll()
+    }
+
+    if (props.isAllPaused) {
+      return props.uppy.resumeAll()
+    }
+
+    return props.uppy.pauseAll()
+  }
+
+  return (
+    <button
+      title={title}
+      aria-label={title}
+      className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
+      type="button"
+      onClick={() => togglePauseResume(props)}
+      data-uppy-super-focusable
+    >
+      {isAllPaused ? (
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          className="uppy-c-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+        >
+          <g fill="none" fillRule="evenodd">
+            <circle fill="#888" cx="8" cy="8" r="8" />
+            <path fill="#FFF" d="M6 4.25L11.5 8 6 11.75z" />
+          </g>
+        </svg>
+      ) : (
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          className="uppy-c-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+        >
+          <g fill="none" fillRule="evenodd">
+            <circle fill="#888" cx="8" cy="8" r="8" />
+            <path d="M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z" fill="#FFF" />
+          </g>
+        </svg>
+      )}
+    </button>
+  )
+}
+
+function DoneBtn (props) {
+  const { i18n } = props
+  return (
+    <button
+      type="button"
+      className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--done"
+      onClick={props.doneButtonHandler}
+      data-uppy-super-focusable
+    >
+      {i18n('done')}
+    </button>
+  )
+}
+
+function LoadingSpinner () {
+  return (
+    <svg
+      className="uppy-StatusBar-spinner"
+      aria-hidden="true"
+      focusable="false"
+      width="14"
+      height="14"
+    >
+      <path
+        d="M13.983 6.547c-.12-2.509-1.64-4.893-3.939-5.936-2.48-1.127-5.488-.656-7.556 1.094C.524 3.367-.398 6.048.162 8.562c.556 2.495 2.46 4.52 4.94 5.183 2.932.784 5.61-.602 7.256-3.015-1.493 1.993-3.745 3.309-6.298 2.868-2.514-.434-4.578-2.349-5.153-4.84a6.226 6.226 0 0 1 2.98-6.778C6.34.586 9.74 1.1 11.373 3.493c.407.596.693 1.282.842 1.988.127.598.073 1.197.161 1.794.078.525.543 1.257 1.15.864.525-.341.49-1.05.456-1.592-.007-.15.02.3 0 0"
+        fillRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+function ProgressBarProcessing (props) {
+  const value = Math.round(props.value * 100)
+
+  return (
+    <div className="uppy-StatusBar-content">
+      <LoadingSpinner />
+      {props.mode === 'determinate' ? `${value}% \u00B7 ` : ''}
+      {props.message}
+    </div>
+  )
+}
+
+function ProgressDetails (props) {
+  const ifShowFilesUploadedOfTotal = props.numUploads > 1
+
+  return (
+    <div className="uppy-StatusBar-statusSecondary">
+      {ifShowFilesUploadedOfTotal
+        && props.i18n('filesUploadedOfTotal', {
+          complete: props.complete,
+          smart_count: props.numUploads,
+        })}
+      <span className="uppy-StatusBar-additionalInfo">
+        {/* When should we render this dot?
+          1. .-additionalInfo is shown (happens only on desktops)
+          2. AND 'filesUploadedOfTotal' was shown
+        */}
+        {ifShowFilesUploadedOfTotal && renderDot()}
+
+        {props.i18n('dataUploadedOfTotal', {
+          complete: prettierBytes(props.totalUploadedSize),
+          total: prettierBytes(props.totalSize),
+        })}
+
+        {renderDot()}
+
+        {props.i18n('xTimeLeft', {
+          time: prettyETA(props.totalETA),
+        })}
+      </span>
+    </div>
+  )
+}
+
+function UnknownProgressDetails (props) {
+  return (
+    <div className="uppy-StatusBar-statusSecondary">
+      {props.i18n('filesUploadedOfTotal', {
+        complete: props.complete,
+        smart_count: props.numUploads,
+      })}
+    </div>
+  )
+}
+
+function UploadNewlyAddedFiles (props) {
+  const uploadBtnClassNames = classNames(
+    'uppy-u-reset',
+    'uppy-c-btn',
+    'uppy-StatusBar-actionBtn',
+    'uppy-StatusBar-actionBtn--uploadNewlyAdded'
+  )
+
+  return (
+    <div className="uppy-StatusBar-statusSecondary">
+      <div className="uppy-StatusBar-statusSecondaryHint">
+        {props.i18n('xMoreFilesAdded', { smart_count: props.newFiles })}
+      </div>
+      <button
+        type="button"
+        className={uploadBtnClassNames}
+        aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
+        onClick={props.startUpload}
+      >
+        {props.i18n('upload')}
+      </button>
+    </div>
+  )
+}
+
+const ThrottledProgressDetails = throttle(ProgressDetails, 500, {
+  leading: true,
+  trailing: true,
+})
+
+function ProgressBarUploading (props) {
+  if (!props.isUploadStarted || props.isAllComplete) {
+    return null
+  }
+
+  const title = props.isAllPaused
+    ? props.i18n('paused')
+    : props.i18n('uploading')
+  const showUploadNewlyAddedFiles = props.newFiles && props.isUploadStarted
+
+  return (
+    <div className="uppy-StatusBar-content" aria-label={title} title={title}>
+      {!props.isAllPaused ? <LoadingSpinner /> : null}
+      <div className="uppy-StatusBar-status">
+        <div className="uppy-StatusBar-statusPrimary">
+          {props.supportsUploadProgress
+            ? `${title}: ${props.totalProgress}%`
+            : title}
+        </div>
+        {/* eslint-disable-next-line no-nested-ternary */}
+        {!props.isAllPaused
+        && !showUploadNewlyAddedFiles
+        && props.showProgressDetails ? (
+            props.supportsUploadProgress ? (
+              <ThrottledProgressDetails {...props} />
+            ) : (
+              <UnknownProgressDetails {...props} />
+            )
+          ) : null}
+        {showUploadNewlyAddedFiles ? (
+          <UploadNewlyAddedFiles {...props} />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ProgressBarComplete ({ i18n }) {
+  return (
+    <div
+      className="uppy-StatusBar-content"
+      role="status"
+      title={i18n('complete')}
+    >
+      <div className="uppy-StatusBar-status">
+        <div className="uppy-StatusBar-statusPrimary">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            className="uppy-StatusBar-statusIndicator uppy-c-icon"
+            width="15"
+            height="11"
+            viewBox="0 0 15 11"
+          >
+            <path d="M.414 5.843L1.627 4.63l3.472 3.472L13.202 0l1.212 1.213L5.1 10.528z" />
+          </svg>
+          {i18n('complete')}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ProgressBarError ({ error, i18n }) {
+  function displayErrorAlert () {
+    const errorMessage = `${i18n('uploadFailed')} \n\n ${error}`
+    // eslint-disable-next-line no-alert
+    alert(errorMessage) // TODO: move to custom alert implementation
+  }
+
+  return (
+    <div
+      className="uppy-StatusBar-content"
+      role="alert"
+      title={i18n('uploadFailed')}
+    >
+      <div className="uppy-StatusBar-status">
+        <div className="uppy-StatusBar-statusPrimary">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            className="uppy-StatusBar-statusIndicator uppy-c-icon"
+            width="11"
+            height="11"
+            viewBox="0 0 11 11"
+          >
+            <path d="M4.278 5.5L0 1.222 1.222 0 5.5 4.278 9.778 0 11 1.222 6.722 5.5 11 9.778 9.778 11 5.5 6.722 1.222 11 0 9.778z" />
+          </svg>
+          {i18n('uploadFailed')}
+        </div>
+      </div>
+      <button
+        className="uppy-StatusBar-details"
+        aria-label={error}
+        data-microtip-position="top-right"
+        data-microtip-size="medium"
+        onClick={displayErrorAlert}
+        type="button"
+      >
+        ?
+      </button>
+    </div>
+  )
+}

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -23,29 +23,39 @@ module.exports = {
 }
 
 function UploadBtn (props) {
+  const {
+    newFiles,
+    isUploadStarted,
+    recoveredState,
+    i18n,
+    uploadState,
+    isSomeGhost,
+    startUpload,
+  } = props
+
   const uploadBtnClassNames = classNames(
     'uppy-u-reset',
     'uppy-c-btn',
     'uppy-StatusBar-actionBtn',
     'uppy-StatusBar-actionBtn--upload',
     {
-      'uppy-c-btn-primary': props.uploadState === statusBarStates.STATE_WAITING,
+      'uppy-c-btn-primary': uploadState === statusBarStates.STATE_WAITING,
     },
-    { 'uppy-StatusBar-actionBtn--disabled': props.isSomeGhost }
+    { 'uppy-StatusBar-actionBtn--disabled': isSomeGhost }
   )
 
   const uploadBtnText
-    = props.newFiles && props.isUploadStarted && !props.recoveredState
-      ? props.i18n('uploadXNewFiles', { smart_count: props.newFiles })
-      : props.i18n('uploadXFiles', { smart_count: props.newFiles })
+    = newFiles && isUploadStarted && !recoveredState
+      ? i18n('uploadXNewFiles', { smart_count: newFiles })
+      : i18n('uploadXFiles', { smart_count: newFiles })
 
   return (
     <button
       type="button"
       className={uploadBtnClassNames}
-      aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
-      onClick={props.startUpload}
-      disabled={props.isSomeGhost}
+      aria-label={i18n('uploadXFiles', { smart_count: newFiles })}
+      onClick={startUpload}
+      disabled={isSomeGhost}
       data-uppy-super-focusable
     >
       {uploadBtnText}
@@ -54,12 +64,14 @@ function UploadBtn (props) {
 }
 
 function RetryBtn (props) {
+  const { i18n, uppy } = props
+
   return (
     <button
       type="button"
       className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--retry"
-      aria-label={props.i18n('retryUpload')}
-      onClick={() => props.uppy.retryAll()}
+      aria-label={i18n('retryUpload')}
+      onClick={() => uppy.retryAll()}
       data-uppy-super-focusable
     >
       <svg
@@ -72,19 +84,21 @@ function RetryBtn (props) {
       >
         <path d="M4 2.408a2.75 2.75 0 1 0 2.75 2.75.626.626 0 0 1 1.25.018v.023a4 4 0 1 1-4-4.041V.25a.25.25 0 0 1 .389-.208l2.299 1.533a.25.25 0 0 1 0 .416l-2.3 1.533A.25.25 0 0 1 4 3.316v-.908z" />
       </svg>
-      {props.i18n('retry')}
+      {i18n('retry')}
     </button>
   )
 }
 
 function CancelBtn (props) {
+  const { i18n, uppy } = props
+
   return (
     <button
       type="button"
       className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
-      title={props.i18n('cancel')}
-      aria-label={props.i18n('cancel')}
-      onClick={() => props.uppy.cancelAll()}
+      title={i18n('cancel')}
+      aria-label={i18n('cancel')}
+      onClick={() => uppy.cancelAll()}
       data-uppy-super-focusable
     >
       <svg
@@ -108,21 +122,21 @@ function CancelBtn (props) {
 }
 
 function PauseResumeButton (props) {
-  const { isAllPaused, i18n } = props
+  const { isAllPaused, i18n, isAllComplete, resumableUploads, uppy } = props
   const title = isAllPaused ? i18n('resume') : i18n('pause')
 
   function togglePauseResume () {
-    if (props.isAllComplete) return null
+    if (isAllComplete) return null
 
-    if (!props.resumableUploads) {
-      return props.uppy.cancelAll()
+    if (!resumableUploads) {
+      return uppy.cancelAll()
     }
 
-    if (props.isAllPaused) {
-      return props.uppy.resumeAll()
+    if (isAllPaused) {
+      return uppy.resumeAll()
     }
 
-    return props.uppy.pauseAll()
+    return uppy.pauseAll()
   }
 
   return (
@@ -131,7 +145,7 @@ function PauseResumeButton (props) {
       aria-label={title}
       className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
       type="button"
-      onClick={() => togglePauseResume(props)}
+      onClick={togglePauseResume}
       data-uppy-super-focusable
     >
       {isAllPaused ? (
@@ -168,12 +182,13 @@ function PauseResumeButton (props) {
 }
 
 function DoneBtn (props) {
-  const { i18n } = props
+  const { i18n, doneButtonHandler } = props
+
   return (
     <button
       type="button"
       className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--done"
-      onClick={props.doneButtonHandler}
+      onClick={doneButtonHandler}
       data-uppy-super-focusable
     >
       {i18n('done')}
@@ -199,26 +214,36 @@ function LoadingSpinner () {
 }
 
 function ProgressBarProcessing (props) {
-  const value = Math.round(props.value * 100)
+  const { value, mode, message } = props
+  const roundedValue = Math.round(value * 100)
 
   return (
     <div className="uppy-StatusBar-content">
       <LoadingSpinner />
-      {props.mode === 'determinate' ? `${value}% \u00B7 ` : ''}
-      {props.message}
+      {mode === 'determinate' ? `${roundedValue}% \u00B7 ` : ''}
+      {message}
     </div>
   )
 }
 
 function ProgressDetails (props) {
-  const ifShowFilesUploadedOfTotal = props.numUploads > 1
+  const {
+    numUploads,
+    complete,
+    totalUploadedSize,
+    totalSize,
+    totalETA,
+    i18n,
+  } = props
+
+  const ifShowFilesUploadedOfTotal = numUploads > 1
 
   return (
     <div className="uppy-StatusBar-statusSecondary">
       {ifShowFilesUploadedOfTotal
-        && props.i18n('filesUploadedOfTotal', {
-          complete: props.complete,
-          smart_count: props.numUploads,
+        && i18n('filesUploadedOfTotal', {
+          complete,
+          smart_count: numUploads,
         })}
       <span className="uppy-StatusBar-additionalInfo">
         {/* When should we render this dot?
@@ -227,15 +252,15 @@ function ProgressDetails (props) {
         */}
         {ifShowFilesUploadedOfTotal && renderDot()}
 
-        {props.i18n('dataUploadedOfTotal', {
-          complete: prettierBytes(props.totalUploadedSize),
-          total: prettierBytes(props.totalSize),
+        {i18n('dataUploadedOfTotal', {
+          complete: prettierBytes(totalUploadedSize),
+          total: prettierBytes(totalSize),
         })}
 
         {renderDot()}
 
-        {props.i18n('xTimeLeft', {
-          time: prettyETA(props.totalETA),
+        {i18n('xTimeLeft', {
+          time: prettyETA(totalETA),
         })}
       </span>
     </div>
@@ -243,17 +268,17 @@ function ProgressDetails (props) {
 }
 
 function UnknownProgressDetails (props) {
+  const { i18n, complete, numUploads } = props
+
   return (
     <div className="uppy-StatusBar-statusSecondary">
-      {props.i18n('filesUploadedOfTotal', {
-        complete: props.complete,
-        smart_count: props.numUploads,
-      })}
+      {i18n('filesUploadedOfTotal', { complete, smart_count: numUploads })}
     </div>
   )
 }
 
 function UploadNewlyAddedFiles (props) {
+  const { i18n, newFiles, startUpload } = props
   const uploadBtnClassNames = classNames(
     'uppy-u-reset',
     'uppy-c-btn',
@@ -264,15 +289,15 @@ function UploadNewlyAddedFiles (props) {
   return (
     <div className="uppy-StatusBar-statusSecondary">
       <div className="uppy-StatusBar-statusSecondaryHint">
-        {props.i18n('xMoreFilesAdded', { smart_count: props.newFiles })}
+        {i18n('xMoreFilesAdded', { smart_count: newFiles })}
       </div>
       <button
         type="button"
         className={uploadBtnClassNames}
-        aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
-        onClick={props.startUpload}
+        aria-label={i18n('uploadXFiles', { smart_count: newFiles })}
+        onClick={startUpload}
       >
-        {props.i18n('upload')}
+        {i18n('upload')}
       </button>
     </div>
   )
@@ -284,36 +309,61 @@ const ThrottledProgressDetails = throttle(ProgressDetails, 500, {
 })
 
 function ProgressBarUploading (props) {
-  if (!props.isUploadStarted || props.isAllComplete) {
+  const {
+    i18n,
+    supportsUploadProgress,
+    totalProgress,
+    showProgressDetails,
+    isUploadStarted,
+    isAllComplete,
+    isAllPaused,
+    newFiles,
+    numUploads,
+    complete,
+    totalUploadedSize,
+    totalSize,
+    totalETA,
+    startUpload,
+  } = props
+  const showUploadNewlyAddedFiles = newFiles && isUploadStarted
+
+  if (!isUploadStarted || isAllComplete) {
     return null
   }
 
-  const title = props.isAllPaused
-    ? props.i18n('paused')
-    : props.i18n('uploading')
-  const showUploadNewlyAddedFiles = props.newFiles && props.isUploadStarted
+  const title = isAllPaused ? i18n('paused') : i18n('uploading')
+
+  function renderProgressDetails () {
+    if (!isAllPaused && !showUploadNewlyAddedFiles && showProgressDetails) {
+      if (supportsUploadProgress) {
+        return (
+          <ThrottledProgressDetails
+            numUploads={numUploads}
+            complete={complete}
+            totalUploadedSize={totalUploadedSize}
+            totalSize={totalSize}
+            totalETA={totalETA}
+            i18n={i18n}
+          />
+        )
+      }
+      return <UnknownProgressDetails i18n={i18n} complete={complete} numUploads={numUploads} />
+    }
+    return null
+  }
 
   return (
     <div className="uppy-StatusBar-content" aria-label={title} title={title}>
-      {!props.isAllPaused ? <LoadingSpinner /> : null}
+      {!isAllPaused ? <LoadingSpinner /> : null}
       <div className="uppy-StatusBar-status">
         <div className="uppy-StatusBar-statusPrimary">
-          {props.supportsUploadProgress
-            ? `${title}: ${props.totalProgress}%`
-            : title}
+          {supportsUploadProgress ? `${title}: ${totalProgress}%` : title}
         </div>
-        {/* eslint-disable-next-line no-nested-ternary */}
-        {!props.isAllPaused
-        && !showUploadNewlyAddedFiles
-        && props.showProgressDetails ? (
-            props.supportsUploadProgress ? (
-              <ThrottledProgressDetails {...props} />
-            ) : (
-              <UnknownProgressDetails {...props} />
-            )
-          ) : null}
+
+        {renderProgressDetails()}
+
         {showUploadNewlyAddedFiles ? (
-          <UploadNewlyAddedFiles {...props} />
+          <UploadNewlyAddedFiles i18n={i18n} newFiles={newFiles} startUpload={startUpload} />
         ) : null}
       </div>
     </div>

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -6,8 +6,7 @@ const { h } = require('preact')
 
 const statusBarStates = require('./StatusBarStates')
 
-const DOT = `\u00B7`
-const renderDot = () => ` ${DOT} `
+const renderDot = () => ' \u00B7 '
 
 module.exports = {
   UploadBtn,
@@ -149,7 +148,8 @@ function PauseResumeButton (props) {
       onClick={togglePauseResume}
       data-uppy-super-focusable
     >
-      <svg
+      {isAllPaused ? (
+        <svg
           aria-hidden="true"
           focusable="false"
           className="uppy-c-icon"
@@ -159,9 +159,24 @@ function PauseResumeButton (props) {
         >
           <g fill="none" fillRule="evenodd">
             <circle fill="#888" cx="8" cy="8" r="8" />
-            <path fill="#FFF" d={isAllPaused ? "M6 4.25L11.5 8 6 11.75z" : "M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z"} />
+            <path fill="#FFF" d="M6 4.25L11.5 8 6 11.75z" />
           </g>
-      </svg>
+        </svg>
+      ) : (
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          className="uppy-c-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+        >
+          <g fill="none" fillRule="evenodd">
+            <circle fill="#888" cx="8" cy="8" r="8" />
+            <path d="M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z" fill="#FFF" />
+          </g>
+        </svg>
+      )}
     </button>
   )
 }

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -6,7 +6,8 @@ const { h } = require('preact')
 
 const statusBarStates = require('./StatusBarStates')
 
-const renderDot = () => ' \u00B7 '
+const DOT = `\u00B7`
+const renderDot = () => ` ${DOT} `
 
 module.exports = {
   UploadBtn,
@@ -148,8 +149,7 @@ function PauseResumeButton (props) {
       onClick={togglePauseResume}
       data-uppy-super-focusable
     >
-      {isAllPaused ? (
-        <svg
+      <svg
           aria-hidden="true"
           focusable="false"
           className="uppy-c-icon"
@@ -159,24 +159,9 @@ function PauseResumeButton (props) {
         >
           <g fill="none" fillRule="evenodd">
             <circle fill="#888" cx="8" cy="8" r="8" />
-            <path fill="#FFF" d="M6 4.25L11.5 8 6 11.75z" />
+            <path fill="#FFF" d={isAllPaused ? "M6 4.25L11.5 8 6 11.75z" : "M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z"} />
           </g>
-        </svg>
-      ) : (
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          className="uppy-c-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-        >
-          <g fill="none" fillRule="evenodd">
-            <circle fill="#888" cx="8" cy="8" r="8" />
-            <path d="M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z" fill="#FFF" />
-          </g>
-        </svg>
-      )}
+      </svg>
     </button>
   )
 }

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -370,7 +370,9 @@ function ProgressBarUploading (props) {
   )
 }
 
-function ProgressBarComplete ({ i18n }) {
+function ProgressBarComplete (props) {
+  const { i18n } = props
+
   return (
     <div
       className="uppy-StatusBar-content"
@@ -396,7 +398,9 @@ function ProgressBarComplete ({ i18n }) {
   )
 }
 
-function ProgressBarError ({ error, i18n }) {
+function ProgressBarError (props) {
+  const { error, i18n } = props
+
   function displayErrorAlert () {
     const errorMessage = `${i18n('uploadFailed')} \n\n ${error}`
     // eslint-disable-next-line no-alert

--- a/packages/@uppy/status-bar/src/Components.js
+++ b/packages/@uppy/status-bar/src/Components.js
@@ -6,21 +6,8 @@ const { h } = require('preact')
 
 const statusBarStates = require('./StatusBarStates')
 
-const renderDot = () => ' \u00B7 '
-
-module.exports = {
-  UploadBtn,
-  RetryBtn,
-  CancelBtn,
-  PauseResumeButton,
-  DoneBtn,
-  LoadingSpinner,
-  ProgressDetails,
-  ProgressBarProcessing,
-  ProgressBarError,
-  ProgressBarUploading,
-  ProgressBarComplete,
-}
+const DOT = `\u00B7`
+const renderDot = () => ` ${DOT} `
 
 function UploadBtn (props) {
   const {
@@ -148,35 +135,26 @@ function PauseResumeButton (props) {
       onClick={togglePauseResume}
       data-uppy-super-focusable
     >
-      {isAllPaused ? (
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          className="uppy-c-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-        >
-          <g fill="none" fillRule="evenodd">
-            <circle fill="#888" cx="8" cy="8" r="8" />
-            <path fill="#FFF" d="M6 4.25L11.5 8 6 11.75z" />
-          </g>
-        </svg>
-      ) : (
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          className="uppy-c-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-        >
-          <g fill="none" fillRule="evenodd">
-            <circle fill="#888" cx="8" cy="8" r="8" />
-            <path d="M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z" fill="#FFF" />
-          </g>
-        </svg>
-      )}
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="uppy-c-icon"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+      >
+        <g fill="none" fillRule="evenodd">
+          <circle fill="#888" cx="8" cy="8" r="8" />
+          <path
+            fill="#FFF"
+            d={
+              isAllPaused
+                ? 'M6 4.25L11.5 8 6 11.75z'
+                : 'M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z'
+            }
+          />
+        </g>
+      </svg>
     </button>
   )
 }
@@ -216,11 +194,12 @@ function LoadingSpinner () {
 function ProgressBarProcessing (props) {
   const { value, mode, message } = props
   const roundedValue = Math.round(value * 100)
+  const dot = `\u00B7`
 
   return (
     <div className="uppy-StatusBar-content">
       <LoadingSpinner />
-      {mode === 'determinate' ? `${roundedValue}% \u00B7 ` : ''}
+      {mode === 'determinate' ? `${roundedValue}% ${dot} ` : ''}
       {message}
     </div>
   )
@@ -347,7 +326,13 @@ function ProgressBarUploading (props) {
           />
         )
       }
-      return <UnknownProgressDetails i18n={i18n} complete={complete} numUploads={numUploads} />
+      return (
+        <UnknownProgressDetails
+          i18n={i18n}
+          complete={complete}
+          numUploads={numUploads}
+        />
+      )
     }
     return null
   }
@@ -363,7 +348,11 @@ function ProgressBarUploading (props) {
         {renderProgressDetails()}
 
         {showUploadNewlyAddedFiles ? (
-          <UploadNewlyAddedFiles i18n={i18n} newFiles={newFiles} startUpload={startUpload} />
+          <UploadNewlyAddedFiles
+            i18n={i18n}
+            newFiles={newFiles}
+            startUpload={startUpload}
+          />
         ) : null}
       </div>
     </div>
@@ -440,4 +429,18 @@ function ProgressBarError (props) {
       </button>
     </div>
   )
+}
+
+module.exports = {
+  UploadBtn,
+  RetryBtn,
+  CancelBtn,
+  PauseResumeButton,
+  DoneBtn,
+  LoadingSpinner,
+  ProgressDetails,
+  ProgressBarProcessing,
+  ProgressBarError,
+  ProgressBarUploading,
+  ProgressBarComplete,
 }

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -110,9 +110,18 @@ function StatusBar (props) {
 
     switch (uploadState) {
       case STATE_WAITING:
-        return hideUploadButton || newFiles > 0
+        if (hideUploadButton) {
+          return true
+        }
+        if (!newFiles > 0) {
+          return true
+        }
+        return false
       case STATE_COMPLETE:
-        return hideAfterFinish
+        if (hideAfterFinish) {
+          return true
+        }
+        return false
       default:
         return false
     }
@@ -122,7 +131,7 @@ function StatusBar (props) {
 
   const isHidden = getIsHidden()
 
-  const width = progressValue ?? 100
+  const width = progressValue || 100
 
   const showUploadBtn
     = !error

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -110,18 +110,9 @@ function StatusBar (props) {
 
     switch (uploadState) {
       case STATE_WAITING:
-        if (hideUploadButton) {
-          return true
-        }
-        if (!newFiles > 0) {
-          return true
-        }
-        return false
+        return hideUploadButton || newFiles > 0
       case STATE_COMPLETE:
-        if (hideAfterFinish) {
-          return true
-        }
-        return false
+        return hideAfterFinish
       default:
         return false
     }
@@ -131,7 +122,7 @@ function StatusBar (props) {
 
   const isHidden = getIsHidden()
 
-  const width = progressValue || 100
+  const width = progressValue ?? 100
 
   const showUploadBtn
     = !error

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -110,18 +110,9 @@ function StatusBar (props) {
 
     switch (uploadState) {
       case STATE_WAITING:
-        if (hideUploadButton) {
-          return true
-        }
-        if (!newFiles > 0) {
-          return true
-        }
-        return false
+        return hideUploadButton || newFiles === 0
       case STATE_COMPLETE:
-        if (hideAfterFinish) {
-          return true
-        }
-        return false
+        return hideAfterFinish
       default:
         return false
     }
@@ -131,7 +122,7 @@ function StatusBar (props) {
 
   const isHidden = getIsHidden()
 
-  const width = progressValue || 100
+  const width = progressValue ?? 100
 
   const showUploadBtn
     = !error

--- a/packages/@uppy/status-bar/src/StatusBar.js
+++ b/packages/@uppy/status-bar/src/StatusBar.js
@@ -1,9 +1,18 @@
-const throttle = require('lodash.throttle')
-const classNames = require('classnames')
-const prettierBytes = require('@transloadit/prettier-bytes')
-const prettyETA = require('@uppy/utils/lib/prettyETA')
 const { h } = require('preact')
+const classNames = require('classnames')
 const statusBarStates = require('./StatusBarStates')
+
+const {
+  UploadBtn,
+  RetryBtn,
+  CancelBtn,
+  PauseResumeButton,
+  DoneBtn,
+  ProgressBarProcessing,
+  ProgressBarError,
+  ProgressBarUploading,
+  ProgressBarComplete,
+} = require('./Components')
 
 function calculateProcessingProgress (files) {
   // Collect pre or postprocessing progress states.
@@ -33,20 +42,6 @@ function calculateProcessingProgress (files) {
     message,
     value,
   }
-}
-
-function togglePauseResume (props) {
-  if (props.isAllComplete) return
-
-  if (!props.resumableUploads) {
-    return props.uppy.cancelAll()
-  }
-
-  if (props.isAllPaused) {
-    return props.uppy.resumeAll()
-  }
-
-  return props.uppy.pauseAll()
 }
 
 module.exports = (props) => {
@@ -148,283 +143,6 @@ module.exports = (props) => {
         {showCancelBtn ? <CancelBtn {...props} /> : null}
         {showDoneBtn ? <DoneBtn {...props} /> : null}
       </div>
-    </div>
-  )
-}
-
-const UploadBtn = (props) => {
-  const uploadBtnClassNames = classNames(
-    'uppy-u-reset',
-    'uppy-c-btn',
-    'uppy-StatusBar-actionBtn',
-    'uppy-StatusBar-actionBtn--upload',
-    { 'uppy-c-btn-primary': props.uploadState === statusBarStates.STATE_WAITING },
-    { 'uppy-StatusBar-actionBtn--disabled': props.isSomeGhost }
-  )
-
-  const uploadBtnText = props.newFiles && props.isUploadStarted && !props.recoveredState
-    ? props.i18n('uploadXNewFiles', { smart_count: props.newFiles })
-    : props.i18n('uploadXFiles', { smart_count: props.newFiles })
-
-  return (
-    <button
-      type="button"
-      className={uploadBtnClassNames}
-      aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
-      onClick={props.startUpload}
-      disabled={props.isSomeGhost}
-      data-uppy-super-focusable
-    >
-      {uploadBtnText}
-    </button>
-  )
-}
-
-const RetryBtn = (props) => {
-  return (
-    <button
-      type="button"
-      className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--retry"
-      aria-label={props.i18n('retryUpload')}
-      onClick={() => props.uppy.retryAll()}
-      data-uppy-super-focusable
-    >
-      <svg aria-hidden="true" focusable="false" className="uppy-c-icon" width="8" height="10" viewBox="0 0 8 10">
-        <path d="M4 2.408a2.75 2.75 0 1 0 2.75 2.75.626.626 0 0 1 1.25.018v.023a4 4 0 1 1-4-4.041V.25a.25.25 0 0 1 .389-.208l2.299 1.533a.25.25 0 0 1 0 .416l-2.3 1.533A.25.25 0 0 1 4 3.316v-.908z" />
-      </svg>
-      {props.i18n('retry')}
-    </button>
-  )
-}
-
-const CancelBtn = (props) => {
-  return (
-    <button
-      type="button"
-      className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
-      title={props.i18n('cancel')}
-      aria-label={props.i18n('cancel')}
-      onClick={() => props.uppy.cancelAll()}
-      data-uppy-super-focusable
-    >
-      <svg aria-hidden="true" focusable="false" className="uppy-c-icon" width="16" height="16" viewBox="0 0 16 16">
-        <g fill="none" fillRule="evenodd">
-          <circle fill="#888" cx="8" cy="8" r="8" />
-          <path fill="#FFF" d="M9.283 8l2.567 2.567-1.283 1.283L8 9.283 5.433 11.85 4.15 10.567 6.717 8 4.15 5.433 5.433 4.15 8 6.717l2.567-2.567 1.283 1.283z" />
-        </g>
-      </svg>
-    </button>
-  )
-}
-
-const PauseResumeButton = (props) => {
-  const { isAllPaused, i18n } = props
-  const title = isAllPaused ? i18n('resume') : i18n('pause')
-
-  return (
-    <button
-      title={title}
-      aria-label={title}
-      className="uppy-u-reset uppy-StatusBar-actionCircleBtn"
-      type="button"
-      onClick={() => togglePauseResume(props)}
-      data-uppy-super-focusable
-    >
-      {isAllPaused ? (
-        <svg aria-hidden="true" focusable="false" className="uppy-c-icon" width="16" height="16" viewBox="0 0 16 16">
-          <g fill="none" fillRule="evenodd">
-            <circle fill="#888" cx="8" cy="8" r="8" />
-            <path fill="#FFF" d="M6 4.25L11.5 8 6 11.75z" />
-          </g>
-        </svg>
-      ) : (
-        <svg aria-hidden="true" focusable="false" className="uppy-c-icon" width="16" height="16" viewBox="0 0 16 16">
-          <g fill="none" fillRule="evenodd">
-            <circle fill="#888" cx="8" cy="8" r="8" />
-            <path d="M5 4.5h2v7H5v-7zm4 0h2v7H9v-7z" fill="#FFF" />
-          </g>
-        </svg>
-      )}
-    </button>
-  )
-}
-
-const DoneBtn = (props) => {
-  const { i18n } = props
-  return (
-    <button
-      type="button"
-      className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--done"
-      onClick={props.doneButtonHandler}
-      data-uppy-super-focusable
-    >
-      {i18n('done')}
-    </button>
-  )
-}
-
-const LoadingSpinner = () => {
-  return (
-    <svg className="uppy-StatusBar-spinner" aria-hidden="true" focusable="false" width="14" height="14">
-      <path d="M13.983 6.547c-.12-2.509-1.64-4.893-3.939-5.936-2.48-1.127-5.488-.656-7.556 1.094C.524 3.367-.398 6.048.162 8.562c.556 2.495 2.46 4.52 4.94 5.183 2.932.784 5.61-.602 7.256-3.015-1.493 1.993-3.745 3.309-6.298 2.868-2.514-.434-4.578-2.349-5.153-4.84a6.226 6.226 0 0 1 2.98-6.778C6.34.586 9.74 1.1 11.373 3.493c.407.596.693 1.282.842 1.988.127.598.073 1.197.161 1.794.078.525.543 1.257 1.15.864.525-.341.49-1.05.456-1.592-.007-.15.02.3 0 0" fillRule="evenodd" />
-    </svg>
-  )
-}
-
-const ProgressBarProcessing = (props) => {
-  const value = Math.round(props.value * 100)
-
-  return (
-    <div className="uppy-StatusBar-content">
-      <LoadingSpinner />
-      {props.mode === 'determinate' ? `${value}% \u00B7 ` : ''}
-      {props.message}
-    </div>
-  )
-}
-
-const renderDot = () => ' \u00B7 '
-
-const ProgressDetails = (props) => {
-  const ifShowFilesUploadedOfTotal = props.numUploads > 1
-
-  return (
-    <div className="uppy-StatusBar-statusSecondary">
-      {
-        ifShowFilesUploadedOfTotal
-        && props.i18n('filesUploadedOfTotal', {
-          complete: props.complete,
-          smart_count: props.numUploads,
-        })
-      }
-      <span className="uppy-StatusBar-additionalInfo">
-        {/* When should we render this dot?
-          1. .-additionalInfo is shown (happens only on desktops)
-          2. AND 'filesUploadedOfTotal' was shown
-        */}
-        {ifShowFilesUploadedOfTotal && renderDot()}
-
-        {
-          props.i18n('dataUploadedOfTotal', {
-            complete: prettierBytes(props.totalUploadedSize),
-            total: prettierBytes(props.totalSize),
-          })
-        }
-
-        {renderDot()}
-
-        {
-          props.i18n('xTimeLeft', {
-            time: prettyETA(props.totalETA),
-          })
-        }
-      </span>
-    </div>
-  )
-}
-
-const UnknownProgressDetails = (props) => {
-  return (
-    <div className="uppy-StatusBar-statusSecondary">
-      {props.i18n('filesUploadedOfTotal', { complete: props.complete, smart_count: props.numUploads })}
-    </div>
-  )
-}
-
-const UploadNewlyAddedFiles = (props) => {
-  const uploadBtnClassNames = classNames(
-    'uppy-u-reset',
-    'uppy-c-btn',
-    'uppy-StatusBar-actionBtn',
-    'uppy-StatusBar-actionBtn--uploadNewlyAdded'
-  )
-
-  return (
-    <div className="uppy-StatusBar-statusSecondary">
-      <div className="uppy-StatusBar-statusSecondaryHint">
-        {props.i18n('xMoreFilesAdded', { smart_count: props.newFiles })}
-      </div>
-      <button
-        type="button"
-        className={uploadBtnClassNames}
-        aria-label={props.i18n('uploadXFiles', { smart_count: props.newFiles })}
-        onClick={props.startUpload}
-      >
-        {props.i18n('upload')}
-      </button>
-    </div>
-  )
-}
-
-const ThrottledProgressDetails = throttle(ProgressDetails, 500, { leading: true, trailing: true })
-
-const ProgressBarUploading = (props) => {
-  if (!props.isUploadStarted || props.isAllComplete) {
-    return null
-  }
-
-  const title = props.isAllPaused ? props.i18n('paused') : props.i18n('uploading')
-  const showUploadNewlyAddedFiles = props.newFiles && props.isUploadStarted
-
-  return (
-    <div className="uppy-StatusBar-content" aria-label={title} title={title}>
-      {!props.isAllPaused ? <LoadingSpinner /> : null}
-      <div className="uppy-StatusBar-status">
-        <div className="uppy-StatusBar-statusPrimary">
-          {props.supportsUploadProgress ? `${title}: ${props.totalProgress}%` : title}
-        </div>
-        {/* eslint-disable-next-line no-nested-ternary */}
-        {!props.isAllPaused && !showUploadNewlyAddedFiles && props.showProgressDetails
-          ? (props.supportsUploadProgress ? <ThrottledProgressDetails {...props} /> : <UnknownProgressDetails {...props} />)
-          : null}
-        {showUploadNewlyAddedFiles ? <UploadNewlyAddedFiles {...props} /> : null}
-      </div>
-    </div>
-  )
-}
-
-const ProgressBarComplete = ({ i18n }) => {
-  return (
-    <div className="uppy-StatusBar-content" role="status" title={i18n('complete')}>
-      <div className="uppy-StatusBar-status">
-        <div className="uppy-StatusBar-statusPrimary">
-          <svg aria-hidden="true" focusable="false" className="uppy-StatusBar-statusIndicator uppy-c-icon" width="15" height="11" viewBox="0 0 15 11">
-            <path d="M.414 5.843L1.627 4.63l3.472 3.472L13.202 0l1.212 1.213L5.1 10.528z" />
-          </svg>
-          {i18n('complete')}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const ProgressBarError = ({ error, i18n }) => {
-  function displayErrorAlert () {
-    const errorMessage = `${i18n('uploadFailed')} \n\n ${error}`
-    // eslint-disable-next-line no-alert
-    alert(errorMessage) // TODO: move to custom alert implementation
-  }
-
-  return (
-    <div className="uppy-StatusBar-content" role="alert" title={i18n('uploadFailed')}>
-      <div className="uppy-StatusBar-status">
-        <div className="uppy-StatusBar-statusPrimary">
-          <svg aria-hidden="true" focusable="false" className="uppy-StatusBar-statusIndicator uppy-c-icon" width="11" height="11" viewBox="0 0 11 11">
-            <path d="M4.278 5.5L0 1.222 1.222 0 5.5 4.278 9.778 0 11 1.222 6.722 5.5 11 9.778 9.778 11 5.5 6.722 1.222 11 0 9.778z" />
-          </svg>
-          {i18n('uploadFailed')}
-        </div>
-      </div>
-      <button
-        className="uppy-StatusBar-details"
-        aria-label={error}
-        data-microtip-position="top-right"
-        data-microtip-size="medium"
-        onClick={displayErrorAlert}
-        type="button"
-      >
-        ?
-      </button>
     </div>
   )
 }

--- a/packages/@uppy/status-bar/src/calculateProcessingProgress.js
+++ b/packages/@uppy/status-bar/src/calculateProcessingProgress.js
@@ -1,0 +1,30 @@
+module.expost = function calculateProcessingProgress (files) {
+  // Collect pre or postprocessing progress states.
+  const progresses = []
+
+  Object.keys(files).forEach((fileID) => {
+    const { progress } = files[fileID]
+    if (progress.preprocess) {
+      progresses.push(progress.preprocess)
+    }
+    if (progress.postprocess) {
+      progresses.push(progress.postprocess)
+    }
+  })
+
+  // In the future we should probably do this differently. For now we'll take the
+  // mode and message from the first file…
+  const { mode, message } = progresses[0]
+  const value = progresses.filter(isDeterminate).reduce((total, progress, index, all) => {
+    return total + progress.value / all.length
+  }, 0)
+  function isDeterminate (progress) {
+    return progress.mode === 'determinate'
+  }
+
+  return {
+    mode,
+    message,
+    value,
+  }
+}

--- a/packages/@uppy/status-bar/src/calculateProcessingProgress.js
+++ b/packages/@uppy/status-bar/src/calculateProcessingProgress.js
@@ -1,26 +1,22 @@
-module.expost = function calculateProcessingProgress (files) {
-  // Collect pre or postprocessing progress states.
-  const progresses = []
+module.export = function calculateProcessingProgress (files) {
+  const values = []
+  let mode
+  let message
 
-  Object.keys(files).forEach((fileID) => {
-    const { progress } = files[fileID]
-    if (progress.preprocess) {
-      progresses.push(progress.preprocess)
+  for (const { progress } of Object.values(files)) {
+    const { preprocess, postprocess } = progress
+    // In the future we should probably do this differently. For now we'll take the
+    // mode and message from the first file…
+    if (message == null && (preprocess || postprocess)) {
+      ({ mode, message } = preprocess || postprocess)
     }
-    if (progress.postprocess) {
-      progresses.push(progress.postprocess)
-    }
-  })
-
-  // In the future we should probably do this differently. For now we'll take the
-  // mode and message from the first file…
-  const { mode, message } = progresses[0]
-  const value = progresses.filter(isDeterminate).reduce((total, progress, index, all) => {
-    return total + progress.value / all.length
-  }, 0)
-  function isDeterminate (progress) {
-    return progress.mode === 'determinate'
+    if (preprocess?.mode === 'determinate') values.push(preprocess.value)
+    if (postprocess?.mode === 'determinate') values.push(postprocess.value)
   }
+
+  const value = values.reduce((total, progressValue) => {
+    return total + progressValue / values.length
+  }, 0)
 
   return {
     mode,

--- a/packages/@uppy/status-bar/src/calculateProcessingProgress.js
+++ b/packages/@uppy/status-bar/src/calculateProcessingProgress.js
@@ -1,27 +1,19 @@
 module.expost = function calculateProcessingProgress (files) {
-  // Collect pre or postprocessing progress states.
-  const progresses = []
-
-  Object.keys(files).forEach((fileID) => {
-    const { progress } = files[fileID]
-    if (progress.preprocess) {
-      progresses.push(progress.preprocess)
+  let values = []
+  let mode, message
+  for (const { progress } of Object.values(files)) {
+    const { preprocess, postprocess } = progress
+    // In the future we should probably do this differently. For now we'll take the
+    // mode and message from the first file…
+    if (message == null && (preprocess || postprocess)) {
+      ({ mode, message } = preprocess || postprocess)
     }
-    if (progress.postprocess) {
-      progresses.push(progress.postprocess)
-    }
-  })
-
-  // In the future we should probably do this differently. For now we'll take the
-  // mode and message from the first file…
-  const { mode, message } = progresses[0]
-  const value = progresses.filter(isDeterminate).reduce((total, progress, index, all) => {
-    return total + progress.value / all.length
-  }, 0)
-  function isDeterminate (progress) {
-    return progress.mode === 'determinate'
+    if (preprocess?.mode === "determinate") values.push(preprocess.value)
+    if (postprocess?.mode === "determinate") values.push(postprocess.value)
   }
-
+  const value = progresses.reduce((total, progress) => {
+    return total + progress.value / values.length
+  }, 0)
   return {
     mode,
     message,

--- a/packages/@uppy/status-bar/src/index.js
+++ b/packages/@uppy/status-bar/src/index.js
@@ -188,7 +188,7 @@ module.exports = class StatusBar extends UIPlugin {
       totalProgress,
       totalSize,
       totalUploadedSize,
-      isAllComplete,
+      isAllComplete: false,
       isAllPaused,
       isAllErrored,
       isUploadStarted,

--- a/packages/@uppy/status-bar/src/style.scss
+++ b/packages/@uppy/status-bar/src/style.scss
@@ -6,17 +6,13 @@
   position: relative;
   z-index: $zIndex-2;
   display: flex;
-  height: 40px;
+  height: 46px;
   color: $white;
   font-weight: 400;
   font-size: 12px;
   line-height: 40px;
   background-color: $white;
   transition: height 0.2s;
-
-  .uppy-size--md & {
-    height: 46px;
-  }
 
   [data-uppy-theme="dark"] & {
     background-color: $gray-900;


### PR DESCRIPTION
Fixes #766

- **Allow hoisted functions in `.eslintrc`**
I'm strongly in favor of using `use-before-define`, but ignoring it for functions. Hoisting is a feature which can be used to write more intention revealing code.

- **Refactor status bar plugin and resolve all eslint warnings**
I took small steps with commits in between to greatly simplify the code and make it more obvious what is happening. See `StatusBar` [before](https://github.com/transloadit/uppy/blob/4b7a2cc67e9c5af691f8e2fe3f5b2d0523939feb/packages/@uppy/status-bar/src/StatusBar.js) and [after](https://github.com/transloadit/uppy/blob/4ef070f580bee4e71cb3a39b11f1732b3354b5a0/packages/@uppy/status-bar/src/StatusBar.js).

- **Show all details on mobile when `showProgressDetails` is `true`**
See this [commit](https://github.com/transloadit/uppy/commit/4ef070f580bee4e71cb3a39b11f1732b3354b5a0) if you only want to see the changes relevant to this fix.