### PR TITLE
Companion: minor code tweaks for node >=14

### DIFF
--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -84,9 +84,8 @@ exports.cors = (options = {}) => (req, res, next) => {
   // HTTP headers are not case sensitive, and express always handles them in lower case, so that's why we lower case them.
   // I believe that HTTP verbs are case sensitive, and should be uppercase.
 
-  // TODO: Move to optional chaining when we drop Node.js v12.x support
   const existingExposeHeaders = res.get('Access-Control-Expose-Headers')
-  const exposeHeadersSet = new Set(existingExposeHeaders && existingExposeHeaders.split(',').map(method => method.trim().toLowerCase()))
+  const exposeHeadersSet = new Set(existingExposeHeaders?.split(',')?.map((method) => method.trim().toLowerCase()))
 
   // exposed so it can be accessed for our custom uppy client preflight
   exposeHeadersSet.add('access-control-allow-headers')
@@ -111,7 +110,7 @@ exports.cors = (options = {}) => (req, res, next) => {
     : allowedHeaders)
 
   const existingAllowMethods = res.get('Access-Control-Allow-Methods')
-  const allowMethodsSet = new Set(existingAllowMethods && existingAllowMethods.split(',').map(method => method.trim().toUpperCase()))
+  const allowMethodsSet = new Set(existingAllowMethods?.split(',')?.map((method) => method.trim().toUpperCase()))
   // Needed for basic operation:
   allowMethodsSet.add('GET').add('POST').add('OPTIONS').add('DELETE')
 


### PR DESCRIPTION
pulled out from #3791

# Breaking changes
- No longer supporting Node.js v12 and older
