### PR TITLE
@uppy/companion: remove support for EOL versions of Node.js

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -7,44 +7,6 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
-  test-legacy:
-    name: Unit tests (legacy)
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.20.1, 12.x, 17.x]
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{matrix.node-version}}
-      - name: Install Corepack if needed
-        run: corepack -v || npm install -g corepack
-      - name: Install dependencies
-        run: corepack yarn@3.1.1 install --no-immutable
-        env:
-          # Necessary for Node.js v10.x
-          NODE_OPTIONS: --experimental-worker
-          YARN_IGNORE_NODE: 1
-      - name: Run tests
-        run: corepack yarn run test:companion
-        env:
-          # Necessary for Node.js v10.x
-          NODE_OPTIONS: --experimental-worker
-          YARN_IGNORE_NODE: 1
   test:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -114,7 +114,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=10.20.1"
+    "node": "^14.19.0 || ^16.15.0 || >=18.0.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"


### PR DESCRIPTION
Node.js 10.x is EOL since 2021-04-31.
Node.js 11.x is EOL since 2019-06-01.
Node.js 12.x is EOL since 2022-04-30.
Node.js 13.x is EOL since 2020-06-01.
Node.js 15.x is EOL since 2021-06-01.
Node.js 17.x is EOL since 2022-06-01.