### PR TITLE
@uppy/core: Fix `Restrictor` counts ghost files against `maxNumberOfFiles`

### DIFF
--- a/packages/@uppy/core/src/Restricter.js
+++ b/packages/@uppy/core/src/Restricter.js
@@ -33,8 +33,11 @@ class Restricter {
   validate (file, files) {
     const { maxFileSize, minFileSize, maxTotalFileSize, maxNumberOfFiles, allowedFileTypes } = this.getOpts().restrictions
 
-    if (maxNumberOfFiles && files.length + 1 > maxNumberOfFiles) {
-      throw new RestrictionError(`${this.i18n('youCanOnlyUploadX', { smart_count: maxNumberOfFiles })}`)
+    if (maxNumberOfFiles) {
+      const nonGhostFiles = files.filter(f => !f.isGhost)
+      if (nonGhostFiles.length + 1 > maxNumberOfFiles) {
+        throw new RestrictionError(`${this.i18n('youCanOnlyUploadX', { smart_count: maxNumberOfFiles })}`)
+      }
     }
 
     if (allowedFileTypes) {

--- a/packages/@uppy/core/src/Uppy.test.js
+++ b/packages/@uppy/core/src/Uppy.test.js
@@ -1652,6 +1652,33 @@ describe('src/Core', () => {
       }
     })
 
+    it('should not enforce the maxNumberOfFiles rule for ghost files', () => {
+      const core = new Core({
+        restrictions: {
+          maxNumberOfFiles: 1,
+        },
+      })
+
+      expect(() => {
+        // add 1 ghost file
+        const fileId1 = core.addFile({
+          source: 'jest',
+          name: 'foo1.jpg',
+          type: 'image/jpeg',
+          data: new File([sampleImage], { type: 'image/jpeg' }),
+        })
+        core.setFileState(fileId1, { isGhost: true })
+
+        // add another file
+        core.addFile({
+          source: 'jest',
+          name: 'foo2.jpg',
+          type: 'image/jpeg',
+          data: new File([sampleImage], { type: 'image/jpeg' }),
+        })
+      }).not.toThrowError()
+    })
+
     xit('should enforce the minNumberOfFiles rule', () => { })
 
     it('should enforce the allowedFileTypes rule', () => {


### PR DESCRIPTION
G'day,

We believe we have identified an issue with the way @uppy/core's `Restrictor` class validates `maxNumberOfFiles` when ghost files are present.

`Restrictor` counts all the files, including files with `isGhost == true`, against the `maxNumberOfFiles` configuration. This prevents a user from uploading a replacement for the ghost file using the 'Re-select' link. A `RestrictionError` is raised instead with the message "You can only select X file".

We have tested this fix in our own implementation's sandbox and would like to raise this with the team for feedback and merge consideration.

### Reproduction steps
- `maxNumberOfFiles` Uppy configuration set to `1`
- Without service worker configured for golden retriever
- Select a larger video file (20mb+)
- Close the uploader without reloading the page
- Open the modal
- See "we could not fully recover one file"
- Re-select the file
- See the error

### Video of bug

https://user-images.githubusercontent.com/565743/187759405-a3f8e39c-24aa-4723-8696-4acf6291ea83.mov




