### PR TITLE
@uppy/store-default: export the class, don't expose `.callbacks`

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -65,7 +65,7 @@ class Uppy {
       meta: {},
       onBeforeFileAdded: (currentFile) => currentFile,
       onBeforeUpload: (files) => files,
-      store: DefaultStore(),
+      store: new DefaultStore(),
       logger: justErrorsLogger,
       infoTimeout: 5000,
     }

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -21,7 +21,7 @@ type anyObject = Record<string, unknown>
 }
 
 {
-  const store = DefaultStore()
+  const store = new DefaultStore()
   new Uppy({ store }) // eslint-disable-line no-new
 }
 

--- a/packages/@uppy/store-default/README.md
+++ b/packages/@uppy/store-default/README.md
@@ -18,7 +18,7 @@ import Uppy from '@uppy/core'
 import DefaultStore from '@uppy/store-default'
 
 const uppy = new Uppy({
-  store: DefaultStore(),
+  store: new DefaultStore(),
 })
 ```
 

--- a/packages/@uppy/store-default/src/index.js
+++ b/packages/@uppy/store-default/src/index.js
@@ -5,9 +5,10 @@ import packageJson from '../package.json'
 class DefaultStore {
   static VERSION = packageJson.version
 
+  #callbacks = new Set()
+
   constructor () {
     this.state = {}
-    this.callbacks = [] // TODO: use a Set instead, make it a private prop
   }
 
   getState () {
@@ -23,24 +24,17 @@ class DefaultStore {
   }
 
   subscribe (listener) {
-    this.callbacks.push(listener)
+    this.#callbacks.add(listener)
     return () => {
-      // Remove the listener.
-      this.callbacks.splice(
-        this.callbacks.indexOf(listener),
-        1,
-      )
+      this.#callbacks.delete(listener)
     }
   }
 
   #publish (...args) {
-    this.callbacks.forEach((listener) => {
+    this.#callbacks.forEach((listener) => {
       listener(...args)
     })
   }
 }
 
-// TODO: export the class instead in the next major.
-export default function defaultStore () {
-  return new DefaultStore()
-}
+export default DefaultStore

--- a/packages/@uppy/store-default/src/index.test.js
+++ b/packages/@uppy/store-default/src/index.test.js
@@ -1,16 +1,14 @@
 import { describe, expect, it } from '@jest/globals'
+import assert from 'node:assert'
 import DefaultStore from './index.js'
 
 describe('DefaultStore', () => {
-  it('can be created with or without new', () => {
-    let store = DefaultStore()
-    expect(typeof store).toBe('object')
-    store = new DefaultStore()
-    expect(typeof store).toBe('object')
+  it('cannot be created without new', () => {
+    assert.throws(() => DefaultStore(), /TypeError/)
   })
 
   it('merges in state using `setState`', () => {
-    const store = DefaultStore()
+    const store = new DefaultStore()
     expect(store.getState()).toEqual({})
 
     store.setState({
@@ -31,7 +29,7 @@ describe('DefaultStore', () => {
       expect([prevState, nextState, patch]).toEqual(expected)
     }
 
-    const store = DefaultStore()
+    const store = new DefaultStore()
     store.subscribe(listener)
 
     expected = [{}, { a: 1, b: 2 }, { a: 1, b: 2 }]

--- a/packages/@uppy/store-default/types/index.d.ts
+++ b/packages/@uppy/store-default/types/index.d.ts
@@ -3,7 +3,7 @@ import type { Store } from '@uppy/utils'
 type State = Record<string, unknown>
 type StateChangeListener = (prevState: State, nextState: State, patch: State) => void
 
-declare class DefaultStore implements Store {
+export default class DefaultStore implements Store {
   constructor ()
 
   getState (): State
@@ -12,7 +12,3 @@ declare class DefaultStore implements Store {
 
   subscribe (listener: StateChangeListener): () => void
 }
-
-declare function createDefaultStore (): DefaultStore
-
-export default createDefaultStore

--- a/packages/@uppy/store-default/types/index.test-d.ts
+++ b/packages/@uppy/store-default/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import DefaultStore from '..'
 
-const store = DefaultStore()
+const store = new DefaultStore()
 
 store.setState({ a: 'b' })
 store.getState()

--- a/website/src/docs/stores.md
+++ b/website/src/docs/stores.md
@@ -26,10 +26,10 @@ You can also use a third-party store:
 To use a store, pass an instance to the [`store` option](/docs/uppy#store-defaultstore) in the Uppy constructor:
 
 ```js
-import defaultStore from '@uppy/store-default'
+import DefaultStore from '@uppy/store-default'
 
 const uppy = new Uppy({
-  store: defaultStore(),
+  store: new DefaultStore(),
 })
 ```
 
@@ -111,7 +111,7 @@ An Uppy store is an object with three methods.
 The default store implementation, for example, looks a bit like this:
 
 ```js
-function defaultStore () {
+function createDefaultStore () {
   let state = {}
   const listeners = new Set()
 


### PR DESCRIPTION
Breaking: `new` keyword is now mandatory.