### PR TITLE
@uppy/robodog: fix CDN bundle

### DIFF
--- a/packages/@uppy/robodog/bundle.js
+++ b/packages/@uppy/robodog/bundle.js
@@ -1,1 +1,2 @@
-module.exports = require('./bundle-legacy.js')
+// eslint-disable-next-line no-multi-assign
+globalThis.Robodog = module.exports = require('./bundle-legacy.js')


### PR DESCRIPTION
It's still unclear to how it was working before that – I couldn't find where the global variable used to be assigned and when that was removed. Anyway, the fix is quite straight-forward, we should release a new version with the fix soon.

Fixes: https://github.com/transloadit/uppy/issues/3582