### PR TITLE
@uppy/companion - Fetch all Google Drive shared drives

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -111,21 +111,30 @@ class Drive extends Provider {
     const isRoot = directory === 'root'
     const isVirtualSharedDirRoot = directory === VIRTUAL_SHARED_DIR
 
-    async function fetchSharedDrives () {
+    async function fetchSharedDrives (pageToken = null) {
       try {
         const shouldListSharedDrives = isRoot && !query.cursor
         if (!shouldListSharedDrives) return undefined
 
         const resp = await new Promise((resolve, reject) => client
           .get('drives')
-          .qs({ fields: SHARED_DRIVE_FIELDS })
+          .qs({ fields: SHARED_DRIVE_FIELDS, pageToken, pageSize: 100 })
           .auth(options.token)
           .request((err, resp2) => {
             if (err || resp2.statusCode !== 200) return reject(handleErrorResponse(err, resp2))
             return resolve(resp2)
           }))
 
-        return resp && resp.body
+        const body = resp && resp.body
+        const nextPageToken = body && body.nextPageToken
+        if (nextPageToken) {
+          return fetchSharedDrives(nextPageToken).then((moreShared) => {
+            const drives = body.drives || []
+            const moreDrives = (moreShared && moreShared.drives) || []
+            return { ...body, ...moreShared, drives: [...drives, ...moreDrives] }
+          })
+        }
+        return body
       } catch (err) {
         logger.error(err, 'provider.drive.sharedDrive.error')
         throw err

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -125,14 +125,14 @@ class Drive extends Provider {
             return resolve(resp2)
           }))
 
-        const body = resp && resp.body
+        if (!resp) return resp
+
+        const { body } = resp
         const nextPageToken = body && body.nextPageToken
         if (nextPageToken) {
-          return fetchSharedDrives(nextPageToken).then((moreShared) => {
-            const drives = body.drives || []
-            const moreDrives = (moreShared && moreShared.drives) || []
-            return { ...body, ...moreShared, drives: [...drives, ...moreDrives] }
-          })
+          const nextBody = await fetchSharedDrives(nextPageToken)
+          if (!nextBody) return body
+          return { ...nextBody, drives: [...body.drives, ...nextBody.drives] }
         }
         return body
       } catch (err) {


### PR DESCRIPTION
Fixes #3539 

By default Google only returns 10 shared drives in `fetchSharedDrives`. I have more than that so some of mine were missing from the file picker.

On `main`, 10 shared drives are loaded before my folders and files.

![image](https://user-images.githubusercontent.com/11539300/157552448-f54d2133-0e47-4751-ab3d-a5522a532169.png)


Two changes in this PR

The first and smallest one was to increase the `pageSize` for listing shared drives to the maximum of 100. This is probably good enough for most use-cases (and would be for mine).

The second was to check the response to `fetchSharedDrives` and see if a `nextPageToken` was returned and to continue fetching shared drives until no page token is returned. This is different from how the file pagination works, but I couldn't figure out how to keep track of two cursors (one for the shared drives and one for the files) for subsequent pagination requests on scroll. I was able to test these changes locally by setting the `pageSize` to something really small like `3` and confirming that all my shared drives were loaded. It does take longer to load if there are additional pages of shared drives, but that would only affect people with more than 100 shared drives (because of the first change) and that seemed like a reasonable trade-off to me.

Here is evidence of this working from this branch. Note there were more shared drives than would fit on one screen, but I checked and all the ones I had access to were loaded.

![image](https://user-images.githubusercontent.com/11539300/157553293-de78ff13-c2fe-43d1-b8cf-089d78a0f5e9.png)
