### PR TITLE
Revert "Remove broken link in `plugin_list.ejs` (#3166)"

### DIFF
--- a/website/themes/uppy/layout/partials/plugin_list.ejs
+++ b/website/themes/uppy/layout/partials/plugin_list.ejs
@@ -36,7 +36,7 @@
 <iframe scrolling="no" seamless="seamless" class="Disc" src="/disc.html"></iframe>
 <p>
   This graph is built with
-  <a href="https://twitter.com/hughskennedy">Hugh Kennedy</a>’s excellent disc.
+  <a href="https://twitter.com/hughskennedy">Hugh Kennedy</a>’s excellent <a href="https://hughsk.io/disc/">disc</a>.
 </p>
 
 <h2 id="browser-support">Browser Support</h2>


### PR DESCRIPTION
The link doesn't look broken to me. I've switched the link to `https:` because it's good practice. Alternatively we could link to the GitHub repo [hughsk/disc](https://github.com/hughsk/disc).

This reverts commit 44ea88a7ca1c6c72f4778f629d8d7ba6dbbf6553.