### PR TITLE
Make tus and transloadit e2e tests more stable

### DIFF
--- a/e2e/cypress/integration/dashboard-transloadit.spec.ts
+++ b/e2e/cypress/integration/dashboard-transloadit.spec.ts
@@ -12,6 +12,7 @@ describe('Dashboard with Transloadit', () => {
 
     cy.wait('@assemblies')
     cy.wait('@resumable')
+    cy.wait('@assemblies')
 
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
   })

--- a/e2e/cypress/integration/dashboard-tus.spec.ts
+++ b/e2e/cypress/integration/dashboard-tus.spec.ts
@@ -45,8 +45,9 @@ describe('Dashboard with Tus', () => {
 
   it('should upload remote image with URL plugin', () => {
     cy.get('[data-cy="Url"]').click()
-    cy.get('.uppy-Url-input').type('https://via.placeholder.com/600x400')
+    cy.get('.uppy-Url-input').type('https://raw.githubusercontent.com/transloadit/uppy/main/assets/developed-by-transloadit.png')
     cy.get('.uppy-Url-importButton').click()
+    cy.wait('@url')
     cy.get('.uppy-StatusBar-actionBtn--upload').click()
     cy.wait('@url')
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')


### PR DESCRIPTION
- Remote image used placeholder website, which now does some checks what kind of browser you are.
- Add another transloadit assembly request wait to prevent possible race condition