### PR TITLE
@uppy/tus: avoid crashing when Tus client report an error before any …

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -256,7 +256,7 @@ export default class Tus extends BasePlugin {
         }
 
         this.resetUploaderReferences(file.id)
-        queuedRequest.abort()
+        queuedRequest?.abort()
 
         this.uppy.emit('upload-error', file, err)
 


### PR DESCRIPTION
…request is queued

Stumbled on this while working on https://github.com/transloadit/uppy/pull/4018, yet another reason to use TypeScript I guess.