### PR TITLE
example: update to new CDN export names

### DIFF
--- a/examples/cdn-example/index.html
+++ b/examples/cdn-example/index.html
@@ -12,13 +12,13 @@
 
     <script type="module">
       import {
-        Core,
+        Uppy,
         Dashboard,
         Webcam,
         Tus,
       } from "https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.mjs";
 
-      const uppy = new Core.Uppy({ debug: true, autoProceed: false })
+      const uppy = new Uppy({ debug: true, autoProceed: false })
         .use(Dashboard, { trigger: "#uppyModalOpener" })
         .use(Webcam, { target: Dashboard })
         .use(Tus, { endpoint: "https://tusd.tusdemo.net/files/" });
@@ -32,8 +32,8 @@
     <script nomodule src="https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.legacy.min.js"></script>
     <script nomodule>
       {
-        const { Core, Dashboard, Webcam, Tus } = Uppy;
-        const uppy = new Core.Uppy({ debug: true, autoProceed: false })
+        const { Dashboard, Webcam, Tus } = Uppy;
+        const uppy = new Uppy.Uppy({ debug: true, autoProceed: false })
           .use(Dashboard, { trigger: "#uppyModalOpener" })
           .use(Webcam, { target: Dashboard })
           .use(Tus, { endpoint: "https://tusd.tusdemo.net/files/" });

--- a/examples/uppy-with-companion/client/index.html
+++ b/examples/uppy-with-companion/client/index.html
@@ -8,13 +8,15 @@
   </head>
   <body>
     <button id="uppyModalOpener">Open Modal</button>
-    <script src="https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.js"></script>
-    <script>
-      const uppy = new Uppy.Core({debug: true, autoProceed: false})
-        .use(Uppy.Dashboard, { trigger: '#uppyModalOpener' })
-        .use(Uppy.Instagram, { target: Uppy.Dashboard, companionUrl: 'http://localhost:3020' })
-        .use(Uppy.GoogleDrive, { target: Uppy.Dashboard, companionUrl: 'http://localhost:3020' })
-        .use(Uppy.Tus, { endpoint: 'https://tusd.tusdemo.net/files/' })
+    <noscript>This web page requires JavaScript to work properly.</noscript>
+    <script type="module">
+      import { Uppy, Dashboard, Instagram, GoogleDrive, Tus } from "https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.js"
+
+      const uppy = new Uppy({debug: true, autoProceed: false})
+        .use(Dashboard, { trigger: '#uppyModalOpener' })
+        .use(Instagram, { target: Dashboard, companionUrl: 'http://localhost:3020' })
+        .use(GoogleDrive, { target: Dashboard, companionUrl: 'http://localhost:3020' })
+        .use(Tus, { endpoint: 'https://tusd.tusdemo.net/files/' })
 
       uppy.on('success', (fileCount) => {
         console.log(`${fileCount} files uploaded`)

--- a/examples/uppy-with-companion/client/index.html
+++ b/examples/uppy-with-companion/client/index.html
@@ -10,7 +10,7 @@
     <button id="uppyModalOpener">Open Modal</button>
     <noscript>This web page requires JavaScript to work properly.</noscript>
     <script type="module">
-      import { Uppy, Dashboard, Instagram, GoogleDrive, Tus } from "https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.js"
+      import { Uppy, Dashboard, Instagram, GoogleDrive, Tus } from "https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.mjs"
 
       const uppy = new Uppy({debug: true, autoProceed: false})
         .use(Dashboard, { trigger: '#uppyModalOpener' })


### PR DESCRIPTION
`Uppy` call is now exported as `Uppy` instead of `Core`.

Refs: https://github.com/transloadit/uppy/pull/3981