### PR TITLE
Propagate `isNetworkError` through error wrappers

### DIFF
--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -4,6 +4,7 @@ const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress')
 const getSocketHost = require('@uppy/utils/lib/getSocketHost')
 const EventTracker = require('@uppy/utils/lib/EventTracker')
 const ProgressTimeout = require('@uppy/utils/lib/ProgressTimeout')
+const ErrorWithCause = require('@uppy/utils/lib/ErrorWithCause')
 const NetworkError = require('@uppy/utils/lib/NetworkError')
 const isNetworkError = require('@uppy/utils/lib/isNetworkError')
 const { internalRateLimitedQueue } = require('@uppy/utils/lib/RateLimitedQueue')
@@ -14,8 +15,7 @@ function buildResponseError (xhr, error) {
 
   // TODO: when we drop support for browsers that do not support this syntax, use:
   // return new Error('Upload error', { cause: error, request: xhr })
-  const err = new Error('Upload error')
-  err.cause = error
+  const err = new ErrorWithCause('Upload error', { cause: error })
   err.request = xhr
   return err
 }
@@ -327,7 +327,7 @@ module.exports = class MiniXHRUpload {
         const resp = errData.response
         const error = resp
           ? opts.getResponseError(resp.responseText, resp)
-          : Object.assign(new Error(errData.error.message), { cause: errData.error })
+          : new ErrorWithCause(errData.error.message, { cause: errData.error })
         this.uppy.emit('upload-error', file, error)
         queuedRequest.done()
         if (this.uploaderEvents[file.id]) {

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fetchWithNetworkError = require('@uppy/utils/lib/fetchWithNetworkError')
+const ErrorWithCause = require('@uppy/utils/lib/ErrorWithCause')
 const AuthError = require('./AuthError')
 
 // Remove the trailing slash so we can always safely append /xyz.
@@ -87,9 +88,8 @@ module.exports = class RequestClient {
   #errorHandler (method, path) {
     return (err) => {
       if (!err?.isAuthError) {
-        const error = new Error(`Could not ${method} ${this.#getUrl(path)}`)
-        error.cause = err
-        err = error // eslint-disable-line no-param-reassign
+        // eslint-disable-next-line no-param-reassign
+        err = new ErrorWithCause(`Could not ${method} ${this.#getUrl(path)}`, { cause: err })
       }
       return Promise.reject(err)
     }

--- a/packages/@uppy/transloadit/src/AssemblyOptions.js
+++ b/packages/@uppy/transloadit/src/AssemblyOptions.js
@@ -1,3 +1,5 @@
+const ErrorWithCause = require('@uppy/utils/lib/ErrorWithCause')
+
 /**
  * Check that Assembly parameters are present and include all required fields.
  */
@@ -12,9 +14,7 @@ function validateParams (params) {
       params = JSON.parse(params)
     } catch (err) {
       // Tell the user that this is not an Uppy bug!
-      const error = new Error('Transloadit: The `params` option is a malformed JSON string.')
-      err.cause = err
-      throw error
+      throw new ErrorWithCause('Transloadit: The `params` option is a malformed JSON string.', { cause: err })
     }
   }
 

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -1,5 +1,6 @@
 const hasProperty = require('@uppy/utils/lib/hasProperty')
 const BasePlugin = require('@uppy/core/lib/BasePlugin')
+const ErrorWithCause = require('@uppy/core/lib/ErrorWithCause')
 const Tus = require('@uppy/tus')
 const Assembly = require('./Assembly')
 const Client = require('./Client')
@@ -17,8 +18,7 @@ function defaultGetAssemblyOptions (file, options) {
 }
 
 const sendErrorToConsole = originalErr => err => {
-  const error = new Error('Failed to send error to the client')
-  error.cause = err
+  const error = new ErrorWithCause('Failed to send error to the client', { cause: err })
   // eslint-ignore-next-line no-console
   console.error(error, originalErr)
 }
@@ -236,10 +236,7 @@ module.exports = class Transloadit extends BasePlugin {
       this.uppy.log(`[Transloadit] Created Assembly ${assemblyID}`)
       return assembly
     }).catch((err) => {
-      const error = new Error(`${this.i18n('creatingAssemblyFailed')}: ${err.message}`)
-      error.cause = err
-      // Reject the promise.
-      throw error
+      throw new ErrorWithCause(`${this.i18n('creatingAssemblyFailed')}: ${err.message}`, { cause: err })
     })
   }
 

--- a/packages/@uppy/utils/src/ErrorWithCause.js
+++ b/packages/@uppy/utils/src/ErrorWithCause.js
@@ -1,0 +1,13 @@
+const hasProperty = require('./hasProperty')
+
+class ErrorWithCause extends Error {
+  constructor (message, options = {}) {
+    super(message)
+    this.cause = options.cause
+    if (this.cause && hasProperty(this.cause, 'isNetworkError')) {
+      this.isNetworkError = this.cause.isNetworkError
+    }
+  }
+}
+
+module.exports = ErrorWithCause

--- a/packages/@uppy/utils/src/ErrorWithCause.test.js
+++ b/packages/@uppy/utils/src/ErrorWithCause.test.js
@@ -1,0 +1,20 @@
+const ErrorWithCause = require('./ErrorWithCause')
+const NetworkError = require('./NetworkError')
+const isNetworkError = require('./isNetworkError')
+
+describe('ErrorWithCause', () => {
+  it('should support a `{ cause }` option', () => {
+    const cause = new Error('cause')
+    expect(new ErrorWithCause('message').cause).toEqual(undefined)
+    expect(new ErrorWithCause('message', {}).cause).toEqual(undefined)
+    expect(new ErrorWithCause('message', { cause }).cause).toEqual(cause)
+  })
+  it('should propagate isNetworkError', () => {
+    const regularError = new Error('cause')
+    const networkError = new NetworkError('cause')
+    expect(isNetworkError(new ErrorWithCause('message', { cause: networkError }).isNetworkError)).toEqual(true)
+    expect(isNetworkError(new ErrorWithCause('message', { cause: regularError }).isNetworkError)).toEqual(false)
+    expect(isNetworkError(new ErrorWithCause('message', {}).isNetworkError)).toEqual(false)
+    expect(isNetworkError(new ErrorWithCause('message').isNetworkError)).toEqual(false)
+  })
+})


### PR DESCRIPTION
The `ErrorWithCause` class uses the same signature as the builtin Error
does, but it supports the `{ cause }` option in older environments, and
it propagates the `isNetworkError` property from the underlying error.