### PR TITLE
Add license field to package.json in @uppy/vue

### DIFF
--- a/packages/@uppy/vue/package.json
+++ b/packages/@uppy/vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uppy/vue",
   "version": "0.4.6",
+  "license": "MIT",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
The readme states that `@uppy/vue` uses the MIT license, but this information is missing in the `package.json`.