### PR TITLE
@uppy/companion: fix deploy Yarn version

### DIFF
--- a/bin/update-yarn.sh
+++ b/bin/update-yarn.sh
@@ -21,7 +21,9 @@ PLUGINS=$(awk '{ if ($1 == "spec:") print $2 }' .yarnrc.yml)
 echo "$PLUGINS" | xargs -n1 -t corepack yarn plugin remove
 
 cp package.json .yarn/cache/tmp.package.json
-sed "s#yarn\": \"$CURRENT_VERSION\"#yarn\": \"$LAST_VERSION\"#;s#\"yarn@$CURRENT_VERSION\"#\"yarn@$LAST_VERSION\"#" .yarn/cache/tmp.package.json > package.json
+sed "s#\"yarn\": \"$CURRENT_VERSION\"#\"yarn\": \"$LAST_VERSION\"#;s#\"yarn@$CURRENT_VERSION\"#\"yarn@$LAST_VERSION\"#" .yarn/cache/tmp.package.json > package.json
+cp packages/@uppy/companion/package.json .yarn/cache/tmp.package.json
+sed "s#\"yarn\": \"$CURRENT_VERSION\"#\"yarn\": \"$LAST_VERSION\"#;s#\"yarn@$CURRENT_VERSION\"#\"yarn@$LAST_VERSION\"#" .yarn/cache/tmp.package.json > packages/@uppy/companion/package.json
 rm .yarn/cache/tmp.package.json
 
 echo "$PLUGINS" | xargs -n1 -t corepack yarn plugin import

--- a/bin/update-yarn.sh
+++ b/bin/update-yarn.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# This script is meant to be run on a dev's machine to update the version on
+# Yarn used by the monorepo. Its goal is to make sure that every mention of Yarn
+# version is updated, and it re-installs the plugins to make sure those are
+# up-to-date as well.
+
 set -o pipefail
 set -o errexit
 set -o nounset

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -112,7 +112,9 @@
     "test": "bash -c 'source env.test.sh && ../../../node_modules/jest/bin/jest.js'",
     "test:watch": "yarn test -- --watch"
   },
+  "packageManager": "yarn@3.1.0",
   "engines": {
-    "node": ">=10.20.1"
+    "node": ">=10.20.1",
+    "yarn": "3.1.0"
   }
 }


### PR DESCRIPTION
When running from the Dockerfile, Corepack cannot pick up the information from the parent package.json and tries to run with an older version of Yarn.

This PR adds the Yarn version info to the Companion `package.json`, which should hopefully fix the issue.