### PR TITLE
Add disableLocalFiles to options summary

### DIFF
--- a/website/src/docs/dashboard.md
+++ b/website/src/docs/dashboard.md
@@ -101,6 +101,7 @@ uppy.use(Dashboard, {
   browserBackButtonClose: false,
   theme: 'light',
   autoOpenFileEditor: false,
+  disableLocalFiles: false,
 })
 ```
 


### PR DESCRIPTION
`disableLocalFiles` is an option that is detailed below, but is easily missed as is not included in the 'content's section at the top of the documentation. This section is useful for quickly scanning for an option you're looking for.