### PR TITLE
Fix `getFileType` for dicom images

### DIFF
--- a/packages/@uppy/utils/src/getFileType.test.js
+++ b/packages/@uppy/utils/src/getFileType.test.js
@@ -32,6 +32,10 @@ describe('getFileType', () => {
       name: 'bar.mkv',
       data: 'sdfsfhfh329fhwihs',
     }
+    const fileDicom = {
+      name: 'bar.dicom',
+      data: 'sdfsfhfh329fhwihs',
+    }
     const toUpper = (file) => ({ ...file, name: file.name.toUpperCase() })
     expect(getFileType(fileMP3)).toEqual('audio/mp3')
     expect(getFileType(toUpper(fileMP3))).toEqual('audio/mp3')
@@ -39,6 +43,8 @@ describe('getFileType', () => {
     expect(getFileType(toUpper(fileYAML))).toEqual('text/yaml')
     expect(getFileType(fileMKV)).toEqual('video/x-matroska')
     expect(getFileType(toUpper(fileMKV))).toEqual('video/x-matroska')
+    expect(getFileType(fileDicom)).toEqual('application/dicom')
+    expect(getFileType(toUpper(fileDicom))).toEqual('application/dicom')
   })
 
   it('should fail gracefully if unable to detect', () => {

--- a/packages/@uppy/utils/src/mimeTypes.js
+++ b/packages/@uppy/utils/src/mimeTypes.js
@@ -23,6 +23,7 @@ module.exports = {
   mks: 'video/x-matroska',
   mkv: 'video/x-matroska',
   mov: 'video/quicktime',
+  dicom: 'application/dicom',
   doc: 'application/msword',
   docm: 'application/vnd.ms-word.document.macroenabled.12',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',


### PR DESCRIPTION
Fixes #3439

Begs the question again whether we should just use a library for mime types because I'm sure this is not the last time this is happening. Unfortunately adding one would be around 20KB, I'm not sure how much our file is but probably way less. It's a tradeoff.  