### PR TITLE
Add 'done' to nb_NO.js

### DIFF
--- a/packages/@uppy/locales/src/nb_NO.js
+++ b/packages/@uppy/locales/src/nb_NO.js
@@ -36,6 +36,7 @@ nb_NO.strings = {
   dashboardTitle: 'Filopplaster',
   dashboardWindowTitle: 'Opplastingsvindu (Trykk Esc-knappen for å lukke)',
   dataUploadedOfTotal: '%{complete} av %{total}',
+  done: 'Ferdig',
   dropHereOr: 'Dra filer hit eller %{browse}',
   dropHint: 'Dra filer hit',
   dropPasteBoth: 'Dra filer hit, %{browseFiles} eller %{browseFolders}',

--- a/packages/@uppy/locales/src/nb_NO.js
+++ b/packages/@uppy/locales/src/nb_NO.js
@@ -26,7 +26,7 @@ nb_NO.strings = {
   closeModal: 'Lukk vindu',
   companionError: 'Kobling til Companion feilet',
   companionUnauthorizeHint: 'For å logge ut av din %{provider}-konto, gå til %{url}',
-  complete: 'Ferdig',
+  complete: 'Fullført',
   connectedToInternet: 'Koblet til internett',
   copyLink: 'Kopier lenke',
   copyLinkToClipboardFallback: 'Kopier URL under',


### PR DESCRIPTION
"Done" is missing for the Norwegian locale.

For "proof" that this is a correct translation, please see: [Google Translate](https://translate.google.com/?sl=en&tl=no&text=Done&op=translate).

Thanks!