### PR TITLE
website: update december 2021 blog post

### DIFF
--- a/website/src/_posts/2021-12-2.1-2.3.md
+++ b/website/src/_posts/2021-12-2.1-2.3.md
@@ -10,9 +10,11 @@ image: https://uppy.io/images/blog/2.1-2.3/audio-cover.jpg
 published: true
 ---
 
+<!--retext-simplify ignore very-->
+
 Last Christmas, we gave you [Uppy 1.24](https://uppy.io/blog/2020/12/1.24/), but this very next year, we’ll take it away (since it’s outdated by now) and give you a brand-new Uppy 2.3 🎁!
 
-After the [release](https://uppy.io/blog/2021/08/2.0/) of our latest major version, 2.0.0, we’ve been busy with many things. First of all is the long-awaited Audio plugin to record and upload live audio directly. We then worked on adding a fast and efficient streaming interface to Companion and made Unsplash production ready. Housekeeping was also part of the job: we made Status Bar improvements, moved from NPM to Yarn 3, did some refactoring, and updated dependencies.
+After the [release](https://uppy.io/blog/2021/08/2.0/) of our latest major version, 2.0.0, we’ve been busy with many things. First of all is the long-awaited Audio plugin to record and upload live audio directly. We then worked on adding a fast and efficient streaming interface to Companion and made Unsplash production ready. Housekeeping was also part of the job: we made Status Bar improvements, moved from npm to Yarn 3, did some refactoring, and updated dependencies.
 
 Last but not least, we got the issue count down from around 110 since 2.0.0 to around 45 now.
 
@@ -58,7 +60,7 @@ The Status Bar plugin would get confused about upload errors in Uppy, and we’v
 
 ## Internal housekeeping
 
-### Yarn v3 instead of NPM
+### Yarn v3 instead of npm
 
 We’ve switched the Uppy repo to Yarn 3 to improve package install performance. With our complex dependency graph and over thirty packages in a monorepo, we are seeing install times reduced by more than a few minutes!
 
@@ -88,7 +90,7 @@ Here are some highlights:
 * A changelog will be generated.
 * The contributions table will be updated.
 * GitHub Actions will create a release candidate pull request.
-* When approved, GitHub Actions automatically merges, publishes to NPM, and creates CDN bundles.
+* When approved, GitHub Actions automatically merges, publishes to the npm public registry, and creates CDN bundles.
 
 [View the PR](https://github.com/transloadit/uppy/pull/3304).
 


### PR DESCRIPTION
The `lint-markdown` job is failing on `main`, this PR fixes it. It also fix `NPM` -> `npm`.