### PR TITLE
Default to HEAD requests when the Companion looks to get meta information about a URL

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -102,13 +102,24 @@ module.exports.getProtectedHttpAgent = (protocol, blockPrivateIPs) => {
  *
  * @param {string} url
  * @param {boolean} blockLocalIPs
+ * @param {string} method
  * @returns {Promise<{type: string, size: number}>}
  */
-exports.getURLMeta = (url, blockLocalIPs = false) => {
+exports.getURLMeta = (url, blockLocalIPs = false, method = 'auto') => {
+  let tryGETOnFailure = false
+
+  // We prefer to use a HEAD request, as it doesn't download the content. If the URL doesn't
+  // support HEAD, or doesn't follow the spec and provide the correct Content-Length, we
+  // fallback to GET.
+  if (method === 'auto') {
+    method = 'HEAD'
+    tryGETOnFailure = true
+  }
+
   return new Promise((resolve, reject) => {
     const opts = {
       uri: url,
-      method: 'GET',
+      method,
       followRedirect: exports.getRedirectEvaluator(url, blockLocalIPs),
       agentClass: exports.getProtectedHttpAgent((new URL(url)).protocol, blockLocalIPs),
     }
@@ -117,6 +128,18 @@ exports.getURLMeta = (url, blockLocalIPs = false) => {
       if (err) reject(err)
     })
     req.on('response', (response) => {
+      // Can be undefined for unknown length URLs, e.g. transfer-encoding: chunked
+      const contentLength = parseInt(response.headers['content-length'], 10)
+
+      if (method === 'HEAD' && tryGETOnFailure) {
+        // We look for status codes in the 400 and 500 ranges here, as 3xx errors are
+        // unlikely to have to do with our choice of method
+        if (response.statusCode >= 400 || contentLength === 0 || Number.isNaN(contentLength)) {
+          resolve(exports.getURLMeta(url, blockLocalIPs, 'GET'))
+          return
+        }
+      }
+
       if (response.statusCode >= 300) {
         // @todo possibly set a status code in the error object to get a more helpful
         // hint at what the cause of error is.
@@ -124,8 +147,6 @@ exports.getURLMeta = (url, blockLocalIPs = false) => {
       } else {
         req.abort() // No need to get the rest of the response, as we only want header
 
-        // Can be undefined for unknown length URLs, e.g. transfer-encoding: chunked
-        const contentLength = parseInt(response.headers['content-length'], 10)
         resolve({
           type: response.headers['content-type'],
           size: Number.isNaN(contentLength) ? null : contentLength,

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -104,6 +104,7 @@ const getConfigFromEnv = () => {
     multipleInstances: true,
     streamingUpload: process.env.COMPANION_STREAMING_UPLOAD === 'true',
     maxFileSize: process.env.COMPANION_MAX_FILE_SIZE ? parseInt(process.env.COMPANION_MAX_FILE_SIZE, 10) : undefined,
+    chunkSize: process.env.COMPANION_CHUNK_SIZE ? parseInt(process.env.COMPANION_CHUNK_SIZE, 10) : undefined,
   }
 }
 

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -248,6 +248,9 @@ export COMPANION_STREAMING_UPLOAD=true
 
 # corresponds to the maxFileSize option
 export COMPANION_MAX_FILE_SIZE="100000000"
+
+# corresponds to the chunkSize option
+export COMPANION_CHUNK_SIZE="50000000"
 ```
 
 See [env.example.sh](https://github.com/transloadit/uppy/blob/main/env.example.sh) for an example configuration script.


### PR DESCRIPTION
At present, the URL loading component of the Companion makes two GET requests to the target URL. The first is only used to gather meta information (the files Content-Length and Content-Type), and then is aborted. The second downloads the file. Of course, depending on how much of the body has already been sent, and how well the delivering server understands aborts, this may result in a significant amount of unnecessary body data also being sent in that first meta request.

HTTP has a way to gather meta information about a file, the HEAD HTTP method. It is specified that a response from HEAD should include the Content-Length that will be returned from a GET request, making this a suitable option assuming the server in question implements HEAD correctly.

This change optimistically attempts a HEAD request. If it fails, or it doesn't return a meaningful Content-Length, it fallsback to the GET request currently used.

# Compatibility

I believe this should not change the behavior of the module significantly unless:

- The URL being fetched implements HEAD in a truly standards-incompliant way which returns a value, but not the right value
- The HEAD request takes a very long time to return it's non-result, slowing down the overall download

# Value

Conversely, I believe that this will slightly improve performance, and potentially significantly decrease server overhead, for URLs which implement standards correctly. Given that I imagine most URLs point to well-behaved instances of popular web servers, I think that probably amounts to 99%+ of the requests being made. Given we still will always fallback to a GET request on failure, I think the percentage of URLs this will cause issues with is quite small.

# Note

I also included a tiny additional change, adding CHUNK_SIZE as an option which can be specified using env vars. Apologies if it can't be merged in this PR.