### PR TITLE
Fix TypeError when invalid initialization vector

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -125,7 +125,18 @@ module.exports.decrypt = (encrypted, secret) => {
 
   const iv = Buffer.from(encrypted.slice(0, 32), 'hex')
   const encryptionWithoutIv = encrypted.slice(32)
-  const decipher = crypto.createDecipheriv('aes256', createSecret(secret), iv)
+
+  let decipher
+  try {
+    decipher = crypto.createDecipheriv('aes256', createSecret(secret), iv)
+  } catch (err) {
+    if (err.code === 'ERR_CRYPTO_INVALID_IV') {
+      throw new Error('Invalid initialization vector')
+    } else {
+      throw err
+    }
+  }
+
   let decrypted = decipher.update(urlDecode(encryptionWithoutIv), 'base64', 'utf8')
   decrypted += decipher.final('utf8')
   return decrypted


### PR DESCRIPTION
This can happen for example when `encrypted` has less than 32 bytes
of hex content.

Without this patch, a `TypeError` is thrown, which is unexpected and set off
monitoring.