### PR TITLE
Allow not setting ACL when uploading to S3

### DIFF
--- a/packages/@uppy/companion/src/config/companion.js
+++ b/packages/@uppy/companion/src/config/companion.js
@@ -10,7 +10,7 @@ const defaultOptions = {
   },
   providerOptions: {
     s3: {
-      acl: 'public-read',
+      acl: 'public-read', // todo default to no ACL in next major
       endpoint: 'https://{service}.{region}.amazonaws.com',
       conditions: [],
       useAccelerateEndpoint: false,

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -611,14 +611,18 @@ class Uploader {
       return chunkSize
     }
 
-    const upload = client.upload({
+    const params = {
       Bucket: options.bucket,
       Key: options.getKey(null, filename, this.options.metadata),
       ACL: options.acl,
       ContentType: this.options.metadata.type,
       Metadata: this.options.metadata,
       Body: stream,
-    }, {
+    }
+
+    if (options.acl != null) params.ACL = options.acl
+
+    const upload = client.upload(params, {
       partSize: getPartSize(this.options.chunkSize),
     })
 

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -79,7 +79,7 @@ const getConfigFromEnv = () => {
         useAccelerateEndpoint:
           process.env.COMPANION_AWS_USE_ACCELERATE_ENDPOINT === 'true',
         expires: parseInt(process.env.COMPANION_AWS_EXPIRES || '300', 10),
-        acl: process.env.COMPANION_AWS_ACL || 'public-read',
+        acl: process.env.COMPANION_AWS_DISABLE_ACL === 'true' ? null : (process.env.COMPANION_AWS_ACL || 'public-read'), // todo default to no ACL in next major and remove COMPANION_AWS_DISABLE_ACL
       },
     },
     server: {


### PR DESCRIPTION
not all people use buckets with ACL

until next major you can use COMPANION_AWS_DISABLE_ACL=true
to disable setting of ACL in s3 (because the default is currently `public-read`)
I thinkwe should set default to no acl in the next major.

fixes #3570