### PR TITLE
fix: add https:// to digital oceans link

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -35,9 +35,9 @@ import isXml from './isXml.js'
 import locale from './locale.js'
 
 function resolveUrl (origin, link) {
-  // Digital oceans don't return the protocal from Location
-  // if we don't adding protocal then new URL will fail with error: Failed to construct 'URL'
-  link = link.startsWith("https://") ? link : `https://${link}`
+  // DigitalOcean doesn’t return the protocol from Location
+  // without it, the `new URL` constructor will fail
+  link = link.startsWith('https://') ? link : `https://${link}`
   return new URL(link, origin || undefined).toString()
 }
 

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -37,7 +37,9 @@ import locale from './locale.js'
 function resolveUrl (origin, link) {
   // DigitalOcean doesn’t return the protocol from Location
   // without it, the `new URL` constructor will fail
-  link = link.startsWith('https://') ? link : `https://${link}`
+  if (!origin && !link.startsWith('https://') && !link.startsWith('http://')) {
+    link = `https://${link}` // eslint-disable-line no-param-reassign
+  }
   return new URL(link, origin || undefined).toString()
 }
 

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -35,6 +35,9 @@ import isXml from './isXml.js'
 import locale from './locale.js'
 
 function resolveUrl (origin, link) {
+  // Digital oceans don't return the protocal from Location
+  // if we don't adding protocal then new URL will fail with error: Failed to construct 'URL'
+  link = link.startsWith("https://") ? link : `https://${link}`
   return new URL(link, origin || undefined).toString()
 }
 


### PR DESCRIPTION
I was getting this error: 
```
TypeError: Failed to construct 'URL': Invalid URL
    at resolveUrl (index.js:46:10)
    at Object.defaultGetResponseData [as getResponseData] (index.js:313:19)
    at Function.<anonymous> (MiniXHRUpload.js:195:27)
    at emitAll (index.js:131:14)
    at Object.emit (index.js:33:7)
    at UppySocket.emit (Socket.js:120:59)
    at WebSocket.value (Socket.js:46:16)
```
it's because from the XML content that Digital ocean space returns, there are no protocal on the link like AWS s3.
You guys also leave a note here about that: https://github.com/transloadit/uppy/blob/bef7b58beff5485c0de208fc3ab4296ae22127e6/packages/%40uppy/aws-s3/src/index.js#L271
```
       // Some S3 alternatives do not reply with an absolute URL.
        // Eg DigitalOcean Spaces uses /$bucketName/xyz
        location: resolveUrl(xhr.responseURL, getXmlValue(content, 'Location')),
```


