### PR TITLE
@uppy/companion: show deprecation message when using legacy s3 options

### DIFF
--- a/packages/@uppy/companion/src/config/companion.js
+++ b/packages/@uppy/companion/src/config/companion.js
@@ -89,10 +89,10 @@ const validateConfig = (companionOptions) => {
   const { providerOptions, periodicPingUrls } = companionOptions
 
   if (providerOptions) {
-    const deprecatedOptions = { microsoft: 'onedrive', google: 'drive' }
-    Object.keys(deprecatedOptions).forEach((deprected) => {
-      if (providerOptions[deprected]) {
-        throw new Error(`The Provider option "${deprected}" is no longer supported. Please use the option "${deprecatedOptions[deprected]}" instead.`)
+    const deprecatedOptions = { microsoft: 'providerOptions.onedrive', google: 'providerOptions.drive', s3: 's3' }
+    Object.keys(deprecatedOptions).forEach((deprecated) => {
+      if (Object.prototype.hasOwnProperty.call(providerOptions, deprecated)) {
+        throw new Error(`The Provider option "providerOptions.${deprecated}" is no longer supported. Please use the option "${deprecatedOptions[deprecated]}" instead.`)
       }
     })
   }


### PR DESCRIPTION
Instead of silently ignoring the legacy option, it now shows `Error: The Provider option "providerOptions.s3" is no longer supported. Please use the option "s3" instead.`.