### PR TITLE
Include status code in HTTP error message

### DIFF
--- a/packages/@uppy/companion/src/server/provider/error.js
+++ b/packages/@uppy/companion/src/server/provider/error.js
@@ -8,7 +8,7 @@ class ProviderApiError extends Error {
    * @param {number} statusCode the http status code from the provider api
    */
   constructor (message, statusCode) {
-    super(message)
+    super(`HTTP ${statusCode}: ${message}`) // Include statusCode to make it easier to debug
     this.name = 'ProviderApiError'
     this.statusCode = statusCode
     this.isAuthError = false


### PR DESCRIPTION
Makes it easier to debug when we can see it in the log files

e.g.:
```
companion: 2021-09-20T20:03:53.226Z [error] provider.onedrive.list.error ProviderApiError: Access Denied
companion: 2021-09-20T19:57:49.897Z [error] provider.onedrive.list.error ProviderApiError: Item does not exist
```
We don't know what is the error code here...