### PR TITLE
meta: Fix yarn caching in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
+          cache: 'yarn'
       - name: Install Corepack if needed
         run: corepack -v || npm install -g corepack
       - name: Install dependencies
@@ -44,6 +45,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Run linter
@@ -65,6 +67,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Run linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install Corepack if needed
+        run: corepack -v || npm install -g corepack
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
@@ -32,8 +34,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
-      - name: Install Corepack if needed
-        run: corepack -v || npm install -g corepack
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
-          cache: 'yarn'
       - name: Install Corepack if needed
         run: corepack -v || npm install -g corepack
       - name: Install dependencies
@@ -35,17 +45,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Run linter
@@ -57,17 +71,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Run linter
@@ -79,6 +97,17 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -16,11 +16,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
-          cache: 'yarn'
       - name: Install Corepack if needed
         run: corepack -v || npm install -g corepack
       - name: Install dependencies

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -16,16 +16,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
+          cache: 'yarn'
       - name: Install Corepack if needed
         run: corepack -v || npm install -g corepack
       - name: Install dependencies

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install Corepack if needed
+        run: corepack -v || npm install -g corepack
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
@@ -31,8 +33,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
-      - name: Install Corepack if needed
-        run: corepack -v || npm install -g corepack
       - name: Install dependencies
         run: corepack yarn install --immutable
         env:

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -17,11 +17,21 @@ jobs:
           # Necessary for yarn version plugin
           # https://yarnpkg.com/features/release-workflow#commit-history
           fetch-depth: 0
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Build Uppy packages

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -17,16 +17,11 @@ jobs:
           # Necessary for yarn version plugin
           # https://yarnpkg.com/features/release-workflow#commit-history
           fetch-depth: 0
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Build Uppy packages

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 16.x
       - name: Install dependencies
-        run: corepack yarn install
+        run: corepack yarn install --immutable
       - name: Build before publishing
         run: corepack yarn run build
       - name: Upload `${{ github.event.inputs.name }}` to CDN

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -13,16 +13,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Build before publishing

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -13,11 +13,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Build before publishing

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: 16.x
       - name: Install dependencies
-        run: corepack yarn install
+        run: corepack yarn install --immutable
       - name: Bump candidate packages version
         run: corepack yarn version apply --all --json | jq -s > releases.json
       - name: Prepare changelog

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,11 +18,21 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git rebase FETCH_HEAD
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Bump candidate packages version

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -20,7 +20,7 @@ jobs:
           git rebase FETCH_HEAD
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,16 +18,11 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git rebase FETCH_HEAD
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Bump candidate packages version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Get CHANGELOG diff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 16.x
       - name: Install dependencies
-        run: corepack yarn install
+        run: corepack yarn install --immutable
       - name: Get CHANGELOG diff
         run: git --no-pager diff HEAD^ -- CHANGELOG.md | awk '{ if( substr($0,0,1) == "+" && $1 != "+##" && $1 != "+Released:" && $1 != "+++" ) { print substr($0,2) } }' > CHANGELOG.diff.md
       - name: Copy README for `uppy` package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install
       - name: Get CHANGELOG diff

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,16 +11,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Cache npm dependencies
-        id: cache-npm-libraries
-        uses: actions/cache@v2
-        with:
-          path: .yarn/cache/*
-          key: ${{ runner.os }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Build Uppy

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,11 +11,21 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'yarn'
       - name: Install dependencies
         run: corepack yarn install --immutable
       - name: Build Uppy

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
I can see that the "install dependencies" (yarn) step on our github actions is taking the majority of the time.
I believe that our caching logic is not valid, and that this may be the reason why.
I believe it should be like this: https://github.com/actions/cache/blob/main/examples.md#node---yarn-2

However the [setup-node](https://github.com/actions/setup-node) action also uses the cache action and hopefully will handle this correctly when specifying "yarn".