### PR TITLE
Pass croppedCanvasOptions to getCroppedCanvas

### DIFF
--- a/packages/@uppy/image-editor/src/Editor.js
+++ b/packages/@uppy/image-editor/src/Editor.js
@@ -35,17 +35,6 @@ module.exports = class Editor extends Component {
     this.cropper.destroy()
   }
 
-  save = () => {
-    const { opts, save, currentImage } = this.props
-
-    this.cropper.getCroppedCanvas(opts.cropperOptions.croppedCanvasOptions)
-      .toBlob(
-        (blob) => save(blob),
-        currentImage.type,
-        opts.quality,
-      )
-  }
-
   granularRotateOnChange = (ev) => {
     const { rotationAngle, rotationDelta } = this.state
     const pendingRotationDelta = Number(ev.target.value) - rotationDelta

--- a/packages/@uppy/image-editor/src/index.js
+++ b/packages/@uppy/image-editor/src/index.js
@@ -91,7 +91,7 @@ module.exports = class ImageEditor extends UIPlugin {
 
     const { currentImage } = this.getPluginState()
 
-    this.cropper.getCroppedCanvas().toBlob(
+    this.cropper.getCroppedCanvas(this.opts.cropperOptions.croppedCanvasOptions).toBlob(
       saveBlobCallback,
       currentImage.type,
       this.opts.quality,


### PR DESCRIPTION
`croppedCanvasOptions` were not being passed to `getCroppedCanvas` when getting the image blob.

I noticed that the options are being passed when called from here though:

https://github.com/transloadit/uppy/blob/main/packages/%40uppy/image-editor/src/Editor.js#L41

But when debugging the issue I couldn't see when that `save` function gets called in the preact component, is it dead code? If someone can confirm this I am happy to delete that function in this PR too.