### PR TITLE
@uppy/aws-s3-multipart: ignore exception inside `abortMultipartUpload`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -425,12 +425,10 @@ class MultipartUploader {
   #abortUpload () {
     this.abortController.abort()
 
-    this.createdPromise.then(() => {
-      this.options.abortMultipartUpload({
-        key: this.key,
-        uploadId: this.uploadId,
-      })
-    }, () => {
+    this.createdPromise.then(() => this.options.abortMultipartUpload({
+      key: this.key,
+      uploadId: this.uploadId,
+    })).catch(() => {
       // if the creation failed we do not need to abort
     })
   }

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -213,11 +213,12 @@ describe('AwsS3Multipart', () => {
         .use(AwsS3Multipart, {
           createMultipartUpload,
           completeMultipartUpload: jest.fn(async () => ({ location: 'test' })),
-          abortMultipartUpload: jest.fn(),
+          // eslint-disable-next-line no-throw-literal
+          abortMultipartUpload: jest.fn(() => { throw 'should ignore' }),
           prepareUploadParts:
-          prepareUploadParts
-          // eslint-disable-next-line prefer-promise-reject-errors
-            .mockImplementationOnce(() => Promise.reject({ source: { status: 500 } })),
+            prepareUploadParts
+              // eslint-disable-next-line prefer-promise-reject-errors
+              .mockImplementationOnce(() => Promise.reject({ source: { status: 500 } })),
         })
       const awsS3Multipart = core.getPlugin('AwsS3Multipart')
       const fileSize = 5 * MB + 1 * MB


### PR DESCRIPTION
The docs say "Cancellation cannot fail in Uppy, so the result of this
function is ignored". So let's ignore it indeed.

Refs: https://community.transloadit.com/t/1-how-to-handle-promise-rejections-2-how-to-cancel-an-upload-that-hasnt-begun/16187