### PR TITLE
Fix Uppy.cancelAll and Uppy.close types

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -32,6 +32,8 @@ type LocaleStrings<TNames extends string> = {
 
 type LogLevel = 'info' | 'warning' | 'error'
 
+type CancelOptions = { reason: 'user' | 'unmount' }
+
 export type Store = UppyUtils.Store
 
 export type InternalMetadata = UppyUtils.InternalMetadata
@@ -352,7 +354,7 @@ export class Uppy {
     UploadResult<TMeta>
   >
 
-  cancelAll(): void
+  cancelAll(options: CancelOptions): void
 
   retryUpload<TMeta extends IndexedObject<any> = Record<string, unknown>>(
     fileID: string
@@ -371,7 +373,7 @@ export class Uppy {
 
   removePlugin(instance: UIPlugin | BasePlugin): void
 
-  close(): void
+  close(options: CancelOptions): void
 
   logout(): void
 


### PR DESCRIPTION
Closes #4126 

Note: I was unable to get my fork working in the project where I discovered the issue, but the change seems simple enough… any tips how I could verify this locally would be appreciated.