### PR TITLE
@uppy/golden-retriever: fix condition to load files from service worker

### DIFF
--- a/packages/@uppy/golden-retriever/src/index.js
+++ b/packages/@uppy/golden-retriever/src/index.js
@@ -163,16 +163,9 @@ export default class GoldenRetriever extends BasePlugin {
     }
 
     return this.ServiceWorkerStore.list().then((blobs) => {
-      const files = this.uppy.getFiles()
-      const localFilesOnly = files.filter((file) => {
-        // maybe && !file.progress.uploadComplete
-        return !file.isRemote
-      })
-
       const numberOfFilesRecovered = Object.keys(blobs).length
-      const numberOfFilesTryingToRecover = localFilesOnly.length
 
-      if (numberOfFilesRecovered === numberOfFilesTryingToRecover) {
+      if (numberOfFilesRecovered > 0) {
         this.uppy.log(`[GoldenRetriever] Successfully recovered ${numberOfFilesRecovered} blobs from Service Worker!`)
         return blobs
       }


### PR DESCRIPTION
Closes #4094 

This aligns the condition with the other storage methods such as IndexedDB. I really can't tell why this condition was there in the first place, if you have an idea please voice concern.