### PR TITLE
build: force use of `@babel/plugin-proposal-optional-chaining`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,10 @@ module.exports = (api) => {
   return {
     presets: [
       ['@babel/preset-env', {
-        include: ['@babel/plugin-proposal-nullish-coalescing-operator'],
+        include: [
+          '@babel/plugin-proposal-nullish-coalescing-operator',
+          '@babel/plugin-proposal-optional-chaining',
+        ],
         loose: true,
         targets,
         useBuiltIns: false, // Don't add polyfills automatically.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/eslint-parser": "^7.11.3",
     "@babel/eslint-plugin": "^7.11.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.16.0",
     "@babel/plugin-transform-react-jsx": "^7.10.4",
     "@babel/preset-env": "^7.14.7",
     "@babel/register": "^7.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42265,6 +42265,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     "@babel/eslint-parser": ^7.11.3
     "@babel/eslint-plugin": ^7.11.3
     "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.5
+    "@babel/plugin-proposal-optional-chaining": ^7.16.0
     "@babel/plugin-transform-react-jsx": ^7.10.4
     "@babel/preset-env": ^7.14.7
     "@babel/register": ^7.10.5


### PR DESCRIPTION
Optional chaining is still not supported on all environments – even though it's supported by browsers Uppy actually supports. Adding the plugin explicitly, it can be removed in a future semver-major.