### PR TITLE
fix broken thumbnails for box and dropbox

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/thumbnail.js
+++ b/packages/@uppy/companion/src/server/controllers/thumbnail.js
@@ -10,12 +10,8 @@ async function thumbnail (req, res, next) {
   const { provider } = req.companion
 
   try {
-    const response = await provider.thumbnail({ id, token })
-    if (response) {
-      response.pipe(res)
-    } else {
-      res.sendStatus(404)
-    }
+    const { stream } = await provider.thumbnail({ id, token })
+    stream.pipe(res)
   } catch (err) {
     if (err.isAuthError) res.sendStatus(401)
     else next(err)


### PR DESCRIPTION
those are the only two providers who use companion-proxied thumbnails
dropbox had been broken after #3159
box did never work before because it just showed a placeholder (see box api)
also upgraded dropbox thumbnail api to v2
and rewrite to async/await