### PR TITLE
meta: add a manual deploy for website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,6 +7,7 @@ on:
       - yarn.lock
       - 'website/**'
       - '.github/workflows/website.yml'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Because the GHA bot is merging the release PR, the website workflow doesn't run automatically. By adding a manual dispatch, we can make sure the website is updated after each release.