### PR TITLE
Reset Uppy instance when React component is unmounted

### DIFF
--- a/packages/@uppy/react/src/useUppy.js
+++ b/packages/@uppy/react/src/useUppy.js
@@ -18,8 +18,9 @@ module.exports = function useUppy (factory) {
   useEffect(() => {
     return () => {
       uppy.current.close({ reason: 'unmount' })
+      uppy.current = undefined
     }
-  }, [])
+  }, [uppy])
 
   return uppy.current
 }


### PR DESCRIPTION
With new version of React [added additional check to `React.StrictMode`](https://reactjs.org/docs/strict-mode.html#:~:text=To%20help%20surface%20these%20issues,state%20on%20the%20second%20mount.).

Beacuse of this uploader plugin is not set - `No uploader type plugins are used` warning is reported.
