### PR TITLE
(aws-s3-multipart) Allow companionHeaders to be modified before uploading files

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -54,6 +54,11 @@ export default class AwsS3Multipart extends BasePlugin {
 
   [Symbol.for('uppy test: getClient')] () { return this.#client }
 
+  // TODO: remove getter and setter for #client on the next major release
+  get client () { return this.#client }
+
+  set client (client) { this.#client = client }
+
   /**
    * Clean up all references for a file's upload: the MultipartUploader instance,
    * any events related to the file, and the Companion WebSocket connection.

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -36,11 +36,13 @@ export default class AwsS3Multipart extends BasePlugin {
       prepareUploadParts: this.prepareUploadParts.bind(this),
       abortMultipartUpload: this.abortMultipartUpload.bind(this),
       completeMultipartUpload: this.completeMultipartUpload.bind(this),
+      companionHeaders: {},
     }
 
     this.opts = { ...defaultOptions, ...opts }
 
     this.upload = this.upload.bind(this)
+    this.setCompanionHeaders = this.setCompanionHeaders.bind(this)
 
     this.requests = new RateLimitedQueue(this.opts.limit)
 
@@ -436,6 +438,11 @@ export default class AwsS3Multipart extends BasePlugin {
     return Promise.all(promises)
   }
 
+  setCompanionHeaders () {
+    this.client.setCompanionHeaders(this.opts.companionHeaders)
+    return Promise.resolve()
+  }
+
   onFileRemove (fileID, cb) {
     this.uploaderEvents[fileID].on('file-removed', (file) => {
       if (fileID === file.id) cb(file.id)
@@ -495,6 +502,7 @@ export default class AwsS3Multipart extends BasePlugin {
         resumableUploads: true,
       },
     })
+    this.uppy.addPreProcessor(this.setCompanionHeaders)
     this.uppy.addUploader(this.upload)
   }
 
@@ -506,6 +514,7 @@ export default class AwsS3Multipart extends BasePlugin {
         resumableUploads: false,
       },
     })
+    this.uppy.removePreProcessor(this.setCompanionHeaders)
     this.uppy.removeUploader(this.upload)
   }
 }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -42,7 +42,6 @@ export default class AwsS3Multipart extends BasePlugin {
     this.opts = { ...defaultOptions, ...opts }
 
     this.upload = this.upload.bind(this)
-    this.setCompanionHeaders = this.setCompanionHeaders.bind(this)
 
     this.requests = new RateLimitedQueue(this.opts.limit)
 
@@ -438,7 +437,7 @@ export default class AwsS3Multipart extends BasePlugin {
     return Promise.all(promises)
   }
 
-  setCompanionHeaders () {
+  #setCompanionHeaders = () => {
     this.client.setCompanionHeaders(this.opts.companionHeaders)
     return Promise.resolve()
   }
@@ -502,7 +501,7 @@ export default class AwsS3Multipart extends BasePlugin {
         resumableUploads: true,
       },
     })
-    this.uppy.addPreProcessor(this.setCompanionHeaders)
+    this.uppy.addPreProcessor(this.#setCompanionHeaders)
     this.uppy.addUploader(this.upload)
   }
 
@@ -514,7 +513,7 @@ export default class AwsS3Multipart extends BasePlugin {
         resumableUploads: false,
       },
     })
-    this.uppy.removePreProcessor(this.setCompanionHeaders)
+    this.uppy.removePreProcessor(this.#setCompanionHeaders)
     this.uppy.removeUploader(this.upload)
   }
 }

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -227,4 +227,33 @@ describe('AwsS3Multipart', () => {
       expect(awsS3Multipart.opts.prepareUploadParts.mock.calls.length).toEqual(2)
     })
   })
+
+  describe('dynamic companionHeader', () => {
+    let core
+    let awsS3Multipart
+    const oldToken = 'old token'
+    const newToken = 'new token'
+
+    beforeEach(() => {
+      core = new Core()
+      core.use(AwsS3Multipart, {
+        companionHeaders: {
+          authorization: oldToken,
+        },
+      })
+      awsS3Multipart = core.getPlugin('AwsS3Multipart')
+    })
+
+    it('companionHeader is updated before uploading file', async () => {
+      awsS3Multipart.setOptions({
+        companionHeaders: {
+          authorization: newToken,
+        },
+      })
+
+      await core.upload()
+
+      expect(awsS3Multipart.client.companionHeaders.authorization).toEqual(newToken)
+    })
+  })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -253,7 +253,7 @@ describe('AwsS3Multipart', () => {
 
       await core.upload()
 
-      expect(awsS3Multipart.client.companionHeaders.authorization).toEqual(newToken)
+      expect(awsS3Multipart.client[Symbol.for('uppy test: getCompanionHeaders')]().authorization).toEqual(newToken)
     })
   })
 })

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -253,7 +253,9 @@ describe('AwsS3Multipart', () => {
 
       await core.upload()
 
-      expect(awsS3Multipart.client[Symbol.for('uppy test: getCompanionHeaders')]().authorization).toEqual(newToken)
+      const client = awsS3Multipart[Symbol.for('uppy test: getClient')]()
+
+      expect(client[Symbol.for('uppy test: getCompanionHeaders')]().authorization).toEqual(newToken)
     })
   })
 })

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -117,6 +117,7 @@ export default class AwsS3 extends BasePlugin {
       limit: 0,
       metaFields: [], // have to opt in
       getUploadParameters: this.getUploadParameters.bind(this),
+      companionHeaders: {},
     }
 
     this.opts = { ...defaultOptions, ...opts }
@@ -127,6 +128,8 @@ export default class AwsS3 extends BasePlugin {
     this.#client = new RequestClient(uppy, opts)
     this.#requests = new RateLimitedQueue(this.opts.limit)
   }
+
+  [Symbol.for('uppy test: getClient')] () { return this.#client }
 
   getUploadParameters (file) {
     if (!this.opts.companionUrl) {
@@ -216,8 +219,14 @@ export default class AwsS3 extends BasePlugin {
     })
   }
 
+  #setCompanionHeaders = () => {
+    this.#client.setCompanionHeaders(this.opts.companionHeaders)
+    return Promise.resolve()
+  }
+
   install () {
     const { uppy } = this
+    uppy.addPreProcessor(this.#setCompanionHeaders)
     uppy.addUploader(this.#handleUpload)
 
     // Get the response data from a successful XMLHttpRequest instance.
@@ -279,6 +288,7 @@ export default class AwsS3 extends BasePlugin {
   }
 
   uninstall () {
+    this.uppy.removePreProcessor(this.#setCompanionHeaders)
     this.uppy.removeUploader(this.#handleUpload)
   }
 }

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -131,6 +131,11 @@ export default class AwsS3 extends BasePlugin {
 
   [Symbol.for('uppy test: getClient')] () { return this.#client }
 
+  // TODO: remove getter and setter for #client on the next major release
+  get client () { return this.#client }
+
+  set client (client) { this.#client = client }
+
   getUploadParameters (file) {
     if (!this.opts.companionUrl) {
       throw new Error('Expected a `companionUrl` option containing a Companion address.')

--- a/packages/@uppy/aws-s3/src/index.test.js
+++ b/packages/@uppy/aws-s3/src/index.test.js
@@ -34,4 +34,35 @@ describe('AwsS3', () => {
       expect(() => awsS3.opts.getUploadParameters(file)).not.toThrow()
     })
   })
+
+  describe('dynamic companionHeader', () => {
+    let core
+    let awsS3
+    const oldToken = 'old token'
+    const newToken = 'new token'
+
+    beforeEach(() => {
+      core = new Core()
+      core.use(AwsS3, {
+        companionHeaders: {
+          authorization: oldToken,
+        },
+      })
+      awsS3 = core.getPlugin('AwsS3')
+    })
+
+    it('companionHeader is updated before uploading file', async () => {
+      awsS3.setOptions({
+        companionHeaders: {
+          authorization: newToken,
+        },
+      })
+
+      await core.upload()
+
+      const client = awsS3[Symbol.for('uppy test: getClient')]()
+
+      expect(client[Symbol.for('uppy test: getCompanionHeaders')]().authorization).toEqual(newToken)
+    })
+  })
 })

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -43,6 +43,11 @@ export default class RequestClient {
     this.onReceiveResponse = this.onReceiveResponse.bind(this)
     this.allowedHeaders = ['accept', 'content-type', 'uppy-auth-token']
     this.preflightDone = false
+    this.companionHeaders = opts !== undefined && opts.companionHeaders !== undefined ? opts.companionHeaders : {}
+  }
+
+  setCompanionHeaders (headers) {
+    this.companionHeaders = headers
   }
 
   get hostname () {
@@ -58,7 +63,7 @@ export default class RequestClient {
   }
 
   headers () {
-    const userHeaders = this.opts.companionHeaders || {}
+    const userHeaders = this.companionHeaders || {}
     return Promise.resolve({
       ...RequestClient.defaultHeaders,
       ...userHeaders,

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -35,7 +35,7 @@ async function handleJSONResponse (res) {
 export default class RequestClient {
   static VERSION = packageJson.version
 
-  #companionHeaders = {}
+  #companionHeaders
 
   #getPostResponseFunc = skip => response => (skip ? response : this.onReceiveResponse(response))
 
@@ -45,7 +45,7 @@ export default class RequestClient {
     this.onReceiveResponse = this.onReceiveResponse.bind(this)
     this.allowedHeaders = ['accept', 'content-type', 'uppy-auth-token']
     this.preflightDone = false
-    this.#companionHeaders = opts !== undefined && opts.companionHeaders !== undefined ? opts.companionHeaders : {}
+    this.#companionHeaders = opts?.companionHeaders
   }
 
   setCompanionHeaders (headers) {
@@ -67,10 +67,9 @@ export default class RequestClient {
   }
 
   headers () {
-    const userHeaders = this.#companionHeaders || {}
     return Promise.resolve({
       ...RequestClient.defaultHeaders,
-      ...userHeaders,
+      ...this.#companionHeaders,
     })
   }
 

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -35,6 +35,8 @@ async function handleJSONResponse (res) {
 export default class RequestClient {
   static VERSION = packageJson.version
 
+  #companionHeaders = {}
+
   #getPostResponseFunc = skip => response => (skip ? response : this.onReceiveResponse(response))
 
   constructor (uppy, opts) {
@@ -43,12 +45,14 @@ export default class RequestClient {
     this.onReceiveResponse = this.onReceiveResponse.bind(this)
     this.allowedHeaders = ['accept', 'content-type', 'uppy-auth-token']
     this.preflightDone = false
-    this.companionHeaders = opts !== undefined && opts.companionHeaders !== undefined ? opts.companionHeaders : {}
+    this.#companionHeaders = opts !== undefined && opts.companionHeaders !== undefined ? opts.companionHeaders : {}
   }
 
   setCompanionHeaders (headers) {
-    this.companionHeaders = headers
+    this.#companionHeaders = headers
   }
+
+  [Symbol.for('uppy test: getCompanionHeaders')] () { return this.#companionHeaders }
 
   get hostname () {
     const { companion } = this.uppy.getState()
@@ -63,7 +67,7 @@ export default class RequestClient {
   }
 
   headers () {
-    const userHeaders = this.companionHeaders || {}
+    const userHeaders = this.#companionHeaders || {}
     return Promise.resolve({
       ...RequestClient.defaultHeaders,
       ...userHeaders,


### PR DESCRIPTION
Closes #2465

I'd like to be able to update the `companionHeaders` object before uploading files so the JWT token can be refreshed if needed.

Let me know your thoughts or if there's a better approach. Thanks