### PR TITLE
Missing comma and wrong attribute name on cors example config

### DIFF
--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -181,8 +181,8 @@ While the Uppy AWS S3 plugin uses `POST` requests when uploading files to an S3 
       "x-amz-date",
       "x-amz-content-sha256",
       "content-type"
-    ]
-    "ExposedHeaders": ["ETag"]
+    ],
+    "ExposeHeaders": ["ETag"]
   },
   {
     "AllowedOrigins": ["*"],


### PR DESCRIPTION
Missing comma and wrong attribute name on cors example config