### PR TITLE
meta: disable ESM to CJS transform in dist files

### DIFF
--- a/__mocks__/nanoid/non-secure.js
+++ b/__mocks__/nanoid/non-secure.js
@@ -1,1 +1,0 @@
-module.exports = { nanoid: () => 'cjd09qwxb000dlql4tp4doz8h' }

--- a/packages/@uppy/core/src/Uppy.test.js
+++ b/packages/@uppy/core/src/Uppy.test.js
@@ -896,7 +896,12 @@ describe('src/Core', () => {
       core.addFile({ source: 'jest', name: 'bar.jpg', type: 'image/jpeg', data: new Uint8Array() })
       core.addFile({ source: 'file3', name: 'file3.jpg', type: 'image/jpeg', data: new Uint8Array() })
 
-      return expect(core.upload()).resolves.toMatchSnapshot()
+      // uploadID is random, we don't want randomness in the snapshot
+      const validateNanoID = r => (
+        typeof r.uploadID === 'string' && r.uploadID.length === 21 ? ({ ...r, uploadID: 'cjd09qwxb000dlql4tp4doz8h' }) : r
+      )
+
+      return expect(core.upload().then(validateNanoID)).resolves.toMatchSnapshot()
     })
 
     it('should not upload if onBeforeUpload returned false', () => {


### PR DESCRIPTION
This commit removes all the hacks that needed to happen in order to ship working CJS code. Onwards, we plan to distribute Uppy packages as ESM.