### PR TITLE
Drop lockedCandidatesForBatch and mark chunks as 'busy' on preparing as a fix for #3341

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -58,7 +58,6 @@ class MultipartUploader {
     this.partsInProgress = 0
     this.chunks = null
     this.chunkState = null
-    this.lockedCandidatesForBatch = []
 
     this.#initChunks()
 
@@ -181,8 +180,6 @@ class MultipartUploader {
 
     const candidates = []
     for (let i = 0; i < this.chunkState.length; i++) {
-      // eslint-disable-next-line no-continue
-      if (this.lockedCandidatesForBatch.includes(i)) continue
       const state = this.chunkState[i]
       // eslint-disable-next-line no-continue
       if (state.done || state.busy) continue
@@ -242,8 +239,6 @@ class MultipartUploader {
   }
 
   async #prepareUploadParts (candidates) {
-    this.lockedCandidatesForBatch.push(...candidates)
-
     const result = await this.#retryable({
       attempt: () => this.options.prepareUploadParts({
         key: this.key,

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -239,6 +239,8 @@ class MultipartUploader {
   }
 
   async #prepareUploadParts (candidates) {
+    candidates.forEach(i => this.chunkState[i].busy = true)
+    
     const result = await this.#retryable({
       attempt: () => this.options.prepareUploadParts({
         key: this.key,

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -239,8 +239,10 @@ class MultipartUploader {
   }
 
   async #prepareUploadParts (candidates) {
-    candidates.forEach(i => this.chunkState[i].busy = true)
-    
+    candidates.forEach((i) => {
+      this.chunkState[i].busy = true
+    })
+
     const result = await this.#retryable({
       attempt: () => this.options.prepareUploadParts({
         key: this.key,


### PR DESCRIPTION
this.lockedCandidatesForBatch code in #uploadParts definitely is the cause of the bug with unresumable uploads after pause (#3341).
Not sure if this.lockedCandidatesForBatch is at all necessary, so proposing to drop it.