### PR TITLE
@uppy/remote-sources: do not rely on `.name` property

### DIFF
--- a/packages/@uppy/remote-sources/src/index.js
+++ b/packages/@uppy/remote-sources/src/index.js
@@ -12,7 +12,8 @@ import Zoom from '@uppy/zoom'
 
 import packageJson from '../package.json'
 
-const availablePlugins = [
+const availablePlugins = {
+  __proto__: null,
   Box,
   Dropbox,
   Facebook,
@@ -22,7 +23,7 @@ const availablePlugins = [
   Unsplash,
   Url,
   Zoom,
-]
+}
 
 export default class RemoteSources extends BasePlugin {
   static VERSION = packageJson.version
@@ -35,16 +36,7 @@ export default class RemoteSources extends BasePlugin {
     this.type = 'acquirer'
 
     const defaultOptions = {
-      sources: [
-        'Box',
-        'Dropbox',
-        'Facebook',
-        'GoogleDrive',
-        'Instagram',
-        'OneDrive',
-        'Unsplash',
-        'Url',
-      ],
+      sources: Object.keys(availablePlugins),
       target: Dashboard,
     }
     this.opts = { ...defaultOptions, ...opts }
@@ -63,9 +55,9 @@ export default class RemoteSources extends BasePlugin {
   install () {
     this.opts.sources.forEach((pluginId) => {
       const optsForRemoteSourcePlugin = { ...this.opts, sources: undefined }
-      const plugin = availablePlugins.find(p => p.name === pluginId)
+      const plugin = availablePlugins[pluginId]
       if (plugin == null) {
-        const pluginNames = availablePlugins.map(p => p.name)
+        const pluginNames = Object.keys(availablePlugins)
         const formatter = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
         throw new Error(`Invalid plugin: "${pluginId}" is not one of: ${formatter.format(pluginNames)}.`)
       }

--- a/packages/@uppy/remote-sources/src/index.js
+++ b/packages/@uppy/remote-sources/src/index.js
@@ -13,6 +13,7 @@ import Zoom from '@uppy/zoom'
 import packageJson from '../package.json'
 
 const availablePlugins = {
+  // Using a null-prototype object to avoid prototype pollution.
   __proto__: null,
   Box,
   Dropbox,


### PR DESCRIPTION
Minifiers may be tempted to overwrite the `.name` property of the plugin classes to save some bytes.