### PR TITLE
Force include babel numeric separator

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,7 @@ module.exports = (api) => {
         include: [
           '@babel/plugin-proposal-nullish-coalescing-operator',
           '@babel/plugin-proposal-optional-chaining',
+          '@babel/plugin-proposal-numeric-separator',
         ],
         loose: true,
         targets,


### PR DESCRIPTION
Fixes #3421 

It's interesting that this needs to be explicitly included, just like nullish coalescing, in order for it to work. 