### PR TITLE
Revert "Convert sets to arrays prior to using spread operator to enable transpilation to ES5"

### DIFF
--- a/bin/build-bundle.js
+++ b/bin/build-bundle.js
@@ -64,7 +64,7 @@ async function transpileDownForIE ([bundleFile, standalone]) {
 
     browserslistEnv: 'legacy',
     presets: [['@babel/preset-env',  {
-      loose: true,
+      loose: false,
       targets: { ie:11 },
       useBuiltIns: 'entry',
       corejs: { version: '3.15', proposals: true },

--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -1559,9 +1559,9 @@ class Uppy {
     const restoreStep = currentUpload.step || 0
 
     const steps = [
-      ...Array.from(this.#preProcessors),
-      ...Array.from(this.#uploaders),
-      ...Array.from(this.#postProcessors),
+      ...this.#preProcessors,
+      ...this.#uploaders,
+      ...this.#postProcessors,
     ]
     try {
       for (let step = restoreStep; step < steps.length; step++) {


### PR DESCRIPTION
Reverts transloadit/uppy#3297
Fixes https://github.com/transloadit/uppy/issues/3328