### PR TITLE
Fix exifr import

### DIFF
--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -2,7 +2,7 @@ const { UIPlugin } = require('@uppy/core')
 const dataURItoBlob = require('@uppy/utils/lib/dataURItoBlob')
 const isObjectURL = require('@uppy/utils/lib/isObjectURL')
 const isPreviewSupported = require('@uppy/utils/lib/isPreviewSupported')
-const exifr = require('exifr')
+const exifr = require('exifr/dist/lite.umd.js')
 
 const locale = require('./locale')
 

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -2,7 +2,7 @@ const { UIPlugin } = require('@uppy/core')
 const dataURItoBlob = require('@uppy/utils/lib/dataURItoBlob')
 const isObjectURL = require('@uppy/utils/lib/isObjectURL')
 const isPreviewSupported = require('@uppy/utils/lib/isPreviewSupported')
-const exifr = require('exifr/dist/mini.legacy.umd.js')
+const exifr = require('exifr')
 
 const locale = require('./locale')
 


### PR DESCRIPTION
Thumbnail generator currently crashes when you add an image.

The sad thing is that `lite` is bigger than `mini` so this increases the bundle size. We only use exifr for rotation so ideally we just abstract that. 