### PR TITLE
Revert "@uppy/companion-client: refactor to ESM"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,6 @@ module.exports = {
         // Packages that have switched to ESM sources:
         'packages/@uppy/audio/src/**/*.js',
         'packages/@uppy/box/src/**/*.js',
-        'packages/@uppy/companion-client/src/**/*.js',
         'packages/@uppy/compressor/src/**/*.js',
         'packages/@uppy/drag-drop/src/**/*.js',
         'packages/@uppy/drop-target/src/**/*.js',

--- a/packages/@uppy/companion-client/package.json
+++ b/packages/@uppy/companion-client/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
-  "type": "module",
   "keywords": [
     "file uploader",
     "uppy",
@@ -24,8 +23,5 @@
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "namespace-emitter": "^2.0.1"
-  },
-  "devDependencies": {
-    "@jest/globals": "^27.4.2"
   }
 }

--- a/packages/@uppy/companion-client/src/AuthError.js
+++ b/packages/@uppy/companion-client/src/AuthError.js
@@ -8,4 +8,4 @@ class AuthError extends Error {
   }
 }
 
-export default AuthError
+module.exports = AuthError

--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -1,13 +1,13 @@
 'use strict'
 
-import RequestClient from './RequestClient.js'
-import tokenStorage from './tokenStorage.js'
+const RequestClient = require('./RequestClient')
+const tokenStorage = require('./tokenStorage')
 
 const getName = (id) => {
   return id.split('-').map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')
 }
 
-export default class Provider extends RequestClient {
+module.exports = class Provider extends RequestClient {
   constructor (uppy, opts) {
     super(uppy, opts)
     this.provider = opts.provider
@@ -37,7 +37,7 @@ export default class Provider extends RequestClient {
   }
 
   onReceiveResponse (response) {
-    response = super.onReceiveResponse(response) // eslint-disable-line no-param-reassign
+    response = super.onReceiveResponse(response)
     const plugin = this.uppy.getPlugin(this.pluginId)
     const oldAuthenticated = plugin.getPluginState().authenticated
     const authenticated = oldAuthenticated ? response.status !== 401 : response.status < 400
@@ -106,7 +106,6 @@ export default class Provider extends RequestClient {
   }
 
   static initPlugin (plugin, opts, defaultOpts) {
-    /* eslint-disable no-param-reassign */
     plugin.type = 'acquirer'
     plugin.files = []
     if (defaultOpts) {
@@ -132,6 +131,5 @@ export default class Provider extends RequestClient {
     }
 
     plugin.storage = plugin.opts.storage || tokenStorage
-    /* eslint-enable no-param-reassign */
   }
 }

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -1,10 +1,8 @@
 'use strict'
 
-import fetchWithNetworkError from '@uppy/utils/lib/fetchWithNetworkError'
-import ErrorWithCause from '@uppy/utils/lib/ErrorWithCause'
-import AuthError from './AuthError.js'
-
-import packageJson from '../package.json'
+const fetchWithNetworkError = require('@uppy/utils/lib/fetchWithNetworkError')
+const ErrorWithCause = require('@uppy/utils/lib/ErrorWithCause')
+const AuthError = require('./AuthError')
 
 // Remove the trailing slash so we can always safely append /xyz.
 function stripSlash (url) {
@@ -32,8 +30,9 @@ async function handleJSONResponse (res) {
   return jsonPromise
 }
 
-export default class RequestClient {
-  static VERSION = packageJson.version
+module.exports = class RequestClient {
+  // eslint-disable-next-line global-require
+  static VERSION = require('../package.json').version
 
   #getPostResponseFunc = skip => response => (skip ? response : this.onReceiveResponse(response))
 

--- a/packages/@uppy/companion-client/src/RequestClient.test.js
+++ b/packages/@uppy/companion-client/src/RequestClient.test.js
@@ -1,5 +1,4 @@
-import { describe, it, expect } from '@jest/globals'
-import RequestClient from './RequestClient.js'
+const RequestClient = require('./RequestClient')
 
 describe('RequestClient', () => {
   it('has a hostname without trailing slash', () => {

--- a/packages/@uppy/companion-client/src/SearchProvider.js
+++ b/packages/@uppy/companion-client/src/SearchProvider.js
@@ -1,12 +1,12 @@
 'use strict'
 
-import RequestClient from './RequestClient.js'
+const RequestClient = require('./RequestClient')
 
 const getName = (id) => {
   return id.split('-').map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')
 }
 
-export default class SearchProvider extends RequestClient {
+module.exports = class SearchProvider extends RequestClient {
   constructor (uppy, opts) {
     super(uppy, opts)
     this.provider = opts.provider
@@ -20,6 +20,7 @@ export default class SearchProvider extends RequestClient {
   }
 
   search (text, queries) {
-    return this.get(`search/${this.id}/list?q=${encodeURIComponent(text)}${queries ? `&${queries}` : ''}`)
+    queries = queries ? `&${queries}` : ''
+    return this.get(`search/${this.id}/list?q=${encodeURIComponent(text)}${queries}`)
   }
 }

--- a/packages/@uppy/companion-client/src/Socket.js
+++ b/packages/@uppy/companion-client/src/Socket.js
@@ -1,6 +1,6 @@
-import ee from 'namespace-emitter'
+const ee = require('namespace-emitter')
 
-export default class UppySocket {
+module.exports = class UppySocket {
   #queued = []
 
   #emitter = ee()

--- a/packages/@uppy/companion-client/src/Socket.test.js
+++ b/packages/@uppy/companion-client/src/Socket.test.js
@@ -1,5 +1,4 @@
-import { jest, describe, it, expect } from '@jest/globals'
-import UppySocket from './Socket.js'
+const UppySocket = require('./Socket')
 
 describe('Socket', () => {
   let webSocketConstructorSpy

--- a/packages/@uppy/companion-client/src/index.js
+++ b/packages/@uppy/companion-client/src/index.js
@@ -4,12 +4,12 @@
  * Manages communications with Companion
  */
 
-import RequestClient from './RequestClient.js'
-import Provider from './Provider.js'
-import SearchProvider from './SearchProvider.js'
-import Socket from './Socket.js'
+const RequestClient = require('./RequestClient')
+const Provider = require('./Provider')
+const SearchProvider = require('./SearchProvider')
+const Socket = require('./Socket')
 
-export {
+module.exports = {
   RequestClient,
   Provider,
   SearchProvider,

--- a/packages/@uppy/companion-client/src/tokenStorage.js
+++ b/packages/@uppy/companion-client/src/tokenStorage.js
@@ -3,18 +3,18 @@
 /**
  * This module serves as an Async wrapper for LocalStorage
  */
-export function setItem (key, value) {
+module.exports.setItem = (key, value) => {
   return new Promise((resolve) => {
     localStorage.setItem(key, value)
     resolve()
   })
 }
 
-export function getItem (key) {
+module.exports.getItem = (key) => {
   return Promise.resolve(localStorage.getItem(key))
 }
 
-export function removeItem (key) {
+module.exports.removeItem = (key) => {
   return new Promise((resolve) => {
     localStorage.removeItem(key)
     resolve()

--- a/yarn.lock
+++ b/yarn.lock
@@ -9713,7 +9713,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/companion-client@workspace:packages/@uppy/companion-client"
   dependencies:
-    "@jest/globals": ^27.4.2
     "@uppy/utils": "workspace:^"
     namespace-emitter: ^2.0.1
   languageName: unknown


### PR DESCRIPTION
Reverts transloadit/uppy#3693

This breaks the dev env because `@uppy/tus` has not been converted to ESM.