### PR TITLE
@uppy/companion: don't pin Yarn version in `package.json`

### DIFF
--- a/bin/update-yarn.sh
+++ b/bin/update-yarn.sh
@@ -28,8 +28,6 @@ echo "$PLUGINS" | xargs -n1 -t corepack yarn plugin remove
 
 cp package.json .yarn/cache/tmp.package.json
 sed "s#\"yarn\": \"$CURRENT_VERSION\"#\"yarn\": \"$LAST_VERSION\"#;s#\"yarn@$CURRENT_VERSION\"#\"yarn@$LAST_VERSION\"#" .yarn/cache/tmp.package.json > package.json
-cp packages/@uppy/companion/package.json .yarn/cache/tmp.package.json
-sed "s#\"yarn\": \"$CURRENT_VERSION\"#\"yarn\": \"$LAST_VERSION\"#;s#\"yarn@$CURRENT_VERSION\"#\"yarn@$LAST_VERSION\"#" .yarn/cache/tmp.package.json > packages/@uppy/companion/package.json
 rm .yarn/cache/tmp.package.json
 
 echo "$PLUGINS" | xargs -n1 -t corepack yarn plugin import

--- a/packages/@uppy/companion/Dockerfile
+++ b/packages/@uppy/companion/Dockerfile
@@ -9,13 +9,13 @@ WORKDIR /app
 ADD package.json package-*.json yarn.* /tmp/
 RUN cd /tmp && apk --update add  --virtual native-dep \
   make gcc g++ python3 libgcc libstdc++ git && \
-  npm install && \
+  corepack yarn install && \
   apk del native-dep
 RUN mkdir -p /app && cd /app && ln -nfs /tmp/node_modules
 RUN apk add bash
 COPY . /app
 ENV PATH "${PATH}:/app/node_modules/.bin"
-RUN npm run build
+RUN corepack yarn run build
 
 FROM node:16.13.0-alpine
 

--- a/packages/@uppy/companion/Dockerfile
+++ b/packages/@uppy/companion/Dockerfile
@@ -9,13 +9,13 @@ WORKDIR /app
 ADD package.json package-*.json yarn.* /tmp/
 RUN cd /tmp && apk --update add  --virtual native-dep \
   make gcc g++ python3 libgcc libstdc++ git && \
-  corepack yarn install && \
+  npm install && \
   apk del native-dep
 RUN mkdir -p /app && cd /app && ln -nfs /tmp/node_modules
 RUN apk add bash
 COPY . /app
 ENV PATH "${PATH}:/app/node_modules/.bin"
-RUN corepack yarn run build
+RUN npm run build
 
 FROM node:16.13.0-alpine
 

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -112,9 +112,7 @@
     "test": "bash -c 'source env.test.sh && ../../../node_modules/jest/bin/jest.js'",
     "test:watch": "yarn test -- --watch"
   },
-  "packageManager": "yarn@3.1.0",
   "engines": {
-    "node": ">=10.20.1",
-    "yarn": "3.1.0"
+    "node": ">=10.20.1"
   }
 }


### PR DESCRIPTION
The Dockerfile tries to build Companion standalone using some
trickery that is very much tied to npm logic, Yarn is not the fittest
tool here.