### PR TITLE
@uppy/url: Trim whitespace around user input url

### DIFF
--- a/packages/@uppy/url/src/UrlUI.jsx
+++ b/packages/@uppy/url/src/UrlUI.jsx
@@ -12,15 +12,15 @@ class UrlUI extends Component {
   }
 
   handleKeyPress (ev) {
-    const { addFile } = this.props
     if (ev.keyCode === 13) {
-      addFile(this.input.value)
+      this.handleSubmit()
     }
   }
 
-  handleClick () {
+  handleSubmit () {
     const { addFile } = this.props
-    addFile(this.input.value)
+    const preparedValue = this.input.value.trim()
+    addFile(preparedValue)
   }
 
   render () {
@@ -39,7 +39,7 @@ class UrlUI extends Component {
         <button
           className="uppy-u-reset uppy-c-btn uppy-c-btn-primary uppy-Url-importButton"
           type="button"
-          onClick={this.handleClick}
+          onClick={this.handleSubmit}
         >
           {i18n('import')}
         </button>


### PR DESCRIPTION
This PR resolves a UX issue where the user uploading would receive an error if they pasted a url that had additional whitespace around it.

Thank you, looking forward to your feedback.

### Solution
`trim()`s the input value within the `UrlUI` preact component before it calls `addFile`.
Because this deals directly with UX by attempting to prevent user error, it seemed most appropriate to place this value transformation directly within the preact component.

### Testing
I wasn't sure where to include a test case for this. I struggled to find a pattern for testing a preact component in the lib. Requesting guidance in understanding where or how this case could be best written in following the existing patterns of the Uppy lib. 🙂


### Preview of bug
https://user-images.githubusercontent.com/565743/195644384-f630c91c-ca7a-4c80-8bb5-77a6bd9da994.mp4

