### PR TITLE
Fix @uppy/aws-s3-multipart when using Companion

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -112,11 +112,12 @@ export default class AwsS3Multipart extends BasePlugin {
       .then(assertServerError)
   }
 
-  prepareUploadParts (file, { key, uploadId, partNumbers }) {
+  prepareUploadParts (file, { key, uploadId, parts }) {
     this.assertHost('prepareUploadParts')
 
     const filename = encodeURIComponent(key)
-    return this.#client.get(`s3/multipart/${uploadId}/batch?key=${filename}&partNumbers=${partNumbers.join(',')}`)
+    const partNumbers = parts.map((part) => part.number).join(',')
+    return this.#client.get(`s3/multipart/${uploadId}/batch?key=${filename}&partNumbers=${partNumbers}`)
       .then(assertServerError)
   }
 


### PR DESCRIPTION
A bit embarrassing, but I forgot to change the default implementation of `prepareUploadParts`, which calls Companion, which meant everything crashed.

We really should get #3665 working. 