### PR TITLE
enable passing optional meta data to Uppy URL plugin's addFile API

### DIFF
--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -104,7 +104,7 @@ export default class Url extends UIPlugin {
       })
   }
 
-  async addFile (protocollessUrl) {
+  async addFile (protocollessUrl, optionalMeta = undefined) {
     const url = this.addProtocolToURL(protocollessUrl)
     if (!this.checkIfCorrectURL(url)) {
       this.uppy.log(`[URL] Incorrect URL entered: ${url}`)
@@ -116,6 +116,7 @@ export default class Url extends UIPlugin {
       const meta = await this.getMeta(url)
 
       const tagFile = {
+        meta: optionalMeta,
         source: this.id,
         name: this.getFileNameFromUrl(url),
         type: meta.type,

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -48,7 +48,9 @@ function checkIfCorrectURL (url) {
 }
 
 function getFileNameFromUrl (url) {
-  return url.substring(url.lastIndexOf('/') + 1).split('?')[0], // make sure filename does not have query params in it
+  const queryParamsIndexOf = url.indexOf('?')
+  const queryParamsStart = queryParamsIndexOf === -1 ? undefined : queryParamsIndexOf
+  return url.substring(url.lastIndexOf('/', queryParamsStart) + 1, queryParamsStart)
 }
 /**
  * Url

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -48,7 +48,7 @@ function checkIfCorrectURL (url) {
 }
 
 function getFileNameFromUrl (url) {
-  return url.substring(url.lastIndexOf('/') + 1)
+  return url.substring(url.lastIndexOf('/') + 1).split('?')[0], // make sure filename does not have query params in it
 }
 /**
  * Url

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -48,9 +48,8 @@ function checkIfCorrectURL (url) {
 }
 
 function getFileNameFromUrl (url) {
-  const queryParamsIndexOf = url.indexOf('?')
-  const queryParamsStart = queryParamsIndexOf === -1 ? undefined : queryParamsIndexOf
-  return url.substring(url.lastIndexOf('/', queryParamsStart) + 1, queryParamsStart)
+  const { pathname } = new URL(url)
+  return pathname.substring(pathname.lastIndexOf('/') + 1)
 }
 /**
  * Url

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -48,8 +48,7 @@ function checkIfCorrectURL (url) {
 }
 
 function getFileNameFromUrl (url) {
-  const { pathname } = new URL(url)
-  return pathname.substring(pathname.lastIndexOf('/') + 1)
+  return url.substring(url.lastIndexOf('/') + 1)
 }
 /**
  * Url

--- a/packages/@uppy/url/types/index.d.ts
+++ b/packages/@uppy/url/types/index.d.ts
@@ -9,7 +9,7 @@ export interface UrlOptions extends PluginOptions, RequestClientOptions {
 }
 
 declare class Url extends UIPlugin<UrlOptions> {
-  public addFile(url: string): undefined | string | never
+  public addFile(url: string, optionalMeta: any = undefined): undefined | string | never
 }
 
 export default Url

--- a/packages/@uppy/url/types/index.d.ts
+++ b/packages/@uppy/url/types/index.d.ts
@@ -1,6 +1,7 @@
 import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 import type { RequestClientOptions } from '@uppy/companion-client'
 import UrlLocale from './generatedLocale'
+import type { IndexedObject } from '@uppy/core'
 
 export interface UrlOptions extends PluginOptions, RequestClientOptions {
     target?: PluginTarget
@@ -9,7 +10,7 @@ export interface UrlOptions extends PluginOptions, RequestClientOptions {
 }
 
 declare class Url extends UIPlugin<UrlOptions> {
-  public addFile(url: string, optionalMeta: any = undefined): undefined | string | never
+  public addFile(url: string, meta?: IndexedObject<any>): undefined | string | never
 }
 
 export default Url

--- a/packages/@uppy/url/types/index.d.ts
+++ b/packages/@uppy/url/types/index.d.ts
@@ -1,7 +1,6 @@
-import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
+import type { PluginOptions, UIPlugin, PluginTarget, IndexedObject } from '@uppy/core'
 import type { RequestClientOptions } from '@uppy/companion-client'
 import UrlLocale from './generatedLocale'
-import type { IndexedObject } from '@uppy/core'
 
 export interface UrlOptions extends PluginOptions, RequestClientOptions {
     target?: PluginTarget


### PR DESCRIPTION
Uppy Url is great! Thank you. For my use case, I need to be able to pass thru some meta data with the File, in addition to the URL.  Harmless to make it optional, but very useful to have it.  Without it, I had to copy/paste the code in addFile to add it externally, since there's no intermediate opportunity to add data before uppy.addFile gets called. 