### PR TITLE
remove chunkSize backwards compatibility

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -636,14 +636,6 @@ class Uploader {
     const filename = this.uploadFileName
     const { client, options } = this.options.s3
 
-    function getPartSize (chunkSize) {
-      // backwards compatibility https://github.com/transloadit/uppy/pull/3511#issuecomment-1050797935
-      // requires min 5MiB and max 5GiB partSize
-      // todo remove this logic in the next major semver
-      if (chunkSize == null || chunkSize >= 5368709120 || chunkSize <= 5242880) return undefined
-      return chunkSize
-    }
-
     const params = {
       Bucket: options.bucket,
       Key: options.getKey(null, filename, this.options.metadata),
@@ -656,7 +648,8 @@ class Uploader {
     if (options.acl != null) params.ACL = options.acl
 
     const upload = client.upload(params, {
-      partSize: getPartSize(this.options.chunkSize),
+      // using chunkSize as partSize too, see https://github.com/transloadit/uppy/pull/3511
+      partSize: this.options.chunkSize,
     })
 
     upload.on('httpUploadProgress', ({ loaded, total }) => {


### PR DESCRIPTION
see #3511

pulled out from #3791

# Breaking changes
- `chunkSize` option will now be used as `partSize` in AWS multipart - previously only **valid** values would be respected. Invalid values would be ignored. Now any value will be passed on to the AWS SDK, possibly throwing an error on invalid values.
