### PR TITLE
@uppy/vue: move `@uppy/` packages to peer dependencies

### DIFF
--- a/packages/@uppy/vue/package.json
+++ b/packages/@uppy/vue/package.json
@@ -5,11 +5,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@uppy/dashboard": "workspace:^",
-    "@uppy/drag-drop": "workspace:^",
-    "@uppy/file-input": "workspace:^",
-    "@uppy/progress-bar": "workspace:^",
-    "@uppy/status-bar": "workspace:^",
     "shallow-equal": "^1.2.1"
   },
   "devDependencies": {
@@ -17,7 +12,29 @@
   },
   "peerDependencies": {
     "@uppy/core": "workspace:^",
+    "@uppy/dashboard": "workspace:^",
+    "@uppy/drag-drop": "workspace:^",
+    "@uppy/file-input": "workspace:^",
+    "@uppy/progress-bar": "workspace:^",
+    "@uppy/status-bar": "workspace:^",
     "vue": ">=2.6.11"
+  },
+  "peerDependenciesMeta": {
+    "@uppy/dashboard": {
+      "optional": true
+    },
+    "@uppy/drag-drop": {
+      "optional": true
+    },
+    "@uppy/file-input": {
+      "optional": true
+    },
+    "@uppy/progress-bar": {
+      "optional": true
+    },
+    "@uppy/status-bar": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/website/src/docs/vue.md
+++ b/website/src/docs/vue.md
@@ -7,13 +7,16 @@ order: 0
 category: "Other Integrations"
 ---
 
-Uppy provides [Vue][] components for the included UI plugins.
+Uppy provides [Vue][] components for some Uppy UI plugins.
 
 Note: _All plugin names are in kebab-case for the HTML element, and in CamelCase for the JavaScript imports, following Vue conventions_
 
 ## Installation
 
-All Vue components are provided through the `@uppy/vue` package
+All Vue components are provided through the `@uppy/vue` package. Not that those
+components rely on external packages that are not longer provided with
+`@uppy/vue` (such as `@uppy/core`, `@uppy/dashboard`, `@uppy/drag-drop`,
+`@uppy/file-input`, `@uppy/progress-bar`, `@uppy/status-bar`).
 
 Install from NPM:
 

--- a/website/src/docs/vue.md
+++ b/website/src/docs/vue.md
@@ -64,13 +64,14 @@ export default {
 </script>
 ```
 
-The following plugins are available as Vue component wrappers:
+The following plugins are available as Vue component wrappers (you need to
+install each package separately):
 
-* `<dashboard />` - renders an inline `@uppy/dashboard`
-* `<dashboard-modal />` - renders a `@uppy/dashboard` modal
-* `<drag-drop />` - renders a `@uppy/drag-drop` area
-* `<progress-bar />` - renders a `@uppy/progress-bar`
-* `<status-bar />` - renders a `@uppy/status-bar`
+* `<dashboard />` - renders an inline [`@uppy/dashboard`][].
+* `<dashboard-modal />` - renders a [`@uppy/dashboard`][] modal.
+* `<drag-drop />` - renders a [`@uppy/drag-drop`][] area.
+* `<progress-bar />` - renders a [`@uppy/progress-bar`][].
+* `<status-bar />` - renders a [`@uppy/status-bar`][].
 
 Each component takes a `props` prop that will be passed to the UI Plugin. Both `@uppy/dashboard` based plugins also take a `plugins` array as a props, making it easier to add your plugins.
 
@@ -195,6 +196,14 @@ Import general Core styles from `@uppy/core/dist/style.css` first, then add the 
 #### Props
 
 The `<status-bar />` component supports all `@uppy/status-bar` options to be passed as an object on the `props` prop. An Uppy instance must be provided in the `:uppy=''` prop.
+
+[`@uppy/dashboard`]: /docs/dashboard
+
+[`@uppy/drag-drop`]: /docs/drag-drop
+
+[`@uppy/progress-bar`]: /docs/progress-bar
+
+[`@uppy/status-bar`]: /docs/status-bar
 
 [`@uppy/webcam`]: /docs/webcam/
 

--- a/website/src/docs/vue.md
+++ b/website/src/docs/vue.md
@@ -13,10 +13,9 @@ Note: _All plugin names are in kebab-case for the HTML element, and in CamelCase
 
 ## Installation
 
-All Vue components are provided through the `@uppy/vue` package. Not that those
-components rely on external packages that are not longer provided with
-`@uppy/vue` (such as `@uppy/core`, `@uppy/dashboard`, `@uppy/drag-drop`,
-`@uppy/file-input`, `@uppy/progress-bar`, `@uppy/status-bar`).
+All Vue components are provided through the `@uppy/vue` package, note that the
+underling Uppy plugin is no longer provided and you would need to install it
+explicitly. See [Usage](#usage) for more info.
 
 Install from NPM:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8966,16 +8966,27 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/vue@workspace:packages/@uppy/vue"
   dependencies:
+    shallow-equal: ^1.2.1
+    vue: ^2.6.14
+  peerDependencies:
+    "@uppy/core": "workspace:^"
     "@uppy/dashboard": "workspace:^"
     "@uppy/drag-drop": "workspace:^"
     "@uppy/file-input": "workspace:^"
     "@uppy/progress-bar": "workspace:^"
     "@uppy/status-bar": "workspace:^"
-    shallow-equal: ^1.2.1
-    vue: ^2.6.14
-  peerDependencies:
-    "@uppy/core": "workspace:^"
     vue: ">=2.6.11"
+  peerDependenciesMeta:
+    "@uppy/dashboard":
+      optional: true
+    "@uppy/drag-drop":
+      optional: true
+    "@uppy/file-input":
+      optional: true
+    "@uppy/progress-bar":
+      optional: true
+    "@uppy/status-bar":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Similar to https://github.com/transloadit/uppy/pull/4004.