### PR TITLE
meta: update linter config to parse ESM files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,6 +146,17 @@ module.exports = {
 
   overrides: [
     {
+      files: [
+        '*.mjs',
+        'private/dev/*.js',
+        'private/release/*.js',
+        'private/remark-lint-uppy/*.js',
+      ],
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
+    {
       files: ['./packages/@uppy/companion/**/*.js'],
       rules: {
         'no-restricted-syntax': 'warn',

--- a/packages/uppy/index.mjs
+++ b/packages/uppy/index.mjs
@@ -3,8 +3,10 @@ export { default as Core } from '@uppy/core'
 
 // Utilities
 export { default as server } from '@uppy/companion-client'
+/* eslint-disable */
 import ProviderView from '@uppy/provider-views'
-export var views = { ProviderView: ProviderView }
+export var views = { ProviderView }
+/* eslint-enable */
 
 // Stores
 export { default as DefaultStore } from '@uppy/store-default'

--- a/private/locale-pack/helpers.mjs
+++ b/private/locale-pack/helpers.mjs
@@ -11,7 +11,7 @@ export function getPaths (globPath) {
 
 export function sortObjectAlphabetically (obj) {
   return Object.fromEntries(
-    Object.entries(obj).sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    Object.entries(obj).sort(([keyA], [keyB]) => keyA.localeCompare(keyB)),
   )
 }
 

--- a/private/locale-pack/index.mjs
+++ b/private/locale-pack/index.mjs
@@ -106,7 +106,7 @@ function generateTypes (pluginName, locale) {
     '@uppy',
     pluginName,
     'types',
-    'generatedLocale.d.ts'
+    'generatedLocale.d.ts',
   )
 
   const localeTypes = dedent`
@@ -131,7 +131,7 @@ function generateLocaleDocs (pluginName) {
 
   if (!fs.existsSync(docPath)) {
     console.error(
-      `⚠️  Could not find markdown documentation file for "${pluginName}". Make sure the plugin name matches the markdown file name.`
+      `⚠️  Could not find markdown documentation file for "${pluginName}". Make sure the plugin name matches the markdown file name.`,
     )
     return
   }

--- a/private/locale-pack/test.mjs
+++ b/private/locale-pack/test.mjs
@@ -76,7 +76,7 @@ function getAllFilesPerPlugin (pluginNames) {
 
     if (name in pluginLocaleDependencies) {
       filesPerPlugin[name] = filesPerPlugin[name].concat(
-        getFiles(pluginLocaleDependencies[name])
+        getFiles(pluginLocaleDependencies[name]),
       )
     }
   }
@@ -93,14 +93,14 @@ async function unused (filesPerPlugin, data) {
       '@uppy',
       name,
       'src',
-      'locale.js'
+      'locale.js',
     )
     const locale = (await import(localePath)).default
 
     for (const key of Object.keys(locale.strings)) {
       const regPat = new RegExp(
         `(i18n|i18nArray)\\([^\\)]*['\`"]${key}['\`"]`,
-        'g'
+        'g',
       )
       if (!fileString.match(regPat)) {
         return Promise.reject(new Error(`Unused locale key "${key}" in @uppy/${name}`))
@@ -136,7 +136,7 @@ function warnings ({ leadingLocale, followerLocales }) {
           `${chalk.cyan(name)} locale has missing string: '${chalk.red(key)}'`,
           `that is present in ${chalk.cyan(leadingLocaleName)}`,
           `with value: ${chalk.yellow(value)}`,
-        ].join(' ')
+        ].join(' '),
       )
     }
 
@@ -150,7 +150,7 @@ function warnings ({ leadingLocale, followerLocales }) {
           `${chalk.cyan(name)} locale has excess string:`,
           `'${chalk.yellow(key)}' that is not present`,
           `in ${chalk.cyan(leadingLocaleName)}.`,
-        ].join(' ')
+        ].join(' '),
       )
     }
   }


### PR DESCRIPTION
Turns out `.mjs` files were not covered by the linter. This PR aims to fix that.