### PR TITLE
@uppy/image-editor: add workaround for when `Cropper` is loaded as ESM

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,6 +30,7 @@ PRs are welcome! Please do open an issue to discuss first if it's a big feature,
 ## `3.0.0`
 
 - [ ] Switch to ES Modules (ESM)
+- [ ] @uppy/image-editor: Remove silly hack to work around non-ESM.
 
 ## `4.0.0`
 

--- a/packages/@uppy/image-editor/src/Editor.js
+++ b/packages/@uppy/image-editor/src/Editor.js
@@ -1,5 +1,8 @@
-const Cropper = require('cropperjs')
+const CropperImport = require('cropperjs')
 const { h, Component } = require('preact')
+
+// eslint-disable-next-line no-underscore-dangle
+const Cropper = CropperImport.__esModule ? CropperImport.default : CropperImport
 
 module.exports = class Editor extends Component {
   constructor (props) {

--- a/packages/@uppy/image-editor/src/Editor.js
+++ b/packages/@uppy/image-editor/src/Editor.js
@@ -1,6 +1,7 @@
 const CropperImport = require('cropperjs')
 const { h, Component } = require('preact')
 
+// @TODO A silly hack that we can get rid of when moving to ESM.
 // eslint-disable-next-line no-underscore-dangle
 const Cropper = CropperImport.__esModule ? CropperImport.default : CropperImport
 


### PR DESCRIPTION
A silly hack that we can get rid of when moving to ESM.

Fixes: https://github.com/transloadit/uppy/issues/3199