### PR TITLE
@uppy/screen-capture: fix TODOs

### DIFF
--- a/packages/@uppy/screen-capture/src/RecorderScreen.jsx
+++ b/packages/@uppy/screen-capture/src/RecorderScreen.jsx
@@ -1,4 +1,3 @@
-// TODO: rename this file to RecorderScreen.jsx in the next major.
 /* eslint-disable react/jsx-props-no-spreading */
 import { h, Component } from 'preact'
 import RecordButton from './RecordButton.jsx'

--- a/packages/@uppy/screen-capture/src/ScreenCapture.jsx
+++ b/packages/@uppy/screen-capture/src/ScreenCapture.jsx
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { UIPlugin } from '@uppy/core'
 import getFileTypeExtension from '@uppy/utils/lib/getFileTypeExtension'
 import ScreenRecIcon from './ScreenRecIcon.jsx'
-import CaptureScreen from './CaptureScreen.jsx'
+import RecorderScreen from './RecorderScreen.jsx'
 
 import packageJson from '../package.json'
 import locale from './locale.js'
@@ -392,7 +392,7 @@ export default class ScreenCapture extends UIPlugin {
     }
 
     return (
-      <CaptureScreen
+      <RecorderScreen
         {...recorderState} // eslint-disable-line react/jsx-props-no-spreading
         onStartRecording={this.startRecording}
         onStopRecording={this.stopRecording}

--- a/packages/@uppy/screen-capture/src/StopWatch.jsx
+++ b/packages/@uppy/screen-capture/src/StopWatch.jsx
@@ -1,7 +1,6 @@
 import { h, Component } from 'preact'
 
-// TODO: rename this class to StopWatch in the next major.
-class Stopwatch extends Component {
+class StopWatch extends Component {
   constructor (props) {
     super(props)
     this.state = { elapsedTime: 0 }
@@ -105,4 +104,4 @@ class Stopwatch extends Component {
   }
 }
 
-export default Stopwatch
+export default StopWatch

--- a/packages/@uppy/screen-capture/types/index.d.ts
+++ b/packages/@uppy/screen-capture/types/index.d.ts
@@ -1,16 +1,5 @@
 import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 
-  // https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_shared_screen_tracks
-  // TODO: use the global DisplayMediaStreamConstraints once typescript includes it by default
-  interface DisplayMediaStreamConstraints {
-    audio?: boolean | MediaTrackConstraints;
-    video?: boolean | (MediaTrackConstraints & {
-      cursor?: 'always' | 'motion' | 'never',
-      displaySurface?: 'application' | 'browser' | 'monitor' | 'window',
-      logicalSurface?: boolean
-    });
-  }
-
 export interface ScreenCaptureOptions extends PluginOptions {
     target?: PluginTarget
     displayMediaConstraints?: DisplayMediaStreamConstraints,

--- a/packages/@uppy/screen-capture/types/index.d.ts
+++ b/packages/@uppy/screen-capture/types/index.d.ts
@@ -1,5 +1,16 @@
 import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core'
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_shared_screen_tracks
+  // TODO: use the global DisplayMediaStreamConstraints once typescript includes it by default
+  interface DisplayMediaStreamConstraints {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | (MediaTrackConstraints & {
+      cursor?: 'always' | 'motion' | 'never',
+      displaySurface?: 'application' | 'browser' | 'monitor' | 'window',
+      logicalSurface?: boolean
+    });
+  }
+
 export interface ScreenCaptureOptions extends PluginOptions {
     target?: PluginTarget
     displayMediaConstraints?: DisplayMediaStreamConstraints,


### PR DESCRIPTION
- rename `RecorderScreen` class file to match with the class name.
- renamte `Stopwatch` to `StopWatch` (PascalCase convention).
- Remove custom TS definition in favor of the built-in one.