### PR TITLE
image-editor: fix controls in small Dashboard

### DIFF
--- a/packages/@uppy/image-editor/src/style.scss
+++ b/packages/@uppy/image-editor/src/style.scss
@@ -31,10 +31,8 @@
   background-color: rgba($black, 0.6);
   transform: translateX(-50%);
 
-  @media screen and (min-width: 768px) {
-    .uppy-size--md & {
-      padding-top: 0;
-    }
+  .uppy-size--md & {
+    padding-top: 0;
   }
 }
 
@@ -72,22 +70,16 @@
   left: 10px;
   height: 38px;
 
-  @media screen and (min-width: 768px) {
-    .uppy-size--md & {
-      position: static !important;
-      height: auto;
-    }
+  .uppy-size--md & {
+    position: static !important;
+    height: auto;
   }
 }
 
-.uppy-ImageCropper-range {
-  @media screen and (min-width: 768px) {
-    .uppy-size--md & {
-      width: 180px;
-      margin-right: 15px;
-      margin-left: 5px;
-    }
-  }
+.uppy-size--md .uppy-ImageCropper-range {
+  width: 180px;
+  margin-right: 15px;
+  margin-left: 5px;
 }
 
 // Cropper overrides

--- a/packages/@uppy/image-editor/src/style.scss
+++ b/packages/@uppy/image-editor/src/style.scss
@@ -32,7 +32,9 @@
   transform: translateX(-50%);
 
   @media screen and (min-width: 768px) {
-    padding-top: 0;
+    .uppy-size--md & {
+      padding-top: 0;
+    }
   }
 }
 
@@ -71,16 +73,20 @@
   height: 38px;
 
   @media screen and (min-width: 768px) {
-    position: static !important;
-    height: auto;
+    .uppy-size--md & {
+      position: static !important;
+      height: auto;
+    }
   }
 }
 
 .uppy-ImageCropper-range {
   @media screen and (min-width: 768px) {
-    width: 180px;
-    margin-right: 15px;
-    margin-left: 5px;
+    .uppy-size--md & {
+      width: 180px;
+      margin-right: 15px;
+      margin-left: 5px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/transloadit/uppy/issues/4112

Apply big-screen styles for controls only if Dashboard width is at least medium-size.