### PR TITLE
@uppy/companion: fix `yarn test` command

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -87,6 +87,7 @@
     "@types/webpack": "^5.28.0",
     "@types/ws": "6.0.4",
     "into-stream": "^6.0.0",
+    "jest": "^27.0.6",
     "nock": "^13.1.3",
     "supertest": "3.4.2",
     "typescript": "~4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9760,6 +9760,7 @@ __metadata:
     into-stream: ^6.0.0
     ipaddr.js: ^2.0.1
     isobject: 3.0.1
+    jest: ^27.0.6
     jsonwebtoken: 8.5.1
     lodash.merge: ^4.6.2
     mime-types: 2.1.25


### PR DESCRIPTION
Previously it would throw `command not found: jest` error
when running `yarn workspace @uppy/companion test`.