### PR TITLE
Fix TypeScript types for cancelAll and close methods

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -20,6 +20,10 @@ export type FileProgress = UppyUtils.FileProgress;
 
 export type FileRemoveReason = 'removed-by-user' | 'cancel-all';
 
+export type CancelReason = 'user' | 'unmount';
+
+export type CloseReason = 'user' | 'unmount'
+
 // Replace the `meta` property type with one that allows omitting internal metadata addFile() will add that
 type UppyFileWithoutMeta<TMeta, TBody> = OmitKey<
   UppyFile<TMeta, TBody>,
@@ -341,7 +345,7 @@ export class Uppy {
     UploadResult<TMeta>
   >
 
-  cancelAll(): void
+  cancelAll(options?: { reason?: CancelReason }): void
 
   retryUpload<TMeta extends IndexedObject<any> = Record<string, unknown>>(
     fileID: string
@@ -360,7 +364,7 @@ export class Uppy {
 
   removePlugin(instance: UIPlugin | BasePlugin): void
 
-  close(): void
+  close(options?: { reason?: CloseReason }): void
 
   logout(): void
 


### PR DESCRIPTION
The `cancelAll` and `close` methods each accept an options object that allows you to specify the reason for cancellation or closure, but those options weren't defined in the TypeScript definitions.