### PR TITLE
@uppy/transloadit: deprecate static properties, export new names

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -25,9 +25,9 @@ const sendErrorToConsole = originalErr => err => {
   console.error(error, originalErr)
 }
 
-const COMPANION = 'https://api2.transloadit.com/companion'
+const COMPANION_URL = 'https://api2.transloadit.com/companion'
 // Regex matching acceptable postMessage() origins for authentication feedback from companion.
-const ALLOWED_COMPANION_PATTERN = /\.transloadit\.com$/
+const COMPANION_ALLOWED_HOSTS = /\.transloadit\.com$/
 // Regex used to check if a Companion address is run by Transloadit.
 const TL_COMPANION = /https?:\/\/api2(?:-\w+)?\.transloadit\.com\/companion/
 
@@ -36,6 +36,12 @@ const TL_COMPANION = /https?:\/\/api2(?:-\w+)?\.transloadit\.com\/companion/
  */
 export default class Transloadit extends BasePlugin {
   static VERSION = packageJson.version
+
+  /** @deprecated */
+  static COMPANION = COMPANION_URL
+
+  /** @deprecated */
+  static COMPANION_PATTERN = COMPANION_ALLOWED_HOSTS
 
   #rateLimitedQueue
 
@@ -850,7 +856,6 @@ export default class Transloadit extends BasePlugin {
 }
 
 export {
-  ALLOWED_COMPANION_PATTERN,
-  COMPANION,
-  ALLOWED_COMPANION_PATTERN as COMPANION_PATTERN,
+  COMPANION_URL,
+  COMPANION_ALLOWED_HOSTS,
 }

--- a/packages/@uppy/transloadit/types/index.d.ts
+++ b/packages/@uppy/transloadit/types/index.d.ts
@@ -121,13 +121,16 @@ export type TransloaditOptions = TransloaditOptionsBase &
         }
       | AssemblyOptions)
 
-declare class Transloadit extends BasePlugin<TransloaditOptions> {
+export default class Transloadit extends BasePlugin<TransloaditOptions> {
+  /** @deprecated */
   static COMPANION: string
 
+  /** @deprecated */
   static COMPANION_PATTERN: RegExp
 }
 
-export default Transloadit
+export const COMPANION_URL: string
+export const COMPANION_ALLOWED_HOSTS: RegExp
 
 // Events
 

--- a/packages/@uppy/transloadit/types/index.test-d.ts
+++ b/packages/@uppy/transloadit/types/index.test-d.ts
@@ -1,10 +1,12 @@
 import { expectError, expectType } from 'tsd'
 import Uppy from '@uppy/core'
 import type { UppyFile } from '@uppy/core'
-import Transloadit from '..'
+import Transloadit, { COMPANION_ALLOWED_HOSTS, COMPANION_URL } from '..'
 
 expectType<string>(Transloadit.COMPANION)
+expectType<string>(COMPANION_URL)
 expectType<RegExp>(Transloadit.COMPANION_PATTERN)
+expectType<RegExp>(COMPANION_ALLOWED_HOSTS)
 
 const validParams = {
   auth: { key: 'not so secret key' },

--- a/packages/uppy/index.mjs
+++ b/packages/uppy/index.mjs
@@ -50,4 +50,9 @@ export { default as GoldenRetriever } from '@uppy/golden-retriever'
 export { default as ReduxDevTools } from '@uppy/redux-dev-tools'
 export { default as ThumbnailGenerator } from '@uppy/thumbnail-generator'
 
+// Special hack for Transloadit static exports
+import Transloadit, { COMPANION_URL, COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit'
+Transloadit.COMPANION_URL = COMPANION_URL
+Transloadit.COMPANION_ALLOWED_HOSTS = COMPANION_ALLOWED_HOSTS
+
 export const locales = {}

--- a/website/src/docs/transloadit.md
+++ b/website/src/docs/transloadit.md
@@ -56,9 +56,12 @@ You can use this plugin together with Transloadit’s hosted Companion service t
 To do so each provider plugin must be configured with Transloadit’s Companion URLs:
 
 ```js
+import { COMPANION_URL, COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit'
+import Dropbox from '@uppy/dropbox'
+
 uppy.use(Dropbox, {
-  companionUrl: Transloadit.COMPANION,
-  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+  companionUrl: COMPANION_URL,
+  companionAllowedHosts: COMPANION_ALLOWED_HOSTS,
 })
 ```
 
@@ -67,9 +70,12 @@ This will already work. Transloadit’s OAuth applications are used to authentic
 To solve that, you can use your own OAuth keys with Transloadit’s hosted Companion servers by using Transloadit Template Credentials. [Create a Template Credential][template-credentials] on the Transloadit site. Select “Companion OAuth” for the service, and enter the key and secret for the provider you want to use. Then you can pass the name of the new credentials to that provider:
 
 ```js
+import { COMPANION_URL, COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit'
+import Dropbox from '@uppy/dropbox'
+
 uppy.use(Dropbox, {
-  companionUrl: Transloadit.COMPANION,
-  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+  companionUrl: COMPANION_URL,
+  companionAllowedHosts: COMPANION_ALLOWED_HOSTS,
   companionKeysParams: {
     key: 'YOUR_TRANSLOADIT_API_KEY',
     credentialsName: 'my_companion_dropbox_creds',
@@ -77,23 +83,22 @@ uppy.use(Dropbox, {
 })
 ```
 
-## Properties
+## Static exports
 
-### `Transloadit.COMPANION`
+### `COMPANION_URL`
 
 The main endpoint for Transloadit’s hosted companions. You can use this constant in remote provider options, like so:
 
 ```js
 import Dropbox from '@uppy/dropbox'
-import Transloadit from '@uppy/transloadit'
+import { COMPANION_URL } from '@uppy/transloadit'
 
 uppy.use(Dropbox, {
-  companionUrl: Transloadit.COMPANION,
-  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+  companionUrl: COMPANION_URL,
 })
 ```
 
-When using `Transloadit.COMPANION`, you should also configure [`companionAllowedHosts: Transloadit.COMPANION_PATTERN`](#Transloadit-COMPANION-PATTERN).
+When using `COMPANION_URL`, you should also configure [`companionAllowedHosts: COMPANION_ALLOWED_HOSTS`](#COMPANION_ALLOWED_HOSTS).
 
 The value of this constant is `https://api2.transloadit.com/companion`. If you are using a custom [`service`](#service) option, you should also set a custom host option in your provider plugins, by taking a Transloadit API url and appending `/companion`:
 
@@ -103,19 +108,18 @@ uppy.use(Dropbox, {
 })
 ```
 
-### `Transloadit.COMPANION_PATTERN`
+### `COMPANION_ALLOWED_HOSTS`
 
 A RegExp pattern matching Transloadit’s hosted companion endpoints. The pattern is used in remote provider `companionAllowedHosts` options, to make sure that third party authentication messages cannot be faked by an attacker’s page, but can only originate from Transloadit’s servers.
 
-Use it whenever you use `companionUrl: Transloadit.COMPANION`, like so:
+Use it whenever you use `companionUrl: COMPANION_URL`, like so:
 
 ```js
 import Dropbox from '@uppy/dropbox'
-import Transloadit from '@uppy/transloadit'
+import { COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit'
 
 uppy.use(Dropbox, {
-  companionUrl: Transloadit.COMPANION,
-  companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+  companionAllowedHosts: COMPANION_ALLOWED_HOSTS,
 })
 ```
 

--- a/website/src/examples/transloadit/app.es6
+++ b/website/src/examples/transloadit/app.es6
@@ -1,11 +1,10 @@
 import Uppy from '@uppy/core'
 import Dashboard from '@uppy/dashboard'
 import Webcam from '@uppy/webcam'
-import Transloadit from '@uppy/transloadit'
+import Transloadit, { COMPANION_ALLOWED_HOSTS, COMPANION_URL } from '@uppy/transloadit'
 import Instagram from '@uppy/instagram'
 import Facebook from '@uppy/facebook'
 import Zoom from '@uppy/zoom'
-import COMPANION from '../env.js'
 
 const enc = new TextEncoder('utf-8')
 async  function sha1 (secret, body) {
@@ -125,20 +124,20 @@ function initUppy (opts = {}) {
     })
     .use(Instagram, {
       target: Dashboard,
-      companionUrl: 'https://api2.transloadit.com/companion',
-      companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+      companionUrl: COMPANION_URL,
+      companionAllowedHosts: COMPANION_ALLOWED_HOSTS,
     })
     .use(Facebook, {
       target: Dashboard,
-      companionUrl: COMPANION,
+      companionUrl: COMPANION_URL,
     })
     .use(Webcam, { target: Dashboard, modes: ['picture'] })
 
   if (zoomMode) {
     uppy.use(Zoom, {
       target: Dashboard,
-      companionUrl: 'https://api2.transloadit.com/companion',
-      companionAllowedHosts: Transloadit.COMPANION_PATTERN,
+      companionUrl: COMPANION_URL,
+      companionAllowedHosts: COMPANION_ALLOWED_HOSTS,
     })
   }
 


### PR DESCRIPTION
Remove export of `ALLOWED_COMPANION_PATTERN`, `COMPANION`, and `COMPANION_PATTERN` in favor of `COMPANION_URL` and `COMPANION_ALLOWED_HOSTS`. This PR also adds back static properties that were present in `2.x` but marked them as deprecated.