### PR TITLE
transloadit: propagate error details when creating Assembly fails

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -243,10 +243,10 @@ export default class Transloadit extends BasePlugin {
       return assembly
     }).catch((err) => {
       const wrapped = new ErrorWithCause(`${this.i18n('creatingAssemblyFailed')}: ${err.message}`, { cause: err })
-      if (err.details) {
+      if ('details' in err) {
         wrapped.details = err.details
       }
-      if (err.assembly) {
+      if ('assembly' in err) {
         wrapped.assembly = err.assembly
       }
       throw wrapped

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -242,7 +242,14 @@ export default class Transloadit extends BasePlugin {
       this.uppy.log(`[Transloadit] Created Assembly ${assemblyID}`)
       return assembly
     }).catch((err) => {
-      throw new ErrorWithCause(`${this.i18n('creatingAssemblyFailed')}: ${err.message}`, { cause: err })
+      const wrapped = new ErrorWithCause(`${this.i18n('creatingAssemblyFailed')}: ${err.message}`, { cause: err })
+      if (err.details) {
+        wrapped.details = err.details
+      }
+      if (err.assembly) {
+        wrapped.assembly = err.assembly
+      }
+      throw wrapped
     })
   }
 


### PR DESCRIPTION
Clients are expected to use `error.assembly` to inspect details about
failed Assemblies, but then we do need to always give that property
back.

I think we should have a test for this but not sure how to approach it,
since it depends on responses from the Transloadit API. I guess we'd
require a new e2e test for it?