### PR TITLE
meta: improve CI npm install time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Run tests
         run: corepack yarn run test:unit
 
@@ -60,6 +63,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Run linter
         run: corepack yarn run lint
 
@@ -86,6 +92,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Run linter
         run: corepack yarn run lint:markdown
 
@@ -112,6 +121,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
         # Need to do a bunch of work to generate the locale typings 🙃
       - name: Prepare type declarations
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         # List all projects that use a custom ESLint config:
-        run: corepack yarn workspaces focus @uppy/angular angular-example @uppy-example/react-native-expo @uppy/react-native @uppy-dev/build
+        run: corepack yarn workspaces focus @uppy/angular @uppy-example/angular @uppy-example/react-native-expo @uppy/react-native @uppy-dev/build
       - name: Run linter
         run: corepack yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
-        run: corepack yarn install --immutable
+        run: corepack yarn workspaces focus $(corepack yarn workspaces list --json | jq -r .name | awk '/^@uppy-example/{ next } { if ($0!="uppy.io") print $0 }')
         env:
           # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
           CYPRESS_INSTALL_BINARY: 0
@@ -62,10 +62,8 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: corepack yarn install --immutable
-        env:
-          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
-          CYPRESS_INSTALL_BINARY: 0
+        # List all projects that use a custom ESLint config:
+        run: corepack yarn workspaces focus @uppy/angular angular-example @uppy-example/react-native-expo @uppy/react-native @uppy-dev/build
       - name: Run linter
         run: corepack yarn run lint
 
@@ -91,10 +89,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: corepack yarn install --immutable
-        env:
-          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
-          CYPRESS_INSTALL_BINARY: 0
+        run: corepack yarn workspaces focus @uppy-dev/build
       - name: Run linter
         run: corepack yarn run lint:markdown
 
@@ -120,7 +115,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: corepack yarn install --immutable
+        run: corepack yarn workspaces focus $(corepack yarn workspaces list --json | jq -r .name | awk '/^@uppy-example/{ next } { if ($0!="uppy.io") print $0 }')
         env:
           # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
           CYPRESS_INSTALL_BINARY: 0

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -33,6 +33,9 @@ jobs:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Run tests
         run: corepack yarn run test:companion
 

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -32,10 +32,7 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
-        run: corepack yarn install --immutable
-        env:
-          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
-          CYPRESS_INSTALL_BINARY: 0
+        run: corepack yarn workspaces focus @uppy/companion
       - name: Run tests
         run: corepack yarn run test:companion
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,12 +32,23 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: create cache folder for Cypress
+        id: cypress-cache-dir-path
+        run: echo "::set-output name=dir::$(mktemp -d)"
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.cypress-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-cypress
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Binary-cache
+          CYPRESS_CACHE_FOLDER: ${{ steps.cypress-cache-dir-path.outputs.dir }}
       - name: Build Uppy packages
         run: corepack yarn build
       - name: Run end-to-end browser tests
@@ -55,6 +66,8 @@ jobs:
           COMPANION_AWS_BUCKET: ${{secrets.COMPANION_AWS_BUCKET}}
           COMPANION_AWS_REGION: ${{secrets.COMPANION_AWS_REGION}}
           COMPANION_AWS_DISABLE_ACL: 'true'
+          # https://docs.cypress.io/guides/references/advanced-installation#Binary-cache
+          CYPRESS_CACHE_FOLDER: ${{ steps.cypress-cache-dir-path.outputs.dir }}
       - name: Upload videos in case of failure
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Build before publishing
         run: corepack yarn run build
       - name: Upload `${{ github.event.inputs.name }}` to CDN

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -35,6 +35,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Bump candidate packages version
         run: corepack yarn version apply --all --json | jq -s > releases.json
       - name: Prepare changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Get CHANGELOG diff
         run: git --no-pager diff HEAD^ -- CHANGELOG.md | awk '{ if( substr($0,0,1) == "+" && $1 != "+##" && $1 != "+Released:" && $1 != "+++" ) { print substr($0,2) } }' > CHANGELOG.diff.md
       - name: Copy README for `uppy` package

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable
+        env:
+          # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+          CYPRESS_INSTALL_BINARY: 0
       - name: Build Uppy
         run: corepack yarn run build
       - name: Build website


### PR DESCRIPTION
We can skip the install of Cypress in all CI jobs but the e2e (which should improve things) and we can cache Cypress cache which should also improve things.

I'm also using [`yarn workspaces focus`](https://yarnpkg.com/cli/workspaces/focus) feature to cut down even more on the install time, especially in the Companion CI that don't need any deps expects Companion's.