### PR TITLE
Companion 3 default to no s3 acl

### DIFF
--- a/packages/@uppy/companion/src/config/companion.js
+++ b/packages/@uppy/companion/src/config/companion.js
@@ -10,7 +10,6 @@ const defaultOptions = {
   },
   providerOptions: {},
   s3: {
-    acl: 'public-read', // todo default to no ACL in next major
     endpoint: 'https://{service}.{region}.amazonaws.com',
     conditions: [],
     useAccelerateEndpoint: false,

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -647,7 +647,6 @@ class Uploader {
     const params = {
       Bucket: options.bucket,
       Key: options.getKey(null, filename, this.options.metadata),
-      ACL: options.acl,
       ContentType: this.options.metadata.type,
       Metadata: this.options.metadata,
       Body: stream,

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -78,7 +78,7 @@ const getConfigFromEnv = () => {
       useAccelerateEndpoint:
       process.env.COMPANION_AWS_USE_ACCELERATE_ENDPOINT === 'true',
       expires: parseInt(process.env.COMPANION_AWS_EXPIRES || '300', 10),
-      acl: process.env.COMPANION_AWS_DISABLE_ACL === 'true' ? null : (process.env.COMPANION_AWS_ACL || 'public-read'), // todo default to no ACL in next major and remove COMPANION_AWS_DISABLE_ACL
+      acl: process.env.COMPANION_AWS_ACL,
     },
     server: {
       host: process.env.COMPANION_DOMAIN,

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -262,7 +262,7 @@ export COMPANION_AWS_USE_ACCELERATE_ENDPOINT="false"
 # to set X-Amz-Expires query param in presigned urls (in seconds, default: 300)
 export COMPANION_AWS_EXPIRES="300"
 # to set a canned ACL for uploaded objects: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
-export COMPANION_AWS_ACL="public-read"
+export COMPANION_AWS_ACL="private"
 
 # corresponds to the server.oauthDomain option
 export COMPANION_OAUTH_DOMAIN="sub.domain.com"
@@ -332,7 +332,7 @@ const options = {
     region: 'us-east-1',
     useAccelerateEndpoint: false, // default: false,
     expires: 3600, // default: 300 (5 minutes)
-    acl: 'private', // default: public-read
+    acl: 'private', // default: none
   },
   server: {
     host: 'localhost:3020', // or yourdomain.com


### PR DESCRIPTION
pulled out from #3791

# Breaking changes
- Default to no ACL for S3 uploads (previous default was `public-read` but AWS now discourages ACLs).
- Remove environment variable `COMPANION_AWS_DISABLE_ACL`, will instead only use `COMPANION_AWS_ACL`
