### PR TITLE
website: fix tag for Activity Feed

### DIFF
--- a/website/themes/uppy/layout/index.ejs
+++ b/website/themes/uppy/layout/index.ejs
@@ -174,7 +174,7 @@
 <section class="IndexActivity">
   <h2>Activity Feed</h2>
 
-  <div class="on-the-githubs" data-event-source="repos/transloadit/uppy">Loading...</div>
+  <ul class="on-the-githubs" data-event-source="repos/transloadit/uppy">Loading...</ul>
 </section>
 
 <section>

--- a/website/themes/uppy/layout/index.ejs
+++ b/website/themes/uppy/layout/index.ejs
@@ -174,7 +174,7 @@
 <section class="IndexActivity">
   <h2>Activity Feed</h2>
 
-<noscript class="activity-feed" data-event-source="repos/transloadit/uppy">You need JavaScript to display the activity feed.</noscript>
+  <noscript class="activity-feed" data-event-source="repos/transloadit/uppy">You need JavaScript to display the activity feed.</noscript>
 </section>
 
 <section>

--- a/website/themes/uppy/layout/index.ejs
+++ b/website/themes/uppy/layout/index.ejs
@@ -174,7 +174,7 @@
 <section class="IndexActivity">
   <h2>Activity Feed</h2>
 
-  <ul class="on-the-githubs" data-event-source="repos/transloadit/uppy">Loading...</ul>
+<noscript class="activity-feed" data-event-source="repos/transloadit/uppy">You need JavaScript to display the activity feed.</noscript>
 </section>
 
 <section>

--- a/website/themes/uppy/layout/layout.ejs
+++ b/website/themes/uppy/layout/layout.ejs
@@ -100,7 +100,10 @@ if (page.series) {
         <script src="//ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script> 
         <script src="//kvz.github.io/on-the-githubs/js/jquery.on-the-githubs.min.js"></script>
         <script type="text/javascript">
-          $('.on-the-githubs').onthegithubs();
+          {
+            const $placeholder = $('.activity-feed');
+            $('<ul>', { class: 'on-the-githubs', data: $placeholder.data() }).replaceAll($placeholder).onthegithubs();
+          }
         </script>
       <% } %>
       <script src="/js/common.js"></script>

--- a/website/themes/uppy/source/css/_stats.scss
+++ b/website/themes/uppy/source/css/_stats.scss
@@ -41,13 +41,14 @@ a.Stats-package {
 }
 
 .on-the-githubs {
-  &:empty::before {
-    content: "Loading...";
-  }
+  @include clearfix;
   margin: 0;
   padding: 0;
   list-style-type: none;
-  @include clearfix;
+
+  &:empty::before {
+    content: "Loading...";
+  }
 
   > li {
     @include clearfix;

--- a/website/themes/uppy/source/css/_stats.scss
+++ b/website/themes/uppy/source/css/_stats.scss
@@ -41,6 +41,9 @@ a.Stats-package {
 }
 
 .on-the-githubs {
+  &:empty::before {
+    content: "Loading...";
+  }
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/website/themes/uppy/source/css/_stats.scss
+++ b/website/themes/uppy/source/css/_stats.scss
@@ -41,10 +41,13 @@ a.Stats-package {
 }
 
 .on-the-githubs {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
   @include clearfix;
+
   > li {
     @include clearfix;
-    list-style-type: none;
     margin: 0;
     padding: 12px 0;
     position: relative;


### PR DESCRIPTION
`div.on-the-githubs` block is populated with `<li>` elements, which [are only allowed within `ul`, `ol` or `menu`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element).

It matters for accessibility (e.g. screen readers).