### PR TITLE
@uppy/image-editor: Add image editor cancel event

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileCard/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.jsx
@@ -60,7 +60,7 @@ class FileCard extends Component {
 
   handleCancel = () => {
     const file = this.props.files[this.props.fileCardFor]
-    this.uppy.emit('file-editor:cancel', file)
+    this.props.uppy.emit('file-editor:cancel', file)
     this.props.toggleFileCard(false)
   }
 

--- a/packages/@uppy/dashboard/src/components/FileCard/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.jsx
@@ -59,7 +59,8 @@ class FileCard extends Component {
   }
 
   handleCancel = () => {
-    const file = this.props.files[this.props.fileCardFor]
+    const { currentImage } = this.getPluginState()
+    const file = this.uppy.getFile(currentImage.id)
     this.props.uppy.emit('file-editor:cancel', file)
     this.props.toggleFileCard(false)
   }

--- a/packages/@uppy/dashboard/src/components/FileCard/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.jsx
@@ -59,6 +59,8 @@ class FileCard extends Component {
   }
 
   handleCancel = () => {
+    const file = this.props.files[this.props.fileCardFor]
+    this.uppy.emit('file-editor:cancel', file)
     this.props.toggleFileCard(false)
   }
 

--- a/packages/@uppy/dashboard/src/components/FileCard/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.jsx
@@ -60,7 +60,7 @@ class FileCard extends Component {
 
   handleCancel = () => {
     const { currentImage } = this.getPluginState()
-    const file = this.uppy.getFile(currentImage.id)
+    const file = this.props.uppy.getFile(currentImage.id)
     this.props.uppy.emit('file-editor:cancel', file)
     this.props.toggleFileCard(false)
   }

--- a/packages/@uppy/image-editor/src/ImageEditor.jsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.jsx
@@ -121,6 +121,10 @@ export default class ImageEditor extends UIPlugin {
   }
 
   uninstall () {
+    const { currentImage } = this.getPluginState()
+    const file = this.uppy.getFile(currentImage.id)
+    this.uppy.emit('file-editor:cancel', file)
+
     this.unmount()
   }
 

--- a/packages/@uppy/image-editor/types/index.d.ts
+++ b/packages/@uppy/image-editor/types/index.d.ts
@@ -34,10 +34,12 @@ export default ImageEditor
 
 export type FileEditorStartCallback<TMeta> = (file: UppyFile<TMeta>) => void;
 export type FileEditorCompleteCallback<TMeta> = (updatedFile: UppyFile<TMeta>) => void;
+export type FileEditorCancelCallback<TMeta> = (file: UppyFile<TMeta>) => void;
 
 declare module '@uppy/core' {
   export interface UppyEventMap<TMeta> {
     'file-editor:start' : FileEditorStartCallback<TMeta>
     'file-editor:complete': FileEditorCompleteCallback<TMeta>
+    'file-editor:cancel': FileEditorCancelCallback<TMeta>
   }
 }

--- a/packages/@uppy/image-editor/types/index.test-d.ts
+++ b/packages/@uppy/image-editor/types/index.test-d.ts
@@ -16,4 +16,8 @@ import ImageEditor from '..'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const fileName = file.name
   })
+  uppy.on('file-editor:cancel', (file) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const fileName = file.name
+  })
 }

--- a/website/src/docs/image-editor.md
+++ b/website/src/docs/image-editor.md
@@ -121,6 +121,16 @@ uppy.on('file-editor:complete', (updatedFile) => {
 })
 ```
 
+### file-editor:cancel
+
+Emitted when `uninstall` is called.
+
+```js
+uppy.on('file-editor:cancel', (file) => {
+  console.log(file)
+})
+```
+
 ### `locale: {}`
 
 ```js

--- a/website/src/docs/image-editor.md
+++ b/website/src/docs/image-editor.md
@@ -123,7 +123,7 @@ uppy.on('file-editor:complete', (updatedFile) => {
 
 ### file-editor:cancel
 
-Emitted when `uninstall` is called.
+Emitted when `uninstall` is called or when the current image editing changes are discarded.
 
 ```js
 uppy.on('file-editor:cancel', (file) => {


### PR DESCRIPTION
This PR adds a `cancel` event to the `@uppy/image-editor` package. This should close #3846.

Do let me know if I missed anything or if any further changes are required.

Thank you!