### PR TITLE
preferredVideoMimeType and preferredVideoMimeType in WebcamOptions interface

### DIFF
--- a/packages/@uppy/webcam/types/index.d.ts
+++ b/packages/@uppy/webcam/types/index.d.ts
@@ -19,6 +19,8 @@ export interface WebcamOptions extends PluginOptions {
     title?: string
     videoConstraints?: MediaTrackConstraints
     showRecordingLength?: boolean
+    preferredImageMimeType?: string
+    preferredVideoMimeType?: string
 }
 
 declare class Webcam extends UIPlugin<WebcamOptions> {}


### PR DESCRIPTION
I found these options in docs and in code, but not in types