### PR TITLE
@uppy/companion: reorder reqToOptions

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -255,7 +255,7 @@ class Uploader {
     const useFormData = useFormDataIsSet ? req.body.useFormData : true
 
     return {
-      // Client provided info.
+      // Client provided info (must be validated and not blindly trusted):
       headers: req.body.headers,
       httpMethod: req.body.httpMethod,
       protocol: req.body.protocol,
@@ -264,7 +264,8 @@ class Uploader {
       metadata: req.body.metadata,
       fieldname: req.body.fieldname,
       useFormData,
-      // Server provided info.
+
+      // Info coming from companion server configuration:
       size,
       companionOptions: req.companion.options,
       pathPrefix: `${req.companion.options.filePath}`,

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -255,22 +255,24 @@ class Uploader {
     const useFormData = useFormDataIsSet ? req.body.useFormData : true
 
     return {
-      companionOptions: req.companion.options,
+      // Client provided info.
+      headers: req.body.headers,
+      httpMethod: req.body.httpMethod,
+      protocol: req.body.protocol,
       endpoint: req.body.endpoint,
       uploadUrl: req.body.uploadUrl,
-      protocol: req.body.protocol,
       metadata: req.body.metadata,
-      httpMethod: req.body.httpMethod,
-      useFormData,
-      size,
       fieldname: req.body.fieldname,
+      useFormData,
+      // Server provided info.
+      size,
+      companionOptions: req.companion.options,
       pathPrefix: `${req.companion.options.filePath}`,
       storage: redis.client(),
       s3: req.companion.s3Client ? {
         client: req.companion.s3Client,
         options: req.companion.options.providerOptions.s3,
       } : null,
-      headers: req.body.headers,
       chunkSize: req.companion.options.chunkSize,
     }
   }


### PR DESCRIPTION
Giving a clear separation between client-provided info and server
provided ones.