### PR TITLE
Simplify example page

### DIFF
--- a/website/src/examples/dashboard/index.ejs
+++ b/website/src/examples/dashboard/index.ejs
@@ -44,9 +44,8 @@ const uppy = new Uppy({
   restrictions: {
     maxFileSize: 1000000,
     maxNumberOfFiles: 3,
-    minNumberOfFiles: 2,
+    minNumberOfFiles: 1,
     allowedFileTypes: ['image/*', 'video/*'],
-    requiredMetaFields: ['caption'],
   }
 })
 .use(Dashboard, {


### PR DESCRIPTION
Currently the user needs to add caption to all files or they get this error, which can be a bit annoying and not so user friendly IMO:
<img width="521" alt="Screenshot 2021-09-10 at 17 41 33" src="https://user-images.githubusercontent.com/402547/132842033-08b6177a-3877-417b-91e4-860126b81177.png">

Also don't require min 2 files