### PR TITLE
meta: `keepNames` in bundle

### DIFF
--- a/bin/build-bundle.mjs
+++ b/bin/build-bundle.mjs
@@ -20,6 +20,7 @@ function buildBundle (srcFile, bundleFile, { minify = true, standalone = '', plu
       js: '"use strict";',
     },
     minify,
+    keepNames: true,
     plugins,
     target,
   }).then(() => {


### PR DESCRIPTION
We rely on `.name` for the `@uppy/remote-sources` plugin.