### PR TITLE
Fix documentation on retry-all vs upload-retry

### DIFF
--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -945,7 +945,7 @@ uppy.on('upload-error', (file, error, response) => {
 
 Fired when an upload has been retried (after an error, for example).
 
-> ⚠️ Note that this method is event is not triggered when the user retries all uploads, it will trigger the `retry-all` event intstead.
+> ⚠️ This event is not triggered when the user retries all uploads, it will trigger the `retry-all` event instead.
 
 **Parameters**
 

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -943,9 +943,9 @@ uppy.on('upload-error', (file, error, response) => {
 
 ### `upload-retry`
 
-Fired when an upload has been retried (after an error, for example). This is not fired when the user click on retry-all.
+Fired when an upload has been retried (after an error, for example).
 
-> ⚠️ Note that this method is event is not triggered when the user retry all uploads. (it trigger a retry-all event)
+> ⚠️ Note that this method is event is not triggered when the user retries all uploads, it will trigger the `retry-all` event intstead.
 
 **Parameters**
 

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -943,7 +943,9 @@ uppy.on('upload-error', (file, error, response) => {
 
 ### `upload-retry`
 
-Fired when an upload has been retried (after an error, for example).
+Fired when an upload has been retried (after an error, for example). This is not fired when the user click on retry-all.
+
+> ⚠️ Note that this method is event is not triggered when the user retry all uploads. (it trigger a retry-all event)
 
 **Parameters**
 
@@ -954,6 +956,22 @@ Fired when an upload has been retried (after an error, for example).
 ```js
 uppy.on('upload-retry', (fileID) => {
   console.log('upload retried:', fileID)
+})
+```
+
+### `retry-all`
+
+Fired when all failed uploads are retried
+
+**Parameters**
+
+* `fileIDs` - Arrays of IDs of the files being retried.
+
+**Example**
+
+```js
+uppy.on('upload-retry', (fileIDs) => {
+  console.log('upload retried:', fileIDs)
 })
 ```
 


### PR DESCRIPTION
Hi,

When a user do a retry-all no upload-retry event is triggered. (I had to debug this)
The retry-all event is not documented and I think behavior is unexpected (not triggering upload-retry at all)

This at least document current the behavior.

Thanks.

Luc
