### PR TITLE
meta: prepare test files for lint rule hardening

### DIFF
--- a/packages/@uppy/audio/package.json
+++ b/packages/@uppy/audio/package.json
@@ -29,6 +29,9 @@
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"
   },
+  "devDependencies": {
+    "@jest/globals": "^27.4.2"
+  },
   "peerDependencies": {
     "@uppy/core": "workspace:^"
   },

--- a/packages/@uppy/audio/src/formatSeconds.test.js
+++ b/packages/@uppy/audio/src/formatSeconds.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals'
 import formatSeconds from './formatSeconds.js'
 
 describe('formatSeconds', () => {

--- a/packages/@uppy/audio/src/supportsMediaRecorder.test.js
+++ b/packages/@uppy/audio/src/supportsMediaRecorder.test.js
@@ -1,22 +1,23 @@
 /* eslint-disable max-classes-per-file */
+import { describe, expect, it } from '@jest/globals'
 import supportsMediaRecorder from './supportsMediaRecorder.js'
 
 describe('supportsMediaRecorder', () => {
   it('should return true if MediaRecorder is supported', () => {
-    global.MediaRecorder = class MediaRecorder {
+    globalThis.MediaRecorder = class MediaRecorder {
       start () {} // eslint-disable-line
     }
     expect(supportsMediaRecorder()).toEqual(true)
   })
 
   it('should return false if MediaRecorder is not supported', () => {
-    global.MediaRecorder = undefined
+    globalThis.MediaRecorder = undefined
     expect(supportsMediaRecorder()).toEqual(false)
 
-    global.MediaRecorder = class MediaRecorder {}
+    globalThis.MediaRecorder = class MediaRecorder {}
     expect(supportsMediaRecorder()).toEqual(false)
 
-    global.MediaRecorder = class MediaRecorder {
+    globalThis.MediaRecorder = class MediaRecorder {
       foo () {} // eslint-disable-line
     }
     expect(supportsMediaRecorder()).toEqual(false)

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals'
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
 import 'whatwg-fetch'
 import nock from 'nock'
@@ -97,7 +97,7 @@ describe('AwsS3Multipart', () => {
         source: 'jest',
         name: 'multitest.dat',
         type: 'application/octet-stream',
-        data: new File([Buffer.alloc(fileSize)], {
+        data: new File([new Uint8Array(fileSize)], {
           type: 'application/octet-stream',
         }),
       })
@@ -138,7 +138,7 @@ describe('AwsS3Multipart', () => {
         source: 'jest',
         name: 'multitest.dat',
         type: 'application/octet-stream',
-        data: new File([Buffer.alloc(fileSize)], {
+        data: new File([new Uint8Array(fileSize)], {
           type: 'application/octet-stream',
         }),
       })
@@ -217,7 +217,7 @@ describe('AwsS3Multipart', () => {
         source: 'jest',
         name: 'multitest.dat',
         type: 'application/octet-stream',
-        data: new File([Buffer.alloc(fileSize)], {
+        data: new File([new Uint8Array(fileSize)], {
           type: 'application/octet-stream',
         }),
       })

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -29,6 +29,7 @@
     "nanoid": "^3.1.25"
   },
   "devDependencies": {
+    "@jest/globals": "^27.4.2",
     "whatwg-fetch": "3.6.2"
   },
   "peerDependencies": {

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals'
 import 'whatwg-fetch'
 import Core from '@uppy/core'
 import AwsS3 from './index.js'

--- a/packages/@uppy/aws-s3/src/isXml.test.js
+++ b/packages/@uppy/aws-s3/src/isXml.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals'
 import isXml from './isXml.js'
 
 describe('AwsS3', () => {

--- a/packages/@uppy/companion-client/src/Socket.test.js
+++ b/packages/@uppy/companion-client/src/Socket.test.js
@@ -1,4 +1,4 @@
-import { jest, describe, it, expect } from '@jest/globals'
+import { afterEach, beforeEach, jest, describe, it, expect } from '@jest/globals'
 import UppySocket from './Socket.js'
 
 describe('Socket', () => {
@@ -11,7 +11,7 @@ describe('Socket', () => {
     webSocketCloseSpy = jest.fn()
     webSocketSendSpy = jest.fn()
 
-    global.WebSocket = class WebSocket {
+    globalThis.WebSocket = class WebSocket {
       constructor (target) {
         webSocketConstructorSpy(target)
       }
@@ -36,7 +36,7 @@ describe('Socket', () => {
     }
   })
   afterEach(() => {
-    global.WebSocket = undefined
+    globalThis.WebSocket = undefined
   })
 
   it('should expose a class', () => {

--- a/packages/@uppy/dashboard/src/index.test.js
+++ b/packages/@uppy/dashboard/src/index.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals'
+import { afterAll, beforeAll, describe, it, expect } from '@jest/globals'
 
 import Core from '@uppy/core'
 import StatusBarPlugin from '@uppy/status-bar'

--- a/packages/@uppy/store-default/package.json
+++ b/packages/@uppy/store-default/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/transloadit/uppy/issues"
   },
+  "devDependencies": {
+    "@jest/globals": "^27.4.2"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"

--- a/packages/@uppy/store-default/src/index.test.js
+++ b/packages/@uppy/store-default/src/index.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals'
 import DefaultStore from './index.js'
 
 describe('DefaultStore', () => {

--- a/packages/@uppy/thumbnail-generator/src/index.test.js
+++ b/packages/@uppy/thumbnail-generator/src/index.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals'
+import { afterEach, beforeEach, describe, it, expect, jest, xit } from '@jest/globals'
 import { UIPlugin } from '@uppy/core'
 import emitter from 'namespace-emitter'
 import ThumbnailGeneratorPlugin from './index.js'

--- a/packages/@uppy/transloadit/src/Assembly.js
+++ b/packages/@uppy/transloadit/src/Assembly.js
@@ -12,7 +12,7 @@ import parseUrl from './parseUrl.js'
 // TODO: remove this hack in the next release.
 let socketIo
 function requireSocketIo () {
-  // eslint-disable-next-line no-return-assign, no-restricted-globals, global-require
+  // eslint-disable-next-line no-return-assign, no-restricted-globals, global-require, no-undef
   return socketIo ??= require('socket.io-client')
 }
 

--- a/packages/@uppy/transloadit/src/AssemblyOptions.test.js
+++ b/packages/@uppy/transloadit/src/AssemblyOptions.test.js
@@ -20,7 +20,7 @@ describe('Transloadit/AssemblyOptions', () => {
   })
 
   it('Uses different assemblies for different params', async () => {
-    const data = Buffer.alloc(10)
+    const data = new Uint8Array(10)
     data.size = data.byteLength
 
     const options = new AssemblyOptions([
@@ -48,8 +48,8 @@ describe('Transloadit/AssemblyOptions', () => {
   })
 
   it('Should merge files with same parameters into one Assembly', async () => {
-    const data = Buffer.alloc(10)
-    const data2 = Buffer.alloc(20)
+    const data = new Uint8Array(10)
+    const data2 = new Uint8Array(20)
 
     const options = new AssemblyOptions([
       { name: 'a.png', data, size: data.byteLength },

--- a/packages/@uppy/webcam/package.json
+++ b/packages/@uppy/webcam/package.json
@@ -30,6 +30,9 @@
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"
   },
+  "devDependencies": {
+    "@jest/globals": "^27.4.2"
+  },
   "peerDependencies": {
     "@uppy/core": "workspace:^"
   }

--- a/packages/@uppy/webcam/src/Webcam.test.js
+++ b/packages/@uppy/webcam/src/Webcam.test.js
@@ -1,10 +1,11 @@
+import { describe, expect, it } from '@jest/globals'
 import Uppy from '@uppy/core'
 import Webcam from '../lib/index.js'
 
 describe('Webcam', () => {
   describe('_getMediaRecorderOptions', () => {
     it('should not have a mimeType set if no preferences given', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: () => true,
       }
 
@@ -15,7 +16,7 @@ describe('Webcam', () => {
     })
 
     it('should use preferredVideoMimeType', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: (ty) => ty === 'video/webm',
       }
 
@@ -26,7 +27,7 @@ describe('Webcam', () => {
     })
 
     it('should not use preferredVideoMimeType if it is not supported', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: (ty) => ty === 'video/webm',
       }
 
@@ -37,7 +38,7 @@ describe('Webcam', () => {
     })
 
     it('should pick type based on `allowedFileTypes`', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: () => true,
       }
 
@@ -50,7 +51,7 @@ describe('Webcam', () => {
     })
 
     it('should use first supported type from allowedFileTypes', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: (ty) => ty === 'video/webm',
       }
 
@@ -63,7 +64,7 @@ describe('Webcam', () => {
     })
 
     it('should prefer preferredVideoMimeType over allowedFileTypes', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: () => true,
       }
 
@@ -77,7 +78,7 @@ describe('Webcam', () => {
     })
 
     it('should not use allowedFileTypes if they are unsupported', () => {
-      global.MediaRecorder = {
+      globalThis.MediaRecorder = {
         isTypeSupported: () => false,
       }
 

--- a/packages/@uppy/webcam/src/formatSeconds.test.js
+++ b/packages/@uppy/webcam/src/formatSeconds.test.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals'
 import formatSeconds from './formatSeconds.js'
 
 describe('formatSeconds', () => {

--- a/packages/@uppy/webcam/src/supportsMediaRecorder.test.js
+++ b/packages/@uppy/webcam/src/supportsMediaRecorder.test.js
@@ -1,22 +1,23 @@
 /* eslint-disable max-classes-per-file, class-methods-use-this */
+import { describe, expect, it } from '@jest/globals'
 import supportsMediaRecorder from './supportsMediaRecorder.js'
 
 describe('supportsMediaRecorder', () => {
   it('should return true if MediaRecorder is supported', () => {
-    global.MediaRecorder = class MediaRecorder {
+    globalThis.MediaRecorder = class MediaRecorder {
       start () {}
     }
     expect(supportsMediaRecorder()).toEqual(true)
   })
 
   it('should return false if MediaRecorder is not supported', () => {
-    global.MediaRecorder = undefined
+    globalThis.MediaRecorder = undefined
     expect(supportsMediaRecorder()).toEqual(false)
 
-    global.MediaRecorder = class MediaRecorder {}
+    globalThis.MediaRecorder = class MediaRecorder {}
     expect(supportsMediaRecorder()).toEqual(false)
 
-    global.MediaRecorder = class MediaRecorder {
+    globalThis.MediaRecorder = class MediaRecorder {
       foo () {}
     }
     expect(supportsMediaRecorder()).toEqual(false)

--- a/packages/@uppy/xhr-upload/src/index.test.js
+++ b/packages/@uppy/xhr-upload/src/index.test.js
@@ -27,7 +27,7 @@ describe('XHRUpload', () => {
       })
       core.addFile({
         name: 'test.jpg',
-        data: new Blob([Buffer.alloc(8192)]),
+        data: new Blob([new Uint8Array(8192)]),
       })
 
       return core.upload().then(() => {
@@ -65,7 +65,7 @@ describe('XHRUpload', () => {
       })
       core.addFile({
         name: 'test.jpg',
-        data: new Blob([Buffer.alloc(8192)]),
+        data: new Blob([new Uint8Array(8192)]),
       })
 
       return core.upload().then(result => {
@@ -102,7 +102,7 @@ describe('XHRUpload', () => {
       })
       core.addFile({
         name: 'test.jpg',
-        data: new Blob([Buffer.alloc(8192)]),
+        data: new Blob([new Uint8Array(8192)]),
       })
 
       await core.upload()

--- a/yarn.lock
+++ b/yarn.lock
@@ -9662,6 +9662,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/audio@workspace:packages/@uppy/audio"
   dependencies:
+    "@jest/globals": ^27.4.2
     "@uppy/utils": "workspace:^"
     preact: ^10.5.13
   peerDependencies:
@@ -9687,6 +9688,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/aws-s3@workspace:packages/@uppy/aws-s3"
   dependencies:
+    "@jest/globals": ^27.4.2
     "@uppy/companion-client": "workspace:^"
     "@uppy/utils": "workspace:^"
     "@uppy/xhr-upload": "workspace:^"
@@ -10116,6 +10118,8 @@ __metadata:
 "@uppy/store-default@workspace:^, @uppy/store-default@workspace:packages/@uppy/store-default":
   version: 0.0.0-use.local
   resolution: "@uppy/store-default@workspace:packages/@uppy/store-default"
+  dependencies:
+    "@jest/globals": ^27.4.2
   languageName: unknown
   linkType: soft
 
@@ -10222,6 +10226,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/utils@workspace:packages/@uppy/utils"
   dependencies:
+    "@jest/globals": ^27.4.2
     lodash.throttle: ^4.1.1
   languageName: unknown
   linkType: soft
@@ -10247,6 +10252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/webcam@workspace:packages/@uppy/webcam"
   dependencies:
+    "@jest/globals": ^27.4.2
     "@uppy/utils": "workspace:^"
     preact: ^10.5.13
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10226,7 +10226,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/utils@workspace:packages/@uppy/utils"
   dependencies:
-    "@jest/globals": ^27.4.2
     lodash.throttle: ^4.1.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Jest globals are not available if we drop Babel, and dropping Babel for our tests is a requirement for mocking ES modules.