### PR TITLE
meta: remove all remaining occurrences of `Uppy.Core`

### DIFF
--- a/BUNDLE-README.md
+++ b/BUNDLE-README.md
@@ -28,13 +28,13 @@ Now you can create an HTML file, for example `./upload.html`, with the following
   </div>
 </body>
 
-<script src="./js/uppy/uppy.min.js"></script>
-<script>
-  var uppy = new Uppy.Core({
+<script type="module">
+  import {Uppy, Dashboard, Tus} from "./js/uppy/uppy.min.mjs"
+  var uppy = new Uppy({
     debug      : true,
     autoProceed: false,
   })
-    .use(Uppy.Dashboard, {
+    .use(Dashboard, {
       browserBackButtonClose: false,
       height                : 470,
       inline                : false,
@@ -47,7 +47,7 @@ Now you can create an HTML file, for example `./upload.html`, with the following
         { id: 'caption', name: 'Caption', placeholder: 'describe what the image is about' }
       ]
     })
-    .use(Uppy.Tus, { endpoint: 'https://tusd.tusdemo.net/files/' })
+    .use(Tus, { endpoint: 'https://tusd.tusdemo.net/files/' })
     .on('upload-success', function (file, response) {
       var url      = response.uploadURL
       var fileName = file.name

--- a/packages/uppy/types/index.test-d.ts
+++ b/packages/uppy/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import * as Uppy from '..';
 
 (() => {
-  const uppy = new Uppy.Core({ autoProceed: false })
+  const uppy = new Uppy.Uppy({ autoProceed: false })
   uppy.use(Uppy.Dashboard, { trigger: '#up_load_file_01' })
   uppy.use(Uppy.DragDrop, { target: '#ttt' })
   uppy.use(Uppy.XHRUpload, {
@@ -15,7 +15,7 @@ import * as Uppy from '..';
 })();
 
 (() => {
-  new Uppy.Core({ autoProceed: false })
+  new Uppy.Uppy({ autoProceed: false })
     .use(Uppy.Dashboard, { trigger: '#select-files' })
     .use(Uppy.GoogleDrive, { target: Uppy.Dashboard, companionUrl: 'https://companion.uppy.io' })
     .use(Uppy.Instagram, { target: Uppy.Dashboard, companionUrl: 'https://companion.uppy.io' })
@@ -29,7 +29,7 @@ import * as Uppy from '..';
 })();
 
 (() => {
-  const uppy = new Uppy.Core()
+  const uppy = new Uppy.Uppy()
   uppy.use(Uppy.DragDrop, { target: '.UppyDragDrop' })
   uppy.use(Uppy.Tus, { endpoint: '//tusd.tusdemo.net/files/' })
 })()

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -592,7 +592,7 @@ uppy.setState({
 })
 ```
 
-State in Uppy is considered to be immutable. When updating values, make sure not mutate them, but instead create copies. See [Redux docs](http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html) for more info on this. Here is an example from Uppy.Core that updates progress for a particular file in state:
+State in Uppy is considered to be immutable. When updating values, make sure not mutate them, but instead create copies. See [Redux docs](http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html) for more info on this. Here is an example that updates progress for a particular file in state:
 
 ```js
 // We use Object.assign({}, obj) to create a copy of `obj`.

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -24,14 +24,14 @@ Here’s the simplest example html page with Uppy (it uses a CDN bundle, while w
   <body>
     <div id="drag-drop-area"></div>
 
-    <script src="https://releases.transloadit.com/uppy/v3.0.1/uppy.min.js"></script>
     <script>
-      var uppy = new Uppy.Core()
-        .use(Uppy.Dashboard, {
+      import {Uppy, Dashbaord, Tus} from "https://releases.transloadit.com/uppy/v3.0.1/uppy.min.js"
+      var uppy = new Uppy()
+        .use(Dashboard, {
           inline: true,
           target: '#drag-drop-area'
         })
-        .use(Uppy.Tus, {endpoint: 'https://tusd.tusdemo.net/files/'})
+        .use(Tus, {endpoint: 'https://tusd.tusdemo.net/files/'})
 
       uppy.on('complete', (result) => {
         console.log('Upload complete! We’ve uploaded these files:', result.successful)
@@ -131,7 +131,7 @@ You can also use a pre-built bundle from Transloadit’s CDN: Edgly. `Uppy` will
 
 ```html
 <script>
-  var uppy = new Uppy.Core()
+  var uppy = new Uppy.Uppy()
   uppy.use(Uppy.DragDrop, { target: '#drag-drop-area' })
   uppy.use(Uppy.Tus, { endpoint: 'https://tusd.tusdemo.net/files/' })
 </script>

--- a/website/src/docs/locales.md
+++ b/website/src/docs/locales.md
@@ -38,7 +38,7 @@ Add a `<script>` tag with Uppy bundle and the locale pack you’d like to use. Y
 <script src="https://releases.transloadit.com/uppy/locales/v3.0.0/de_DE.min.js"></script>
 
 <script>
-var uppy = new Uppy.Core({
+var uppy = new Uppy.Uppy({
   debug: true,
   locale: Uppy.locales.de_DE
 })

--- a/website/src/docs/plugin-common-options.md
+++ b/website/src/docs/plugin-common-options.md
@@ -43,7 +43,7 @@ In the example above, the `Dashboard` gets rendered into an element with ID `upp
 
 ### `locale: {}`
 
-Same as with Uppy.Core’s setting above, this allows you to override plugin’s locale string, so that instead of `Select files` in English, your users will see `Выберите файлы` in Russian. Example:
+Same as with Uppy’s setting above, this allows you to override plugin’s locale string, so that instead of `Select files` in English, your users will see `Выберите файлы` in Russian. Example:
 
 ```js
 uppy.use(FileInput, {

--- a/website/src/examples/i18n/app.html
+++ b/website/src/examples/i18n/app.html
@@ -18,14 +18,14 @@
 <script>
 window.addEventListener('DOMContentLoaded', function () {
   'use strict';
-  var uppy = new Uppy.Core({
+  var uppy = new Uppy.Uppy({
     debug: true,
     autoProceed: true,
     locale: Uppy.locales.ru_RU
   });
   uppy.use(Uppy.DragDrop, {
     target: '.UppyDragDrop',
-    // We are using the ru_RU locale pack (set above in Uppy.Core options),
+    // We are using the ru_RU locale pack (set above in Uppy class options),
     // but you can also override specific strings like so:
     locale: {
       strings: {

--- a/website/src/uppy.ejs
+++ b/website/src/uppy.ejs
@@ -17,7 +17,7 @@ permalink: uppy/
     <script src="uppy.min.js"></script>
     <script src="locales/ru_RU.min.js"></script>
     <script>
-      var uppy = new Uppy.Core({locales: Uppy.locales.ru_RU, debug: true})
+      var uppy = new Uppy.Uppy({locales: Uppy.locales.ru_RU, debug: true})
       // uppy.use(Uppy.plugins.DragDrop, {target: 'body'});
         .use(Uppy.plugins.Modal, {trigger: '#uppyModalOpener'})
         .use(Uppy.plugins.Dummy, {target: Uppy.plugins.Modal})


### PR DESCRIPTION
I don't know if we want to rewrite all the examples to ESM, and/or if you want to keep demonstrating the legacy bundle. In any case, we should merge ASAP so we don't keep incorrect examples on the website.