### PR TITLE
Only publish Companion to Dockerhub on release

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
     paths:
-    - 'packages/@uppy/companion/**'
+    - 'packages/@uppy/companion/CHANGELOG.md'
 
 jobs:
   docker:

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -1,9 +1,7 @@
 name: Companion Deploy
 
-
 on:
   push:
-    branches: [main]
     tags:
       - '@uppy/companion*'
 

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -4,8 +4,8 @@ name: Companion Deploy
 on:
   push:
     branches: [main]
-    paths:
-    - 'packages/@uppy/companion/CHANGELOG.md'
+    tags:
+      - '@uppy/companion*'
 
 jobs:
   docker:

--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ Alternatively, you can also use a pre-built bundle from Transloadit’s CDN: Edg
 <!-- 1. Add CSS to `<head>` -->
 <link href="https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.css" rel="stylesheet">
 
-<!-- 2. Add JS before the closing `</body>` -->
-
-<!-- 3. Initialize -->
+<!-- 2. Initialize -->
 <div id="files-drag-drop"></div>
 <script type="module">
   import { Uppy, Dashboard, Tus } from "https://releases.transloadit.com/uppy/v3.0.0-beta.5/uppy.min.mjs"


### PR DESCRIPTION
I didn't agree with the change in https://github.com/transloadit/uppy/pull/3677, where Companion is deployed on _any change_ in the Companion folder. Users of Docker are forcibly on a nightly version, we could push a broken commit and they get a broken build. It also results in lots of tags and pushes to Dockerhub, people feel like they are always behind.

This PR changes the publish to only happen when a new git tag is pushed for Companion, which is what happens automatically by our GitHub Actions CI when a release happens. 