### PR TITLE
@uppy/drop-target: ignore if dropped elements aren't files

### DIFF
--- a/packages/@uppy/drop-target/src/index.js
+++ b/packages/@uppy/drop-target/src/index.js
@@ -45,7 +45,17 @@ module.exports = class DropTarget extends BasePlugin {
     }
   }
 
+  isFileTransfer = (event) => {
+    return [].some.call(event.dataTransfer.types, (t) => {
+      return t === 'Files'
+    })
+  }
+
   handleDrop = async (event) => {
+    if (!this.isFileTransfer(event)) {
+      return
+    }
+
     event.preventDefault()
     event.stopPropagation()
     clearTimeout(this.removeDragOverClassTimeout)
@@ -85,6 +95,10 @@ module.exports = class DropTarget extends BasePlugin {
   }
 
   handleDragOver = (event) => {
+    if (!this.isFileTransfer(event)) {
+      return
+    }
+
     event.preventDefault()
     event.stopPropagation()
 
@@ -100,6 +114,10 @@ module.exports = class DropTarget extends BasePlugin {
   }
 
   handleDragLeave = (event) => {
+    if (!this.isFileTransfer(event)) {
+      return
+    }
+
     event.preventDefault()
     event.stopPropagation()
 


### PR DESCRIPTION
We're using the drop-target package in Discourse, and a user noticed that when used in an element that contains form elements, DropTarget blocks dragging text into an input or a textarea form element. I tracked this down to the 

```
      event.preventDefault();
      event.stopPropagation();
```

calls in DropTarget's event listeners and added a check in this PR, if the dropped objects aren't files, all of DropTarget's event listeners are skipped. 