### PR TITLE
@uppy/transloadit: fix `COMPANION_PATTERN` export

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -836,11 +836,11 @@ export default class Transloadit extends BasePlugin {
 
 export {
   COMPANION,
-  ALLOWED_COMPANION_PATTERN,
+  ALLOWED_COMPANION_PATTERN as COMPANION_PATTERN,
 }
 
-// Backward compatibility: we want `COMPANION` and `ALLOWED_COMPANION_PATTERN`
+// Backward compatibility: we want `COMPANION` and `COMPANION_PATTERN`
 // to keep being accessible as static properties of `Transloadit` to avoid a
 // breaking change.
 Transloadit.COMPANION = COMPANION // TODO: remove this line on the next major
-Transloadit.ALLOWED_COMPANION_PATTERN = ALLOWED_COMPANION_PATTERN // TODO: remove this line on the next major
+Transloadit.COMPANION_PATTERN = ALLOWED_COMPANION_PATTERN // TODO: remove this line on the next major

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -835,6 +835,7 @@ export default class Transloadit extends BasePlugin {
 }
 
 export {
+  ALLOWED_COMPANION_PATTERN,
   COMPANION,
   ALLOWED_COMPANION_PATTERN as COMPANION_PATTERN,
 }
@@ -842,5 +843,6 @@ export {
 // Backward compatibility: we want `COMPANION` and `COMPANION_PATTERN`
 // to keep being accessible as static properties of `Transloadit` to avoid a
 // breaking change.
+Transloadit.ALLOWED_COMPANION_PATTERN = ALLOWED_COMPANION_PATTERN // TODO: remove this line on the next major
 Transloadit.COMPANION = COMPANION // TODO: remove this line on the next major
 Transloadit.COMPANION_PATTERN = ALLOWED_COMPANION_PATTERN // TODO: remove this line on the next major


### PR DESCRIPTION
This was broken during the ESM transition.

Refs: https://github.com/transloadit/uppy/pull/3725