### PR TITLE
@uppy/tus: fix dependencies

### DIFF
--- a/packages/@uppy/tus/package.json
+++ b/packages/@uppy/tus/package.json
@@ -27,8 +27,10 @@
     "@uppy/utils": "workspace:^",
     "tus-js-client": "^2.1.1"
   },
+  "devDependencies": {
+    "@jest/globals": "^27.4.2"
+  },
   "peerDependencies": {
-    "@jest/globals": "^27.4.2",
     "@uppy/core": "workspace:^"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10498,11 +10498,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/tus@workspace:packages/@uppy/tus"
   dependencies:
+    "@jest/globals": ^27.4.2
     "@uppy/companion-client": "workspace:^"
     "@uppy/utils": "workspace:^"
     tus-js-client: ^2.1.1
   peerDependencies:
-    "@jest/globals": ^27.4.2
     "@uppy/core": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`@jest/globals` should be in the `devDependencies` list, not in the
`peerDependencies`.

Refs: https://community.transloadit.com/t/why-is-jest-globals-a-peer-dependency-of-every-uppy-package/16182/1