### PR TITLE
meta: prepare internal script files for lint rule hardening

### DIFF
--- a/bin/update-contributors.mjs
+++ b/bin/update-contributors.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process'
+import { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
+import process from 'node:process'
 
 const README_FILE_NAME = new URL('../README.md', import.meta.url)
 

--- a/private/locale-pack/test.mjs
+++ b/private/locale-pack/test.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, prefer-arrow-callback */
 import path from 'node:path'
+import process from 'node:process'
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 

--- a/private/release/updateChangelogs.js
+++ b/private/release/updateChangelogs.js
@@ -2,6 +2,7 @@
 
 import { createReadStream, promises as fs } from 'node:fs'
 import { createInterface } from 'node:readline'
+import { Buffer } from 'node:buffer'
 import process from 'node:process'
 
 const ROOT = new URL('../../', import.meta.url)


### PR DESCRIPTION
Let's not use Node.js-specific globals in our ESM code.