### PR TITLE
Getkey safe behavior

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -63,6 +63,10 @@ module.exports.app = (optionsArg = {}) => {
   validateConfig(optionsArg)
 
   const options = merge({}, defaultOptions, optionsArg)
+
+  // todo remove in next major and default to the safer getKey instead
+  if (options.providerOptions.s3.getKey === defaultOptions.providerOptions.s3.getKey) process.emitWarning('The current default getKey implementation is not safe because it will cause files with the same name to be overwritten and should be avoided. Please use the environment variable COMPANION_S3_GETKEY_SAFE_BEHAVIOR=true (standalone) or provide your own getKey implementation instead')
+
   const providers = providerManager.getDefaultProviders()
   const searchProviders = providerManager.getSearchProviders()
   providerManager.addProviderOptions(options, grantConfig)

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const merge = require('lodash.merge')
 const stripIndent = require('common-tags/lib/stripIndent')
 const crypto = require('crypto')
-const uuid = require('uuid')
+const uuid = require('uuid') // TODO: migrate to `crypto.getRandomUUID` when removing support for Node.js <14.
 
 const utils = require('../server/helpers/utils')
 const logger = require('../server/logger')

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -2,6 +2,8 @@ const fs = require('fs')
 const merge = require('lodash.merge')
 const stripIndent = require('common-tags/lib/stripIndent')
 const crypto = require('crypto')
+const uuid = require('uuid')
+
 const utils = require('../server/helpers/utils')
 const logger = require('../server/logger')
 // @ts-ignore
@@ -27,7 +29,7 @@ const getConfigFromEnv = () => {
   const domains = process.env.COMPANION_DOMAINS || process.env.COMPANION_DOMAIN || null
   const validHosts = domains ? domains.split(',') : []
 
-  return {
+  const envConfig = {
     providerOptions: {
       drive: {
         key: process.env.COMPANION_GOOGLE_KEY,
@@ -113,6 +115,13 @@ const getConfigFromEnv = () => {
     maxFileSize: process.env.COMPANION_MAX_FILE_SIZE ? parseInt(process.env.COMPANION_MAX_FILE_SIZE, 10) : undefined,
     chunkSize: process.env.COMPANION_CHUNK_SIZE ? parseInt(process.env.COMPANION_CHUNK_SIZE, 10) : undefined,
   }
+
+  // todo remove COMPANION_S3_GETKEY_SAFE_BEHAVIOR in next major and use this getKey implementation instead by default
+  if (process.env.COMPANION_S3_GETKEY_SAFE_BEHAVIOR === 'true') {
+    envConfig.providerOptions.s3.getKey = (req, filename) => `${uuid.v4()}-${filename}`
+  }
+
+  return envConfig
 }
 
 /**


### PR DESCRIPTION
[add warning about default getKey](https://github.com/transloadit/uppy/commit/94f19a6d3a4d57191656ec5302a0b5ee8f65ae72)

[add env variable to get a safer getKey default](https://github.com/transloadit/uppy/commit/9626a87f85aae0bfade6266f44b35af82f5716b7) 

COMPANION_S3_GETKEY_SAFE_BEHAVIOR