### PR TITLE
rewrite companion.app() to return an object

### DIFF
--- a/examples/aws-companion/server.js
+++ b/examples/aws-companion/server.js
@@ -46,7 +46,9 @@ process.on('exit', () => {
   fs.rmSync(DATA_DIR, { recursive: true, force: true })
 })
 
-app.use(companion.app(options))
+const { app: companionApp } = companion.app(options)
+
+app.use(companionApp)
 
 const server = app.listen(3020, () => {
   console.log('listening on port 3020')

--- a/examples/digitalocean-spaces/server.js
+++ b/examples/digitalocean-spaces/server.js
@@ -27,7 +27,7 @@ const app = router()
 app.use(require('cors')())
 app.use(require('body-parser').json())
 
-app.use('/companion', companion.app({
+const { app: companionApp } = companion.app({
   providerOptions: {
     s3: {
       // This is the crucial part; set an endpoint template for the service you want to use.
@@ -41,7 +41,9 @@ app.use('/companion', companion.app({
     },
   },
   server: { serverUrl: `localhost:${PORT}` },
-}))
+})
+
+app.use('/companion', companionApp)
 
 // Serve the built CSS file.
 app.get('/uppy.min.css', (req, res) => {

--- a/examples/uppy-with-companion/server/index.js
+++ b/examples/uppy-with-companion/server/index.js
@@ -53,7 +53,8 @@ const uppyOptions = {
   debug: true,
 }
 
-app.use(companion.app(uppyOptions))
+const { app: companionApp } = companion.app(uppyOptions)
+app.use(companionApp)
 
 // handle 404
 app.use((req, res) => {

--- a/packages/@uppy/companion/README.md
+++ b/packages/@uppy/companion/README.md
@@ -48,7 +48,8 @@ const options = {
   filePath: '/path/to/folder/',
 }
 
-app.use(companion.app(options))
+const { app: companionApp } = companion.app(options)
+app.use(companionApp)
 ```
 
 To enable companion socket for realtime feed to the client while upload is going on, you call the `socket` method like so.

--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -57,7 +57,7 @@ module.exports.socket = require('./server/socket')
  * Entry point into initializing the Companion app.
  *
  * @param {object} optionsArg
- * @returns {import('express').Express}
+ * @returns {{ app: import('express').Express, emitter: any }}}
  */
 module.exports.app = (optionsArg = {}) => {
   validateConfig(optionsArg)
@@ -152,8 +152,5 @@ module.exports.app = (optionsArg = {}) => {
     processId,
   })
 
-  // todo split emitter from app in next major
-  // @ts-ignore
-  app.companionEmitter = emitter
-  return app
+  return { app, emitter }
 }

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -167,7 +167,7 @@ module.exports = function server (inputCompanionOptions = {}) {
   }
 
   // initialize companion
-  const companionApp = companion.app(companionOptions)
+  const { app: companionApp } = companion.app(companionOptions)
 
   // add companion to server middleware
   router.use(companionApp)

--- a/website/src/docs/companion.md
+++ b/website/src/docs/companion.md
@@ -54,7 +54,7 @@ Companion may either be used as a pluggable express app, which you plug into you
 
 ### Plugging into an existing express server
 
-To plug Companion into an existing server, call its `.app` method, passing in an [options](#Options) object as a parameter. This returns a server instance that you can mount on a subpath in your Express or app.
+To plug Companion into an existing server, call its `.app()` method, passing in an [options](#Options) object as a parameter. This returns an object with an `app` property which is a server instance that you can mount on a subpath in your Express or app.
 
 ```js
 import express from 'express'
@@ -88,7 +88,9 @@ const options = {
   filePath: '/path/to/folder/',
 }
 
-app.use('/companion', companion.app(options))
+const { app: companionApp } = companion.app(options)
+
+app.use('/companion', companionApp)
 ```
 
 See [Options](#Options) for valid configuration options.
@@ -105,7 +107,7 @@ This takes your `server` instance as an argument.
 
 #### Events
 
-The object returned by `companion.app()` also has a property `companionEmitter` which is an `EventEmitter` that emits the following events:
+The object returned by `companion.app()` also has a property `emitter` which is an `EventEmitter` that emits the following events:
 
 * `upload-start` - When an upload starts, this event is emitted with an object containing the property `token`, which is a unique ID for the upload.
 * **token** - The event name is the token from `upload-start`. The event has an object with the following properties:
@@ -117,8 +119,7 @@ The object returned by `companion.app()` also has a property `companionEmitter` 
 Example code for using the `EventEmitter` to handle a finished file upload:
 
 ```js
-const companionApp = companion.app(options)
-const { companionEmitter: emitter } = companionApp
+const { app, emitter } = companion.app(options)
 
 emitter.on('upload-start', ({ token }) => {
   console.log('Upload started', token)


### PR DESCRIPTION
with { app, emitter }
gives more flexibility in the future

pulled out from #3791

# Breaking changes
- `companion.app()` function now returns an object `{ app, emitter }` where `app` is the object that was returned in previous versions
