### PR TITLE
meta: limit the number of unnecessary CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - 'examples/**'
       - 'private/**'
       - 'website/**'
-      - .github/workflows/*
+      - '.github/workflows/**'
 
 jobs:
   unit_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     # We want all branches so we configure types to be the GH default again
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'examples/**'
+      - 'private/**'
+      - 'website/**'
+      - .github/workflows/*
 
 jobs:
   unit_tests:

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -7,7 +7,7 @@ on:
     types: [ opened, synchronize, reopened ]
     paths:
       - yarn.lock
-      - 'packages/@uppy/companion'
+      - 'packages/@uppy/companion/**'
 
 jobs:
   test:

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     # We want all branches so we configure types to be the GH default again
     types: [ opened, synchronize, reopened ]
+    paths:
+      - yarn.lock
+      - 'packages/@uppy/companion'
 
 jobs:
   test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ on:
       - 'examples/**'
       - 'private/**'
       - 'website/**'
-      - .github/workflows/e2e.yml
+      - '.github/workflows/**'
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: main
     paths:
+      - yarn.lock
       - 'website/**'
 
 jobs:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,6 +3,8 @@ name: Deploy uppy.io
 on:
   push:
     branches: main
+    paths:
+      - 'website/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
E.g. we don't need to run the e2e suite on PRs that are only changing a GHA workflow file, or the companion CI if Companion wasn't touched.