### PR TITLE
fix: @uppy/utils - `getFileType()` always returns a string

### DIFF
--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -162,7 +162,7 @@ declare module '@uppy/utils/lib/getFileNameAndExtension' {
 declare module '@uppy/utils/lib/getFileType' {
   import UppyUtils = require('@uppy/utils')
 
-  function getFileType (file: UppyUtils.UppyFile): string | null
+  function getFileType (file: UppyUtils.UppyFile): string
   export = getFileType
 }
 


### PR DESCRIPTION
Small fix in type definitions