### PR TITLE
Convert sets to arrays prior to using spread operator to enable transpilation to ES5

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -1592,9 +1592,9 @@ class Uppy {
     const restoreStep = currentUpload.step || 0
 
     const steps = [
-      ...this.#preProcessors,
-      ...this.#uploaders,
-      ...this.#postProcessors,
+      ...Array.from(this.#preProcessors),
+      ...Array.from(this.#uploaders),
+      ...Array.from(this.#postProcessors),
     ]
     try {
       for (let step = restoreStep; step < steps.length; step++) {


### PR DESCRIPTION

This goes with: https://github.com/transloadit/uppy/issues/3296

Transpiling Uppy 2 to ES5 results in errors due to the lack of polyfill support for the spread operator in ES5. Converting Sets to arrays prior to spreading fixes this and allows for Uppy 2 to be used in ES5 browsers.
