### PR TITLE
@uppy/dashboard: use webkitRelativePath when querying a file's relative path

### DIFF
--- a/packages/@uppy/dashboard/src/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/Dashboard.jsx
@@ -380,7 +380,7 @@ export default class Dashboard extends UIPlugin {
       meta: {
         // path of the file relative to the ancestor directory the user selected.
         // e.g. 'docs/Old Prague/airbnb.pdf'
-        relativePath: file.relativePath || null,
+        relativePath: file.relativePath || file.webkitRelativePath || null,
       },
     }))
 


### PR DESCRIPTION
Chrome doesn't seem to provide a valid "relativePath" property for files that get passed from a HTMLInputElement.webkitdirectory.

I'm actually not sure if the "file.relativePath" test is necessary at all here?

fixes #3765