### PR TITLE
upgrade `nanoid` to v4

### DIFF
--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -26,7 +26,7 @@
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^",
     "@uppy/xhr-upload": "workspace:^",
-    "nanoid": "^3.1.25"
+    "nanoid": "^4.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.4.2",

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -27,7 +27,7 @@
     "lodash.throttle": "^4.1.1",
     "mime-match": "^1.0.2",
     "namespace-emitter": "^2.0.1",
-    "nanoid": "^3.1.25",
+    "nanoid": "^4.0.0",
     "preact": "^10.5.13"
   },
   "devDependencies": {

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -33,7 +33,7 @@
     "is-shallow-equal": "^1.0.1",
     "lodash.debounce": "^4.0.8",
     "memoize-one": "^5.0.4",
-    "nanoid": "^3.1.25",
+    "nanoid": "^4.0.0",
     "preact": "^10.5.13"
   },
   "devDependencies": {

--- a/packages/@uppy/store-redux/package.json
+++ b/packages/@uppy/store-redux/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "nanoid": "^3.1.25"
+    "nanoid": "^4.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.4.2",

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^",
-    "nanoid": "^3.1.25"
+    "nanoid": "^4.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10104,7 +10104,7 @@ __metadata:
     "@uppy/companion-client": "workspace:^"
     "@uppy/utils": "workspace:^"
     "@uppy/xhr-upload": "workspace:^"
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     whatwg-fetch: 3.6.2
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -10226,7 +10226,7 @@ __metadata:
     lodash.throttle: ^4.1.1
     mime-match: ^1.0.2
     namespace-emitter: ^2.0.1
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     preact: ^10.5.13
   languageName: unknown
   linkType: soft
@@ -10247,7 +10247,7 @@ __metadata:
     is-shallow-equal: ^1.0.1
     lodash.debounce: ^4.0.8
     memoize-one: ^5.0.4
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     preact: ^10.5.13
     resize-observer-polyfill: ^1.5.0
   peerDependencies:
@@ -10559,7 +10559,7 @@ __metadata:
   resolution: "@uppy/store-redux@workspace:packages/@uppy/store-redux"
   dependencies:
     "@jest/globals": ^27.4.2
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     redux: 4.0.5
   languageName: unknown
   linkType: soft
@@ -10698,7 +10698,7 @@ __metadata:
     "@jest/globals": ^27.4.2
     "@uppy/companion-client": "workspace:^"
     "@uppy/utils": "workspace:^"
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     nock: ^13.1.0
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -28930,7 +28930,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.25, nanoid@npm:^3.1.30":
+"nanoid@npm:^3.1.30":
   version: 3.1.30
   resolution: "nanoid@npm:3.1.30"
   bin:
@@ -28945,6 +28945,15 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "nanoid@npm:4.0.0"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 7d5946df5c6d383694195b781ae7b5067c149d164ec71e910d6b06676309c3459b68af570b944fb5ecd5065d19df464f05700d141d70bb712ff8ca06642fd8df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`nanoid` recently released a new ESM-only version.

Refs: https://github.com/ai/nanoid/blob/main/CHANGELOG.md