### PR TITLE
@uppy/transloadit: send `assembly-cancelled` only once

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -238,14 +238,13 @@ export default class Transloadit extends BasePlugin {
       const fileRemovedHandler = (fileRemoved, reason) => {
         if (reason === 'cancel-all') {
           assembly.close()
-          this.client.cancelAssembly(newAssembly).catch(() => { /* ignore potential errors */ })
           this.uppy.off(fileRemovedHandler)
         } else if (fileRemoved.id in updatedFiles) {
           delete updatedFiles[fileRemoved.id]
           const nbOfRemainingFiles = Object.keys(updatedFiles).length
           if (nbOfRemainingFiles === 0) {
             assembly.close()
-            this.client.cancelAssembly(newAssembly).catch(() => { /* ignore potential errors */ })
+            this.#cancelAssembly(newAssembly).catch(() => { /* ignore potential errors */ })
             this.uppy.off(fileRemovedHandler)
           } else {
             this.client.updateNumberOfFilesInAssembly(newAssembly, nbOfRemainingFiles)


### PR DESCRIPTION
That should also avoid sending more than one `DELETE` request to Transloadit API.