### PR TITLE
Add chunks back to prepareUploadParts, indexed by partNumber

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -248,6 +248,11 @@ class MultipartUploader {
         key: this.key,
         uploadId: this.uploadId,
         partNumbers: candidates.map((index) => index + 1),
+        chunks: candidates.reduce((chunks, candidate) => ({
+          ...chunks,
+          // Use the part number as the index
+          [candidate + 1]: this.chunks[candidate],
+        }), {}),
       }),
     })
 

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -143,10 +143,18 @@ describe('AwsS3Multipart', () => {
 
       await core.upload()
 
+      function validatePartData ({ partNumbers, chunks }, expected) {
+        expect(partNumbers).toEqual(expected)
+        partNumbers.forEach(partNumber => {
+          expect(chunks[partNumber]).toBeDefined()
+        })
+      }
+
       expect(awsS3Multipart.opts.prepareUploadParts.mock.calls.length).toEqual(3)
-      expect(awsS3Multipart.opts.prepareUploadParts.mock.calls[0][1].partNumbers).toEqual([1, 2, 3, 4, 5])
-      expect(awsS3Multipart.opts.prepareUploadParts.mock.calls[1][1].partNumbers).toEqual([6, 7, 8])
-      expect(awsS3Multipart.opts.prepareUploadParts.mock.calls[2][1].partNumbers).toEqual([9, 10])
+
+      validatePartData(awsS3Multipart.opts.prepareUploadParts.mock.calls[0][1], [1, 2, 3, 4, 5])
+      validatePartData(awsS3Multipart.opts.prepareUploadParts.mock.calls[1][1], [6, 7, 8])
+      validatePartData(awsS3Multipart.opts.prepareUploadParts.mock.calls[2][1], [9, 10])
 
       const completeCall = awsS3Multipart.opts.completeMultipartUpload.mock.calls[0][1]
 

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -21,7 +21,7 @@ interface AwsS3MultipartOptions extends PluginOptions {
     ) => MaybePromise<AwsS3Part[]>
     prepareUploadParts?: (
       file: UppyFile,
-      partData: { uploadId: string; key: string; partNumbers: Array<number> }
+      partData: { uploadId: string; key: string; partNumbers: Array<number>; chunks: { [k: number]: Blob } }
     ) => MaybePromise<{ presignedUrls: { [k: number]: string }, headers?: { [k: string]: string } }>
     abortMultipartUpload?: (
       file: UppyFile,

--- a/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
@@ -22,6 +22,7 @@ import type { AwsS3Part } from '..'
       expectType<string>(partData.uploadId)
       expectType<string>(partData.key)
       expectType<Array<number>>(partData.partNumbers)
+      expectType<{ [k: number]: Blob }>(partData.chunks)
       return { presignedUrls: {} }
     },
     abortMultipartUpload (file, opts) {

--- a/website/src/docs/aws-s3-multipart.md
+++ b/website/src/docs/aws-s3-multipart.md
@@ -110,6 +110,7 @@ A function that generates a batch of signed URLs for the specified part numbers.
 * `uploadId` - The UploadID of this Multipart upload.
 * `key` - The object key in the S3 bucket.
 * `partNumbers` - An array of indecies of this part in the file (`PartNumber` in S3 terminology). Note that part numbers are _not_ zero-based.
+* `chunks` - A Javascript object with the part numbers as keys and the Blob data for each part as the value.
 
 `prepareUploadParts` should return a `Promise` with an `Object` with keys:
 


### PR DESCRIPTION
This updates the part data passed to prepareUploadParts to also include an object of chunk data. Every part number passed should have a key in the object, with the value being it's associated chunk.

I added some tests for validation, but it mostly just tests that the chunks are indexed correctly in the object. It would be nice to actually validate that it's passing the proper chunk data as well, but I couldn't figure out how to do something like that with the mocked Blob objects.

This is intended to fix https://github.com/transloadit/uppy/issues/3391