### PR TITLE
Make debounced re-render target actual DOM element

### DIFF
--- a/packages/@uppy/core/src/UIPlugin.js
+++ b/packages/@uppy/core/src/UIPlugin.js
@@ -62,6 +62,7 @@ class UIPlugin extends BasePlugin {
         if (!this.uppy.getPlugin(this.id)) return
         render(this.render(state), uppyRootElement)
         targetElement.appendChild(uppyRootElement)
+        this.el = targetElement
         this.afterUpdate()
       })
 

--- a/packages/@uppy/core/src/UIPlugin.js
+++ b/packages/@uppy/core/src/UIPlugin.js
@@ -61,6 +61,7 @@ class UIPlugin extends BasePlugin {
         // hence the check
         if (!this.uppy.getPlugin(this.id)) return
         render(this.render(state), uppyRootElement)
+        targetElement.appendChild(uppyRootElement)
         this.afterUpdate()
       })
 


### PR DESCRIPTION
_This is a solution for https://github.com/transloadit/uppy/issues/3608._

Pretty much, Uppy is debouncing re-renders to what is called the "microtask queue"&mdash;which makes sense&mdash;however, these debounced re-renders never introduce the newly rendered version to the actual target DOM element, hence this effect that nothing has happened after a few (re)renders.

The goal of this fix is simply rendering the debounced re-renders content against the DOM as well. This was never an issue for plugins such as the `Dashboard` because the way `UIPlugin` handles rendering through a plugin's perspective is different from a mere DOM element or selector.