### PR TITLE
Reset filter input correctly in provider views

### DIFF
--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.jsx
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.jsx
@@ -119,7 +119,7 @@ export default class ProviderView extends View {
 
         this.username = res.username || this.username
         this.#updateFilesAndFolders(res, files, folders)
-        this.plugin.setPluginState({ directories: updatedDirectories })
+        this.plugin.setPluginState({ directories: updatedDirectories, filterInput: '' })
       },
       this.handleError,
     )
@@ -155,6 +155,7 @@ export default class ProviderView extends View {
             files: [],
             folders: [],
             directories: [],
+            filterInput: '',
           }
           this.plugin.setPluginState(newState)
         }
@@ -209,7 +210,7 @@ export default class ProviderView extends View {
         loading: false,
         files: ids,
       }
-      this.plugin.setPluginState({ selectedFolders: folders })
+      this.plugin.setPluginState({ selectedFolders: folders, filterInput: '' })
 
       let message
 

--- a/packages/@uppy/provider-views/src/View.js
+++ b/packages/@uppy/provider-views/src/View.js
@@ -44,7 +44,7 @@ export default class View {
   }
 
   clearSelection () {
-    this.plugin.setPluginState({ currentSelection: [] })
+    this.plugin.setPluginState({ currentSelection: [], filterInput: '' })
   }
 
   cancelPicking () {


### PR DESCRIPTION
Fixes #3973

When going into a folder, adding a folder, logging out, or cancelling the filter input remains in state but is not rendered in the input field. This causes a weird and unobvious state. 