### PR TITLE
meta: fix Companion deploy

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -1,4 +1,7 @@
-name: Companion Deploy
+# N.B.: This won't run on releases because of
+# https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow.
+# However, we have a companion deploy that's part of the release.yml workflow.
+name: Companion Edge Deploy
 
 on:
   push:
@@ -10,7 +13,7 @@ on:
 
 jobs:
   npm:
-    name: Upload npm tarball
+    name: Generate npm tarball
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -9,6 +9,23 @@ on:
       - '.github/workflows/companion.yml'
 
 jobs:
+  npm:
+    name: Upload npm tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Set SHA commit in version
+        run: (cd packages/@uppy/companion && node -e 'const pkg=require("./package.json");pkg.version+="+${{ github.sha }}";fs.writeFileSync("package.json",JSON.stringify(pkg, undefined, 2)+"\n")')
+      - name: Create Companion tarball
+        run: corepack yarn workspace @uppy/companion pack --install-if-needed -o /tmp/companion-${{ github.sha }}.tar.gz
+      - name: Upload artifact
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: companion-${{ github.sha }}.tar.gz
+          path: /tmp/companion-${{ github.sha }}.tar.gz
+
   docker:
     name: DockerHub
     runs-on: ubuntu-latest

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -2,8 +2,11 @@ name: Companion Deploy
 
 on:
   push:
-    tags:
-      - '@uppy/companion@*'
+    branches: [ 'main' ]
+    paths:
+      - yarn.lock
+      - 'packages/@uppy/companion/**'
+      - '.github/workflows/companion.yml'
 
 jobs:
   docker:
@@ -17,12 +20,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v4
         with:
           images: transloadit/companion
-          tag-sha: true
-          tag-match: |
-            \d{1,3}.\d{1,3}.\d{1,3}
+          tags: |
+            type=edge
+            type=raw,value=latest,enable=false
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Log in to DockerHub
@@ -39,20 +42,3 @@ jobs:
           file: Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-  heroku:
-    name: Heroku
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: Alter dockerfile
-        run: |
-          sed -i 's/^EXPOSE 3020$/EXPOSE $PORT/g' Dockerfile
-      - name: Deploy to heroku
-        uses: akhileshns/heroku-deploy@v3.12.12
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: companion-demo
-          heroku_email: ${{secrets.HEROKU_EMAIL}}
-          usedocker: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   release:
     name: Publish releases
     if: ${{ github.event.review.state == 'approved' && github.event.sender.login == github.event.pull_request.assignee.login && github.event.pull_request.head.ref == 'release-candidate' }}
+    outputs:
+      companionWasReleased: ${{ steps.checkIfCompanionWasReleased.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -78,6 +80,9 @@ jobs:
         env:
           EDGLY_KEY: ${{secrets.EDGLY_KEY}}
           EDGLY_SECRET: ${{secrets.EDGLY_SECRET}}
+      - name: Check if Companion was released
+        id: checkIfCompanionWasReleased
+        run: git diff --exit-code --quiet HEAD^ -- packages/@uppy/companion/package.json || echo "::set-output name=version::$(jq .version < packages/@uppy/companion/package.json)"
       - name: Remove release-candidate branch
         run: gh api -X DELETE repos/${{ github.repository }}/git/refs/heads/release-candidate || echo "Already deleted"
         env:
@@ -95,3 +100,59 @@ jobs:
         run: gh pr comment ${{ github.event.pull_request.number }} --body "Release job failed, please take action."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: DockerHub
+    needs: release
+    if: ${{ needs.release.outputs.companionWasReleased }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 0
+      COMPOSE_DOCKER_CLI_BUILD: 0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: transloadit/companion
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.companionWasReleased }}
+            # set latest tag for default branch
+            type=raw,value=latest,enable=true
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+
+  heroku:
+    name: Heroku
+    needs: release
+    if: ${{ needs.release.outputs.companionWasReleased }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Alter dockerfile
+        run: |
+          sed -i 's/^EXPOSE 3020$/EXPOSE $PORT/g' Dockerfile
+      - name: Deploy to heroku
+        uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: companion-demo
+          heroku_email: ${{secrets.HEROKU_EMAIL}}
+          usedocker: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # See also companion-deploy.yml
   docker:
     name: DockerHub
     needs: release
@@ -118,6 +119,7 @@ jobs:
         with:
           images: transloadit/companion
           tags: |
+            type=edge
             type=semver,pattern={{version}},value=${{ needs.release.outputs.companionWasReleased }}
             # set latest tag for default branch
             type=raw,value=latest,enable=true


### PR DESCRIPTION
Alternative to https://github.com/transloadit/uppy/pull/4074.

- Keep deploying to DockerHub on every push to `main`, but mark it as `edge`.
- Make Heroku deploy part of the release process so Heroku demo only uses the stable version.
- Add DockerHub deploy step to the release process marking it with the correct semver tag.