### PR TITLE
aws-s3: fix incorrect comparison for `file-removed`

### DIFF
--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -100,8 +100,12 @@ export default class MiniXHRUpload {
   }
 
   #addEventHandlerForFile (eventName, fileID, eventHandler) {
-    this.uploaderEvents[fileID].on(eventName, (targetFileID) => {
-      if (fileID === targetFileID) eventHandler()
+    this.uploaderEvents[fileID].on(eventName, (fileOrID) => {
+      // TODO (major): refactor Uppy events to consistently send file objects (or consistently IDs)
+      // We created a generic `addEventListenerForFile` but not all events
+      // use file IDs, some use files, so we need to do this weird check.
+      const id = fileOrID?.id ?? fileOrID
+      if (fileID === id) eventHandler()
     })
   }
 


### PR DESCRIPTION
Fixes #3919

Unfortunately I can't easily test this as we can't get the AWS S3 E2E tests to work: #3665.

But the issue is clear enough to know where the problem is. 