### PR TITLE
`@uppy/tus`: add file argument to `onBeforeRequest`

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -217,7 +217,7 @@ export default class Tus extends BasePlugin {
 
         let userProvidedPromise
         if (typeof opts.onBeforeRequest === 'function') {
-          userProvidedPromise = opts.onBeforeRequest(req)
+          userProvidedPromise = opts.onBeforeRequest(req, file)
         }
 
         if (hasProperty(queuedRequest, 'shouldBeRequeued')) {

--- a/packages/@uppy/tus/types/index.d.ts
+++ b/packages/@uppy/tus/types/index.d.ts
@@ -1,9 +1,10 @@
-import type { PluginOptions, BasePlugin } from '@uppy/core'
-import type { UploadOptions } from 'tus-js-client'
+import type { PluginOptions, BasePlugin, UppyFile } from '@uppy/core'
+import type { UploadOptions, HttpRequest } from 'tus-js-client'
 
 type TusUploadOptions = Pick<UploadOptions, Exclude<keyof UploadOptions,
   | 'fingerprint'
   | 'metadata'
+  | 'onBeforeRequest'
   | 'onProgress'
   | 'onChunkComplete'
   | 'onShouldRetry'
@@ -21,6 +22,7 @@ export interface TusOptions extends PluginOptions, TusUploadOptions {
     useFastRemoteRetry?: boolean
     withCredentials?: boolean
     onShouldRetry?: (err: Error | undefined, retryAttempt: number, options: TusOptions, next: Next) => boolean
+    onBeforeRequest?: (req: HttpRequest, file: UppyFile) => Promise<void>
   }
 
 declare class Tus extends BasePlugin<TusOptions> {}

--- a/website/src/docs/tus.md
+++ b/website/src/docs/tus.md
@@ -37,7 +37,7 @@ const { Tus } = Uppy
 
 ## Options
 
-**Note**: all options are passed to `tus-js-client` and we document the ones here that we added or changed. This means you can also pass functions like [`onBeforeRequest`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onbeforerequest) and [`onAfterResponse`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onafterresponse).
+**Note**: all options are passed to `tus-js-client` and we document the ones here that we added or changed. This means you can also pass functions like [`onAfterResponse`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onafterresponse).
 
 We recommended taking a look at the [API reference](https://github.com/tus/tus-js-client/blob/master/docs/api.md) from `tus-js-client` to know what is supported.
 
@@ -90,6 +90,10 @@ Whether the POST method should be used instead of PATCH for transfering file chu
 When uploading a chunk fails, automatically try again after the millisecond intervals specified in this array. By default, we first retry instantly; if that fails, we retry after 1 second; if that fails, we retry after 3 seconds, etc.
 
 Set to `null` to disable automatic retries, and fail instantly if any chunk fails to upload.
+
+### `onBeforeRequest(req, file)`
+
+Behaves like the [`onBeforeRequest`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onbeforerequest) function from `tus-js-client` but with the added `file` argument.
 
 ### `onShouldRetry: (err, retryAttempt, options, next) => next(err)`
 


### PR DESCRIPTION
Closes #3977

I think the use case is valid enough to add `file` as a second argument, even though we deviate from `tus-js-client` on this.