### PR TITLE
improve Uppy Url's url->filename

### DIFF
--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -49,7 +49,7 @@ function checkIfCorrectURL (url) {
 
 function getFileNameFromUrl (url) {
   const { pathname } = new URL(url)
-  return pathname.substring(pathname.lastIndexOf('/') + 1)  
+  return pathname.substring(pathname.lastIndexOf('/') + 1)
 }
 /**
  * Url

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -48,7 +48,8 @@ function checkIfCorrectURL (url) {
 }
 
 function getFileNameFromUrl (url) {
-  return url.substring(url.lastIndexOf('/') + 1)
+  const { pathname } = new URL(url)
+  return pathname.substring(pathname.lastIndexOf('/') + 1)  
 }
 /**
  * Url


### PR DESCRIPTION
Need to strip query string from URL when turning into a filename.