### PR TITLE
@uppy/unsplash: fix nested meta

### DIFF
--- a/packages/@uppy/provider-views/src/View.js
+++ b/packages/@uppy/provider-views/src/View.js
@@ -101,7 +101,7 @@ module.exports = class View {
     }
 
     if (file.author) {
-      if (file.author.name) tagFile.meta.authorName = file.author.name
+      if (file.author.name != null) tagFile.meta.authorName = String(file.author.name)
       if (file.author.url) tagFile.meta.authorUrl = file.author.url
     }
 


### PR DESCRIPTION
causing error #3477

originally worked on by @mifi in https://github.com/transloadit/uppy/pull/3478, but we need to release a fix asap