### PR TITLE
@uppy/companion: migrate from Jest to `node:test`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -325,6 +325,9 @@ module.exports = {
     },
     {
       files: ['./packages/@uppy/companion/**/*.js'],
+      env: {
+        jest: false,
+      },
       rules: {
         'no-underscore-dangle': 'off',
 

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -82,10 +82,11 @@
     "@types/request": "2.48.4",
     "@types/webpack": "^5.28.0",
     "@types/ws": "6.0.4",
-    "into-stream": "^6.0.0",
-    "jest": "^27.0.6",
+    "expect": "^28.1.3",
+    "jest-mock": "^28.1.3",
     "nock": "^13.1.3",
-    "supertest": "3.4.2",
+    "supertest": "^6.2.0",
+    "test": "^3.2.1",
     "typescript": "~4.4"
   },
   "files": [
@@ -107,7 +108,7 @@
     "deploy": "kubectl apply -f infra/kube/companion-kube.yml",
     "prepublishOnly": "yarn run build",
     "start": "node ./lib/standalone/start-server.js",
-    "test": "jest"
+    "test": "node--test"
   },
   "engines": {
     "node": "^14.19.0 || ^16.15.0 || >=18.0.0"

--- a/packages/@uppy/companion/test/__tests__/callback.js
+++ b/packages/@uppy/companion/test/__tests__/callback.js
@@ -1,13 +1,32 @@
-/* global jest:false, test:false, expect:false, describe:false */
-
+const { describe, test } = require('test')
+const expect = require('expect').default
 const mockOauthState = require('../mockoauthstate')()
 
 const request = require('supertest')
 const tokenService = require('../../src/server/helpers/jwt')
 const { getServer } = require('../mockserver')
 
-jest.mock('../../src/server/helpers/oauth-state', () => ({
-  ...jest.requireActual('../../src/server/helpers/oauth-state'),
+function mock (package, replacer) {
+  const actualPath = require.resolve(package)
+  if (arguments.length === 1) {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    require.cache[actualPath] = require(`../__mocks__/${package}`)
+  } else {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    const actual = require(package)
+    const Module = require('node:module') // eslint-disable-line global-require
+    require.cache[actualPath] = new Module(actualPath, module)
+    Object.defineProperties(require.cache[actualPath], {
+      exports: {
+        __proto__: null,
+        value: replacer(actual),
+      },
+      resetFn: { __proto__: null, value: replacer.bind(null, actual) },
+    })
+  }
+}
+mock('../../src/server/helpers/oauth-state', (actual) => ({
+  ...actual,
   ...mockOauthState,
 }))
 

--- a/packages/@uppy/companion/test/__tests__/cors.js
+++ b/packages/@uppy/companion/test/__tests__/cors.js
@@ -1,13 +1,13 @@
-/* global jest:false, test:false, describe:false, expect:false */
-
+const { test, describe } = require('test')
+const expect = require('expect').default
 const { cors } = require('../../src/server/middlewares')
 
 function testWithMock ({ corsOptions, get = () => {}, origin = 'https://localhost:1234' } = {}) {
   const res = {
     get,
     getHeader: get,
-    setHeader: jest.fn(),
-    end: jest.fn(),
+    setHeader: Function.prototype,
+    end: Function.prototype,
   }
   const req = {
     method: 'OPTIONS',
@@ -15,7 +15,7 @@ function testWithMock ({ corsOptions, get = () => {}, origin = 'https://localhos
       origin,
     },
   }
-  const next = jest.fn()
+  const next = Function.prototype
   cors(corsOptions)(req, res, next)
   return { res }
 }

--- a/packages/@uppy/companion/test/__tests__/credentials.js
+++ b/packages/@uppy/companion/test/__tests__/credentials.js
@@ -1,7 +1,27 @@
-/* global jest:false, test:false, expect:false, describe:false */
+const { test, describe } = require('test')
+const expect = require('expect').default
 
+function mock (package, replacer) {
+  const actualPath = require.resolve(package)
+  if (arguments.length === 1) {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    require.cache[actualPath] = require(`../__mocks__/${package}`)
+  } else {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    const actual = require(package)
+    const Module = require('node:module') // eslint-disable-line global-require
+    require.cache[actualPath] = new Module(actualPath, module)
+    Object.defineProperties(require.cache[actualPath], {
+      exports: {
+        __proto__: null,
+        value: replacer(actual),
+      },
+      resetFn: { __proto__: null, value: replacer.bind(null, actual) },
+    })
+  }
+}
 // mocking request module used to fetch custom oauth credentials
-jest.mock('request', () => {
+mock('request', () => {
   const { remoteZoomKey, remoteZoomSecret, remoteZoomVerificationToken } = require('../fixtures/zoom').expects
 
   return {

--- a/packages/@uppy/companion/test/__tests__/deauthorization.js
+++ b/packages/@uppy/companion/test/__tests__/deauthorization.js
@@ -1,5 +1,4 @@
-/* global test:false, describe:false */
-
+const { test, describe } = require('test')
 const request = require('supertest')
 const { getServer } = require('../mockserver')
 

--- a/packages/@uppy/companion/test/__tests__/header-blacklist.js
+++ b/packages/@uppy/companion/test/__tests__/header-blacklist.js
@@ -1,5 +1,5 @@
-/* global test:false, expect:false, describe:false, */
-
+const { test, describe } = require('test')
+const expect = require('expect').default
 const headerSanitize = require('../../src/server/header-blacklist')
 
 describe('Header black-list testing', () => {

--- a/packages/@uppy/companion/test/__tests__/http-agent.js
+++ b/packages/@uppy/companion/test/__tests__/http-agent.js
@@ -1,5 +1,5 @@
-/* global test:false, expect:false, describe:false, */
-
+const { test, describe } = require('test')
+const expect = require('expect').default
 const request = require('request')
 const http = require('node:http')
 const https = require('node:https')
@@ -20,49 +20,43 @@ describe('test getRedirectEvaluator', () => {
     },
   }
 
-  test('when original URL has "https:" as protocol', (done) => {
+  test('when original URL has "https:" as protocol', () => {
     const shouldRedirectHttps = getRedirectEvaluator(httpsURL, true)
     expect(shouldRedirectHttps(httpsRedirectResp)).toEqual(true)
     expect(shouldRedirectHttps(httpRedirectResp)).toEqual(false)
-    done()
   })
 
-  test('when original URL has "http:" as protocol', (done) => {
+  test('when original URL has "http:" as protocol', () => {
     const shouldRedirectHttp = getRedirectEvaluator(httpURL, true)
     expect(shouldRedirectHttp(httpRedirectResp)).toEqual(true)
     expect(shouldRedirectHttp(httpsRedirectResp)).toEqual(false)
-    done()
   })
 })
 
 describe('test getProtectedHttpAgent', () => {
-  test('setting "https:" as protocol', (done) => {
+  test('setting "https:" as protocol', () => {
     const Agent = getProtectedHttpAgent('https:')
     expect(Agent).toEqual(https.Agent)
-    done()
   })
 
-  test('setting "https" as protocol', (done) => {
+  test('setting "https" as protocol', () => {
     const Agent = getProtectedHttpAgent('https')
     expect(Agent).toEqual(https.Agent)
-    done()
   })
 
-  test('setting "http:" as protocol', (done) => {
+  test('setting "http:" as protocol', () => {
     const Agent = getProtectedHttpAgent('http:')
     expect(Agent).toEqual(http.Agent)
-    done()
   })
 
-  test('setting "http" as protocol', (done) => {
+  test('setting "http" as protocol', () => {
     const Agent = getProtectedHttpAgent('http')
     expect(Agent).toEqual(http.Agent)
-    done()
   })
 })
 
 describe('test protected request Agent', () => {
-  test('allows URLs without IP addresses', (done) => {
+  test('allows URLs without IP addresses', (context, done) => {
     const options = {
       uri: 'https://transloadit.com',
       method: 'GET',
@@ -80,7 +74,7 @@ describe('test protected request Agent', () => {
     })
   })
 
-  test('blocks private http IP address', (done) => {
+  test('blocks private http IP address', (context, done) => {
     const options = {
       uri: 'http://172.20.10.4:8090',
       method: 'GET',
@@ -94,7 +88,7 @@ describe('test protected request Agent', () => {
     })
   })
 
-  test('blocks private https IP address', (done) => {
+  test('blocks private https IP address', (context, done) => {
     const options = {
       uri: 'https://172.20.10.4:8090',
       method: 'GET',
@@ -108,7 +102,7 @@ describe('test protected request Agent', () => {
     })
   })
 
-  test('blocks localhost IP address', (done) => {
+  test('blocks localhost IP address', (context, done) => {
     const options = {
       uri: 'http://127.0.0.1:8090',
       method: 'GET',

--- a/packages/@uppy/companion/test/__tests__/logger.js
+++ b/packages/@uppy/companion/test/__tests__/logger.js
@@ -1,4 +1,5 @@
-/* global test:false, expect:false, describe:false, beforeAll:false, */
+const { it: test, describe, before: beforeAll } = require('test')
+const expect = require('expect').default
 const chalk = require('chalk')
 const logger = require('../../src/server/logger')
 

--- a/packages/@uppy/companion/test/__tests__/preauth.js
+++ b/packages/@uppy/companion/test/__tests__/preauth.js
@@ -1,6 +1,21 @@
-/* global jest:false, test:false, expect:false, describe:false */
-
-jest.mock('../../src/server/helpers/jwt', () => {
+function mock (package, replacer) {
+  const actualPath = require.resolve(package)
+  if (arguments.length === 1) {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    require.cache[actualPath] = require(`../__mocks__/${package}`)
+  } else {
+    const Module = require('node:module') // eslint-disable-line global-require
+    require.cache[actualPath] = new Module(actualPath, module)
+    Object.defineProperties(require.cache[actualPath], {
+      exports: {
+        __proto__: null,
+        value: replacer(),
+      },
+      resetFn: { __proto__: null, value: replacer },
+    })
+  }
+}
+mock('../../src/server/helpers/jwt', () => {
   return {
     generateToken: () => {},
     verifyToken: () => {},
@@ -15,6 +30,8 @@ jest.mock('../../src/server/helpers/jwt', () => {
   }
 })
 
+const { test, describe } = require('test')
+const expect = require('expect').default
 const request = require('supertest')
 const { getServer } = require('../mockserver')
 // the order in which getServer is called matters because, once an env is passed,

--- a/packages/@uppy/companion/test/__tests__/provider-manager.js
+++ b/packages/@uppy/companion/test/__tests__/provider-manager.js
@@ -1,5 +1,5 @@
-/* global jest:false, test:false, expect:false, describe:false, beforeEach:false */
-
+const { beforeEach, describe, it:test } = require('test')
+const expect = require('expect').default
 const providerManager = require('../../src/server/provider')
 const { getCompanionOptions } = require('../../src/standalone/helper')
 const { setDefaultEnv } = require('../mockserver')
@@ -148,7 +148,7 @@ describe('Test Custom Provider options', () => {
           key: 'foo_key',
           secret: 'foo_secret',
         },
-        module: jest.mock(),
+        module: {},
       },
     }, providers, grantConfig)
 

--- a/packages/@uppy/companion/test/__tests__/providers.js
+++ b/packages/@uppy/companion/test/__tests__/providers.js
@@ -1,16 +1,43 @@
-/* global jest:false, test:false, expect:false, describe:false */
-
-jest.mock('tus-js-client')
-jest.mock('purest')
-jest.mock('../../src/server/helpers/request', () => {
+function mock (package, replacer) {
+  const actualPath = require.resolve(package)
+  if (arguments.length === 1) {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    require.cache[actualPath] = require(`../__mocks__/${package}`)
+  } else {
+    const Module = require('node:module') // eslint-disable-line global-require
+    require.cache[actualPath] = new Module(actualPath, module)
+    Object.defineProperties(require.cache[actualPath], {
+      exports: {
+        __proto__: null,
+        value: replacer(),
+      },
+      resetFn: { __proto__: null, value: replacer },
+    })
+  }
+}
+mock('tus-js-client')
+mock('purest')
+mock('../../src/server/helpers/request', () => {
   return {
     getURLMeta: () => Promise.resolve({ size: 758051 }),
   }
 })
-jest.mock('../../src/server/helpers/oauth-state', () => require('../mockoauthstate')())
+mock('../../src/server/helpers/oauth-state', () => require('../mockoauthstate')())
 
+const { before: beforeAll, after: afterAll, describe, it } = require('test')
+const expect = require('expect').default
 const request = require('supertest')
 const nock = require('nock')
+
+const test = {
+  each (iterable) {
+    return (message, fn) => {
+      for (const val of iterable) {
+        it(message, fn.bind(null, val))
+      }
+    }
+  },
+}
 
 const fixtures = require('../fixtures')
 const tokenService = require('../../src/server/helpers/jwt')

--- a/packages/@uppy/companion/test/__tests__/subpath.js
+++ b/packages/@uppy/companion/test/__tests__/subpath.js
@@ -1,3 +1,4 @@
+const { it, test } = require('test')
 const request = require('supertest')
 const { getServer } = require('../mockserver')
 

--- a/packages/@uppy/companion/test/__tests__/uploader.js
+++ b/packages/@uppy/companion/test/__tests__/uploader.js
@@ -1,9 +1,13 @@
 'use strict'
 
-jest.mock('tus-js-client')
+require.cache[require.resolve('tus-js-client')] = require('../__mocks__/tus-js-client')
 
-const intoStream = require('into-stream')
 const fs = require('node:fs')
+const path = require('node:path')
+const { Readable } = require('node:stream')
+const { describe, test, after: afterAll } = require('test')
+const expect = require('expect').default
+const jest = require('jest-mock')
 const nock = require('nock')
 
 const Uploader = require('../../src/server/Uploader')
@@ -16,9 +20,13 @@ afterAll(() => {
   nock.restore()
 })
 
-process.env.COMPANION_DATADIR = './test/output'
+process.env.COMPANION_DATADIR = path.join(__dirname, '..', 'output')
 process.env.COMPANION_DOMAIN = 'localhost:3020'
 const { companionOptions } = standalone()
+
+function intoStream (buffer) {
+  return Readable.from(buffer, { objectMode: false })
+}
 
 describe('uploader with tus protocol', () => {
   test('uploader respects uploadUrls', async () => {

--- a/packages/@uppy/companion/test/__tests__/url.js
+++ b/packages/@uppy/companion/test/__tests__/url.js
@@ -1,18 +1,27 @@
-/* global jest:false, test:false, expect:false, describe:false */
+const { before: beforeAll, after: afterAll, describe, it:test } = require('test')
+const expect = require('expect').default
+
+require.cache[require.resolve('tus-js-client')] = require('../__mocks__/tus-js-client')
+
+{
+  const request = require.resolve('../../src/server/helpers/request')
+  require(request) // eslint-disable-line global-require,import/no-dynamic-require
+  require.cache[request].getURLMeta = () => {
+    return Promise.resolve({ size: 7580, type: 'image/jpg' })
+  }
+}
 
 const nock = require('nock')
 const request = require('supertest')
-
-jest.mock('tus-js-client')
-jest.mock('../../src/server/helpers/request', () => {
-  return {
-    ...jest.requireActual('../../src/server/helpers/request'),
-    getURLMeta: () => {
-      return Promise.resolve({ size: 7580, type: 'image/jpg' })
-    },
-  }
-})
 const { getServer } = require('../mockserver')
+
+test.each = function each (iterable) {
+  return (message, fn) => {
+    for (const val of iterable) {
+      test(message, fn.bind(null, val))
+    }
+  }
+}
 
 const mockServer = getServer({ COMPANION_CLIENT_SOCKET_CONNECT_TIMEOUT: '0' })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4702,6 +4702,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect-utils@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "@jest/expect-utils@npm:28.1.3"
+  dependencies:
+    jest-get-type: ^28.0.2
+  checksum: 808ea3a68292a7e0b95490fdd55605c430b4cf209ea76b5b61bfb2a1badcb41bc046810fe4e364bd5fe04663978aa2bd73d8f8465a761dd7c655aeb44cf22987
+  languageName: node
+  linkType: hard
+
 "@jest/expect@npm:^28.1.0":
   version: 28.1.0
   resolution: "@jest/expect@npm:28.1.0"
@@ -4817,6 +4826,15 @@ __metadata:
   dependencies:
     "@sinclair/typebox": ^0.23.3
   checksum: 6a177e97b112c99f377697fe803a34f4489b92cd07949876250c69edc9029c7cbda771fcbb03caebd20ffbcfa89b9c22b4dc9d1e9a7fbc9873185459b48ba780
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "@jest/schemas@npm:28.1.3"
+  dependencies:
+    "@sinclair/typebox": ^0.24.1
+  checksum: 3cf1d4b66c9c4ffda58b246de1ddcba8e6ad085af63dccdf07922511f13b68c0cc480a7bc620cb4f3099a6f134801c747e1df7bfc7a4ef4dceefbdea3e31e1de
   languageName: node
   linkType: hard
 
@@ -5019,6 +5037,20 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: 22705aed92a76d45465a6c51147bc71c1fbd300b912ebad2769e3ff7fd51c1938017e29fcea52e00c00dab7130697359b2a2c2be6ee601e37c8b1042a2c4040e
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "@jest/types@npm:28.1.3"
+  dependencies:
+    "@jest/schemas": ^28.1.3
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 1e258d9c063fcf59ebc91e46d5ea5984674ac7ae6cae3e50aa780d22b4405bf2c925f40350bf30013839eb5d4b5e521d956ddf8f3b7c78debef0e75a07f57350
   languageName: node
   linkType: hard
 
@@ -6701,6 +6733,13 @@ __metadata:
   version: 0.23.5
   resolution: "@sinclair/typebox@npm:0.23.5"
   checksum: c96056d35d9cb862aeb635ff8873e2e7633e668dd544e162aee2690a82c970d0b3f90aa2b3501fe374dfa8e792388559a3e3a86712b23ebaef10061add534f47
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.24.1":
+  version: 0.24.27
+  resolution: "@sinclair/typebox@npm:0.24.27"
+  checksum: c283de9158c0206da3d1ebd7c5f994da0b1cf86df89674da7709850300ecdceb0d4c9680dccce84b60cdcc3d8858f54df8235b250ba092726fadb2bebe720bd1
   languageName: node
   linkType: hard
 
@@ -10171,6 +10210,7 @@ __metadata:
     cors: ^2.8.5
     escape-goat: 3.0.0
     escape-string-regexp: 2.0.0
+    expect: ^28.1.3
     express: 4.17.1
     express-interceptor: 1.2.0
     express-prom-bundle: 6.3.0
@@ -10178,9 +10218,8 @@ __metadata:
     express-session: 1.17.1
     grant: 4.7.0
     helmet: ^4.6.0
-    into-stream: ^6.0.0
     ipaddr.js: ^2.0.1
-    jest: ^27.0.6
+    jest-mock: ^28.1.3
     jsonwebtoken: 8.5.1
     lodash.merge: ^4.6.2
     mime-types: 2.1.25
@@ -10197,7 +10236,8 @@ __metadata:
     semver: 6.3.0
     serialize-error: ^2.1.0
     serialize-javascript: ^6.0.0
-    supertest: 3.4.2
+    supertest: ^6.2.0
+    test: ^3.2.1
     tus-js-client: ^3.0.0
     typescript: ~4.4
     validator: ^12.1.0
@@ -12670,7 +12710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.3, asap@npm:~2.0.3, asap@npm:~2.0.6":
+"asap@npm:^2.0.0, asap@npm:^2.0.3, asap@npm:~2.0.3, asap@npm:~2.0.6":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: b296c92c4b969e973260e47523207cd5769abd27c245a68c26dc7a0fe8053c55bb04360237cb51cab1df52be939da77150ace99ad331fb7fb13b3423ed73ff3d
@@ -15489,7 +15529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"component-emitter@npm:^1.2.0, component-emitter@npm:^1.2.1, component-emitter@npm:~1.3.0":
+"component-emitter@npm:^1.2.1, component-emitter@npm:^1.3.0, component-emitter@npm:~1.3.0":
   version: 1.3.0
   resolution: "component-emitter@npm:1.3.0"
   checksum: b3c46de38ffd35c57d1c02488355be9f218e582aec72d72d1b8bbec95a3ac1b38c96cd6e03ff015577e68f550fbb361a3bfdbd9bb248be9390b7b3745691be6b
@@ -15778,7 +15818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookiejar@npm:^2.1.0":
+"cookiejar@npm:^2.1.3":
   version: 2.1.3
   resolution: "cookiejar@npm:2.1.3"
   checksum: 88259983ebc52ceb23cdacfa48762b6a518a57872eff1c7ed01d214fff5cf492e2660d7d5c04700a28f1787a76811df39e8639f8e17670b3cf94ecd86e161f07
@@ -17174,6 +17214,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dezalgo@npm:1.0.3":
+  version: 1.0.3
+  resolution: "dezalgo@npm:1.0.3"
+  dependencies:
+    asap: ^2.0.0
+    wrappy: 1
+  checksum: 8b26238db91423b2702a7a6d9629d0019c37c415e7b6e75d4b3e8d27e9464e21cac3618dd145f4d4ee96c70cc6ff034227b5b8a0e9c09015a8bdbe6dace3cfb9
+  languageName: node
+  linkType: hard
+
 "dfa@npm:^1.2.0":
   version: 1.2.0
   resolution: "dfa@npm:1.2.0"
@@ -17209,6 +17259,13 @@ __metadata:
   version: 28.0.2
   resolution: "diff-sequences@npm:28.0.2"
   checksum: 482360a8ec93333ea61bc93a800a1bee37c943b94a48fa1597825076adcad24620b44a0d3aa8f3d190584a4156c4b3315028453ca33e1174001fae3cdaa7f8f8
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^28.1.1":
+  version: 28.1.1
+  resolution: "diff-sequences@npm:28.1.1"
+  checksum: e2529036505567c7ca5a2dea86b6bcd1ca0e3ae63bf8ebf529b8a99cfa915bbf194b7021dc1c57361a4017a6d95578d4ceb29fabc3232a4f4cb866a2726c7690
   languageName: node
   linkType: hard
 
@@ -20067,6 +20124,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "expect@npm:28.1.3"
+  dependencies:
+    "@jest/expect-utils": ^28.1.3
+    jest-get-type: ^28.0.2
+    jest-matcher-utils: ^28.1.3
+    jest-message-util: ^28.1.3
+    jest-util: ^28.1.3
+  checksum: 101e0090de300bcafedb7dbfd19223368a2251ce5fe0105bbb6de5720100b89fb6b64290ebfb42febc048324c76d6a4979cdc4b61eb77747857daf7a5de9b03d
+  languageName: node
+  linkType: hard
+
 "expo-application@npm:~3.2.0":
   version: 3.2.0
   resolution: "expo-application@npm:3.2.0"
@@ -20562,7 +20632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:^2.0.7, fast-safe-stringify@npm:^2.0.8":
+"fast-safe-stringify@npm:^2.0.7, fast-safe-stringify@npm:^2.0.8, fast-safe-stringify@npm:^2.1.1":
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
@@ -21117,7 +21187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^2.3.1, form-data@npm:^2.5.0":
+"form-data@npm:^2.5.0":
   version: 2.5.1
   resolution: "form-data@npm:2.5.1"
   dependencies:
@@ -21136,6 +21206,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -21166,10 +21247,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formidable@npm:^1.2.0, formidable@npm:^1.2.1":
+"formidable@npm:^1.2.1":
   version: 1.2.6
   resolution: "formidable@npm:1.2.6"
   checksum: 2b68ed07ba88302b9c63f8eda94f19a460cef6017bfda48348f09f41d2a36660c9353137991618e0e4c3db115b41e4b8f6fa63bc973b7a7c91dec66acdd02a56
+  languageName: node
+  linkType: hard
+
+"formidable@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "formidable@npm:2.0.1"
+  dependencies:
+    dezalgo: 1.0.3
+    hexoid: 1.0.0
+    once: 1.4.0
+    qs: 6.9.3
+  checksum: b35445444e7b6f6f3cacbadd5e6fadd6b5b2e83162e7c41fa22586df584cc515bbd1ee0dc2b701ce031fcb000d71769bc77bd0958db8a89a0ceb8b2227bdc695
   languageName: node
   linkType: hard
 
@@ -21212,7 +21305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"from2@npm:^2.0.3, from2@npm:^2.1.0, from2@npm:^2.3.0":
+"from2@npm:^2.0.3, from2@npm:^2.1.0":
   version: 2.3.0
   resolution: "from2@npm:2.3.0"
   dependencies:
@@ -22736,6 +22829,13 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"hexoid@npm:1.0.0":
+  version: 1.0.0
+  resolution: "hexoid@npm:1.0.0"
+  checksum: 27a148ca76a2358287f40445870116baaff4a0ed0acc99900bf167f0f708ffd82e044ff55e9949c71963852b580fc024146d3ac6d5d76b508b78d927fa48ae2d
+  languageName: node
+  linkType: hard
+
 "highcharts@npm:^9.2.2":
   version: 9.3.2
   resolution: "highcharts@npm:9.3.2"
@@ -23700,16 +23800,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   version: 2.2.0
   resolution: "interpret@npm:2.2.0"
   checksum: f51efef7cb8d02da16408ffa3504cd6053014c5aeb7bb8c223727e053e4235bf565e45d67028b0c8740d917c603807aa3c27d7bd2f21bf20b6417e2bb3e5fd6e
-  languageName: node
-  linkType: hard
-
-"into-stream@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "into-stream@npm:6.0.0"
-  dependencies:
-    from2: ^2.3.0
-    p-is-promise: ^3.0.0
-  checksum: 8df24c9eadd7cdd1cbc160bc20914b961dfd0ca29767785b69e698f799e85466b6f7c637d237dca1472d09d333399f70cc05a2fb8d08cb449dc9a80d92193980
   languageName: node
   linkType: hard
 
@@ -24947,6 +25037,18 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-diff@npm:28.1.3"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^28.1.1
+    jest-get-type: ^28.0.2
+    pretty-format: ^28.1.3
+  checksum: fa8583e0ccbe775714ce850b009be1b0f6b17a4b6759f33ff47adef27942ebc610dbbcc8a5f7cfb7f12b3b3b05afc9fb41d5f766674616025032ff1e4f9866e0
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^27.4.0":
   version: 27.4.0
   resolution: "jest-docblock@npm:27.4.0"
@@ -25174,6 +25276,18 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-matcher-utils@npm:28.1.3"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^28.1.3
+    jest-get-type: ^28.0.2
+    pretty-format: ^28.1.3
+  checksum: 6b34f0cf66f6781e92e3bec97bf27796bd2ba31121e5c5997218d9adba6deea38a30df5203937d6785b68023ed95cbad73663cc9aad6fb0cb59aeb5813a58daf
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-message-util@npm:24.9.0"
@@ -25224,6 +25338,23 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-message-util@npm:28.1.3"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^28.1.3
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^28.1.3
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 1f266854166dcc6900d75a88b54a25225a2f3710d463063ff1c99021569045c35c7d58557b25447a17eb3a65ce763b2f9b25550248b468a9d4657db365f39e96
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-mock@npm:24.9.0"
@@ -25260,6 +25391,16 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     "@jest/types": ^28.1.0
     "@types/node": "*"
   checksum: 013428db82f418059314588e5d02a2a8f6697940ffeb1b1a23f61e9b94b1dca3ea0061d91f284e217bf0ce0e5251ff8f2f182a393cecd1ec6788d766cc18ded4
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-mock@npm:28.1.3"
+  dependencies:
+    "@jest/types": ^28.1.3
+    "@types/node": "*"
+  checksum: a573bf8e5f12f4c29c661266c31b5c6b69a28d3195b83049983bce025b2b1a0152351567e89e63b102ef817034c2a3aa97eda4e776f3bae2aee54c5765573aa7
   languageName: node
   linkType: hard
 
@@ -25538,6 +25679,20 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: 14c2ee1c24c6efa2d7adfe81ece8b9bbda78fa871f40bed80db72726166e96f7fb22bf1d9fb1689fb433b9bcd748027eb1ee5f0851a12f1aa1c49ee0bd4d7508
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-util@npm:28.1.3"
+  dependencies:
+    "@jest/types": ^28.1.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: fd6459742c941f070223f25e38a2ac0719aad92561591e9fb2a50d602a5d19d754750b79b4074327a42b00055662b95da3b006542ceb8b54309da44d4a62e721
   languageName: node
   linkType: hard
 
@@ -28035,7 +28190,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"methods@npm:^1.1.1, methods@npm:^1.1.2, methods@npm:~1.1.2":
+"methods@npm:^1.1.2, methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 0917ff4041fa8e2f2fda5425a955fe16ca411591fbd123c0d722fcf02b73971ed6f764d85f0a6f547ce49ee0221ce2c19a5fa692157931cecb422984f1dcd13a
@@ -30416,7 +30571,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.3.2, once@npm:^1.3.3, once@npm:^1.4.0":
+"once@npm:1.4.0, once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.3.2, once@npm:^1.3.3, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -30751,13 +30906,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
   checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
-  languageName: node
-  linkType: hard
-
-"p-is-promise@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "p-is-promise@npm:3.0.0"
-  checksum: 74e511225fde5eeda7a120d51c60c284de90d68dec7c73611e7e59e8d1c44cc7e2246686544515849149b74ed0571ad470a456ac0d00314f8d03d2cc1ad43aae
   languageName: node
   linkType: hard
 
@@ -32992,6 +33140,18 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "pretty-format@npm:28.1.3"
+  dependencies:
+    "@jest/schemas": ^28.1.3
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: e69f857358a3e03d271252d7524bec758c35e44680287f36c1cb905187fbc82da9981a6eb07edfd8a03bc3cbeebfa6f5234c13a3d5b59f2bbdf9b4c4053e0a7f
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^3.8.0":
   version: 3.8.0
   resolution: "pretty-format@npm:3.8.0"
@@ -33439,6 +33599,22 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   version: 6.7.0
   resolution: "qs@npm:6.7.0"
   checksum: dfd5f6adef50e36e908cfa70a6233871b5afe66fbaca37ecc1da352ba29eb2151a3797991948f158bb37fccde51bd57845cb619a8035287bfc24e4591172c347
+  languageName: node
+  linkType: hard
+
+"qs@npm:6.9.3":
+  version: 6.9.3
+  resolution: "qs@npm:6.9.3"
+  checksum: 89cd1b5e521c19a7e0a7a056ddc261c5c30889664608cf9ce6085f9f25606fc48568cf6a6249e641b4b5c04dac7889e3b82133142523abf397228eb4f488fc38
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.10.3":
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 
@@ -33950,7 +34126,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:1 || 2, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.3, readable-stream@npm:~2.3.6":
+"readable-stream@npm:1 || 2, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.3, readable-stream@npm:~2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -37606,6 +37782,20 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"string.prototype.replaceall@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "string.prototype.replaceall@npm:1.0.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.3
+    es-abstract: ^1.19.1
+    get-intrinsic: ^1.1.1
+    has-symbols: ^1.0.2
+    is-regex: ^1.1.4
+  checksum: 5020755c7bc8931fc7fb8c73b2f5b3600bbc6ce0fc1df7fef834798f6623e49b57afc2b997e83a69d50686b94b2d47304571435a6adbe59ca53c02a9ceec3422
+  languageName: node
+  linkType: hard
+
 "string.prototype.trimend@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimend@npm:1.0.4"
@@ -38103,31 +38293,32 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"superagent@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "superagent@npm:3.8.3"
+"superagent@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "superagent@npm:8.0.0"
   dependencies:
-    component-emitter: ^1.2.0
-    cookiejar: ^2.1.0
-    debug: ^3.1.0
-    extend: ^3.0.0
-    form-data: ^2.3.1
-    formidable: ^1.2.0
-    methods: ^1.1.1
-    mime: ^1.4.1
-    qs: ^6.5.1
-    readable-stream: ^2.3.5
-  checksum: b13d0303259d76c9180bd40d97d9f0713760f5ced1aef089bdb2fcdf69cfaef89004cd6e986416d59bd9a2f0f9933d72521b5171fa26f89b781a2c3460c516fe
+    component-emitter: ^1.3.0
+    cookiejar: ^2.1.3
+    debug: ^4.3.4
+    fast-safe-stringify: ^2.1.1
+    form-data: ^4.0.0
+    formidable: ^2.0.1
+    methods: ^1.1.2
+    mime: 2.6.0
+    qs: ^6.10.3
+    readable-stream: ^3.6.0
+    semver: ^7.3.7
+  checksum: 14343e59327eafd85fa230acb876017079d5efcecc72a56566abc0f965220bb460af2e070dddecd9e2856410b2d2b318d81d9cc1d342aa5922da93c29a295dd7
   languageName: node
   linkType: hard
 
-"supertest@npm:3.4.2":
-  version: 3.4.2
-  resolution: "supertest@npm:3.4.2"
+"supertest@npm:^6.2.0":
+  version: 6.2.4
+  resolution: "supertest@npm:6.2.4"
   dependencies:
     methods: ^1.1.2
-    superagent: ^3.8.3
-  checksum: 849f64dfdc743292f7c40c47db73f5c79138adbfb15535222346204767c9077b56e2fed21ea902f86639503b3224ce6ccfa5b93633ebfe7b56cf1be42cc94b92
+    superagent: ^8.0.0
+  checksum: f2ddc4f3ba467a5c4036dd4aad41351e4b60eb13c39ecf5233ccd2ebb425504073b2b7036c973a70c7047f5c6bc1b9fef096b7bbff114d357cbe80654441db23
   languageName: node
   linkType: hard
 
@@ -38701,6 +38892,20 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     glob: ^7.1.4
     minimatch: ^3.0.4
   checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
+  languageName: node
+  linkType: hard
+
+"test@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "test@npm:3.2.1"
+  dependencies:
+    minimist: ^1.2.6
+    string.prototype.replaceall: ^1.0.6
+  bin:
+    node--test: bin/node--test.js
+    node--test-only: bin/node--test-only.js
+    test: bin/node-core-test.js
+  checksum: 8bb0886d135890157037d1e37505228f1cd4eac6225ff6705bb094a75d2848d5199af2c671de0225d9e786be77725aea6adb09085c365fc9c9f22e4c70a1b356
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tests are not passing, I figured I should open it as a draft PR and leave it as it for now, we might want to come back to it at a later time.
The upside of `node:test` in comparison to Jest is that's it's much simpler, doesn't create its own env (and therefore avoid running into issues specific to the test runner rather than the actual code), and would support whatever Node.js itself support – including ESM packages.