### PR TITLE
Retry `prepareUploadParts` on fail for `@uppy/aws-s3-multipart`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -243,27 +243,21 @@ class MultipartUploader {
 
   async #prepareUploadParts (candidates) {
     this.lockedCandidatesForBatch.push(...candidates)
-    let result
 
-    try {
-      result = await this.#retryable({
-        attempt: () => this.options.prepareUploadParts({
-          key: this.key,
-          uploadId: this.uploadId,
-          partNumbers: candidates.map((index) => index + 1),
-        }),
-      })
-    } catch (error) {
-      throw new Error(error)
-    }
+    const result = await this.#retryable({
+      attempt: () => this.options.prepareUploadParts({
+        key: this.key,
+        uploadId: this.uploadId,
+        partNumbers: candidates.map((index) => index + 1),
+      }),
+    })
 
-    const valid = typeof result?.presignedUrls === 'object'
-
-    if (!valid) {
+    if (typeof result?.presignedUrls !== 'object') {
       throw new TypeError(
         'AwsS3/Multipart: Got incorrect result from `prepareUploadParts()`, expected an object `{ presignedUrls }`.'
       )
     }
+
     return result
   }
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -254,7 +254,7 @@ class MultipartUploader {
         }),
       })
     } catch (error) {
-      this.#onError(error)
+      throw new Error(error)
     }
 
     const valid = typeof result?.presignedUrls === 'object'

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -244,19 +244,25 @@ class MultipartUploader {
   async #prepareUploadParts (candidates) {
     this.lockedCandidatesForBatch.push(...candidates)
 
-    const result = await this.options.prepareUploadParts({
-      key: this.key,
-      uploadId: this.uploadId,
-      partNumbers: candidates.map((index) => index + 1),
-    })
+    try {
+      const result = await this.#retryable({
+        attempt: () => this.options.prepareUploadParts({
+          key: this.key,
+          uploadId: this.uploadId,
+          partNumbers: candidates.map((index) => index + 1),
+        }),
+      })
+      const valid = typeof result?.presignedUrls === 'object'
 
-    const valid = typeof result?.presignedUrls === 'object'
-    if (!valid) {
-      throw new TypeError(
-        'AwsS3/Multipart: Got incorrect result from `prepareUploadParts()`, expected an object `{ presignedUrls }`.'
-      )
+      if (!valid) {
+        throw new TypeError(
+          'AwsS3/Multipart: Got incorrect result from `prepareUploadParts()`, expected an object `{ presignedUrls }`.'
+        )
+      }
+      return result
+    } catch (error) {
+      throw new Error(error)
     }
-    return result
   }
 
   #uploadPartRetryable (index, prePreparedPart) {

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -50,9 +50,9 @@ describe('AwsS3Multipart', () => {
             key: 'test/upload/multitest.dat',
           }
         }),
-        completeMultipartUpload: jest.fn(() => Promise.resolve({ location: 'test' })),
+        completeMultipartUpload: jest.fn(async () => ({ location: 'test' })),
         abortMultipartUpload: jest.fn(),
-        prepareUploadParts: jest.fn(() => new Promise((resolve) => {
+        prepareUploadParts: jest.fn(async () => {
           const presignedUrls = {}
           const possiblePartNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
           possiblePartNumbers.forEach((partNumber) => {
@@ -60,8 +60,8 @@ describe('AwsS3Multipart', () => {
               partNumber
             ] = `https://bucket.s3.us-east-2.amazonaws.com/test/upload/multitest.dat?partNumber=${partNumber}&uploadId=6aeb1980f3fc7ce0b5454d25b71992&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATEST%2F20210729%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20210729T014044Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=test`
           })
-          return resolve({ presignedUrls })
-        })),
+          return { presignedUrls }
+        }),
       })
       awsS3Multipart = core.getPlugin('AwsS3Multipart')
     })
@@ -178,10 +178,10 @@ describe('AwsS3Multipart', () => {
             key: 'test/upload/multitest.dat',
           }
         }),
-        completeMultipartUpload: jest.fn(() => Promise.resolve({ location: 'test' })),
+        completeMultipartUpload: jest.fn(async () => ({ location: 'test' })),
         abortMultipartUpload: jest.fn(),
         prepareUploadParts: jest
-          .fn(() => new Promise((resolve) => {
+          .fn(async () => {
             const presignedUrls = {}
             const possiblePartNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
@@ -191,8 +191,8 @@ describe('AwsS3Multipart', () => {
               ] = `https://bucket.s3.us-east-2.amazonaws.com/test/upload/multitest.dat?partNumber=${partNumber}&uploadId=6aeb1980f3fc7ce0b5454d25b71992&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATEST%2F20210729%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20210729T014044Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=test`
             })
 
-            return resolve({ presignedUrls })
-          }))
+            return { presignedUrls }
+          })
           // This runs first and only once
           // eslint-disable-next-line prefer-promise-reject-errors
           .mockImplementationOnce(() => Promise.reject({ source: { status: 500 } })),

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -47,7 +47,9 @@ For example, with a 50MB file and a `limit` of 5 we end up with 10 chunks. 5 of 
 
 ### `retryDelays: [0, 1000, 3000, 5000]`
 
-When uploading a chunk to S3 using a presigned URL fails, automatically try again after the millisecond intervals specified in this array. By default, we first retry instantly; if that fails, we retry after 1 second; if that fails, we retry after 3 seconds, etc.
+`retryDelays` are the intervals in milliseconds used to retry a failed chunk as well as [`prepareUploadParts`](#prepareUploadParts-file-partData).
+
+By default, we first retry instantly; if that fails, we retry after 1 second; if that fails, we retry after 3 seconds, etc.
 
 Set to `null` to disable automatic retries, and fail instantly if any chunk fails to upload.
 
@@ -109,19 +111,30 @@ A function that generates a batch of signed URLs for the specified part numbers.
  - `key` - The object key in the S3 bucket.
  - `partNumbers` - An array of indecies of this part in the file (`PartNumber` in S3 terminology). Note that part numbers are _not_ zero-based.
 
-Return a Promise for an object with keys:
+`prepareUploadParts` should return a `Promise` with an `Object` with keys:
 
  - `presignedUrls` - A JavaScript object with the part numbers as keys and the presigned URL for each part as the value. An example of what the return value should look like:
-
-   ```js
-   // for partNumbers [1, 2, 3]
-   return {
-     1: 'https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=1&...',
-     2: 'https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=2&...',
-     3: 'https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=3&...',
-   }
-   ```
  - `headers` - **(Optional)** Custom headers that should be sent to the S3 presigned URL.
+
+```json
+{
+  "presignedUrls": {
+    "1": "https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=1&...",
+    "2": "https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=2&...",
+    "3": "https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=3&..."
+  },
+  "headers": { "some-header": "value" }
+}
+```
+
+If an error occured, reject the `Promise` with an `Object` with the following keys:
+
+<!-- eslint-disable -->
+```json
+{ "source": { "status": 500 } }
+```
+
+`status` is the HTTP code and is required for determining whether to retry the request. `prepareUploadParts` will be retried if the code is `0`, `409`, `423`, or between `500` and `600`.
 
 ### `abortMultipartUpload(file, { uploadId, key })`
 

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -113,9 +113,10 @@ A function that generates a batch of signed URLs for the specified part numbers.
 
 `prepareUploadParts` should return a `Promise` with an `Object` with keys:
 
- - `presignedUrls` - A JavaScript object with the part numbers as keys and the presigned URL for each part as the value. An example of what the return value should look like:
+ - `presignedUrls` - A JavaScript object with the part numbers as keys and the presigned URL for each part as the value.
  - `headers` - **(Optional)** Custom headers that should be sent to the S3 presigned URL.
 
+An example of what the return value should look like:
 ```json
 {
   "presignedUrls": {


### PR DESCRIPTION
Fixes #3190

**Questions**

The current retry implementation only retries under these conditions:

https://github.com/transloadit/uppy/blob/a298e59f17d6a1aba7786fe8c60df73242104940/packages/%40uppy/aws-s3-multipart/src/MultipartUploader.js#L216-L223

This means the implementer _must_ return something like this when their custom `prepareUploadParts` fails: 

```js
Promise.reject({ source: { status: 500 } })
```

Do we want to have the same logic for retrying `prepareUploadParts`? Something else? Either way it would need to be documented. 