### PR TITLE
meta: use Vite for examples/dev

### DIFF
--- a/.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809
+++ b/.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809
@@ -1,0 +1,47 @@
+diff --git a/dist/index.js b/dist/index.js
+index 0f9a4b342c75d75309b78a36473fb5c68f7b89b5..57effed56c190a946756d191cb3d390dbc84aee3 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -92,18 +92,32 @@ exports.default = helper_plugin_utils_1.declare((api, options) => {
+                                     const specifiers = [];
+                                     // Convert to named import.
+                                     if (core_1.types.isObjectPattern(path.parentPath.node.id)) {
+-                                        path.parentPath.node.id.properties.forEach(prop => {
+-                                            specifiers.push(core_1.types.importSpecifier(prop.value, prop.key));
+-                                            state.globals.add(prop.value.name);
+-                                        });
+-                                        const decl = core_1.types.importDeclaration(specifiers, core_1.types.stringLiteral(str.value));
+-                                        // @ts-ignore
+-                                        decl.__replaced = true;
+-                                        path.scope.getProgramParent().path.unshiftContainer('body', decl);
+-                                        path.parentPath.remove();
++                                        if(node.arguments[0].value.startsWith('.') || node.arguments[0].value.startsWith('@uppy/')) {
++                                            const id = path.scope.generateUidIdentifier(node.arguments[0].value)
++                                            const destructuring = core_1.types.variableDeclarator(path.parentPath.node.id, id)
++                                            const decl = core_1.types.importDeclaration([core_1.types.importDefaultSpecifier(id)], core_1.types.stringLiteral(str.value));
++                                            // @ts-ignore
++                                            decl.__replaced = true;
++                                            path.scope.getProgramParent().path.unshiftContainer('body', decl);
++                                            path.parentPath.replaceWith(destructuring)
++                                        } else {
++                                            path.parentPath.node.id.properties.forEach(prop => {
++                                                specifiers.push(core_1.types.importSpecifier(prop.value, prop.key));
++                                                state.globals.add(prop.value.name);
++                                            });
++                                            const decl = core_1.types.importDeclaration(specifiers, core_1.types.stringLiteral(str.value));
++                                            // @ts-ignore
++                                            decl.__replaced = true;
++                                            path.scope.getProgramParent().path.unshiftContainer('body', decl);
++                                            path.parentPath.remove()
++                                        }
+                                     }
++                                    else if (node.arguments[0].value === 'tus-js-client' && str) {
++                                        const decl = core_1.types.importDeclaration([core_1.types.importNamespaceSpecifier(path.parentPath.node.id)], core_1.types.stringLiteral(str.value))
++                                        path.scope.getProgramParent().path.unshiftContainer('body', decl);
++                                        path.parentPath.remove()
+                                     // Convert to default import.
+-                                    else if (str) {
++                                    } else if (str) {
+                                         const { parentPath } = path;
+                                         const { left } = parentPath.node;
+                                         // @ts-ignore

--- a/babel.config.js
+++ b/babel.config.js
@@ -20,7 +20,7 @@ module.exports = (api) => {
     ],
     plugins: [
       ['@babel/plugin-transform-react-jsx', { pragma: 'h' }],
-      'babel-plugin-inline-package-json',
+      process.env.NODE_ENV !== 'dev' && 'babel-plugin-inline-package-json',
     ].filter(Boolean),
   }
 }

--- a/examples/dev/Dashboard.js
+++ b/examples/dev/Dashboard.js
@@ -1,28 +1,28 @@
-// The @uppy/ dependencies are resolved using aliasify
+// The @uppy/ dependencies are resolved from source
 /* eslint-disable import/no-extraneous-dependencies */
-const Uppy = require('@uppy/core/src')
-const Dashboard = require('@uppy/dashboard/src')
-const Instagram = require('@uppy/instagram/src')
-const Facebook = require('@uppy/facebook/src')
-const OneDrive = require('@uppy/onedrive/src')
-const Dropbox = require('@uppy/dropbox/src')
-const Box = require('@uppy/box/src')
-const GoogleDrive = require('@uppy/google-drive/src')
-const Unsplash = require('@uppy/unsplash/src')
-const Zoom = require('@uppy/zoom/src')
-const Url = require('@uppy/url/src')
-const Webcam = require('@uppy/webcam/src')
-const ScreenCapture = require('@uppy/screen-capture/src')
-const GoldenRetriever = require('@uppy/golden-retriever/src')
-const Tus = require('@uppy/tus/src')
-const AwsS3 = require('@uppy/aws-s3/src')
-const AwsS3Multipart = require('@uppy/aws-s3-multipart/src')
-const XHRUpload = require('@uppy/xhr-upload/src')
-const Transloadit = require('@uppy/transloadit/src')
-const Form = require('@uppy/form/src')
-const ImageEditor = require('@uppy/image-editor/src')
-const DropTarget = require('@uppy/drop-target/src')
-const Audio = require('@uppy/audio/src')
+import Uppy from '@uppy/core'
+import Dashboard from '@uppy/dashboard'
+import Instagram from '@uppy/instagram'
+import Facebook from '@uppy/facebook'
+import OneDrive from '@uppy/onedrive'
+import Dropbox from '@uppy/dropbox'
+import Box from '@uppy/box'
+import GoogleDrive from '@uppy/google-drive'
+import Unsplash from '@uppy/unsplash'
+import Zoom from '@uppy/zoom'
+import Url from '@uppy/url'
+import Webcam from '@uppy/webcam'
+import ScreenCapture from '@uppy/screen-capture'
+import GoldenRetriever from '@uppy/golden-retriever'
+import Tus from '@uppy/tus'
+import AwsS3 from '@uppy/aws-s3'
+import AwsS3Multipart from '@uppy/aws-s3-multipart'
+import XHRUpload from '@uppy/xhr-upload'
+import Transloadit from '@uppy/transloadit'
+import Form from '@uppy/form'
+import ImageEditor from '@uppy/image-editor'
+import DropTarget from '@uppy/drop-target'
+import Audio from '@uppy/audio'
 /* eslint-enable import/no-extraneous-dependencies */
 
 // DEV CONFIG: pick an uploader
@@ -55,7 +55,7 @@ const RESTORE = false
 
 // Rest is implementation! Obviously edit as necessary...
 
-module.exports = () => {
+export default () => {
   const uppyDashboard = new Uppy({
     logger: Uppy.debugLogger,
     meta: {

--- a/examples/dev/DragDrop.js
+++ b/examples/dev/DragDrop.js
@@ -1,12 +1,12 @@
-// The @uppy/ dependencies are resolved using aliasify
+// The @uppy/ dependencies are resolved from source
 /* eslint-disable import/no-extraneous-dependencies */
-const Uppy = require('@uppy/core/src')
-const Tus = require('@uppy/tus/src')
-const DragDrop = require('@uppy/drag-drop/src')
-const ProgressBar = require('@uppy/progress-bar/src')
+import Uppy from '@uppy/core'
+import Tus from '@uppy/tus'
+import DragDrop from '@uppy/drag-drop'
+import ProgressBar from '@uppy/progress-bar'
 /* eslint-enable import/no-extraneous-dependencies */
 
-module.exports = () => {
+export default () => {
   const uppyDragDrop = new Uppy({
     debug: true,
     autoProceed: true,

--- a/examples/dev/index.html
+++ b/examples/dev/index.html
@@ -51,7 +51,6 @@
       </form>
     </main>
 
-    <link href="uppy.min.css" rel="stylesheet">
-    <script src="output/index.js"></script>
+    <script src="./index.js" type="module"></script>
   </body>
 </html>

--- a/examples/dev/index.js
+++ b/examples/dev/index.js
@@ -1,5 +1,8 @@
-const DragDrop = require('./DragDrop.js')
-const Dashboard = require('./Dashboard.js')
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'uppy/src/style.scss'
+
+import DragDrop from './DragDrop.js'
+import Dashboard from './Dashboard.js'
 
 switch (window.location.pathname.toLowerCase()) {
   case '/':

--- a/examples/dev/package.json
+++ b/examples/dev/package.json
@@ -6,18 +6,17 @@
       "@uppy": "../../packages/@uppy"
     }
   },
-  "dependencies": {
-    "@babel/core": "^7.4.4",
-    "aliasify": "^2.1.0",
-    "babelify": "^10.0.0",
-    "watchify": "^3.11.0"
-  },
   "devDependencies": {
-    "browser-sync": "^2.27.4"
+    "@babel/core": "^7.4.4",
+    "@babel/plugin-transform-react-jsx": "^7.10.4",
+    "babel-plugin-transform-commonjs": "1.1.6",
+    "vite": "^2.7.1"
   },
   "private": true,
+  "type": "module",
   "scripts": {
-    "start": "browser-sync start --no-open --no-ghost-mode false --server . --index Dashboard.html --port 3452 --serveStatic ../../packages/uppy/dist --files \"./output/*.js, ../../packages/uppy/dist/uppy.min.css, ../../packages/uppy/lib/**/*\"",
-    "watch:sandbox": "watchify -vd -t [ babelify --cwd ../../ ] -g aliasify index.js -o output/index.js"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   }
 }

--- a/examples/dev/vite.config.js
+++ b/examples/dev/vite.config.js
@@ -1,0 +1,76 @@
+import { fileURLToPath } from 'node:url'
+import { transformAsync } from '@babel/core'
+
+const ROOT = new URL('../../', import.meta.url)
+const PACKAGES_ROOT = fileURLToPath(new URL('./packages/', ROOT))
+
+// To enable the plugin, it looks like we need to interact with the resolution
+// algorithm, but we need to stop afterwards otherwise it messes up somewhere
+// else. This hack can be removed when we get rid of JSX inside of .js files.
+let counter = 0
+
+/**
+ * @type {import('vite').UserConfig}
+ */
+const config = {
+  build: {
+    commonjsOptions: {
+      defaultIsModuleExports: true,
+    },
+  },
+  esbuild: {
+    jsxFactory: 'h',
+    jsxFragment: 'Fragment',
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^uppy\/(.+)$/,
+        replacement: `${PACKAGES_ROOT}uppy/$1`,
+      },
+      {
+        find: /^@uppy\/([^/]+)$/,
+        replacement: `${PACKAGES_ROOT}@uppy/$1/src/index.js`,
+      },
+      {
+        find: /^@uppy\/([^/]+)\/lib\/(.+)$/,
+        replacement: `${PACKAGES_ROOT}@uppy/$1/src/$2`,
+      },
+      //   {
+      //     find: /^@uppy\/([^/]+)\/(.+)$/,
+      //     replacement: PACKAGES_ROOT + "@uppy/$1/src/$2",
+      //   },
+    ],
+  },
+  plugins: [
+    // TODO: remove plugin when we switch to ESM and get rid of JSX inside .js files.
+    {
+      name: 'vite-plugin-jsx-commonjs',
+      // TODO: remove this hack when we get rid of JSX inside .js files.
+      enforce: 'pre',
+      // eslint-disable-next-line consistent-return
+      resolveId (id) {
+        if (id.startsWith(PACKAGES_ROOT) && id.endsWith('.js')) {
+          return id
+        }
+        // TODO: remove this hack when we get rid of JSX inside .js files.
+        if (counter++ < 2) {
+          return id
+        }
+      },
+      transform (code, id) {
+        if (id.startsWith(PACKAGES_ROOT) && id.endsWith('.js')) {
+          return transformAsync(code, {
+            plugins: [
+              ['@babel/plugin-transform-react-jsx', { pragma: 'h' }],
+              'transform-commonjs',
+            ],
+          })
+        }
+        return code
+      },
+    },
+  ],
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "dev:browsersync": "yarn workspace @uppy-example/dev start",
     "dev:watch-sandbox": "yarn workspace @uppy-example/dev watch:sandbox",
     "dev:with-companion": "npm-run-all --parallel start:companion dev:watch-sandbox watch:js:lib watch:css dev:browsersync",
-    "dev": "npm-run-all --parallel dev:watch-sandbox watch:js:lib watch:css dev:browsersync",
+    "dev": "yarn workspace @uppy-example/dev dev",
     "example": "yarn node bin/run-example",
     "lint:fix": "yarn run lint -- --fix",
     "lint:markdown": "remark -f -q . -i .remarkignore",
@@ -192,6 +192,7 @@
   "resolutions": {
     "@types/redis": "2",
     "@types/eslint@^7.2.13": "^8.2.0",
-    "npm-auth-to-token@1.0.0": "patch:npm-auth-to-token@npm:1.0.0#.yarn/patches/npm-auth-to-token-npm-1.0.0-c288ce201f"
+    "npm-auth-to-token@1.0.0": "patch:npm-auth-to-token@npm:1.0.0#.yarn/patches/npm-auth-to-token-npm-1.0.0-c288ce201f",
+    "babel-plugin-transform-commonjs@1.1.6": "patch:babel-plugin-transform-commonjs@npm:1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,10 +7541,9 @@ __metadata:
   resolution: "@uppy-example/dev@workspace:examples/dev"
   dependencies:
     "@babel/core": ^7.4.4
-    aliasify: ^2.1.0
-    babelify: ^10.0.0
-    browser-sync: ^2.27.4
-    watchify: ^3.11.0
+    "@babel/plugin-transform-react-jsx": ^7.10.4
+    babel-plugin-transform-commonjs: 1.1.6
+    vite: ^2.7.1
   languageName: unknown
   linkType: soft
 
@@ -11219,6 +11218,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-transform-commonjs@npm:1.1.6":
+  version: 1.1.6
+  resolution: "babel-plugin-transform-commonjs@npm:1.1.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.0.0
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: fc3f938b5d593457726c53e92305a3f1a3119524f057dedbe5adf16bc85b5b2bb376f8d50deb96bbf1aa168c46ba1c4a6a1cab35837d27049d2ab9fc402aeb9e
+  languageName: node
+  linkType: hard
+
+"babel-plugin-transform-commonjs@patch:babel-plugin-transform-commonjs@npm:1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809::locator=uppy-build%40workspace%3A.":
+  version: 1.1.6
+  resolution: "babel-plugin-transform-commonjs@patch:babel-plugin-transform-commonjs@npm%3A1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809::version=1.1.6&hash=f83dbd&locator=uppy-build%40workspace%3A."
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.0.0
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: 5995b2641a8551fcc8d0f9d24222ae15698100917edffc8d98f8033cc65b1e577e6b346ac4dbf2456425e494bd1caf1f6646002163953a88290e901f611d83ad
+  languageName: node
+  linkType: hard
+
 "babel-preset-current-node-syntax@npm:^1.0.0":
   version: 1.0.1
   resolution: "babel-preset-current-node-syntax@npm:1.0.1"
@@ -11915,7 +11936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-sync@npm:^2.18.13, browser-sync@npm:^2.27.4":
+"browser-sync@npm:^2.18.13":
   version: 2.27.7
   resolution: "browser-sync@npm:2.27.7"
   dependencies:
@@ -17087,6 +17108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-android-arm64@npm:0.13.15"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-android-arm64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-android-arm64@npm:0.14.2"
@@ -17097,6 +17125,13 @@ __metadata:
 "esbuild-darwin-64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-darwin-64@npm:0.13.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-darwin-64@npm:0.13.15"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -17115,6 +17150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-darwin-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-darwin-arm64@npm:0.13.15"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-darwin-arm64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-darwin-arm64@npm:0.14.2"
@@ -17125,6 +17167,13 @@ __metadata:
 "esbuild-freebsd-64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-freebsd-64@npm:0.13.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-freebsd-64@npm:0.13.15"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -17143,6 +17192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-freebsd-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-freebsd-arm64@npm:0.13.15"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-freebsd-arm64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-freebsd-arm64@npm:0.14.2"
@@ -17153,6 +17209,13 @@ __metadata:
 "esbuild-linux-32@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-linux-32@npm:0.13.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-32@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-32@npm:0.13.15"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -17171,6 +17234,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-64@npm:0.13.15"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-linux-64@npm:0.14.2"
@@ -17181,6 +17251,13 @@ __metadata:
 "esbuild-linux-arm64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-linux-arm64@npm:0.13.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-arm64@npm:0.13.15"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -17199,6 +17276,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-arm@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-arm@npm:0.13.15"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-arm@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-linux-arm@npm:0.14.2"
@@ -17209,6 +17293,13 @@ __metadata:
 "esbuild-linux-mips64le@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-linux-mips64le@npm:0.13.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-mips64le@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-mips64le@npm:0.13.15"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -17227,6 +17318,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-ppc64le@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-ppc64le@npm:0.13.15"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-ppc64le@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-linux-ppc64le@npm:0.14.2"
@@ -17237,6 +17335,13 @@ __metadata:
 "esbuild-netbsd-64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-netbsd-64@npm:0.13.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-netbsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-netbsd-64@npm:0.13.15"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -17255,6 +17360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-openbsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-openbsd-64@npm:0.13.15"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-openbsd-64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-openbsd-64@npm:0.14.2"
@@ -17265,6 +17377,13 @@ __metadata:
 "esbuild-sunos-64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-sunos-64@npm:0.13.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-sunos-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-sunos-64@npm:0.13.15"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -17301,6 +17420,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-windows-32@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-32@npm:0.13.15"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-32@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-windows-32@npm:0.14.2"
@@ -17315,6 +17441,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-windows-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-64@npm:0.13.15"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-windows-64@npm:0.14.2"
@@ -17325,6 +17458,13 @@ __metadata:
 "esbuild-windows-arm64@npm:0.13.12":
   version: 0.13.12
   resolution: "esbuild-windows-arm64@npm:0.13.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-arm64@npm:0.13.15"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -17395,6 +17535,68 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 7ef4ef3e8eec11b832224b8886ccea22f72e89e2d9b59ec45d03bb2a512ca725fdb06e88609884e0721a4b90d1095e3ec898bd6f39a4efa0e2c99770730e0041
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.13.12":
+  version: 0.13.15
+  resolution: "esbuild@npm:0.13.15"
+  dependencies:
+    esbuild-android-arm64: 0.13.15
+    esbuild-darwin-64: 0.13.15
+    esbuild-darwin-arm64: 0.13.15
+    esbuild-freebsd-64: 0.13.15
+    esbuild-freebsd-arm64: 0.13.15
+    esbuild-linux-32: 0.13.15
+    esbuild-linux-64: 0.13.15
+    esbuild-linux-arm: 0.13.15
+    esbuild-linux-arm64: 0.13.15
+    esbuild-linux-mips64le: 0.13.15
+    esbuild-linux-ppc64le: 0.13.15
+    esbuild-netbsd-64: 0.13.15
+    esbuild-openbsd-64: 0.13.15
+    esbuild-sunos-64: 0.13.15
+    esbuild-windows-32: 0.13.15
+    esbuild-windows-64: 0.13.15
+    esbuild-windows-arm64: 0.13.15
+  dependenciesMeta:
+    esbuild-android-arm64:
+      optional: true
+    esbuild-darwin-64:
+      optional: true
+    esbuild-darwin-arm64:
+      optional: true
+    esbuild-freebsd-64:
+      optional: true
+    esbuild-freebsd-arm64:
+      optional: true
+    esbuild-linux-32:
+      optional: true
+    esbuild-linux-64:
+      optional: true
+    esbuild-linux-arm:
+      optional: true
+    esbuild-linux-arm64:
+      optional: true
+    esbuild-linux-mips64le:
+      optional: true
+    esbuild-linux-ppc64le:
+      optional: true
+    esbuild-netbsd-64:
+      optional: true
+    esbuild-openbsd-64:
+      optional: true
+    esbuild-sunos-64:
+      optional: true
+    esbuild-windows-32:
+      optional: true
+    esbuild-windows-64:
+      optional: true
+    esbuild-windows-arm64:
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: d5fac8f28a6328592e45f9d49a7e98420cf2c2a3ff5a753bbf011ab79bcb5c062209ef862d3ae0875d8f2a50d40c112b0224e8b419a7cbffc6e2b02cee11ef7e
   languageName: node
   linkType: hard
 
@@ -32540,7 +32742,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.10, postcss@npm:^8.2.1, postcss@npm:^8.2.10, postcss@npm:^8.2.15, postcss@npm:^8.2.4, postcss@npm:^8.3.0, postcss@npm:^8.3.5, postcss@npm:^8.3.6, postcss@npm:^8.3.7":
+"postcss@npm:^8.1.10, postcss@npm:^8.2.1, postcss@npm:^8.2.10, postcss@npm:^8.2.15, postcss@npm:^8.2.4, postcss@npm:^8.3.0, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.3.6, postcss@npm:^8.3.7":
   version: 8.4.4
   resolution: "postcss@npm:8.4.4"
   dependencies:
@@ -35560,6 +35762,20 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   bin:
     rollup: dist/bin/rollup
   checksum: bcd41dfe8afb7e0d97ce2237752165bdda689bcce6321d96821d565de3e0c865a49b544923f315985be2bfde086f72b54aae4ae7c87f798b3cb9558a5bec4e65
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^2.59.0":
+  version: 2.61.1
+  resolution: "rollup@npm:2.61.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: a41bd821c1d9f296e71e867828150080fb05d08cbdff9b6b5c0e3642da4d0723f7a847189f197c2a695a8a353d968ad89ebd54a4228dc3e92765c00e6bbadf87
   languageName: node
   linkType: hard
 
@@ -41549,6 +41765,35 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"vite@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "vite@npm:2.7.1"
+  dependencies:
+    esbuild: ^0.13.12
+    fsevents: ~2.3.2
+    postcss: ^8.3.11
+    resolve: ^1.20.0
+    rollup: ^2.59.0
+  peerDependencies:
+    less: "*"
+    sass: "*"
+    stylus: "*"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    less:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 3e7bfcf2b37b27cbd8de7846fc5cc49aeebb2d793484ae40d2d4174894f1339c0c3c3fc4c9a1919c28b089efa5e64c9fadec5bd0a0a2fa852e771ff7fdd4dc94
+  languageName: node
+  linkType: hard
+
 "vlq@npm:^1.0.0":
   version: 1.0.1
   resolution: "vlq@npm:1.0.1"
@@ -41733,7 +41978,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"watchify@npm:^3.11.0, watchify@npm:^3.11.1":
+"watchify@npm:^3.11.1":
   version: 3.11.1
   resolution: "watchify@npm:3.11.1"
   dependencies:


### PR DESCRIPTION
It's a bit hacky, but it works :)

We should be getting even more performance when we switch to ESM and
stop using JSX in `.js` files.

Next step would be to migrate the website to Vite (EDIT: probably not, the website is using Hexo there's no reason to move away from it), and the bundle to ESBuild.