### PR TITLE
meta: do not test on EOL versions of Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install Corepack if needed
-        run: corepack -v || npm install -g corepack
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(corepack yarn config get cacheFolder)"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "pre-commit": "lint:staged",
   "license": "MIT",
   "engines": {
-    "node": "^v14.17.0 || >=v16.0.0",
+    "node": "^16.15.0 || >=18.0.0",
     "yarn": "3.2.1"
   },
   "packageManager": "yarn@3.2.1",


### PR DESCRIPTION
Removing v14.x in the `package.json` as we don't want to maintain that version for developing Uppy, but keep it in the CI to catch potential fixable errors.