### PR TITLE
Fix provider-views restrictions checkboxes

### DIFF
--- a/packages/@uppy/provider-views/src/Browser.js
+++ b/packages/@uppy/provider-views/src/Browser.js
@@ -115,7 +115,7 @@ function Browser (props) {
                   viewType,
                   i18n,
                   type: 'file',
-                  isDisabled: !validated.result && isChecked(file),
+                  isDisabled: !validated.result && !isChecked(file),
                   restrictionReason: validated.reason,
                 })
               })}


### PR DESCRIPTION
I think it broke here: https://github.com/transloadit/uppy/pull/3196/files#diff-07601b1fb93ec00e2790e18a70cdc9025a2e722d971a092148f29f312322ab63L56