### PR TITLE
dev: fix Vite custom plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,6 @@
     "@types/redis": "2",
     "@types/eslint@^7.2.13": "^8.2.0",
     "npm-auth-to-token@1.0.0": "patch:npm-auth-to-token@npm:1.0.0#.yarn/patches/npm-auth-to-token-npm-1.0.0-c288ce201f",
-    "babel-plugin-transform-commonjs@2.1.6": "patch:babel-plugin-transform-commonjs@npm:1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809"
+    "babel-plugin-transform-commonjs@1.1.6": "patch:babel-plugin-transform-commonjs@npm:1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11299,6 +11299,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-transform-commonjs@patch:babel-plugin-transform-commonjs@npm:1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
+  version: 1.1.6
+  resolution: "babel-plugin-transform-commonjs@patch:babel-plugin-transform-commonjs@npm%3A1.1.6#.yarn/patches/babel-plugin-transform-commonjs-npm-1.1.6-0007fa2809::version=1.1.6&hash=f83dbd&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.0.0
+  peerDependencies:
+    "@babel/core": ">=7"
+  checksum: 5995b2641a8551fcc8d0f9d24222ae15698100917edffc8d98f8033cc65b1e577e6b346ac4dbf2456425e494bd1caf1f6646002163953a88290e901f611d83ad
+  languageName: node
+  linkType: hard
+
 "babel-preset-current-node-syntax@npm:^1.0.0":
   version: 1.0.1
   resolution: "babel-preset-current-node-syntax@npm:1.0.1"


### PR DESCRIPTION
In https://github.com/transloadit/uppy/pull/3363, the `"resolutions"` field in `package.json` was mistakenly altered, which broke `yarn dev`.