### PR TITLE
Add unique class to discard button

### DIFF
--- a/packages/@uppy/webcam/src/DiscardButton.js
+++ b/packages/@uppy/webcam/src/DiscardButton.js
@@ -3,7 +3,7 @@ const { h } = require('preact')
 function DiscardButton ({ onDiscard, i18n }) {
   return (
     <button
-      className="uppy-u-reset uppy-c-btn uppy-Webcam-button"
+      className="uppy-u-reset uppy-c-btn uppy-Webcam-button uppy-Webcam-button--discard"
       type="button"
       title={i18n('discardRecordedFile')}
       aria-label={i18n('discardRecordedFile')}


### PR DESCRIPTION
The current discard button does not have a unique classname like the submit button. This will help in customizing the styles just for the discard button.