### PR TITLE
Save meta fields when opening the image editor

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -153,6 +153,10 @@ class FileCard extends Component {
                 type="button"
                 className="uppy-u-reset uppy-c-btn uppy-Dashboard-FileCard-edit"
                 onClick={(event) => {
+                  // When opening the image editor we want to save any meta fields changes.
+                  // Otherwise it's confusing for the user to click save in the editor,
+                  // but the changes here are discarded. This bypasses validation,
+                  // but we are okay with that. 
                   this.handleSave(event)
                   this.props.openFileEditor(file)
                 }}

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -156,7 +156,7 @@ class FileCard extends Component {
                   // When opening the image editor we want to save any meta fields changes.
                   // Otherwise it's confusing for the user to click save in the editor,
                   // but the changes here are discarded. This bypasses validation,
-                  // but we are okay with that. 
+                  // but we are okay with that.
                   this.handleSave(event)
                   this.props.openFileEditor(file)
                 }}

--- a/packages/@uppy/dashboard/src/components/FileCard/index.js
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.js
@@ -152,7 +152,10 @@ class FileCard extends Component {
               <button
                 type="button"
                 className="uppy-u-reset uppy-c-btn uppy-Dashboard-FileCard-edit"
-                onClick={() => this.props.openFileEditor(file)}
+                onClick={(event) => {
+                  this.handleSave(event)
+                  this.props.openFileEditor(file)
+                }}
                 form={this.form.id}
               >
                 {this.props.i18n('editFile')}


### PR DESCRIPTION
Closes #2754

If you edit a file, change a meta field such as caption, then click edit file and click save or cancel — your meta field change is discarded. This saves your changes when opening the image editor. 