### PR TITLE
meta: fix CDN bundle

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,7 @@ website/themes/uppy/source/js/uppy.js
 website/themes/uppy/source/uppy/**
 test/endtoend/*/build
 examples/dev/output
-bundle.js
+bundle-legacy.js
 website/src/_posts/201*.md
 website/src/_posts/2020-*.md
 website/src/_posts/2021-01-*.md

--- a/bin/build-bundle.mjs
+++ b/bin/build-bundle.mjs
@@ -37,12 +37,12 @@ await fs.mkdir(new URL('./@uppy/locales/dist', PACKAGES_ROOT), { recursive: true
 
 const methods = [
   buildBundle(
-    './packages/uppy/index.js',
+    './packages/uppy/bundle.js',
     './packages/uppy/dist/uppy.min.js',
     { standalone: 'Uppy' },
   ),
   buildBundle(
-    './packages/uppy/bundle.js',
+    './packages/uppy/bundle-legacy.js',
     './packages/uppy/dist/uppy.legacy.min.js',
     {
       standalone: 'Uppy (with polyfills)',

--- a/packages/@uppy/robodog/bundle-legacy.js
+++ b/packages/@uppy/robodog/bundle-legacy.js
@@ -1,0 +1,11 @@
+require('core-js')
+require('whatwg-fetch')
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
+// Order matters: AbortController needs fetch which needs Promise.
+
+require('md-gum-polyfill')
+const ResizeObserver = require('resize-observer-polyfill')
+
+if (typeof window.ResizeObserver !== 'function') window.ResizeObserver = ResizeObserver
+
+module.exports = require('.')

--- a/packages/@uppy/robodog/bundle.js
+++ b/packages/@uppy/robodog/bundle.js
@@ -1,11 +1,1 @@
-require('core-js')
-require('whatwg-fetch')
-require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
-// Order matters: AbortController needs fetch which needs Promise.
-
-require('md-gum-polyfill')
-const ResizeObserver = require('resize-observer-polyfill')
-
-if (typeof window.ResizeObserver !== 'function') window.ResizeObserver = ResizeObserver
-
-module.exports = require('.')
+module.exports = require('./bundle-legacy.js')

--- a/packages/uppy/bundle-legacy.js
+++ b/packages/uppy/bundle-legacy.js
@@ -1,0 +1,14 @@
+require('core-js')
+require('whatwg-fetch')
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
+// Order matters: AbortController needs fetch which needs Promise.
+
+require('md-gum-polyfill')
+const ResizeObserver = require('resize-observer-polyfill')
+
+if (typeof window.ResizeObserver !== 'function') window.ResizeObserver = ResizeObserver
+
+// Needed for Babel
+require("regenerator-runtime/runtime")
+
+require('./bundle.js')

--- a/packages/uppy/bundle.js
+++ b/packages/uppy/bundle.js
@@ -1,14 +1,2 @@
-require('core-js')
-require('whatwg-fetch')
-require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
-// Order matters: AbortController needs fetch which needs Promise.
-
-require('md-gum-polyfill')
-const ResizeObserver = require('resize-observer-polyfill')
-
-if (typeof window.ResizeObserver !== 'function') window.ResizeObserver = ResizeObserver
-
-// Needed for Babel
-require("regenerator-runtime/runtime");
-
+// eslint-disable-next-line no-multi-assign
 globalThis.Uppy = module.exports = require('.')


### PR DESCRIPTION
Make `Uppy` available on the global scope when loaded from the CDN bundle.