### PR TITLE
Add `save` translation to Spanish locale

### DIFF
--- a/packages/@uppy/dashboard/src/components/EditorPanel.js
+++ b/packages/@uppy/dashboard/src/components/EditorPanel.js
@@ -29,7 +29,7 @@ function EditorPanel (props) {
           type="button"
           onClick={props.saveFileEditor}
         >
-          {props.i18n('save')}
+          {props.i18n('saveChanges')}
         </button>
       </div>
       <div className="uppy-DashboardContent-panelBody">

--- a/packages/@uppy/dashboard/src/components/EditorPanel.js
+++ b/packages/@uppy/dashboard/src/components/EditorPanel.js
@@ -29,7 +29,7 @@ function EditorPanel (props) {
           type="button"
           onClick={props.saveFileEditor}
         >
-          {props.i18n('saveChanges')}
+          {props.i18n('save')}
         </button>
       </div>
       <div className="uppy-DashboardContent-panelBody">

--- a/packages/@uppy/locales/src/es_ES.js
+++ b/packages/@uppy/locales/src/es_ES.js
@@ -82,6 +82,7 @@ es_ES.strings = {
   resumeUpload: 'Reanudar subida',
   retry: 'Intentar nuevamente',
   retryUpload: 'Intentar subida nuevamente',
+  save: 'Guardar',
   saveChanges: 'Guardar cambios',
   selectX: {
     '0': 'Seleccionar %{smart_count}',


### PR DESCRIPTION
Add missing `save` translation to Spanish locale.

![image](https://user-images.githubusercontent.com/664474/166177039-77f42578-ddb4-48fd-ae79-72a58b2fdef1.png)
