### PR TITLE
Fix endless webcam re-render with Golden Retriever

### DIFF
--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -113,8 +113,10 @@ export default class GoldenRetriever extends BasePlugin {
 
     // If all files have been removed by the user, clear recovery state
     if (Object.keys(filesToSave).length === 0) {
-      this.uppy.setState({ recoveredState: null })
-      MetaDataStore.cleanup(this.uppy.opts.id)
+      if (this.uppy.getState().recoveredState) {
+        this.uppy.setState({ recoveredState: null })
+        MetaDataStore.cleanup(this.uppy.opts.id)
+      }
       return
     }
 
@@ -350,7 +352,6 @@ export default class GoldenRetriever extends BasePlugin {
       })
     } else {
       this.uppy.log('[GoldenRetriever] No files need to be loaded, only restoring processing state...')
-      this.onBlobsLoaded([])
     }
   }
 

--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -113,10 +113,10 @@ export default class GoldenRetriever extends BasePlugin {
 
     // If all files have been removed by the user, clear recovery state
     if (Object.keys(filesToSave).length === 0) {
-      if (this.uppy.getState().recoveredState) {
+      if (this.uppy.getState().recoveredState !== null) {
         this.uppy.setState({ recoveredState: null })
-        MetaDataStore.cleanup(this.uppy.opts.id)
       }
+      MetaDataStore.cleanup(this.uppy.opts.id)
       return
     }
 
@@ -362,6 +362,9 @@ export default class GoldenRetriever extends BasePlugin {
     this.uppy.on('file-added', this.addBlobToStores)
     this.uppy.on('file-editor:complete', this.replaceBlobInStores)
     this.uppy.on('file-removed', this.removeBlobFromStores)
+    // TODO: the `state-update` is bad practise. It fires on any state change in Uppy
+    // or any state change in any of the plugins. We should to able to only listen
+    // for the state changes we need, somehow.
     this.uppy.on('state-update', this.saveFilesStateToLocalStorage)
     this.uppy.on('restore-confirmed', this.handleRestoreConfirmed)
     this.uppy.on('restore-canceled', this.abortRestore)

--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -113,7 +113,7 @@ export default class GoldenRetriever extends BasePlugin {
 
     // If all files have been removed by the user, clear recovery state
     if (Object.keys(filesToSave).length === 0) {
-      if (this.uppy.getState().recoveredState !== null) {
+      if (this.uppy.getState().recoveredState) {
         this.uppy.setState({ recoveredState: null })
         MetaDataStore.cleanup(this.uppy.opts.id)
       }

--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -113,7 +113,7 @@ export default class GoldenRetriever extends BasePlugin {
 
     // If all files have been removed by the user, clear recovery state
     if (Object.keys(filesToSave).length === 0) {
-      if (this.uppy.getState().recoveredState) {
+      if (this.uppy.getState().recoveredState !== null) {
         this.uppy.setState({ recoveredState: null })
         MetaDataStore.cleanup(this.uppy.opts.id)
       }


### PR DESCRIPTION
Fixes #4093

During this I shockingly found out about this in the `install` of Golden Retriever:

```js
    this.uppy.on('state-update', this.saveFilesStateToLocalStorage)
```

`state-update` is an undocumented event which triggers on **any state change in uppy or in any of the plugin states**. This results in this function being called regularly every second. Every call, whenever there are no files (happens a lot), we do a state update, **which triggers this function again**. This PR fixes the latter problem.

But in my opinion the `state-update` event shouldn't exist and we should only be able to listen to updates that matter for Golden Retriever. However, that discussion/solution shouldn't have to block this fix. 