### PR TITLE
Fix Companion license

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -5,7 +5,7 @@
   "main": "lib/companion.js",
   "types": "lib/companion.d.ts",
   "author": "Transloadit.com",
-  "license": "ISC",
+  "license": "MIT",
   "homepage": "https://github.com/transloadit/uppy#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixing this license issue from https://socket.dev/npm/package/@uppy/companion

<img width="1307" alt="Screenshot 2022-08-24 at 16 00 15" src="https://user-images.githubusercontent.com/9060226/186438212-b9ec2915-7726-46d4-ad05-70752388b49d.png">

