### PR TITLE
Fix `net::ERR_OUT_OF_MEMORY` in `@uppy/aws-s3-multipart`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -357,7 +357,7 @@ class MultipartUploader {
         defer.reject(error)
         return
       }
-      this.chunks[index] = null;  // Note: by uploading thousands of files with a total of many GB, this avoids the net::ERR_OUT_OF_MEMORY in CHromium Browsers
+      this.chunks[index] = null;  // This avoids the net::ERR_OUT_OF_MEMORY in Chromium Browsers.
 
       this.#onPartProgress(index, body.size, body.size)
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -357,6 +357,7 @@ class MultipartUploader {
         defer.reject(error)
         return
       }
+      this.chunks[index] = null;  // Note: by uploading thousands of files with a total of many GB, this avoids the net::ERR_OUT_OF_MEMORY in CHromium Browsers
 
       this.#onPartProgress(index, body.size, body.size)
 


### PR DESCRIPTION
**Use case**: Encrypting AWS Multipart Parts in AWS Multipart Uploader 

**What happens**:
Each underlying blob of each chunk in the prepareUploadParts (new v2 version) is replaced with an encrypted version of itself:
```
this.uploaders[file.id].chunks[partNum] =  new Blob([new Uint8Array(ciphertext)]);

```

This works perfectly. 
**Except in the following case**:
If one is uploading thousands of files with a total of many GB, we see a ```net::ERR_OUT_OF_MEMORY``` in Chromium based Browsers during the ```xhr.send``` in ```uploadPartBytes``` method in ```packages/@uppy/aws-s3-multipart/src/MultipartUploader.js```

I guess, under some circumstances, the garbage collector is a bit behind which may create this case, where the ```xhr.send``` cannot allocate sufficient memory. By explicitly deleting the blob after successful upload, this problem is solved.

