### PR TITLE
remove deprecated duplicated metrics

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -13,7 +13,6 @@ const s3 = require('./server/controllers/s3')
 const url = require('./server/controllers/url')
 const createEmitter = require('./server/emitter')
 const redis = require('./server/redis')
-const { getURLBuilder } = require('./server/helpers/utils')
 const jobs = require('./server/jobs')
 const logger = require('./server/logger')
 const middlewares = require('./server/middlewares')
@@ -85,17 +84,6 @@ module.exports.app = (optionsArg = {}) => {
 
   if (options.metrics) {
     app.use(middlewares.metrics({ path: options.server.path }))
-
-    // backward compatibility
-    // TODO remove in next major semver
-    if (options.server.path) {
-      const buildUrl = getURLBuilder(options)
-      app.get('/metrics', (req, res) => {
-        process.emitWarning('/metrics is deprecated when specifying a path to companion')
-        const metricsUrl = buildUrl('/metrics', true)
-        res.redirect(metricsUrl)
-      })
-    }
   }
 
   app.use(cookieParser()) // server tokens are added to cookies

--- a/packages/@uppy/companion/src/config/companion.js
+++ b/packages/@uppy/companion/src/config/companion.js
@@ -22,6 +22,7 @@ const defaultOptions = {
   periodicPingUrls: [],
   streamingUpload: false,
   clientSocketConnectTimeout: 60000,
+  metrics: true,
 }
 
 /**

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -112,6 +112,7 @@ const getConfigFromEnv = () => {
     chunkSize: process.env.COMPANION_CHUNK_SIZE ? parseInt(process.env.COMPANION_CHUNK_SIZE, 10) : undefined,
     clientSocketConnectTimeout: process.env.COMPANION_CLIENT_SOCKET_CONNECT_TIMEOUT
       ? parseInt(process.env.COMPANION_CLIENT_SOCKET_CONNECT_TIMEOUT, 10) : undefined,
+    metrics: process.env.COMPANION_HIDE_METRICS !== 'true',
   }
 }
 

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -12,8 +12,6 @@ const logger = require('../server/logger')
 const redis = require('../server/redis')
 const companion = require('../companion')
 const helper = require('./helper')
-const middlewares = require('../server/middlewares')
-const { getURLBuilder } = require('../server/helpers/utils')
 
 /**
  * Configures an Express app for running Companion standalone
@@ -101,26 +99,6 @@ module.exports = function server (inputCompanionOptions = {}) {
       return censored ? `${parsed.href.split('?')[0]}?${qs.stringify(query)}` : parsed.href
     }
   })
-
-  // for server metrics tracking.
-  // make app metrics available at '/metrics'.
-  // TODO for the next major version: use instead companion option "metrics": true and remove this code
-  // eslint-disable-next-line max-len
-  // See discussion: https://github.com/transloadit/uppy/pull/2854/files/64be97205e4012818abfcc8b0b8b7fe09de91729#diff-68f5e3eb307c1c9d1fd02224fd7888e2f74718744e1b6e35d929fcab1cc50ed1
-  if (process.env.COMPANION_HIDE_METRICS !== 'true') {
-    router.use(middlewares.metrics({ path: companionOptions.server.path }))
-
-    // backward compatibility
-    // TODO remove in next major semver
-    if (companionOptions.server.path) {
-      const buildUrl = getURLBuilder(companionOptions)
-      app.get('/metrics', (req, res) => {
-        process.emitWarning('/metrics is deprecated when specifying a path to companion')
-        const metricsUrl = buildUrl('/metrics', true)
-        res.redirect(metricsUrl)
-      })
-    }
-  }
 
   router.use(bodyParser.json())
   router.use(bodyParser.urlencoded({ extended: false }))

--- a/packages/@uppy/companion/test/__tests__/subpath.js
+++ b/packages/@uppy/companion/test/__tests__/subpath.js
@@ -7,9 +7,7 @@ it('can be served under a subpath', async () => {
   await request(server).get('/subpath').expect(200)
   await request(server).get('/subpath/metrics').expect(200)
   await request(server).get('/').expect(404)
-  // todo in next major:
-  await request(server).get('/metrics').expect(302)
-  // await request(server).get('/metrics').expect(404)
+  await request(server).get('/metrics').expect(404)
 })
 
 test('can be served without a subpath', async () => {


### PR DESCRIPTION
pulled out from #3791

# Breaking changes
- `/metrics` endpoint will now always lie under `options.server.path`
