### PR TITLE
Remove references of incorrect `options` argument for `companion.socket`

### DIFF
--- a/examples/aws-companion/server.js
+++ b/examples/aws-companion/server.js
@@ -52,4 +52,4 @@ const server = app.listen(3020, () => {
   console.log('listening on port 3020')
 })
 
-companion.socket(server, options)
+companion.socket(server)

--- a/examples/uppy-with-companion/server/index.js
+++ b/examples/uppy-with-companion/server/index.js
@@ -66,7 +66,7 @@ app.use((err, req, res) => {
   res.status(err.status || 500).json({ message: err.message, error: err })
 })
 
-companion.socket(app.listen(3020), uppyOptions)
+companion.socket(app.listen(3020))
 
 console.log('Welcome to Companion!')
 console.log(`Listening on http://0.0.0.0:${3020}`)

--- a/packages/@uppy/companion/README.md
+++ b/packages/@uppy/companion/README.md
@@ -57,7 +57,7 @@ To enable companion socket for realtime feed to the client while upload is going
 // ...
 const server = app.listen(PORT)
 
-companion.socket(server, options)
+companion.socket(server)
 ```
 
 ### Run as standalone server

--- a/website/src/_posts/2020-03-custom-providers.md
+++ b/website/src/_posts/2020-03-custom-providers.md
@@ -113,7 +113,7 @@ app.use((req, res, next) => {
   return res.status(404).json({ message: 'Not Found' })
 })
 
-companion.socket(app.listen(3020), companionOptions)
+companion.socket(app.listen(3020))
 
 console.log('Welcome to Companion!')
 console.log(`Listening on http://0.0.0.0:3020`)

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -98,7 +98,7 @@ Then, add the Companion WebSocket server for realtime upload progress, using the
 ```js
 const server = app.listen(PORT)
 
-companion.socket(server, options)
+companion.socket(server)
 ```
 
 This takes your `server` instance and [Options](#Options) as parameters.

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -101,7 +101,7 @@ const server = app.listen(PORT)
 companion.socket(server)
 ```
 
-This takes your `server` instance and [Options](#Options) as parameters.
+This takes your `server` instance as an argument.
 
 ### Running as a standalone server
 


### PR DESCRIPTION
It was never an option. See #3306