### PR TITLE
Update "AWS S3" to rename master branch to main

### DIFF
--- a/website/src/docs/aws-s3.md
+++ b/website/src/docs/aws-s3.md
@@ -249,7 +249,7 @@ export COMPANION_AWS_BUCKET="my-space-name"
 
 The `{region}` string will be replaced by the contents of the `COMPANION_AWS_REGION` environment variable.
 
-For a working example that you can run and play around with, see the [digitalocean-spaces](https://github.com/transloadit/uppy/tree/master/examples/digitalocean-spaces) folder in the Uppy repository.
+For a working example that you can run and play around with, see the [digitalocean-spaces](https://github.com/transloadit/uppy/tree/main/examples/digitalocean-spaces) folder in the Uppy repository.
 
 ### Google Cloud Storage
 
@@ -356,7 +356,7 @@ uppy.use(AwsS3, {
 })
 ```
 
-See the [aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/master/examples/aws-presigned-url) for a small example that implements both the server-side and the client-side.
+See the [aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-presigned-url) for a small example that implements both the server-side and the client-side.
 
 ### Retrieving presign parameters of the uploaded file
 


### PR DESCRIPTION
Update "AWS S3" documentation to rename repository links pointing to "master" branch with "main".