### PR TITLE
Order Google Drive results by folder to show all folders first

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -143,6 +143,7 @@ class Drive extends Provider {
         pageToken: query.cursor,
         q,
         // pageSize: 10, // can be used for testing pagination if you don't have many files
+        orderBy: 'folder,name',
         includeItemsFromAllDrives: true,
         supportsAllDrives: true,
       }

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -17,10 +17,6 @@ const SHARED_DRIVE_FIELDS = '*'
 // Hopefully this name will not be used by Google
 const VIRTUAL_SHARED_DIR = 'shared-with-me'
 
-function sortByName (first, second) {
-  return first.name.localeCompare(second.name)
-}
-
 async function waitForFailedResponse (resp) {
   const buf = await new Promise((resolve) => {
     let data = ''
@@ -71,7 +67,7 @@ function adaptData (listFilesResp, sharedDrivesResp, directory, query, showShare
 
   const adaptedItems = [
     ...(virtualItem ? [virtualItem] : []), // shared folder first
-    ...([...sharedDrives, ...items].map(adaptItem).sort(sortByName)),
+    ...([...sharedDrives, ...items].map(adaptItem)),
   ]
 
   return {


### PR DESCRIPTION
Fixes https://github.com/transloadit/uppy/issues/3387

`orderBy: 'folder,name'` sorts the files returned from https://www.googleapis.com/drive/v3/files with folders first and then sorts by name. This should prevent the insertion of folders to the top of the results when scrolling/paginating like see in #3387 