### PR TITLE
@uppy/react: move `@uppy/` packages to peer dependencies

### DIFF
--- a/packages/@uppy/react/package.json
+++ b/packages/@uppy/react/package.json
@@ -22,11 +22,6 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@uppy/dashboard": "workspace:^",
-    "@uppy/drag-drop": "workspace:^",
-    "@uppy/file-input": "workspace:^",
-    "@uppy/progress-bar": "workspace:^",
-    "@uppy/status-bar": "workspace:^",
     "@uppy/utils": "workspace:^",
     "prop-types": "^15.6.1"
   },
@@ -36,6 +31,28 @@
   },
   "peerDependencies": {
     "@uppy/core": "workspace:^",
+    "@uppy/dashboard": "workspace:^",
+    "@uppy/drag-drop": "workspace:^",
+    "@uppy/file-input": "workspace:^",
+    "@uppy/progress-bar": "workspace:^",
+    "@uppy/status-bar": "workspace:^",
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@uppy/dashboard": {
+      "optional": true
+    },
+    "@uppy/drag-drop": {
+      "optional": true
+    },
+    "@uppy/file-input": {
+      "optional": true
+    },
+    "@uppy/progress-bar": {
+      "optional": true
+    },
+    "@uppy/status-bar": {
+      "optional": true
+    }
   }
 }

--- a/website/src/docs/react-dashboard-modal.md
+++ b/website/src/docs/react-dashboard-modal.md
@@ -14,7 +14,7 @@ The `<DashboardModal />` component wraps the [`@uppy/dashboard`][] plugin, allow
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/dashboard @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react-dashboard.md
+++ b/website/src/docs/react-dashboard.md
@@ -14,7 +14,7 @@ The `<Dashboard />` component wraps the [`@uppy/dashboard`][] plugin. It only re
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/dashboard @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react-dragdrop.md
+++ b/website/src/docs/react-dragdrop.md
@@ -15,7 +15,7 @@ The `<DragDrop />` component wraps the [`@uppy/drag-drop`](/docs/drag-drop/) plu
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/drag-drop @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react-fileinput.md
+++ b/website/src/docs/react-fileinput.md
@@ -15,7 +15,7 @@ The `<FileInput />` component wraps the [`@uppy/file-input`](/docs/file-input/) 
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/file-input @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react-progressbar.md
+++ b/website/src/docs/react-progressbar.md
@@ -15,7 +15,7 @@ The `<ProgressBar />` component wraps the [`@uppy/progress-bar`][] plugin.
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/progress-bar @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react-statusbar.md
+++ b/website/src/docs/react-statusbar.md
@@ -15,7 +15,7 @@ The `<StatusBar />` component wraps the [`@uppy/status-bar`][] plugin.
 Install from NPM:
 
 ```shell
-npm install @uppy/react
+npm install @uppy/react @uppy/status-bar @uppy/core
 ```
 
 ```js

--- a/website/src/docs/react.md
+++ b/website/src/docs/react.md
@@ -73,13 +73,14 @@ const AvatarPicker = ({ currentAvatar }) => {
 }
 ```
 
-The following plugins are available as React component wrappers:
+The following plugins are available as React component wrappers (you need to
+install each package separately):
 
-* [\<Dashboard />][<Dashboard />] - renders an inline [`@uppy/dashboard`][]
-* [\<DashboardModal />][<DashboardModal />] - renders a [`@uppy/dashboard`][] modal
-* [\<DragDrop />][<DragDrop />] - renders a [`@uppy/drag-drop`][] area
-* [\<ProgressBar />][<ProgressBar />] - renders a [`@uppy/progress-bar`][]
-* [\<StatusBar />][<StatusBar />] - renders a [`@uppy/status-bar`][]
+* [\<Dashboard />][<Dashboard />] - renders an inline [`@uppy/dashboard`][].
+* [\<DashboardModal />][<DashboardModal />] - renders a [`@uppy/dashboard`][] modal.
+* [\<DragDrop />][<DragDrop />] - renders a [`@uppy/drag-drop`][] area.
+* [\<ProgressBar />][<ProgressBar />] - renders a [`@uppy/progress-bar`][].
+* [\<StatusBar />][<StatusBar />] - renders a [`@uppy/status-bar`][].
 
 [React]: https://facebook.github.io/react
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9016,17 +9016,28 @@ __metadata:
   resolution: "@uppy/react@workspace:packages/@uppy/react"
   dependencies:
     "@types/react": ^18.0.8
-    "@uppy/dashboard": "workspace:^"
-    "@uppy/drag-drop": "workspace:^"
-    "@uppy/file-input": "workspace:^"
-    "@uppy/progress-bar": "workspace:^"
-    "@uppy/status-bar": "workspace:^"
     "@uppy/utils": "workspace:^"
     prop-types: ^15.6.1
     react: ^18.1.0
   peerDependencies:
     "@uppy/core": "workspace:^"
+    "@uppy/dashboard": "workspace:^"
+    "@uppy/drag-drop": "workspace:^"
+    "@uppy/file-input": "workspace:^"
+    "@uppy/progress-bar": "workspace:^"
+    "@uppy/status-bar": "workspace:^"
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@uppy/dashboard":
+      optional: true
+    "@uppy/drag-drop":
+      optional: true
+    "@uppy/file-input":
+      optional: true
+    "@uppy/progress-bar":
+      optional: true
+    "@uppy/status-bar":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I tried what was the behavior of the major package managers with regard to `ppe`:

- **npm**: it installs peer dependencies only if they are mandatory, and simply ignores them if they are optional.
- **Yarn (Berry)**: will emit the same warning `doesn't provide @uppy/dashboard (pce892), requested by @uppy/react` regardless if the peer dependency is optional.
- **pnpm**: does the right thing (ignores missing optional peer deps, and throw an error if there are required peer deps missing).

Having the packages as peer dependencies lets the users choose which part of Uppy they want to use – no need to install `@uppy/dashbaord` f you're only using `@uppy/file-input`, and most users needed to install those packages anyway to use the CSS files.