### PR TITLE
@uppy/drop-target: remove `isFileTransfer` from the public API

### DIFF
--- a/packages/@uppy/drop-target/src/index.js
+++ b/packages/@uppy/drop-target/src/index.js
@@ -51,10 +51,8 @@ export default class DropTarget extends BasePlugin {
     }
   }
 
-  isFileTransfer = isFileTransfer // TODO: expose this as a static instead (or don't expose it at all) in the next major.
-
   handleDrop = async (event) => {
-    if (!this.isFileTransfer(event)) {
+    if (!isFileTransfer(event)) {
       return
     }
 
@@ -97,7 +95,7 @@ export default class DropTarget extends BasePlugin {
   }
 
   handleDragOver = (event) => {
-    if (!this.isFileTransfer(event)) {
+    if (!isFileTransfer(event)) {
       return
     }
 
@@ -116,7 +114,7 @@ export default class DropTarget extends BasePlugin {
   }
 
   handleDragLeave = (event) => {
-    if (!this.isFileTransfer(event)) {
+    if (!isFileTransfer(event)) {
       return
     }
 


### PR DESCRIPTION
I don't think we need it exposed (unless we want users to be able to overwrite it, but then we should have tests for that, and it would make more sense as a static or as a prototype method). Let's remove it for now, we can always re-introduce it later if someone complains.