### PR TITLE
doc: update bundler recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ const uppy = new Uppy({ autoProceed: false })
 $ npm install @uppy/core @uppy/dashboard @uppy/tus
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Add CSS [uppy.min.css](https://releases.transloadit.com/uppy/v2.10.0/uppy.min.css), either to your HTML page’s `<head>` or include in JS, if your bundler of choice supports it.
 
 Alternatively, you can also use a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ const uppy = new Uppy({ autoProceed: false })
 $ npm install @uppy/core @uppy/dashboard @uppy/tus
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
-Add CSS [uppy.min.css](https://releases.transloadit.com/uppy/v2.10.0/uppy.min.css), either to your HTML page’s `<head>` or include in JS, if your bundler of choice supports it — transforms and plugins are available for Browserify and Webpack.
+Add CSS [uppy.min.css](https://releases.transloadit.com/uppy/v2.10.0/uppy.min.css), either to your HTML page’s `<head>` or include in JS, if your bundler of choice supports it.
 
 Alternatively, you can also use a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object.
 

--- a/packages/@uppy/angular/projects/uppy/angular/README.md
+++ b/packages/@uppy/angular/projects/uppy/angular/README.md
@@ -20,7 +20,7 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 $ npm install @uppy/angular --save
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/angular/projects/uppy/angular/README.md
+++ b/packages/@uppy/angular/projects/uppy/angular/README.md
@@ -20,8 +20,6 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 $ npm install @uppy/angular --save
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/audio/README.md
+++ b/packages/@uppy/audio/README.md
@@ -24,7 +24,7 @@ uppy.use(Audio)
 $ npm install @uppy/audio
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/audio/README.md
+++ b/packages/@uppy/audio/README.md
@@ -24,8 +24,6 @@ uppy.use(Audio)
 $ npm install @uppy/audio
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/aws-s3-multipart/README.md
+++ b/packages/@uppy/aws-s3-multipart/README.md
@@ -30,7 +30,7 @@ uppy.use(AwsS3Multipart, {
 $ npm install @uppy/aws-s3-multipart
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/aws-s3-multipart/README.md
+++ b/packages/@uppy/aws-s3-multipart/README.md
@@ -30,8 +30,6 @@ uppy.use(AwsS3Multipart, {
 $ npm install @uppy/aws-s3-multipart
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/aws-s3/README.md
+++ b/packages/@uppy/aws-s3/README.md
@@ -31,8 +31,6 @@ uppy.use(AwsS3, {
 $ npm install @uppy/aws-s3
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/aws-s3/README.md
+++ b/packages/@uppy/aws-s3/README.md
@@ -31,7 +31,7 @@ uppy.use(AwsS3, {
 $ npm install @uppy/aws-s3
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/box/README.md
+++ b/packages/@uppy/box/README.md
@@ -31,7 +31,7 @@ uppy.use(Box, {
 $ npm install @uppy/box
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/box/README.md
+++ b/packages/@uppy/box/README.md
@@ -31,8 +31,6 @@ uppy.use(Box, {
 $ npm install @uppy/box
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/core/README.md
+++ b/packages/@uppy/core/README.md
@@ -32,7 +32,7 @@ uppy.use(SomePlugin)
 $ npm install @uppy/core
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/core/README.md
+++ b/packages/@uppy/core/README.md
@@ -32,8 +32,6 @@ uppy.use(SomePlugin)
 $ npm install @uppy/core
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/dashboard/README.md
+++ b/packages/@uppy/dashboard/README.md
@@ -39,7 +39,7 @@ uppy.use(Dashboard, {
 $ npm install @uppy/dashboard
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/dashboard/README.md
+++ b/packages/@uppy/dashboard/README.md
@@ -39,8 +39,6 @@ uppy.use(Dashboard, {
 $ npm install @uppy/dashboard
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/drag-drop/README.md
+++ b/packages/@uppy/drag-drop/README.md
@@ -31,7 +31,7 @@ uppy.use(DragDrop, {
 $ npm install @uppy/drag-drop
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/drag-drop/README.md
+++ b/packages/@uppy/drag-drop/README.md
@@ -31,8 +31,6 @@ uppy.use(DragDrop, {
 $ npm install @uppy/drag-drop
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/dropbox/README.md
+++ b/packages/@uppy/dropbox/README.md
@@ -31,8 +31,6 @@ uppy.use(Dropbox, {
 $ npm install @uppy/dropbox
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/dropbox/README.md
+++ b/packages/@uppy/dropbox/README.md
@@ -31,7 +31,7 @@ uppy.use(Dropbox, {
 $ npm install @uppy/dropbox
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/facebook/README.md
+++ b/packages/@uppy/facebook/README.md
@@ -31,8 +31,6 @@ uppy.use(Facebook, {
 $ npm install @uppy/facebook
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/facebook/README.md
+++ b/packages/@uppy/facebook/README.md
@@ -31,7 +31,7 @@ uppy.use(Facebook, {
 $ npm install @uppy/facebook
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/file-input/README.md
+++ b/packages/@uppy/file-input/README.md
@@ -31,8 +31,6 @@ uppy.use(FileInput, {
 $ npm install @uppy/file-input
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/file-input/README.md
+++ b/packages/@uppy/file-input/README.md
@@ -31,7 +31,7 @@ uppy.use(FileInput, {
 $ npm install @uppy/file-input
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/form/README.md
+++ b/packages/@uppy/form/README.md
@@ -33,7 +33,7 @@ uppy.use(Form, {
 $ npm install @uppy/form
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/form/README.md
+++ b/packages/@uppy/form/README.md
@@ -33,8 +33,6 @@ uppy.use(Form, {
 $ npm install @uppy/form
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/golden-retriever/README.md
+++ b/packages/@uppy/golden-retriever/README.md
@@ -29,8 +29,6 @@ uppy.use(GoldenRetriever, {
 $ npm install @uppy/golden-retriever
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/golden-retriever/README.md
+++ b/packages/@uppy/golden-retriever/README.md
@@ -29,7 +29,7 @@ uppy.use(GoldenRetriever, {
 $ npm install @uppy/golden-retriever
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/google-drive/README.md
+++ b/packages/@uppy/google-drive/README.md
@@ -31,8 +31,6 @@ uppy.use(GoogleDrive, {
 $ npm install @uppy/google-drive
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/google-drive/README.md
+++ b/packages/@uppy/google-drive/README.md
@@ -31,7 +31,7 @@ uppy.use(GoogleDrive, {
 $ npm install @uppy/google-drive
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/image-editor/README.md
+++ b/packages/@uppy/image-editor/README.md
@@ -36,7 +36,7 @@ uppy.use(ImageEditor, {
 $ npm install @uppy/image-editor
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/image-editor/README.md
+++ b/packages/@uppy/image-editor/README.md
@@ -36,8 +36,6 @@ uppy.use(ImageEditor, {
 $ npm install @uppy/image-editor
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/informer/README.md
+++ b/packages/@uppy/informer/README.md
@@ -29,8 +29,6 @@ uppy.use(Informer, {
 $ npm install @uppy/informer
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/informer/README.md
+++ b/packages/@uppy/informer/README.md
@@ -29,7 +29,7 @@ uppy.use(Informer, {
 $ npm install @uppy/informer
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/instagram/README.md
+++ b/packages/@uppy/instagram/README.md
@@ -30,8 +30,6 @@ uppy.use(Instagram, {
 $ npm install @uppy/instagram
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/instagram/README.md
+++ b/packages/@uppy/instagram/README.md
@@ -30,7 +30,7 @@ uppy.use(Instagram, {
 $ npm install @uppy/instagram
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/onedrive/README.md
+++ b/packages/@uppy/onedrive/README.md
@@ -31,7 +31,7 @@ uppy.use(OneDrive, {
 $ npm install @uppy/onedrive
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/onedrive/README.md
+++ b/packages/@uppy/onedrive/README.md
@@ -31,8 +31,6 @@ uppy.use(OneDrive, {
 $ npm install @uppy/onedrive
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/progress-bar/README.md
+++ b/packages/@uppy/progress-bar/README.md
@@ -29,8 +29,6 @@ uppy.use(ProgressBar, {
 $ npm install @uppy/progress-bar
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/progress-bar/README.md
+++ b/packages/@uppy/progress-bar/README.md
@@ -29,7 +29,7 @@ uppy.use(ProgressBar, {
 $ npm install @uppy/progress-bar
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/react/README.md
+++ b/packages/@uppy/react/README.md
@@ -44,8 +44,6 @@ class Example extends React.Component {
 $ npm install @uppy/react
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/react/README.md
+++ b/packages/@uppy/react/README.md
@@ -44,7 +44,7 @@ class Example extends React.Component {
 $ npm install @uppy/react
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/redux-dev-tools/README.md
+++ b/packages/@uppy/redux-dev-tools/README.md
@@ -27,7 +27,7 @@ uppy.use(ReduxDevTools)
 $ npm install @uppy/redux-dev-tools
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/redux-dev-tools/README.md
+++ b/packages/@uppy/redux-dev-tools/README.md
@@ -27,8 +27,6 @@ uppy.use(ReduxDevTools)
 $ npm install @uppy/redux-dev-tools
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/robodog/README.md
+++ b/packages/@uppy/robodog/README.md
@@ -15,8 +15,6 @@ Robodog is an Uppy-based library that pulls your files through Transloadit for a
 $ npm install @uppy/robodog
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this package in a pre-built bundle from Transloadit’s CDN: Edgly.
 
 ```html

--- a/packages/@uppy/robodog/README.md
+++ b/packages/@uppy/robodog/README.md
@@ -15,7 +15,7 @@ Robodog is an Uppy-based library that pulls your files through Transloadit for a
 $ npm install @uppy/robodog
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](http://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this package in a pre-built bundle from Transloadit’s CDN: Edgly.
 

--- a/packages/@uppy/screen-capture/README.md
+++ b/packages/@uppy/screen-capture/README.md
@@ -27,7 +27,7 @@ uppy.use(ScreenCapture)
 $ npm install @uppy/screen-capture
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/screen-capture/README.md
+++ b/packages/@uppy/screen-capture/README.md
@@ -27,8 +27,6 @@ uppy.use(ScreenCapture)
 $ npm install @uppy/screen-capture
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/status-bar/README.md
+++ b/packages/@uppy/status-bar/README.md
@@ -33,8 +33,6 @@ uppy.use(StatusBar, {
 $ npm install @uppy/status-bar
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/status-bar/README.md
+++ b/packages/@uppy/status-bar/README.md
@@ -33,7 +33,7 @@ uppy.use(StatusBar, {
 $ npm install @uppy/status-bar
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/store-default/README.md
+++ b/packages/@uppy/store-default/README.md
@@ -28,8 +28,6 @@ const uppy = new Uppy({
 $ npm install @uppy/store-default
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this package in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/store-default/README.md
+++ b/packages/@uppy/store-default/README.md
@@ -28,7 +28,7 @@ const uppy = new Uppy({
 $ npm install @uppy/store-default
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this package in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/store-redux/README.md
+++ b/packages/@uppy/store-redux/README.md
@@ -36,7 +36,7 @@ const uppy = new Uppy({ store })
 $ npm install @uppy/store-redux
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/store-redux/README.md
+++ b/packages/@uppy/store-redux/README.md
@@ -36,8 +36,6 @@ const uppy = new Uppy({ store })
 $ npm install @uppy/store-redux
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/thumbnail-generator/README.md
+++ b/packages/@uppy/thumbnail-generator/README.md
@@ -29,7 +29,7 @@ uppy.use(ThumbnailGenerator, {
 $ npm install @uppy/thumbnail-generator
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/thumbnail-generator/README.md
+++ b/packages/@uppy/thumbnail-generator/README.md
@@ -29,8 +29,6 @@ uppy.use(ThumbnailGenerator, {
 $ npm install @uppy/thumbnail-generator
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 <!-- Undocumented currently

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -31,8 +31,6 @@ uppy.use(Transloadit, {
 $ npm install @uppy/transloadit
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -31,7 +31,7 @@ uppy.use(Transloadit, {
 $ npm install @uppy/transloadit
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/tus/README.md
+++ b/packages/@uppy/tus/README.md
@@ -31,7 +31,7 @@ uppy.use(Tus, {
 $ npm install @uppy/tus
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/tus/README.md
+++ b/packages/@uppy/tus/README.md
@@ -31,8 +31,6 @@ uppy.use(Tus, {
 $ npm install @uppy/tus
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/unsplash/README.md
+++ b/packages/@uppy/unsplash/README.md
@@ -31,8 +31,6 @@ uppy.use(Unsplash, {
 $ npm install @uppy/unsplash --save
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/unsplash/README.md
+++ b/packages/@uppy/unsplash/README.md
@@ -31,7 +31,7 @@ uppy.use(Unsplash, {
 $ npm install @uppy/unsplash --save
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/url/README.md
+++ b/packages/@uppy/url/README.md
@@ -31,8 +31,6 @@ uppy.use(Url, {
 $ npm install @uppy/url
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/url/README.md
+++ b/packages/@uppy/url/README.md
@@ -31,7 +31,7 @@ uppy.use(Url, {
 $ npm install @uppy/url
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/vue/README.md
+++ b/packages/@uppy/vue/README.md
@@ -52,7 +52,7 @@ export default {
 $ npm install @uppy/vue
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/vue/README.md
+++ b/packages/@uppy/vue/README.md
@@ -52,8 +52,6 @@ export default {
 $ npm install @uppy/vue
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/webcam/README.md
+++ b/packages/@uppy/webcam/README.md
@@ -31,7 +31,7 @@ uppy.use(Webcam, {
 $ npm install @uppy/webcam
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/webcam/README.md
+++ b/packages/@uppy/webcam/README.md
@@ -31,8 +31,6 @@ uppy.use(Webcam, {
 $ npm install @uppy/webcam
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/xhr-upload/README.md
+++ b/packages/@uppy/xhr-upload/README.md
@@ -29,8 +29,6 @@ uppy.use(Uppy, {
 $ npm install @uppy/xhr-upload
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/packages/@uppy/xhr-upload/README.md
+++ b/packages/@uppy/xhr-upload/README.md
@@ -29,7 +29,7 @@ uppy.use(Uppy, {
 $ npm install @uppy/xhr-upload
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/zoom/README.md
+++ b/packages/@uppy/zoom/README.md
@@ -31,7 +31,7 @@ uppy.use(Zoom, {
 $ npm install @uppy/zoom
 ```
 
-We recommend installing from npm and then using a module bundler such as [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/) or [Rollup.js](http://rollupjs.org/).
+We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
 
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 

--- a/packages/@uppy/zoom/README.md
+++ b/packages/@uppy/zoom/README.md
@@ -31,8 +31,6 @@ uppy.use(Zoom, {
 $ npm install @uppy/zoom
 ```
 
-We recommend installing from npm and then using a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org).
-
 Alternatively, you can also use this plugin in a pre-built bundle from Transloadit’s CDN: Edgly. In that case `Uppy` will attach itself to the global `window.Uppy` object. See the [main Uppy documentation](https://uppy.io/docs/#Installation) for instructions.
 
 ## Documentation

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -49,7 +49,7 @@ Adding [Companion](/docs/companion/) to the mix enables remote sources such as I
 
 ## Installation
 
-Uppy can be used with a module bundler such as [Webpack](http://webpack.js.org/) or [Browserify](http://browserify.org/), or by including it in a script tag.
+Uppy can be used with a module bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org), or by including it in a script tag.
 
 > You may need polyfills if your application supports Internet Explorer or other older browsers. See [Browser Support](#Browser-Support).
 

--- a/website/src/docs/robodog.md
+++ b/website/src/docs/robodog.md
@@ -21,7 +21,7 @@ Robodog can be downloaded from npm:
 npm install @uppy/robodog
 ```
 
-Then, with a bundler such as [webpack][webpack] or [Browserify][browserify], do:
+Then, with a bundler such as [Vite](https://vitejs.dev/), [Parcel](https://parceljs.org/), or [Rollup](https://rollupjs.org), do:
 
 ```js
 import robodog from '@uppy/robodog'
@@ -113,7 +113,3 @@ resultPromise.then((bundle) => {
 <a class="MoreButton" href="/docs/robodog/upload">View Documentation</a>
 
 [transloadit]: https://transloadit.com/
-
-[browserify]: https://browserify.org
-
-[webpack]: https://webpack.js.org


### PR DESCRIPTION
With the switch to ESM, Browserify will no longer work with Uppy. I'm also removing Webpack from the list as it doesn't seem like a good fit to me. Instead, I suggest we recommend bundlers that we actually test with.