### PR TITLE
@uppy/core: fix `TypeError` when file was removed

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -851,7 +851,7 @@ class Uppy {
   }
 
   calculateProgress (file, data) {
-    if (!this.getFile(file.id)) {
+    if (file == null || !this.getFile(file.id)) {
       this.log(`Not setting progress for a file that has been removed: ${file.id}`)
       return
     }


### PR DESCRIPTION
Should have been done as part of #3629