### PR TITLE
Merge new name and type into compressed file

### DIFF
--- a/e2e/clients/dashboard-compressor/app.js
+++ b/e2e/clients/dashboard-compressor/app.js
@@ -10,7 +10,9 @@ const uppy = new Uppy()
     target: document.body,
     inline: true,
   })
-  .use(Compressor)
+  .use(Compressor, {
+    mimeType: 'image/webp',
+  })
 
 // Keep this here to access uppy in tests
 window.uppy = uppy

--- a/e2e/cypress/integration/dashboard-compressor.spec.ts
+++ b/e2e/cypress/integration/dashboard-compressor.spec.ts
@@ -36,7 +36,7 @@ describe('dashboard-compressor', () => {
     cy.get('.uppy-StatusBar-actionBtn--upload').click()
 
     cy.get('.uppy-Informer p[role="alert"]', {
-      timeout: 10000,
+      timeout: 12000,
     }).should('be.visible')
 
     cy.window().then(({ uppy }) => {

--- a/e2e/cypress/integration/dashboard-compressor.spec.ts
+++ b/e2e/cypress/integration/dashboard-compressor.spec.ts
@@ -39,6 +39,13 @@ describe('dashboard-compressor', () => {
       timeout: 10000,
     }).should('be.visible')
 
+    cy.window().then(({ uppy }) => {
+      for (const file of uppy.getFiles()) {
+        expect(file.name.split('.')[1]).to.equal('webp')
+        expect(file.type).to.equal('image/webp')
+      }
+    })
+
     cy.get('.uppy-Dashboard-Item-statusSize').should((elements) => {
       expect(elements).to.have.length(sizeBeforeCompression.length)
 

--- a/e2e/cypress/integration/dashboard-compressor.spec.ts
+++ b/e2e/cypress/integration/dashboard-compressor.spec.ts
@@ -41,7 +41,7 @@ describe('dashboard-compressor', () => {
 
     cy.window().then(({ uppy }) => {
       for (const file of uppy.getFiles()) {
-        expect(file.name.split('.')[1]).to.equal('webp')
+        expect(file.extension).to.equal('webp')
         expect(file.type).to.equal('image/webp')
       }
     })

--- a/packages/@uppy/compressor/src/index.js
+++ b/packages/@uppy/compressor/src/index.js
@@ -1,5 +1,6 @@
 import { BasePlugin } from '@uppy/core'
 import { RateLimitedQueue } from '@uppy/utils/lib/RateLimitedQueue'
+import getFileNameAndExtension from '@uppy/utils/lib/getFileNameAndExtension'
 import prettierBytes from '@transloadit/prettier-bytes'
 import CompressorJS from 'compressorjs/dist/compressor.common.js'
 import locale from './locale.js'
@@ -49,8 +50,11 @@ export default class Compressor extends BasePlugin {
           const compressedSavingsSize = file.data.size - compressedBlob.size
           this.uppy.log(`[Image Compressor] Image ${file.id} compressed by ${prettierBytes(compressedSavingsSize)}`)
           totalCompressedSize += compressedSavingsSize
+          const { name } = compressedBlob
+          const { extension } = getFileNameAndExtension(name)
           this.uppy.setFileState(file.id, {
-            name: compressedBlob.name,
+            name,
+            extension,
             type: compressedBlob.type,
             data: compressedBlob,
             size: compressedBlob.size,

--- a/packages/@uppy/compressor/src/index.js
+++ b/packages/@uppy/compressor/src/index.js
@@ -50,8 +50,11 @@ export default class Compressor extends BasePlugin {
           this.uppy.log(`[Image Compressor] Image ${file.id} compressed by ${prettierBytes(compressedSavingsSize)}`)
           totalCompressedSize += compressedSavingsSize
           this.uppy.setFileState(file.id, {
+            name: compressedBlob.name,
+            type: compressedBlob.type,
             data: compressedBlob,
             size: compressedBlob.size,
+            
           })
         } catch (err) {
           this.uppy.log(`[Image Compressor] Failed to compress ${file.id}:`, 'warning')

--- a/packages/@uppy/compressor/src/index.js
+++ b/packages/@uppy/compressor/src/index.js
@@ -54,7 +54,6 @@ export default class Compressor extends BasePlugin {
             type: compressedBlob.type,
             data: compressedBlob,
             size: compressedBlob.size,
-            
           })
         } catch (err) {
           this.uppy.log(`[Image Compressor] Failed to compress ${file.id}:`, 'warning')


### PR DESCRIPTION
When using the mimeType option of compressorJS to set a specific output format, although compressorJS converts the image successfully, the file keeps it's original filename with the original extension, plus the original type.

This solution seemed simple enough, I tested it in my local machine and now all images get a `originalfilename.webp` name and a `image/webp` extension when initializing the plugin with the `mimeType: 'image/webp'` option