### PR TITLE
meta: fix e2e

### DIFF
--- a/bin/build-lib.js
+++ b/bin/build-lib.js
@@ -103,13 +103,14 @@ async function buildLib () {
       visitor: {
         // eslint-disable-next-line no-shadow
         ImportDeclaration (path) {
-          const { value } = path.node.source
+          let { value } = path.node.source
           if (value.endsWith('.jsx') && value.startsWith('./')) {
             // Rewrite .jsx imports to .js:
-            path.node.source.value = value.slice(0, -1) // eslint-disable-line no-param-reassign
-          } else if (PACKAGE_JSON_IMPORT.test(value)
-                     && path.node.specifiers.length === 1
-                     && path.node.specifiers[0].type === 'ImportDefaultSpecifier') {
+            value = path.node.source.value = value.slice(0, -1) // eslint-disable-line no-param-reassign,no-multi-assign
+          }
+          if (PACKAGE_JSON_IMPORT.test(value)
+              && path.node.specifiers.length === 1
+              && path.node.specifiers[0].type === 'ImportDefaultSpecifier') {
             // Vendor-in version number from package.json files:
             const version = versionCache.get(file.slice(0, file.indexOf('/src/')))
             if (version != null) {
@@ -121,12 +122,34 @@ async function buildLib () {
                   ]))]),
               )
             }
-          } else if (!value.startsWith('.')
-                     && path.node.specifiers.length === 1
-                     && path.node.specifiers[0].type === 'ImportDefaultSpecifier'
-          ) {
-            // Replace default imports with straight require calls (CommonJS interop):
-            const [{ local }] = path.node.specifiers
+          } else if (path.node.specifiers[0].type === 'ImportDefaultSpecifier') {
+            const [{ local }, ...otherSpecifiers] = path.node.specifiers
+            if (otherSpecifiers.length === 1 && otherSpecifiers[0].type === 'ImportNamespaceSpecifier') {
+              // import defaultVal, * as namespaceImport from '@uppy/package'
+              // is transformed into:
+              // const defaultVal = require('@uppy/package'); const namespaceImport = defaultVal
+              path.insertAfter(
+                t.variableDeclaration('const', [
+                  t.variableDeclarator(
+                    otherSpecifiers[0].local,
+                    local,
+                  ),
+                ]),
+              )
+            } else if (otherSpecifiers.length !== 0) {
+              // import defaultVal, { exportedVal as importedName, other } from '@uppy/package'
+              // is transformed into:
+              // const defaultVal = require('@uppy/package'); const { exportedVal: importedName, other } = defaultVal
+              path.insertAfter(t.variableDeclaration('const', [t.variableDeclarator(
+                t.objectPattern(
+                  otherSpecifiers.map(specifier => t.objectProperty(
+                    t.identifier(specifier.imported.name),
+                    specifier.local,
+                  )),
+                ),
+                local,
+              )]))
+            }
             path.replaceWith(
               t.variableDeclaration('const', [
                 t.variableDeclarator(

--- a/e2e/clients/dashboard-compressor/index.html
+++ b/e2e/clients/dashboard-compressor/index.html
@@ -5,7 +5,5 @@
     <title>dashboard-compressor</title>
     <script defer type="module" src="app.js"></script>
   </head>
-  <body>
-    <div id="app"></div>
-  </body>
+  <body></body>
 </html>

--- a/e2e/clients/index.html
+++ b/e2e/clients/index.html
@@ -8,12 +8,12 @@
     <h1>Test apps</h1>
     <nav>
       <ul>
-        <li><a href="dashboard-tus/index.html">dashboard-tus</a></li>
-        <li><a href="dashboard-transloadit/index.html">dashboard-transloadit</a></li>
-				<li><a href="dashboard-ui/index.html">dashboard-ui</a></li>
-				<li><a href="dashboard-react/index.html">dashboard-react</a></li>
-				<li><a href="dashboard-vue/index.html">dashboard-vue</a></li>
 				<li><a href="dashboard-compressor/index.html">dashboard-compressor</a></li>
+				<li><a href="dashboard-react/index.html">dashboard-react</a></li>
+        <li><a href="dashboard-transloadit/index.html">dashboard-transloadit</a></li>
+        <li><a href="dashboard-tus/index.html">dashboard-tus</a></li>
+				<li><a href="dashboard-ui/index.html">dashboard-ui</a></li>
+				<li><a href="dashboard-vue/index.html">dashboard-vue</a></li>
 			</ul>
     <nav>
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,19 +5056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/babel-ast-utils@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/babel-ast-utils@npm:2.0.1"
-  dependencies:
-    "@babel/parser": ^7.0.0
-    "@parcel/babylon-walk": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    astring: ^1.6.2
-  checksum: e286a28aa7d716de23ddcdfc5494fdb388699b681ff56be1e3cbc1c04352903f79d5cf22873340adf951846d43dbb2b6548bb6bbeb7758f5cd5c789f6c555e81
-  languageName: node
-  linkType: hard
-
 "@parcel/babel-ast-utils@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/babel-ast-utils@npm:2.2.1"
@@ -5082,16 +5069,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/babylon-walk@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/babylon-walk@npm:2.0.1"
-  dependencies:
-    "@babel/types": ^7.12.13
-    lodash.clone: ^4.5.0
-  checksum: 6926e782983f33af18cac61ce537e7873f4867ddc6c515975b2c353ca13d1580c463e8965cf69088650dffcb3979d79b915906def13494801c77059f34b68136
-  languageName: node
-  linkType: hard
-
 "@parcel/babylon-walk@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/babylon-walk@npm:2.2.1"
@@ -5099,19 +5076,6 @@ __metadata:
     "@babel/types": ^7.12.13
     lodash.clone: ^4.5.0
   checksum: 76996c6672e7dd033b4e2a56f96430ca8631155f10003226bb441849b60f938ad0a4f8ee140a8bdfb4570d57f2ea0bc9bc230c374996f7cd51f81f17e498f057
-  languageName: node
-  linkType: hard
-
-"@parcel/bundler-default@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/bundler-default@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/hash": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-  checksum: 3664ced6fe5cbf6efdbfec9b478276e5215bdda5cc0d0184b03fe2c342efa29399d9cff839d1ab5bbee3cabb53eada551f579151dfebc11209fa659fdbfb1e93
   languageName: node
   linkType: hard
 
@@ -5125,19 +5089,6 @@ __metadata:
     "@parcel/utils": ^2.2.1
     nullthrows: ^1.1.1
   checksum: 3b5d55f87572a9be1a0d2a381320a8b85ba8cdd51fbcb08a1fa9754f02396ad8481ad83435e1bf05b2c3b503b07f95cc4565dacd06f56dbcb6edaf3d7f61f815
-  languageName: node
-  linkType: hard
-
-"@parcel/cache@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/cache@npm:2.0.1"
-  dependencies:
-    "@parcel/logger": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    lmdb-store: ^1.5.5
-  peerDependencies:
-    "@parcel/core": ^2.0.0
-  checksum: 2d150a5ebf425f82a658f063a5e42467593d8c105c648250c952451ecd6105c5c3a25a46cf0a70d7f35b6af5ca035046c31b11bd0b88cb30e31dc9aaf93c73a8
   languageName: node
   linkType: hard
 
@@ -5155,18 +5106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/codeframe@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/codeframe@npm:2.0.1"
-  dependencies:
-    chalk: ^4.1.0
-    emphasize: ^4.2.0
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.0
-  checksum: 31d4ad02f342454a3492d78afd16c100f115efb8d625f112a3424f52c495738071a5dc621bf723a0c37484247ebe3da268c6eb40d904295c8d2ecec555258ee7
-  languageName: node
-  linkType: hard
-
 "@parcel/codeframe@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/codeframe@npm:2.2.1"
@@ -5179,61 +5118,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/compressor-raw@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/compressor-raw@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-  checksum: eae932bc954a9973c59fa1a2008329720b76eeecb20f9a87efd4b58576187fc21b2ba811bffc3755d6fb5f239d782c52e8dda7b88d371f432430073dce6dad54
-  languageName: node
-  linkType: hard
-
 "@parcel/compressor-raw@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/compressor-raw@npm:2.2.1"
   dependencies:
     "@parcel/plugin": ^2.2.1
   checksum: d48746253c4606116d7053c0ec814c78c2645b9d9cfe036bdf9cbbe715f9eaf258c5b679874558e1b5cbf1c46882353d946d757c837e2e6a3a9c6ff3a3808e33
-  languageName: node
-  linkType: hard
-
-"@parcel/config-default@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/config-default@npm:2.0.1"
-  dependencies:
-    "@parcel/bundler-default": ^2.0.1
-    "@parcel/compressor-raw": ^2.0.1
-    "@parcel/namer-default": ^2.0.1
-    "@parcel/optimizer-cssnano": ^2.0.1
-    "@parcel/optimizer-htmlnano": ^2.0.1
-    "@parcel/optimizer-image": ^2.0.1
-    "@parcel/optimizer-svgo": ^2.0.1
-    "@parcel/optimizer-terser": ^2.0.1
-    "@parcel/packager-css": ^2.0.1
-    "@parcel/packager-html": ^2.0.1
-    "@parcel/packager-js": ^2.0.1
-    "@parcel/packager-raw": ^2.0.1
-    "@parcel/packager-svg": ^2.0.1
-    "@parcel/reporter-dev-server": ^2.0.1
-    "@parcel/resolver-default": ^2.0.1
-    "@parcel/runtime-browser-hmr": ^2.0.1
-    "@parcel/runtime-js": ^2.0.1
-    "@parcel/runtime-react-refresh": ^2.0.1
-    "@parcel/runtime-service-worker": ^2.0.1
-    "@parcel/transformer-babel": ^2.0.1
-    "@parcel/transformer-css": ^2.0.1
-    "@parcel/transformer-html": ^2.0.1
-    "@parcel/transformer-image": ^2.0.1
-    "@parcel/transformer-js": ^2.0.1
-    "@parcel/transformer-json": ^2.0.1
-    "@parcel/transformer-postcss": ^2.0.1
-    "@parcel/transformer-posthtml": ^2.0.1
-    "@parcel/transformer-raw": ^2.0.1
-    "@parcel/transformer-react-refresh-wrap": ^2.0.1
-    "@parcel/transformer-svg": ^2.0.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0
-  checksum: 39dd37242ad07587d1e050ad8fd2bb57308330c66394223c3946f46b293953b4ecfb8805aed210a62715bdadb20c35482864300d08902bb3a8dbb8af0048511a
   languageName: node
   linkType: hard
 
@@ -5277,38 +5167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/core@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/core@npm:2.0.1"
-  dependencies:
-    "@parcel/cache": ^2.0.1
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/events": ^2.0.1
-    "@parcel/fs": ^2.0.1
-    "@parcel/graph": ^2.0.1
-    "@parcel/hash": ^2.0.1
-    "@parcel/logger": ^2.0.1
-    "@parcel/package-manager": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    "@parcel/workers": ^2.0.1
-    abortcontroller-polyfill: ^1.1.9
-    base-x: ^3.0.8
-    browserslist: ^4.6.6
-    clone: ^2.1.1
-    dotenv: ^7.0.0
-    dotenv-expand: ^5.1.0
-    json-source-map: ^0.6.1
-    json5: ^1.0.1
-    micromatch: ^4.0.2
-    nullthrows: ^1.1.1
-    semver: ^5.4.1
-  checksum: b92d36f0e2d2ba3a0a86e2763468e4b91a4ab2e0a1a68d952ce75887ca6b1eea3d8b33bdc33ab5aa67f6831a3ca8da3c86302e9e43d835e2b60b864eb86ad21e
-  languageName: node
-  linkType: hard
-
 "@parcel/core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/core@npm:2.2.1"
@@ -5342,16 +5200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/diagnostic@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/diagnostic@npm:2.0.1"
-  dependencies:
-    json-source-map: ^0.6.1
-    nullthrows: ^1.1.1
-  checksum: e117392814404e74e0ccef4d50026215c24c5a1cfd1a336ccba5c47b9d5c97de0335727c4be86de435fe94cb94094cc174e72fe5c40bdcb93f2c8dde4bfa9c95
-  languageName: node
-  linkType: hard
-
 "@parcel/diagnostic@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/diagnostic@npm:2.2.1"
@@ -5362,26 +5210,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/events@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/events@npm:2.0.1"
-  checksum: 49f0f94c6090f41f183f499ac98f3d96dff9cf3974ff7f28839aa42b2026f17dac62066d509dd046f466783fd62cbe68954c1e145e2030f5d1213713ec9c0e9a
-  languageName: node
-  linkType: hard
-
 "@parcel/events@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/events@npm:2.2.1"
   checksum: f6818d4050aabd1a900b4609f12f47509fb2c4d1a7cbc4b170519b4ea5bcb29ef2f9ae136a65690f2a2524f62451c316b711c7ae0218b4919f73babd7943845d
-  languageName: node
-  linkType: hard
-
-"@parcel/fs-search@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/fs-search@npm:2.0.1"
-  dependencies:
-    detect-libc: ^1.0.3
-  checksum: 5dbb91ae735f80f72bdfa6e6d34e3b89b30db7f6ede105d18fcd8dffcf07c6054424791f13a16bf25b6afc80641fc5407296aae9b59a51ed907e9295ba61e6ad
   languageName: node
   linkType: hard
 
@@ -5394,18 +5226,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/fs-write-stream-atomic@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/fs-write-stream-atomic@npm:2.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    iferr: ^1.0.2
-    imurmurhash: ^0.1.4
-    readable-stream: 1 || 2
-  checksum: b0992b587f7a6eb11bc8ecd6605d91cfb6caf2788528efe292a2179904e479ccd91e3b8b0137eade0e40438899e20101360c36c85f3c6b94c3ce92f6d2f753b2
-  languageName: node
-  linkType: hard
-
 "@parcel/fs-write-stream-atomic@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/fs-write-stream-atomic@npm:2.2.1"
@@ -5415,28 +5235,6 @@ __metadata:
     imurmurhash: ^0.1.4
     readable-stream: 1 || 2
   checksum: 41637f72befeb7f23ea4599f32227687fb90b9e8bcd94b8630436e79f4a1164c9663f2e86122093153075fa37cb6bd88cc8fb18412885d3d2584cafce01e34b5
-  languageName: node
-  linkType: hard
-
-"@parcel/fs@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/fs@npm:2.0.1"
-  dependencies:
-    "@parcel/fs-search": ^2.0.1
-    "@parcel/fs-write-stream-atomic": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    "@parcel/watcher": ^2.0.0
-    "@parcel/workers": ^2.0.1
-    graceful-fs: ^4.2.4
-    mkdirp: ^0.5.1
-    ncp: ^2.0.0
-    nullthrows: ^1.1.1
-    rimraf: ^3.0.2
-    utility-types: ^3.10.0
-  peerDependencies:
-    "@parcel/core": ^2.0.0
-  checksum: afaf442321946b474e979d3cbc90cef52722f2443ca2815e32bcc5afa186eea09ba58f0d4fe808a11bfd4f7a505a73623a0df4fe00b5d3498baaa049a078eeaf
   languageName: node
   linkType: hard
 
@@ -5462,15 +5260,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/graph@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/graph@npm:2.0.1"
-  dependencies:
-    nullthrows: ^1.1.1
-  checksum: 58c45040ec821ea4902aef12e193722b865e2d27a4d332e0d895e1f4c6b430ba192d60cb559cb1756e75c67be9994c33ec44086efac94d361984cbd1393603e7
-  languageName: node
-  linkType: hard
-
 "@parcel/graph@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/graph@npm:2.2.1"
@@ -5478,16 +5267,6 @@ __metadata:
     "@parcel/utils": ^2.2.1
     nullthrows: ^1.1.1
   checksum: 037e8c28fb421fd913ecc2f33b48a7a1348697e292c7a3657312c60c3516ef011bc220bb8cd0983c786ab93edca29402db19cd6799573796b56e0131a80c31b6
-  languageName: node
-  linkType: hard
-
-"@parcel/hash@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/hash@npm:2.0.1"
-  dependencies:
-    detect-libc: ^1.0.3
-    xxhash-wasm: ^0.4.1
-  checksum: 8db7d0b37b780baf0ec7a16b852d816767af09013efa9dc980da48f21c3ce3ae42e490fb6c61a15e5683feba23ea0339f0758e588d2ddb389e22533c36d57fee
   languageName: node
   linkType: hard
 
@@ -5501,16 +5280,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/logger@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/logger@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/events": ^2.0.1
-  checksum: 89af4a642710ef96f86d4333303a480cbebb3108da49c9f114d69599c28603a544b0f17d04614812abe0d7f74301f0dc2a398c50d5e743ec45b55dc4908bcf52
-  languageName: node
-  linkType: hard
-
 "@parcel/logger@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/logger@npm:2.2.1"
@@ -5518,15 +5287,6 @@ __metadata:
     "@parcel/diagnostic": ^2.2.1
     "@parcel/events": ^2.2.1
   checksum: 4187100c35f7bb2871c009e6db65242c9b1380d59d9d7894e6a12be7e2daec6fba5c8452e73dffbffec09561c19d879e170ec4d6d3665bb22dfb206c934a8532
-  languageName: node
-  linkType: hard
-
-"@parcel/markdown-ansi@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/markdown-ansi@npm:2.0.1"
-  dependencies:
-    chalk: ^4.1.0
-  checksum: 46bf9bf543ab1b5791b4fc31a420da45c5ed929717f3a154ad0a6526f4738a067e8fc5997fbeaeb464513e5094638c6ff0715f4c5906b3fbe97643268aeaa283
   languageName: node
   linkType: hard
 
@@ -5539,17 +5299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/namer-default@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/namer-default@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    nullthrows: ^1.1.1
-  checksum: fc4b41688d194b276ff7b99f59d4b695ab3fcfcec92062161c14b62f6ffea107bd8cb6ee86097a92134c015231d9fc55fcc60e251e042ddfc0b3fb50d1fd3632
-  languageName: node
-  linkType: hard
-
 "@parcel/namer-default@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/namer-default@npm:2.2.1"
@@ -5558,36 +5307,6 @@ __metadata:
     "@parcel/plugin": ^2.2.1
     nullthrows: ^1.1.1
   checksum: 1685fc7479ee4b9fe70119e554237e532d82cd8cf74083582cc541992ec9cfa33df181e151d39ecec60c321918e2ce024e9fbd7fe3ad8bd2265b412042515137
-  languageName: node
-  linkType: hard
-
-"@parcel/node-libs-browser@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/node-libs-browser@npm:2.0.1"
-  dependencies:
-    assert: ^2.0.0
-    browserify-zlib: ^0.2.0
-    buffer: ^5.5.0
-    console-browserify: ^1.2.0
-    constants-browserify: ^1.0.0
-    crypto-browserify: ^3.12.0
-    domain-browser: ^3.5.0
-    events: ^3.1.0
-    https-browserify: ^1.0.0
-    os-browserify: ^0.3.0
-    path-browserify: ^1.0.0
-    process: ^0.11.10
-    punycode: ^1.4.1
-    querystring-es3: ^0.2.1
-    stream-browserify: ^3.0.0
-    stream-http: ^3.1.0
-    string_decoder: ^1.3.0
-    timers-browserify: ^2.0.11
-    tty-browserify: ^0.0.1
-    url: ^0.11.0
-    util: ^0.12.3
-    vm-browserify: ^1.1.2
-  checksum: 4f983b01afc0736f007ba80e52655ba2a6417b71ecd9018272d13b6d139661b2112e00981b4415c84fc3bb9c88f4a9d031fa88b1f23d39fba4eac68af14d6f6d
   languageName: node
   linkType: hard
 
@@ -5621,19 +5340,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/node-resolver-core@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/node-resolver-core@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/node-libs-browser": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    micromatch: ^4.0.4
-    nullthrows: ^1.1.1
-  checksum: d10a575f851e39aad98322bd3e969ed7102468ee3b5a38dec66e4956c4bb4a1e25a1087579630205a60cfa4064c1c575dfb27356ec122ab19a72b6a6688b6779
-  languageName: node
-  linkType: hard
-
 "@parcel/node-resolver-core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/node-resolver-core@npm:2.2.1"
@@ -5647,18 +5353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-cssnano@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/optimizer-cssnano@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    cssnano: ^5.0.5
-    postcss: ^8.3.0
-  checksum: 369b4fdf1d116cd531822b7fe74cc8190f4a61b2a1e9c4a6d542e2c1526f5b81816c8e854ccd7488df1334e3938c0fcb776bbcf1614143415b090548111a0743
-  languageName: node
-  linkType: hard
-
 "@parcel/optimizer-cssnano@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/optimizer-cssnano@npm:2.2.1"
@@ -5668,19 +5362,6 @@ __metadata:
     cssnano: ^5.0.15
     postcss: ^8.4.5
   checksum: e81cd429ba796e5d16a169b9c54ef4ca355bee3e54808ae9b59a2584447cc21f94a4876a97adedd4fd84bd5c0dc3a3d91a85b503f7019129a150c0dca29e52fd
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-htmlnano@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/optimizer-htmlnano@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    htmlnano: ^1.0.1
-    nullthrows: ^1.1.1
-    posthtml: ^0.16.5
-    svgo: ^2.4.0
-  checksum: 794f927429c0eb4154d0851589f69b878e897cbb0d23c948168238e191aa2bc4620c7e18fe5b3c6f0c810b470674efd3aaf5d9c2cbd595afcdb7a06381efdb32
   languageName: node
   linkType: hard
 
@@ -5697,18 +5378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-image@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/optimizer-image@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    detect-libc: ^1.0.3
-  checksum: 0af9a9000c0ee474f87d7efb3912f79f523ae95f88bdc63ee4f20a19a13a99a6b6498c429d40bf1f789f663b4ce4d205f42338198df26321fe093d1d99742b5c
-  languageName: node
-  linkType: hard
-
 "@parcel/optimizer-image@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/optimizer-image@npm:2.2.1"
@@ -5719,18 +5388,6 @@ __metadata:
     "@parcel/workers": ^2.2.1
     detect-libc: ^1.0.3
   checksum: 05f91ac69a98ca141a8787ed23714856350bcee94ee909f30515a71cbf6c5e6fc649c4cf7b429d3c12b5a178e55ddeb106eef29d619f192f29251143e0e7e4a3
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-svgo@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/optimizer-svgo@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    svgo: ^2.4.0
-  checksum: b5a54fe11fba40da8e976e5a05a44a939c46d9855609a943e45322f86d369a7296838271dac32fc116a588475128ae030bcf78868c6fda70971970fdb3812399
   languageName: node
   linkType: hard
 
@@ -5746,20 +5403,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-terser@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/optimizer-terser@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-    terser: ^5.2.0
-  checksum: 728fdf7e82d53e2f48a32ff949102f79dc4cf3688a9efb7e33b94f88483701cac39e3295ccb95e0b00d69fbb55411c594a0262ee99c8c8cbb0e8b52fd8b8f9d3
-  languageName: node
-  linkType: hard
-
 "@parcel/optimizer-terser@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/optimizer-terser@npm:2.2.1"
@@ -5771,27 +5414,6 @@ __metadata:
     nullthrows: ^1.1.1
     terser: ^5.2.0
   checksum: 5e92a839f570b5d83909fe8da12a8f44f6d1f3191ce5beec6c2b17436c4dd9e82dbc8282d3ab24905ba9b99c5ff09fda8d22233f178324f002d21be26448697b
-  languageName: node
-  linkType: hard
-
-"@parcel/package-manager@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/package-manager@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/fs": ^2.0.1
-    "@parcel/logger": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    "@parcel/workers": ^2.0.1
-    command-exists: ^1.2.6
-    cross-spawn: ^6.0.4
-    nullthrows: ^1.1.1
-    semver: ^5.4.1
-    split2: ^3.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0
-  checksum: d3d760014e050b10642dc8d0ce4866c66d94ae67e16a97f9b0b85cec76a5fa49edf52ef6541dbe432987ba83519354373a1b392d4fd85ac0130687063ed14443
   languageName: node
   linkType: hard
 
@@ -5816,19 +5438,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/packager-css@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/packager-css@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-    postcss: ^8.3.0
-  checksum: 14070304114a6ccbc56f56c238816dbdcc5e9cbc07872b48a7cfa061721283ffa3ee1bdc121101d6643bd00abaf4cd8a80d2f25f0b538fa02358c8a016516140
-  languageName: node
-  linkType: hard
-
 "@parcel/packager-css@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/packager-css@npm:2.2.1"
@@ -5842,19 +5451,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/packager-html@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/packager-html@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-    posthtml: ^0.16.5
-  checksum: d1c466e47eab57062b9b0ce08a5c1dca9ba0c256c337a7b313ea3dac6d00e9359274d62b3b365b4b5d2a3f0ad2021b4eac4e07f4806ce48b34e79df1942986d2
-  languageName: node
-  linkType: hard
-
 "@parcel/packager-html@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/packager-html@npm:2.2.1"
@@ -5865,21 +5461,6 @@ __metadata:
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
   checksum: fc3da9be79008bc7c964c597c3d1924586ce9fdf69fd979c20e3477578f2336f169b051aa12eb180abe6396f9d5d0de2ed0f4913b3c1aa812113caaafad5199c
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-js@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/packager-js@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/hash": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    globals: ^13.2.0
-    nullthrows: ^1.1.1
-  checksum: af604c37b95152c8e5ea896b11e9c8b16d9bd6341c9f28868cbd761a6dd48a7b3c4193e510a1129b337c28abd00f422bdc3c03572559e640d68c3b468b35afb0
   languageName: node
   linkType: hard
 
@@ -5898,33 +5479,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/packager-raw@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/packager-raw@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-  checksum: a7598ac87873374c1ba27292a4722939422025a85c8965603cbeb1cd7a6236450fbb1924ae1beb23c4f5837fdd65116ce281262a4f4907a39f21ea88a031374f
-  languageName: node
-  linkType: hard
-
 "@parcel/packager-raw@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/packager-raw@npm:2.2.1"
   dependencies:
     "@parcel/plugin": ^2.2.1
   checksum: 9aee912c892bb13ef914214d6ee316e7b407d6257263c492fa635e0c52db52dad2e113591a3b2a7da4f4115cd853f942e44912fc029f5360f8a86e6edbee8270
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-svg@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/packager-svg@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    posthtml: ^0.16.4
-  checksum: 871eccaed281672136e2913a1c59c272575dfcf30a52b4349e4de0fe2d5b3351d2782eec876dafdd291754a3c8fb487f825d43562a4cf082b8bd0ddb9ca8a2ac
   languageName: node
   linkType: hard
 
@@ -5940,40 +5500,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/plugin@npm:2.0.1"
-  dependencies:
-    "@parcel/types": ^2.0.1
-  checksum: d99e970724fc7f76e84378d62ee91dcf203e1d18ee9451a680ff0e6404c0604c6a75bb96a9e4cfcca42d55251bdc8cb66704a19e22d21f7f2d21c7cbc83ea01d
-  languageName: node
-  linkType: hard
-
 "@parcel/plugin@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/plugin@npm:2.2.1"
   dependencies:
     "@parcel/types": ^2.2.1
   checksum: 47712a2af23b6890fddacf15fe2e3e82553bc77710590345287c5a8983b9db132f7d25fd36f66d32b547e70a2fd9bd021964ca002496d2af15cc15dd93daced7
-  languageName: node
-  linkType: hard
-
-"@parcel/reporter-cli@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/reporter-cli@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    chalk: ^4.1.0
-    filesize: ^6.1.0
-    nullthrows: ^1.1.1
-    ora: ^5.2.0
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    term-size: ^2.2.1
-    wrap-ansi: ^7.0.0
-  checksum: 2237af80df2bc48ea9d3e685563dcf186bcd2d294c2fe880a6e68dbd6ac5ebe851cfb76d6232aeea1a92c82fe9614606b97cfb068006bee6afdb73a7a856cbb6
   languageName: node
   linkType: hard
 
@@ -5996,22 +5528,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/reporter-dev-server@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/reporter-dev-server@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    connect: ^3.7.0
-    ejs: ^3.1.6
-    http-proxy-middleware: ^1.0.0
-    nullthrows: ^1.1.1
-    serve-handler: ^6.0.0
-    ws: ^7.0.0
-  checksum: f6d9f084892032fea3be90ccac9705d3c3f78a8dbb5e83cfedc95f12865fc27a543f178a9f4985d7b85f39429794f518ea048c6dc0b3d687d2398176ebeee0ae
-  languageName: node
-  linkType: hard
-
 "@parcel/reporter-dev-server@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/reporter-dev-server@npm:2.2.1"
@@ -6028,16 +5544,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/resolver-default@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/resolver-default@npm:2.0.1"
-  dependencies:
-    "@parcel/node-resolver-core": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-  checksum: c6c816a37fcfdccc1bf6dae4d8b968be2e947b8d03d9e44870e59543022885350b985d3ae852e5de76f2befa1c7b8c150b892ab1e0a48201894a641516633fe8
-  languageName: node
-  linkType: hard
-
 "@parcel/resolver-default@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/resolver-default@npm:2.2.1"
@@ -6048,16 +5554,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/runtime-browser-hmr@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/runtime-browser-hmr@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-  checksum: f221e1a2c59278772f0e272946e272bdb72da611e3135e7b14f3939a48fac060d82b695554b2026b4b70120c352f254bdf6c1aebbd9ba469cd1148043dd10d99
-  languageName: node
-  linkType: hard
-
 "@parcel/runtime-browser-hmr@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/runtime-browser-hmr@npm:2.2.1"
@@ -6065,17 +5561,6 @@ __metadata:
     "@parcel/plugin": ^2.2.1
     "@parcel/utils": ^2.2.1
   checksum: 1a660d824900c6d0d03b520aea3a0eb40d68ea19ea871cd91b1af6d9d4aa23618f52533f31b07b9047770efd025d96b7efe9e988fed21af12dfd558c45cd5d33
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-js@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/runtime-js@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-  checksum: 22c6b6a0fbcad42a71775ca01fa243bb3a37939e5fa5768c46507bf75c6e1a219064950cf68e645c2ae3e826ea6ffc33cf9f45ac49fc64a80ea50be1ea91be50
   languageName: node
   linkType: hard
 
@@ -6090,17 +5575,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/runtime-react-refresh@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/runtime-react-refresh@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    react-refresh: ^0.9.0
-  checksum: 9488c026f09608b36b46f1bca747ba8a08846f733c74645851800c77fbc0ccb912b07717029a0fcbcc83681f20cd03d41ce984b43d3297de92d880b8ded4d245
-  languageName: node
-  linkType: hard
-
 "@parcel/runtime-react-refresh@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/runtime-react-refresh@npm:2.2.1"
@@ -6109,17 +5583,6 @@ __metadata:
     "@parcel/utils": ^2.2.1
     react-refresh: ^0.9.0
   checksum: c6c849d3cd525eaa4a718854ff92a3eb2708843c2ecbfc540f2088cd7b591b36112ae2228f6eacd3bf31e98cec18ed9e0379ac2f298bbd4b4260d97380f7cd5c
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-service-worker@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/runtime-service-worker@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-  checksum: 9dbc5b38cb3e83b94e164d8ffdc6ce0d741dc7d277c4c252c4344126fa86c3c25968e605cbd5d4766e044e0ffa8626d9f13953fb047724553c98c5bec95365a3
   languageName: node
   linkType: hard
 
@@ -6141,29 +5604,6 @@ __metadata:
     detect-libc: ^1.0.3
     globby: ^11.0.3
   checksum: 57d964efc4ae6fbebcc3abae4132fe06be8edecbdcb361ef69754f1d0a1814e9a4d7c65aaf93e37fedac41a14e7a535b876d1cc56a27673eb49c3e7a58d7ccad
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-babel@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-babel@npm:2.0.1"
-  dependencies:
-    "@babel/core": ^7.12.0
-    "@babel/generator": ^7.9.0
-    "@babel/helper-compilation-targets": ^7.8.4
-    "@babel/plugin-transform-flow-strip-types": ^7.0.0
-    "@babel/traverse": ^7.0.0
-    "@parcel/babel-ast-utils": ^2.0.1
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    browserslist: ^4.6.6
-    core-js: ^3.2.1
-    json5: ^2.1.0
-    nullthrows: ^1.1.1
-    semver: ^5.7.0
-  checksum: 151538e68248cf119e4a8b5730299f7bbc843bfe738755288d52665bc3c678b336a7735ec9c9c2ce58659784264ec718e85ca60838e86847b2bf246842d0f96d
   languageName: node
   linkType: hard
 
@@ -6190,21 +5630,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-css@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-css@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-    postcss: ^8.3.0
-    postcss-value-parser: ^4.1.0
-    semver: ^5.4.1
-  checksum: b88253c57304b99a6fa2610668a69da054fc82af89668346ed7ba5c12a0eba8b5bb89d6661421ba09669431d4b669bc7b0ac0027a1db030b1bad84a7faee830f
-  languageName: node
-  linkType: hard
-
 "@parcel/transformer-css@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/transformer-css@npm:2.2.1"
@@ -6219,21 +5644,6 @@ __metadata:
     postcss-value-parser: ^4.2.0
     semver: ^5.7.1
   checksum: b5951680780fc7f846a005703a5aa4883440aedc994653290bfd5d0e52b9b486945ad65809d3abc9e201df6740989796493b18d59d1f7d219a33284d3bf1c015
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-html@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-html@npm:2.0.1"
-  dependencies:
-    "@parcel/hash": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    nullthrows: ^1.1.1
-    posthtml: ^0.16.5
-    posthtml-parser: ^0.10.1
-    posthtml-render: ^3.0.0
-    semver: ^5.4.1
-  checksum: c8da872a3a22c670434b492a2d3dd507a331ea38f6f46d6734657c498656e4ce54f665fa79a8957e386ac1b51602c5b85efe1955062bcd10c85b928f28e416b3
   languageName: node
   linkType: hard
 
@@ -6253,17 +5663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-image@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-image@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/workers": ^2.0.1
-    nullthrows: ^1.1.1
-  checksum: d52f40321db3daa44717d49fd4352edd1eaa19e39a9409f1d708dc4d321df61cc72dc767e04626ca8557780c5704119c1be0ef50d7493196fcf4e81c86f312e7
-  languageName: node
-  linkType: hard
-
 "@parcel/transformer-image@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/transformer-image@npm:2.2.1"
@@ -6272,25 +5671,6 @@ __metadata:
     "@parcel/workers": ^2.2.1
     nullthrows: ^1.1.1
   checksum: 0365ffe7079b2e8f72eb142a92302bf2f78ca3e8227678744c65bc6ea8a910b99a71d6d6a402c1b5add2f941925c22689c718e44cf7a8f00ef71b735ccfc2c11
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-js@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-js@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/utils": ^2.0.1
-    "@swc/helpers": ^0.2.11
-    browserslist: ^4.6.6
-    detect-libc: ^1.0.3
-    micromatch: ^4.0.2
-    nullthrows: ^1.1.1
-    regenerator-runtime: ^0.13.7
-    semver: ^5.4.1
-  checksum: 3039089da3df3cfe8a4fc47b8ac5b2d8366fe272bbb7fe9a58597d6a675825c9a5a38e78743321315c84ee93cb82c8ea40700eea289dba5f0d97609675ec92aa
   languageName: node
   linkType: hard
 
@@ -6314,16 +5694,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-json@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-json@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    json5: ^2.1.0
-  checksum: a5e347d79d2351a1421669fe8bb1d967b14390fbecc47a710b17714003bde687520ff13aeadee73c7714eadd6540d5f7eb2a90657ffc911b1a54ef405dcaf116
-  languageName: node
-  linkType: hard
-
 "@parcel/transformer-json@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/transformer-json@npm:2.2.1"
@@ -6331,23 +5701,6 @@ __metadata:
     "@parcel/plugin": ^2.2.1
     json5: ^2.2.0
   checksum: b4c1f373fa73aa0f044fdde6be6b5b43eb15073f5d520d3247e4bb3bb8951e64d3ad45779dd3acdd7e200639c75e77c440d9b488660f098b99b4904af7c94011
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-postcss@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-postcss@npm:2.0.1"
-  dependencies:
-    "@parcel/hash": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    clone: ^2.1.1
-    css-modules-loader-core: ^1.1.0
-    nullthrows: ^1.1.1
-    postcss-modules: ^3.2.2
-    postcss-value-parser: ^4.1.0
-    semver: ^5.4.1
-  checksum: 5d4f37b44a818690762c783f1815d8405474b5f71115fa5732399f879962cb7e1ed1b859caeb868fd678fd4e92b7b33a0b7e0b151bf551a38735b96f031a8166
   languageName: node
   linkType: hard
 
@@ -6367,21 +5720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-posthtml@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-posthtml@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    nullthrows: ^1.1.1
-    posthtml: ^0.16.5
-    posthtml-parser: ^0.10.1
-    posthtml-render: ^3.0.0
-    semver: ^5.4.1
-  checksum: 642b425ec9ce45cf8ceed47dbb9f4916b83090a4eaa344e4d1248b2230311af64d8d9b9ae8aab539d3d5259490fb81cd9ba27e181df305f3881398eba39d1627
-  languageName: node
-  linkType: hard
-
 "@parcel/transformer-posthtml@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/transformer-posthtml@npm:2.2.1"
@@ -6397,32 +5735,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-raw@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-raw@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-  checksum: d47c9bb2a8b4afeeb78f45bd3a66de6eab6cd2cd13af1b697174f32025e53bd922d0eac0d57870d263d4084d36b2f7f5cc30dbc7af5ff6c1dde424c11fa0c638
-  languageName: node
-  linkType: hard
-
 "@parcel/transformer-raw@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/transformer-raw@npm:2.2.1"
   dependencies:
     "@parcel/plugin": ^2.2.1
   checksum: 7c470cb6ef3cd036180a478fb2683f83d210909864d85a92f932a2b1f63a09ccfd001aa797f48f1cb5d7bb2f9207ffa9730172b8c67d1cdb78545dc97f7ba0ef
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-react-refresh-wrap@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.0.1"
-  dependencies:
-    "@parcel/plugin": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    react-refresh: ^0.9.0
-  checksum: ac0985be5d5f85aba2ca2761ce8163037adef9acbdd9d5b7d4ea80afb5637a5138420f0dc4a276e85c1fe9c492b2d76414b05aec9b2d35f73dc5672a5f5db893
   languageName: node
   linkType: hard
 
@@ -6434,21 +5752,6 @@ __metadata:
     "@parcel/utils": ^2.2.1
     react-refresh: ^0.9.0
   checksum: 8b9e0f692cf87d3afcdb4eb353ef090091af557e0e301bd81b6a46251aa400629f37975fed4b2ce07ec7c127bd53ecf0b7981f4820dafa7979e54b76944b83c9
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-svg@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/transformer-svg@npm:2.0.1"
-  dependencies:
-    "@parcel/hash": ^2.0.1
-    "@parcel/plugin": ^2.0.1
-    nullthrows: ^1.1.1
-    posthtml: ^0.16.5
-    posthtml-parser: ^0.10.1
-    posthtml-render: ^3.0.0
-    semver: ^5.4.1
-  checksum: 04c47c24160fc06799333d0d37dc78859d45f97f019d96db3563e892c46e20d69f28ca67f93590baa1e3ed4ed5b8e713aec41b5fbca7745c63e68cfbf3cf31bf
   languageName: node
   linkType: hard
 
@@ -6484,21 +5787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/types@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/types@npm:2.0.1"
-  dependencies:
-    "@parcel/cache": ^2.0.1
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/fs": ^2.0.1
-    "@parcel/package-manager": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    "@parcel/workers": ^2.0.1
-    utility-types: ^3.10.0
-  checksum: bf0823732efd2187bb960b587e739e978f322380c990d5b69bdfea7bb61e44eae3af9e8efd44a74d964cf1975172bb693113af85e2660b8d32a4127456c6ef35
-  languageName: node
-  linkType: hard
-
 "@parcel/types@npm:^2.2.1":
   version: 2.2.1
   resolution: "@parcel/types@npm:2.2.1"
@@ -6511,35 +5799,6 @@ __metadata:
     "@parcel/workers": ^2.2.1
     utility-types: ^3.10.0
   checksum: a08069156cf5a27bbd616e2e8cd49789da873680e5967e6207badc299b15d21d9152b09df4cd21f66a92780736f51cdc77416d791d8e86459ae5abda4293c896
-  languageName: node
-  linkType: hard
-
-"@parcel/utils@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/utils@npm:2.0.1"
-  dependencies:
-    "@iarna/toml": ^2.2.0
-    "@parcel/codeframe": ^2.0.1
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/hash": ^2.0.1
-    "@parcel/logger": ^2.0.1
-    "@parcel/markdown-ansi": ^2.0.1
-    "@parcel/source-map": ^2.0.0
-    ansi-html-community: 0.0.8
-    chalk: ^4.1.0
-    clone: ^2.1.1
-    fast-glob: 3.1.1
-    fastest-levenshtein: ^1.0.8
-    is-glob: ^4.0.0
-    is-url: ^1.2.2
-    json5: ^1.0.1
-    lru-cache: ^6.0.0
-    micromatch: ^4.0.4
-    node-forge: ^0.10.0
-    nullthrows: ^1.1.1
-    open: ^7.0.3
-    terminal-link: ^2.1.1
-  checksum: 54e5249b95ad4959f2783c2bf746b4bb12c60d2405c4611f959aa28764bf4c0d433c52400c273b810796ab674584197048f1b267dfcad0c65e8a0a2de795dd21
   languageName: node
   linkType: hard
 
@@ -6580,22 +5839,6 @@ __metadata:
     node-gyp: latest
     node-gyp-build: ^4.3.0
   checksum: 890bdc69a52942791b276caa2cd65ef816576d6b5ada91aa28cf302b35d567c801dafe167f2525dcb313f5b420986ea11bd56228dd7ddde1116944d8f924a0a1
-  languageName: node
-  linkType: hard
-
-"@parcel/workers@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@parcel/workers@npm:2.0.1"
-  dependencies:
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/logger": ^2.0.1
-    "@parcel/types": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    chrome-trace-event: ^1.0.2
-    nullthrows: ^1.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0
-  checksum: 656b6531539b0d1e011048122b3c590ce46c43a68e41c3bb2e0e3acd5501005df148674747d75b4cd4f809db67a07a000ccc355b076814454291c536141c1494
   languageName: node
   linkType: hard
 
@@ -12171,7 +11414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-globals@npm:^4.3.0, acorn-globals@npm:^4.3.2":
+"acorn-globals@npm:^4.3.2":
   version: 4.3.4
   resolution: "acorn-globals@npm:4.3.4"
   dependencies:
@@ -12245,7 +11488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^6.0.1, acorn@npm:^6.0.4, acorn@npm:^6.4.1":
+"acorn@npm:^6.0.1, acorn@npm:^6.4.1":
   version: 6.4.2
   resolution: "acorn@npm:6.4.2"
   bin:
@@ -16966,20 +16209,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-modules-loader-core@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "css-modules-loader-core@npm:1.1.0"
-  dependencies:
-    icss-replace-symbols: 1.1.0
-    postcss: 6.0.1
-    postcss-modules-extract-imports: 1.1.0
-    postcss-modules-local-by-default: 1.2.0
-    postcss-modules-scope: 1.1.0
-    postcss-modules-values: 1.3.0
-  checksum: e2d513cee6a407b46806e50b3eec9d9034355b6ee14f2f7303353ab0853b8dba9600cffc83ec46cebd3efd68fe2b2aa31808a1c906d043f1c405568fd484eaf5
-  languageName: node
-  linkType: hard
-
 "css-prefers-color-scheme@npm:^3.1.1":
   version: 3.1.1
   resolution: "css-prefers-color-scheme@npm:3.1.1"
@@ -17033,16 +16262,6 @@ __metadata:
     domutils: ^2.6.0
     nth-check: ^2.0.0
   checksum: 40928f1aa6c71faf36430e7f26bcbb8ab51d07b98b754caacb71906400a195df5e6c7020a94f2982f02e52027b9bd57c99419220cf7020968c3415f14e4be5f8
-  languageName: node
-  linkType: hard
-
-"css-selector-tokenizer@npm:^0.7.0":
-  version: 0.7.3
-  resolution: "css-selector-tokenizer@npm:0.7.3"
-  dependencies:
-    cssesc: ^3.0.0
-    fastparse: ^1.1.2
-  checksum: 92560a9616a8bc073b88c678aa04f22c599ac23c5f8587e60f4861069e2d5aeb37b722af581ae3c5fbce453bed7a893d9c3e06830912e6d28badc3b8b99acd24
   languageName: node
   linkType: hard
 
@@ -17312,7 +16531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^5.0.5, cssnano@npm:^5.0.6, cssnano@npm:^5.0.8":
+"cssnano@npm:^5.0.6":
   version: 5.0.12
   resolution: "cssnano@npm:5.0.12"
   dependencies:
@@ -17335,13 +16554,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssom@npm:0.3.x, cssom@npm:^0.3.4, cssom@npm:~0.3.6":
-  version: 0.3.8
-  resolution: "cssom@npm:0.3.8"
-  checksum: 24beb3087c76c0d52dd458be9ee1fbc80ac771478a9baef35dd258cdeb527c68eb43204dd439692bb2b1ae5272fa5f2946d10946edab0d04f1078f85e06bc7f6
-  languageName: node
-  linkType: hard
-
 "cssom@npm:^0.4.1, cssom@npm:^0.4.4":
   version: 0.4.4
   resolution: "cssom@npm:0.4.4"
@@ -17349,12 +16561,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^1.1.1":
-  version: 1.4.0
-  resolution: "cssstyle@npm:1.4.0"
-  dependencies:
-    cssom: 0.3.x
-  checksum: 7efb9731d68dd042f32e0e3bbc7c1096653ba521f21ab1c5b158862321e4fcbfb51070641b834fadc8dd070a634dd43f328177e00d1b8481b5143a3e09f3d3f6
+"cssom@npm:~0.3.6":
+  version: 0.3.8
+  resolution: "cssom@npm:0.3.8"
+  checksum: 24beb3087c76c0d52dd458be9ee1fbc80ac771478a9baef35dd258cdeb527c68eb43204dd439692bb2b1ae5272fa5f2946d10946edab0d04f1078f85e06bc7f6
   languageName: node
   linkType: hard
 
@@ -17442,8 +16652,8 @@ __metadata:
   linkType: hard
 
 "cypress@npm:^9.0.0":
-  version: 9.4.1
-  resolution: "cypress@npm:9.4.1"
+  version: 9.5.1
+  resolution: "cypress@npm:9.5.1"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -17489,7 +16699,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: d068704a1a13b6ab22db2cb6867683d0c2d383c41f4d8ded7529999ed1f2bc929f91edc0a69df56a272230c984458ee8198e007af611860dca6a4a1c918319e8
+  checksum: 96efebb8bfca52f214f793856a7eb40a6eb4a7bc06e5d7c17c7378cec8e3e3975d5777147066d04d95d88b99d4052bbf8749d96b4a25d3f79cc65e88e93f703d
   languageName: node
   linkType: hard
 
@@ -20142,7 +19352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^1.11.0, escodegen@npm:^1.11.1":
+"escodegen@npm:^1.11.1":
   version: 1.14.3
   resolution: "escodegen@npm:1.14.3"
   dependencies:
@@ -21564,13 +20774,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastparse@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "fastparse@npm:1.1.2"
-  checksum: c4d199809dc4e8acafeb786be49481cc9144de296e2d54df4540ccfd868d0df73afc649aba70a748925eb32bbc4208b723d6288adf92382275031a8c7e10c0aa
-  languageName: node
-  linkType: hard
-
 "fastq@npm:^1.6.0":
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
@@ -22561,15 +21764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generic-names@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "generic-names@npm:2.0.1"
-  dependencies:
-    loader-utils: ^1.1.0
-  checksum: 5f2d6837dcddf4d7139f7c7ee4ff6ed82564123ae363aadc7a1c1c9967724da1e10d92c904b76b6ff58912465cf63cf47d87f3b400286845f289f54d5092e78f
-  languageName: node
-  linkType: hard
-
 "generic-names@npm:^4.0.0":
   version: 4.0.0
   resolution: "generic-names@npm:4.0.0"
@@ -23237,13 +22431,6 @@ __metadata:
   version: 1.1.0
   resolution: "has-cors@npm:1.1.0"
   checksum: 549ce94113fd23895b22d71ade9809918577b8558cd4d701fe79045d8b1d58d87eba870260b28f6a3229be933a691c55653afd496d0fc52e98fd2ff577f01197
-  languageName: node
-  linkType: hard
-
-"has-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-flag@npm:1.0.0"
-  checksum: ce3f8ae978e70f16e4bbe17d3f0f6d6c0a3dd3b62a23f97c91d0fda9ed8e305e13baf95cc5bee4463b9f25ac9f5255de113165c5fb285e01b8065b2ac079b301
   languageName: node
   linkType: hard
 
@@ -23991,13 +23178,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"html-tags@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "html-tags@npm:1.2.0"
-  checksum: c4d314997bedd91355dd12e1fc11188b3ec4ab7088974b4d2935950bb571694f9b7164e47edfee46d6b5aced3c57322e0077168d4705e5a191ca54a635621f97
-  languageName: node
-  linkType: hard
-
 "html-tags@npm:^2.0.0":
   version: 2.0.0
   resolution: "html-tags@npm:2.0.0"
@@ -24074,25 +23254,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   version: 1.1.1
   resolution: "htmlescape@npm:1.1.1"
   checksum: c59a915ae6ae076b5720243c8c594fd8c76e927d511ed5f205e4d586f47d521478d7148dc7fbe3d4a0cfc30abcc2dd215b30255903c09ed04eb38bca44367c5d
-  languageName: node
-  linkType: hard
-
-"htmlnano@npm:^1.0.1":
-  version: 1.1.1
-  resolution: "htmlnano@npm:1.1.1"
-  dependencies:
-    cosmiconfig: ^7.0.1
-    cssnano: ^5.0.8
-    postcss: ^8.3.6
-    posthtml: ^0.16.5
-    purgecss: ^4.0.0
-    relateurl: ^0.2.7
-    srcset: ^4.0.0
-    svgo: ^2.6.1
-    terser: ^5.8.0
-    timsort: ^0.3.0
-    uncss: ^0.17.3
-  checksum: c9e25b63de2ac42f232c32e0e3bc0b3aaa1a5ee969259a0fb93e9dcd80813180a4fc940f854fc6028e4520689b955d58bde1f49cce3e285f62c17be992487558
   languageName: node
   linkType: hard
 
@@ -24329,19 +23490,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^1.0.0":
-  version: 1.3.1
-  resolution: "http-proxy-middleware@npm:1.3.1"
-  dependencies:
-    "@types/http-proxy": ^1.17.5
-    http-proxy: ^1.18.1
-    is-glob: ^4.0.1
-    is-plain-obj: ^3.0.0
-    micromatch: ^4.0.2
-  checksum: c6f0fe6d5aa58f3757084f1fad8109e7384fdea1b0a5c62f58ac767c42f367a18d3819bed8cbf8b5183f17e3e14fad04322f179c569629004da5fbec9b81a88a
-  languageName: node
-  linkType: hard
-
 "http-proxy-middleware@npm:^2.0.0":
   version: 2.0.1
   resolution: "http-proxy-middleware@npm:2.0.1"
@@ -24490,7 +23638,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"icss-replace-symbols@npm:1.1.0, icss-replace-symbols@npm:^1.1.0":
+"icss-replace-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "icss-replace-symbols@npm:1.1.0"
   checksum: 24575b2c2f7e762bfc6f4beee31be9ba98a01cad521b5aa9954090a5de2b5e1bf67814c17e22f9e51b7d798238db8215a173d6c2b4726ce634ce06b68ece8045
@@ -25054,7 +24202,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"is-absolute-url@npm:^3.0.0, is-absolute-url@npm:^3.0.1, is-absolute-url@npm:^3.0.3":
+"is-absolute-url@npm:^3.0.0, is-absolute-url@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-absolute-url@npm:3.0.3"
   checksum: 5159b51d065d9ad29e16a2f78d6c0e41c43227caf90a45e659c54ea6fd50ef0595b1871ce392e84b1df7cfdcad9a8e66eec0813a029112188435abf115accb16
@@ -25440,15 +24588,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   version: 1.0.4
   resolution: "is-hexadecimal@npm:1.0.4"
   checksum: a452e047587b6069332d83130f54d30da4faf2f2ebaa2ce6d073c27b5703d030d58ed9e0b729c8e4e5b52c6f1dab26781bb77b7bc6c7805f14f320e328ff8cd5
-  languageName: node
-  linkType: hard
-
-"is-html@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-html@npm:1.1.0"
-  dependencies:
-    html-tags: ^1.0.0
-  checksum: 8dc04ac3898453348472829d81802cf6833156e126b227c65d0bdd144cddf02976a67764d0c54c27f2ad4cbce356a7a9969a911427490b815a1fddb6aa5d03b2
   languageName: node
   linkType: hard
 
@@ -27035,40 +26174,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "jsdom@npm:14.1.0"
-  dependencies:
-    abab: ^2.0.0
-    acorn: ^6.0.4
-    acorn-globals: ^4.3.0
-    array-equal: ^1.0.0
-    cssom: ^0.3.4
-    cssstyle: ^1.1.1
-    data-urls: ^1.1.0
-    domexception: ^1.0.1
-    escodegen: ^1.11.0
-    html-encoding-sniffer: ^1.0.2
-    nwsapi: ^2.1.3
-    parse5: 5.1.0
-    pn: ^1.1.0
-    request: ^2.88.0
-    request-promise-native: ^1.0.5
-    saxes: ^3.1.9
-    symbol-tree: ^3.2.2
-    tough-cookie: ^2.5.0
-    w3c-hr-time: ^1.0.1
-    w3c-xmlserializer: ^1.1.2
-    webidl-conversions: ^4.0.2
-    whatwg-encoding: ^1.0.5
-    whatwg-mimetype: ^2.3.0
-    whatwg-url: ^7.0.0
-    ws: ^6.1.2
-    xml-name-validator: ^3.0.0
-  checksum: c8ece2c4324be30536411a5ef9e52ebccefeb1605bd1ba31d14e40ab576a40a0e7d009bd89edd0e422654e4518383bb1f4ab6f574ccecaf98e5839c200fd7772
-  languageName: node
-  linkType: hard
-
 "jsdom@npm:^16.6.0":
   version: 16.7.0
   resolution: "jsdom@npm:16.7.0"
@@ -27235,7 +26340,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.0.0, json5@npm:^2.1.0, json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0":
+"json5@npm:^2.0.0, json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0":
   version: 2.2.0
   resolution: "json5@npm:2.2.0"
   dependencies:
@@ -28075,20 +27180,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   bin:
     livereload: bin/livereload.js
   checksum: c5d62a974f7206bad7f2f49f64efa28817132b3528d24eff5940ee392ca32464bb8a546fa6205bc31b372feee5ccf223ce440c70e765c2ae8955d1108a0a66d8
-  languageName: node
-  linkType: hard
-
-"lmdb-store@npm:^1.5.5":
-  version: 1.6.14
-  resolution: "lmdb-store@npm:1.6.14"
-  dependencies:
-    msgpackr: ^1.5.0
-    nan: ^2.14.2
-    node-gyp: latest
-    node-gyp-build: ^4.2.3
-    ordered-binary: ^1.0.0
-    weak-lru-cache: ^1.0.0
-  checksum: ba5fbed286efc981fcb0de523e4637d9ef62ebfa96da5ba537b26b74bc60b6eec75b9d8029f5450049c5371cb99be0a8781969491bdf386e5a509b1224ddd6b0
   languageName: node
   linkType: hard
 
@@ -30684,18 +29775,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"msgpackr@npm:^1.5.0":
-  version: 1.5.1
-  resolution: "msgpackr@npm:1.5.1"
-  dependencies:
-    msgpackr-extract: ^1.0.14
-  dependenciesMeta:
-    msgpackr-extract:
-      optional: true
-  checksum: 2289a241283ec8ea17b668fb44bd1ba8eba86a37ae280c1bf438f39588eaabdb997583238c3d83e96e13c6dec502524dbc21c8a2402051e727b1548d10bfbddf
-  languageName: node
-  linkType: hard
-
 "msgpackr@npm:^1.5.1, msgpackr@npm:^1.5.4":
   version: 1.5.4
   resolution: "msgpackr@npm:1.5.4"
@@ -31747,7 +30826,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.1.3, nwsapi@npm:^2.2.0":
+"nwsapi@npm:^2.2.0":
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
   checksum: 5ef4a9bc0c1a5b7f2e014aa6a4b359a257503b796618ed1ef0eb852098f77e772305bb0e92856e4bbfa3e6c75da48c0113505c76f144555ff38867229c2400a7
@@ -32194,13 +31273,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"ordered-binary@npm:^1.0.0":
-  version: 1.2.1
-  resolution: "ordered-binary@npm:1.2.1"
-  checksum: 736f9b228a916af18156adcce309049f171129a08728b5f7041fa2f52706588b668b5ca67613cdfa210cc93300b11960fc56faa101554e98efe1053ec9da1e7b
-  languageName: node
-  linkType: hard
-
 "ordered-binary@npm:^1.2.4":
   version: 1.2.4
   resolution: "ordered-binary@npm:1.2.4"
@@ -32622,33 +31694,9 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"parcel@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "parcel@npm:2.0.1"
-  dependencies:
-    "@parcel/config-default": ^2.0.1
-    "@parcel/core": ^2.0.1
-    "@parcel/diagnostic": ^2.0.1
-    "@parcel/events": ^2.0.1
-    "@parcel/fs": ^2.0.1
-    "@parcel/logger": ^2.0.1
-    "@parcel/package-manager": ^2.0.1
-    "@parcel/reporter-cli": ^2.0.1
-    "@parcel/reporter-dev-server": ^2.0.1
-    "@parcel/utils": ^2.0.1
-    chalk: ^4.1.0
-    commander: ^7.0.0
-    get-port: ^4.2.0
-    v8-compile-cache: ^2.0.0
-  bin:
-    parcel: lib/bin.js
-  checksum: 253da8849417572b9a913150b50665da006961755c67aee1c6a5fd27378161af11c985bcba4e071806781cf51cc4c149b3fc6e7c179a0ebd272d2e3ea5811568
-  languageName: node
-  linkType: hard
-
-"parcel@npm:^2.0.1":
-  version: 2.2.1
-  resolution: "parcel@npm:2.2.1"
+"parcel@npm:^2.0.0, parcel@npm:^2.0.1":
+  version: 2.3.2
+  resolution: "parcel@npm:2.3.2"
   dependencies:
     "@parcel/config-default": ^2.2.1
     "@parcel/core": ^2.2.1
@@ -32666,7 +31714,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     v8-compile-cache: ^2.0.0
   bin:
     parcel: lib/bin.js
-  checksum: 081fdc011a631b88477236f1df4232c16b45e71c1c7a7e861a7b319b042698944e0fb6f9e5615b79f8d4ba5b343bb2736b4393c3798d736951cbfe1ecb1bc8dd
+  checksum: 38c8158afee67ab364a962e480f71d453f449d0bcde1aef15b2e3bb8b397729df1ea03477c1242bd7990d69bba19cecfdbbc5067242bf73d598bf738dd17f6aa
   languageName: node
   linkType: hard
 
@@ -34238,15 +33286,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss-modules-extract-imports@npm:1.1.0":
-  version: 1.1.0
-  resolution: "postcss-modules-extract-imports@npm:1.1.0"
-  dependencies:
-    postcss: ^6.0.1
-  checksum: 3dc9ed98509f654c1220bb8ec7489b30fa4441f2797eb5c894badfd6f4ab1b086f8002f59d47845d827a3f23a40400ba4c18959c7a3702285d4e5bfcfcd180d4
-  languageName: node
-  linkType: hard
-
 "postcss-modules-extract-imports@npm:^2.0.0":
   version: 2.0.0
   resolution: "postcss-modules-extract-imports@npm:2.0.0"
@@ -34262,16 +33301,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   peerDependencies:
     postcss: ^8.1.0
   checksum: 4b65f2f1382d89c4bc3c0a1bdc5942f52f3cb19c110c57bd591ffab3a5fee03fcf831604168205b0c1b631a3dce2255c70b61aaae3ef39d69cd7eb450c2552d2
-  languageName: node
-  linkType: hard
-
-"postcss-modules-local-by-default@npm:1.2.0":
-  version: 1.2.0
-  resolution: "postcss-modules-local-by-default@npm:1.2.0"
-  dependencies:
-    css-selector-tokenizer: ^0.7.0
-    postcss: ^6.0.1
-  checksum: c8bbe0a9584e0a02339f4143125bf5febbcbfdbabedc33a5f2debdc5b0089f5c238b236101dbf923ea66c11637c0dee8bcf91d1692ed0443762203286b864ea2
   languageName: node
   linkType: hard
 
@@ -34300,16 +33329,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss-modules-scope@npm:1.1.0":
-  version: 1.1.0
-  resolution: "postcss-modules-scope@npm:1.1.0"
-  dependencies:
-    css-selector-tokenizer: ^0.7.0
-    postcss: ^6.0.1
-  checksum: e1b7dd8b1aabb0dc719015352835c6865a5b80ef469cf956749540847b751ccac860d7f0f5659aa2c4b8a484c4a9291098895e5c91c9707e02c7f79a7288297e
-  languageName: node
-  linkType: hard
-
 "postcss-modules-scope@npm:^2.2.0":
   version: 2.2.0
   resolution: "postcss-modules-scope@npm:2.2.0"
@@ -34331,16 +33350,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss-modules-values@npm:1.3.0":
-  version: 1.3.0
-  resolution: "postcss-modules-values@npm:1.3.0"
-  dependencies:
-    icss-replace-symbols: ^1.1.0
-    postcss: ^6.0.1
-  checksum: c1d542f71df43ec8b998808ea8de5e74e215a2428e92a8c157da436724aacf246b77440da1cd3d5daae610c875b46e7f8a845b52e1a49afdc37668093de8e3e7
-  languageName: node
-  linkType: hard
-
 "postcss-modules-values@npm:^3.0.0":
   version: 3.0.0
   resolution: "postcss-modules-values@npm:3.0.0"
@@ -34359,23 +33368,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   peerDependencies:
     postcss: ^8.1.0
   checksum: f7f2cdf14a575b60e919ad5ea52fed48da46fe80db2733318d71d523fc87db66c835814940d7d05b5746b0426e44661c707f09bdb83592c16aea06e859409db6
-  languageName: node
-  linkType: hard
-
-"postcss-modules@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "postcss-modules@npm:3.2.2"
-  dependencies:
-    generic-names: ^2.0.1
-    icss-replace-symbols: ^1.1.0
-    lodash.camelcase: ^4.3.0
-    postcss: ^7.0.32
-    postcss-modules-extract-imports: ^2.0.0
-    postcss-modules-local-by-default: ^3.0.2
-    postcss-modules-scope: ^2.2.0
-    postcss-modules-values: ^3.0.0
-    string-hash: ^1.1.1
-  checksum: 6e249518933288f6a8b9fcf988d96e4ea0e5e9d66ccb003ce6bb16bd7565f0c553d7c554497e0ca8feae7cfb049c5c951511b906e481cdd4647085d956b6c7b0
   languageName: node
   linkType: hard
 
@@ -34982,17 +33974,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:6.0.2":
-  version: 6.0.2
-  resolution: "postcss-selector-parser@npm:6.0.2"
-  dependencies:
-    cssesc: ^3.0.0
-    indexes-of: ^1.0.1
-    uniq: ^1.0.1
-  checksum: 5fa344e63bfeda65720d49669696d243b31dd533095fc7a7f39ef8556f511e1ed91ebbe049ff967b2dfa1ac3d5d452091a09614158c94687e24895411ab3c23e
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:^3.0.0, postcss-selector-parser@npm:^3.1.0":
   version: 3.1.2
   resolution: "postcss-selector-parser@npm:3.1.2"
@@ -35015,7 +33996,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4, postcss-selector-parser@npm:^6.0.5, postcss-selector-parser@npm:^6.0.6":
+"postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4, postcss-selector-parser@npm:^6.0.5":
   version: 6.0.6
   resolution: "postcss-selector-parser@npm:6.0.6"
   dependencies:
@@ -35162,17 +34143,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss@npm:6.0.1":
-  version: 6.0.1
-  resolution: "postcss@npm:6.0.1"
-  dependencies:
-    chalk: ^1.1.3
-    source-map: ^0.5.6
-    supports-color: ^3.2.3
-  checksum: 2533d218b6c23dad42fffb98979f3fd2b98bbe11c923e3245ed8f83da9591c176a5de2403ad3ebaedea819f50d5f6c88c40d322265c59b6b10ed8a02c12fd4bc
-  languageName: node
-  linkType: hard
-
 "postcss@npm:8.3.11":
   version: 8.3.11
   resolution: "postcss@npm:8.3.11"
@@ -35181,17 +34151,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     picocolors: ^1.0.0
     source-map-js: ^0.6.2
   checksum: 1a230553d74c66aa9585c90781ed8ea75f19cefea405d2117b67fbeb24b5b5e0e17be2e0c5a07db31dd085643a13394127ab2222e940771b70498331bf20f35e
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^6.0.1":
-  version: 6.0.23
-  resolution: "postcss@npm:6.0.23"
-  dependencies:
-    chalk: ^2.4.1
-    source-map: ^0.6.1
-    supports-color: ^5.4.0
-  checksum: cc6cb2c1dbcdefa6f57a71d67fe535c9e96543298bbe28f9a6a64c4f1e21b6127113890dd4cda8873d3f4e6613a0566b7b4bbb230204f3a9a309190bda065d81
   languageName: node
   linkType: hard
 
@@ -35205,7 +34164,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.10, postcss@npm:^8.2.10, postcss@npm:^8.2.15, postcss@npm:^8.2.4, postcss@npm:^8.3.0, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.3.6, postcss@npm:^8.3.7":
+"postcss@npm:^8.1.10, postcss@npm:^8.2.10, postcss@npm:^8.2.15, postcss@npm:^8.2.4, postcss@npm:^8.3.11, postcss@npm:^8.3.7":
   version: 8.4.5
   resolution: "postcss@npm:8.4.5"
   dependencies:
@@ -35847,20 +34806,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     "@request/api": ^0.6.0
     extend: ^3.0.0
   checksum: 76d723fe820aa236b46ee2a9d928bfaa37fe2a9b4da0495049a6972535a7ac04eb90ee4e01c3051c0d4f49b57c895a3e0bf4f9560caa2aefb5ec10a3314f4db9
-  languageName: node
-  linkType: hard
-
-"purgecss@npm:^4.0.0":
-  version: 4.1.3
-  resolution: "purgecss@npm:4.1.3"
-  dependencies:
-    commander: ^8.0.0
-    glob: ^7.1.7
-    postcss: ^8.3.5
-    postcss-selector-parser: ^6.0.6
-  bin:
-    purgecss: bin/purgecss.js
-  checksum: 508613f904b130401f2a403d3383533f703c6bcd56e1254c1e8f57818a5337db3a667f66f48355f86271b20dd576691357752f460eb2edd94c095e4178391c5f
   languageName: node
   linkType: hard
 
@@ -37386,7 +36331,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"request-promise-native@npm:^1.0.5, request-promise-native@npm:^1.0.7":
+"request-promise-native@npm:^1.0.7":
   version: 1.0.9
   resolution: "request-promise-native@npm:1.0.9"
   dependencies:
@@ -39654,13 +38599,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"srcset@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "srcset@npm:4.0.0"
-  checksum: aceb898c9281101ef43bfbf96bf04dfae828e1bf942a45df6fad74ae9f8f0a425f4bca1480e0d22879beb40dd2bc6947e0e1e5f4d307a714666196164bc5769d
-  languageName: node
-  linkType: hard
-
 "sshpk@npm:^1.14.1":
   version: 1.17.0
   resolution: "sshpk@npm:1.17.0"
@@ -40761,16 +39699,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "supports-color@npm:3.2.3"
-  dependencies:
-    has-flag: ^1.0.0
-  checksum: 56afc05fa87d00100d90148c4d0a6e20a0af0d56dca5c54d4d40b2553ee737dab0ca4e8b53c4471afc035227b5b44dfa4824747a7f01ad733173536f7da6fbbb
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^5.3.0, supports-color@npm:^5.4.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -40937,7 +39866,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"svgo@npm:^2.4.0, svgo@npm:^2.6.1, svgo@npm:^2.7.0":
+"svgo@npm:^2.4.0, svgo@npm:^2.7.0":
   version: 2.8.0
   resolution: "svgo@npm:2.8.0"
   dependencies:
@@ -41298,7 +40227,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.0.0, terser@npm:^5.2.0, terser@npm:^5.7.2, terser@npm:^5.8.0":
+"terser@npm:^5.0.0, terser@npm:^5.2.0, terser@npm:^5.7.2":
   version: 5.10.0
   resolution: "terser@npm:5.10.0"
   dependencies:
@@ -41681,7 +40610,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^2.3.3, tough-cookie@npm:^2.5.0, tough-cookie@npm:~2.5.0":
+"tough-cookie@npm:^2.3.3, tough-cookie@npm:~2.5.0":
   version: 2.5.0
   resolution: "tough-cookie@npm:2.5.0"
   dependencies:
@@ -42324,25 +41253,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     buffer: ^5.2.1
     through: ^2.3.8
   checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
-  languageName: node
-  linkType: hard
-
-"uncss@npm:^0.17.3":
-  version: 0.17.3
-  resolution: "uncss@npm:0.17.3"
-  dependencies:
-    commander: ^2.20.0
-    glob: ^7.1.4
-    is-absolute-url: ^3.0.1
-    is-html: ^1.1.0
-    jsdom: ^14.1.0
-    lodash: ^4.17.15
-    postcss: ^7.0.17
-    postcss-selector-parser: 6.0.2
-    request: ^2.88.0
-  bin:
-    uncss: bin/uncss
-  checksum: 8829b669f02e593313ceb50a29dc4fd9bfb48648a97160bcfb829859ae274dcad2399cd8fb9fd25853273b36919d4626032c9afb0ef5476ad0a91b797e1c749f
   languageName: node
   linkType: hard
 
@@ -44025,13 +42935,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"weak-lru-cache@npm:^1.0.0":
-  version: 1.1.3
-  resolution: "weak-lru-cache@npm:1.1.3"
-  checksum: bc1572721f4fdef536dbeda6c753c8d5879e6f4aed62dc757cc3a438d0f28056345ffa9605c148f8c532862fb0366fed41dc1035adf963497cd51d8001232331
-  languageName: node
-  linkType: hard
-
 "weak-lru-cache@npm:^1.2.2":
   version: 1.2.2
   resolution: "weak-lru-cache@npm:1.2.2"
@@ -44960,7 +43863,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"ws@npm:6.2.2, ws@npm:^6.0.0, ws@npm:^6.1.2, ws@npm:^6.2.1":
+"ws@npm:6.2.2, ws@npm:^6.0.0, ws@npm:^6.2.1":
   version: 6.2.2
   resolution: "ws@npm:6.2.2"
   dependencies:
@@ -45201,7 +44104,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"xxhash-wasm@npm:^0.4.1, xxhash-wasm@npm:^0.4.2":
+"xxhash-wasm@npm:^0.4.2":
   version: 0.4.2
   resolution: "xxhash-wasm@npm:0.4.2"
   checksum: 747b32fcfed1dc9a1e7592b134e4e65794bc10fd5d32515792e486bf4d0b65f9dec790cfc49ce2f9c01dd02e3593c3a6cd51df1ef37adf003c5bbd386c43c64d


### PR DESCRIPTION
- Upgrade Parcel and Cypress to latest versions (not actually related to the CI failure, but nice to have imo)
- Fix output of ESM packages: the failure comes from the fact the transpile step was treating default import as `require('…').default`. It should have been caught by the e2e GHA then, but that's another issue that https://github.com/transloadit/uppy/pull/3561 is trying to address.