### PR TITLE
Fix Companion deploy workflow & use semver as tag

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -37,7 +37,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
-          tags: ${{ env.GITHUB_REF }}
+          tags: ${{ github.ref_name }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   heroku:

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -23,11 +23,6 @@ jobs:
           tag-sha: true
           tag-match: |
             \d{1,3}.\d{1,3}.\d{1,3}
-      - name: Get Companion version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@main
-        with:
-          path: packages/@uppy/companion/package.json
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Log in to DockerHub
@@ -42,7 +37,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
-          tags: ${{ steps.package-version.outputs.current-version }}
+          tags: $GITHUB_REF
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   heroku:

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -3,7 +3,7 @@ name: Companion Deploy
 on:
   push:
     tags:
-      - '@uppy/companion@*'
+      - '@uppy/companion@**'
 
 jobs:
   docker:
@@ -23,6 +23,11 @@ jobs:
           tag-sha: true
           tag-match: |
             \d{1,3}.\d{1,3}.\d{1,3}
+      - name: Get Companion version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: packages/@uppy/companion/package.json
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Log in to DockerHub
@@ -37,7 +42,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.package-version.outputs.current-version }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   heroku:

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -37,7 +37,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
-          tags: $GITHUB_REF
+          tags: ${{ env.GITHUB_REF }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   heroku:


### PR DESCRIPTION
Closes #3655 

- Fix matching of tags which trigger the release
- Use the version of Companion as the Docker tag. This makes it easier for people to know what they are using, or want to use. 