### PR TITLE
always log errors with stack trace

### DIFF
--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -42,7 +42,7 @@ exports.verifyToken = (req, res, next) => {
   const { err, payload } = tokenService.verifyEncryptedToken(token, req.companion.options.secret)
   if (err || !payload[providerName]) {
     if (err) {
-      logger.error(err, 'token.verify.error', req.id)
+      logger.error(err.message, 'token.verify.error', req.id)
     }
     return res.sendStatus(401)
   }

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -197,18 +197,17 @@ module.exports = function server (inputCompanionOptions = {}) {
 
   // @ts-ignore
   app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
-    const logStackTrace = true
     if (app.get('env') === 'production') {
       // if the error is a URIError from the requested URL we only log the error message
       // to avoid uneccessary error alerts
       if (err.status === 400 && err instanceof URIError) {
         logger.error(err.message, 'root.error', req.id)
       } else {
-        logger.error(err, 'root.error', req.id, logStackTrace)
+        logger.error(err, 'root.error', req.id)
       }
       res.status(err.status || 500).json({ message: 'Something went wrong', requestId: req.id })
     } else {
-      logger.error(err, 'root.error', req.id, logStackTrace)
+      logger.error(err, 'root.error', req.id)
       res.status(err.status || 500).json({ message: err.message, error: err, requestId: req.id })
     }
   })

--- a/packages/@uppy/companion/test/__tests__/logger.js
+++ b/packages/@uppy/companion/test/__tests__/logger.js
@@ -57,14 +57,13 @@ describe('Test Logger secret mask', () => {
 
     const exptectedMsg = chalk.bold.red('Error: this error has ****** and ****** and case-insensitive ******')
 
-    expect(loggedMessage).toBeTruthy()
-    expect(loggedMessage).toBe(exptectedMsg)
+    expect(loggedMessage.startsWith(exptectedMsg)).toBeTruthy()
   })
 
   test('masks secret values present in log.error stack trace', () => {
     const loggedMessage = captureConsoleLog(() => {
       const err = new Error('this error has ToBeMasked1 and toBeMasked2 and case-insensitive TOBEMasKED2')
-      logger.error(err, '', '', true)
+      logger.error(err, '', '')
     })
 
     const exptectedMsg = chalk.bold.red('Error: this error has ****** and ****** and case-insensitive ******')


### PR DESCRIPTION
but don't do it for common error types that we ourselves produce

I implemented this as a middle ground. not logging stack traces for ProviderApiError and ProviderAuthError because those are part of the normal flow and not really bugs from us.

fixes #3495