### PR TITLE
add `.npmignore` files to ignore .gitignore when packing

### DIFF
--- a/packages/@uppy/angular/.npmignore
+++ b/packages/@uppy/angular/.npmignore
@@ -1,0 +1,1 @@
+# This file need to be there so .gitignored files are still uploaded to the npm registry.

--- a/packages/@uppy/companion/.npmignore
+++ b/packages/@uppy/companion/.npmignore
@@ -1,0 +1,1 @@
+# This file need to be there so .gitignored files are still uploaded to the npm registry.

--- a/packages/@uppy/svelte/.npmignore
+++ b/packages/@uppy/svelte/.npmignore
@@ -1,0 +1,1 @@
+# This file need to be there so .gitignored files are still uploaded to the npm registry.

--- a/packages/@uppy/vue/.npmignore
+++ b/packages/@uppy/vue/.npmignore
@@ -1,0 +1,1 @@
+# This file need to be there so .gitignored files are still uploaded to the npm registry.

--- a/packages/uppy/.npmignore
+++ b/packages/uppy/.npmignore
@@ -1,0 +1,1 @@
+# This file need to be there so .gitignored files are still uploaded to the npm registry.


### PR DESCRIPTION
This issue was probably introduced when we switched to Yarn, I suppose Lerna was not following the same rules as npm and Yarn.

See: https://www.npmjs.com/package/npm-packlist
Fixes: https://github.com/transloadit/uppy/issues/3360
Fixes: https://github.com/transloadit/uppy/issues/3378