### PR TITLE
@uppy/companion: use Node.js 16.x for Dockerfile

### DIFF
--- a/packages/@uppy/companion/Dockerfile
+++ b/packages/@uppy/companion/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0-alpine as build
+FROM node:16.13.0-alpine as build
 
 COPY package.json /app/package.json
 
@@ -6,12 +6,10 @@ WORKDIR /app
 
 # Install node_modules
 # * to optionally copy lock files that _might_ _not_ exist
-ADD package.json package-*.json yarn.* /tmp/
+ADD package.json package-*.json yarn.* .yarn /tmp/
 RUN cd /tmp && apk --update add  --virtual native-dep \
   make gcc g++ python libgcc libstdc++ git && \
-  npm install -g corepack && \
   corepack yarn install && \
-  corepack yarn ls && \
   apk del native-dep
 RUN mkdir -p /app && cd /app && ln -nfs /tmp/node_modules
 RUN apk add bash
@@ -19,7 +17,7 @@ COPY . /app
 ENV PATH "${PATH}:/app/node_modules/.bin"
 RUN corepack yarn run build
 
-FROM node:14.15.3-alpine
+FROM node:16.13.0-alpine
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Attempt to fix https://github.com/transloadit/uppy/issues/3287

Maybe a simple solution is to switch to the most recent LTS version that includes Corepack, so we don't have to install it ourselves.
I've also removed the `yarn ls` call, which looks like is a npm only thing: https://docs.npmjs.com/cli/v7/commands/npm-ls