### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/@uppy/core/src/Restricter.js
+++ b/packages/@uppy/core/src/Restricter.js
@@ -59,7 +59,7 @@ class Restricter {
 
         // otherwise this is likely an extension
         if (type[0] === '.' && file.extension) {
-          return file.extension.toLowerCase() === type.substr(1).toLowerCase()
+          return file.extension.toLowerCase() === type.slice(1).toLowerCase()
         }
         return false
       })


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.