### PR TITLE
Changed the quotes around id for SWC

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -1154,7 +1154,7 @@ class Uppy {
     if (existsPluginAlready) {
       const msg = `Already found a plugin named '${existsPluginAlready.id}'. `
         + `Tried to use: '${pluginId}'.\n`
-        + 'Uppy plugins must have unique `id` options. See https://uppy.io/docs/plugins/#id.'
+        + 'Uppy plugins must have unique "id" options. See https://uppy.io/docs/plugins/#id.'
       throw new Error(msg)
     }
 


### PR DESCRIPTION
SWC minify will remove the backslash around the quotes which will make uppy fail in production. Simply changing the quotes will make the code work