### PR TITLE
Add `companionCookiesRule` type to @uppy/aws-s3-multipart

### DIFF
--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -11,6 +11,7 @@ export interface AwsS3Part {
 interface AwsS3MultipartOptions extends PluginOptions {
     companionHeaders?: { [type: string]: string }
     companionUrl?: string
+    companionCookiesRule?: string
     getChunkSize?: (file: UppyFile) => number
     createMultipartUpload?: (
       file: UppyFile


### PR DESCRIPTION
This tiny PR adds companionCookiesRule parameter in AWS S3 Multipart plugin which was missing. 

Related issue: https://github.com/transloadit/uppy/issues/3619