### PR TITLE
Fix "attempted to use private field on non-instance"

### DIFF
--- a/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.js
+++ b/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.js
@@ -244,7 +244,7 @@ module.exports = class ProviderView {
       pluginIcon: this.plugin.icon,
       i18n: this.plugin.uppy.i18n,
       uppyFiles: this.plugin.uppy.getFiles(),
-      validateRestrictions: this.plugin.uppy.validateRestrictions,
+      validateRestrictions: (...args) => this.plugin.uppy.validateRestrictions(...args)
     }
 
     return (

--- a/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.js
+++ b/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.js
@@ -244,7 +244,7 @@ module.exports = class ProviderView {
       pluginIcon: this.plugin.icon,
       i18n: this.plugin.uppy.i18n,
       uppyFiles: this.plugin.uppy.getFiles(),
-      validateRestrictions: (...args) => this.plugin.uppy.validateRestrictions(...args)
+      validateRestrictions: (...args) => this.plugin.uppy.validateRestrictions(...args),
     }
 
     return (


### PR DESCRIPTION
Copied the same code changes as in the`ProviderView.js`.

This change fixes the "attempted to use private field on non-instance" error message and also fixes the `isDisabled` issue.