### PR TITLE
@uppy/companion-client: prevent preflight race condition

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.js
+++ b/packages/@uppy/companion-client/src/Provider.js
@@ -19,25 +19,23 @@ export default class Provider extends RequestClient {
     this.preAuthToken = null
   }
 
-  headers () {
-    return Promise.all([super.headers(), this.getAuthToken()])
-      .then(([headers, token]) => {
-        const authHeaders = {}
-        if (token) {
-          authHeaders['uppy-auth-token'] = token
-        }
+  async headers () {
+    const [headers, token] = await Promise.all([super.headers(), this.getAuthToken()])
+    const authHeaders = {}
+    if (token) {
+      authHeaders['uppy-auth-token'] = token
+    }
 
-        if (this.companionKeysParams) {
-          authHeaders['uppy-credentials-params'] = btoa(
-            JSON.stringify({ params: this.companionKeysParams }),
-          )
-        }
-        return { ...headers, ...authHeaders }
-      })
+    if (this.companionKeysParams) {
+      authHeaders['uppy-credentials-params'] = btoa(
+        JSON.stringify({ params: this.companionKeysParams }),
+      )
+    }
+    return { ...headers, ...authHeaders }
   }
 
   onReceiveResponse (response) {
-    response = super.onReceiveResponse(response) // eslint-disable-line no-param-reassign
+    super.onReceiveResponse(response)
     const plugin = this.uppy.getPlugin(this.pluginId)
     const oldAuthenticated = plugin.getPluginState().authenticated
     const authenticated = oldAuthenticated ? response.status !== 401 : response.status < 400

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -143,12 +143,6 @@ export default class RequestClient {
     }))
   }
 
-  get = async (path, skipPostResponse) => this.#request({ path, skipPostResponse })
-
-  post = async (path, data, skipPostResponse) => this.#request({ path, method: 'POST', data, skipPostResponse })
-
-  delete = async (path, data, skipPostResponse) => this.#request({ path, method: 'DELETE', data, skipPostResponse })
-
   async #request ({ path, method = 'GET', data, skipPostResponse }) {
     try {
       const headers = await this.preflightAndHeaders(path)
@@ -165,4 +159,10 @@ export default class RequestClient {
       throw new ErrorWithCause(`Could not ${method} ${this.#getUrl(path)}`, { cause: err })
     }
   }
+
+  async get (path, skipPostResponse) { return this.#request({ path, skipPostResponse }) }
+
+  async post (path, data, skipPostResponse) { return this.#request({ path, method: 'POST', data, skipPostResponse }) }
+
+  async delete (path, data, skipPostResponse) { return this.#request({ path, method: 'DELETE', data, skipPostResponse }) }
 }

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -16,16 +16,17 @@ async function handleJSONResponse (res) {
     throw new AuthError()
   }
 
-  // todo why is 300 considered success?
-  // shouldn't we use res.ok?
-  if (res.status >= 200 && res.status <= 300) {
-    return res.json()
+  const jsonPromise = res.json()
+  if (res.ok) {
+    return jsonPromise
   }
 
   let errMsg = `Failed request with status: ${res.status}. ${res.statusText}`
-  const errData = await res.json()
-  errMsg = errData.message ? `${errMsg} message: ${errData.message}` : errMsg
-  errMsg = errData.requestId ? `${errMsg} request-Id: ${errData.requestId}` : errMsg
+  try {
+    const errData = await jsonPromise
+    errMsg = errData.message ? `${errMsg} message: ${errData.message}` : errMsg
+    errMsg = errData.requestId ? `${errMsg} request-Id: ${errData.requestId}` : errMsg
+  } catch { /* if the response contains invalid JSON, let's ignore the error */ }
   throw new Error(errMsg)
 }
 

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -101,6 +101,7 @@ export default class RequestClient {
     The preflight only happens once throughout the life-cycle of a certain
     Companion-client <-> Companion-server pair (allowedHeadersCache).
     Subsequent requests use the cached result of the preflight.
+    However if there is an error retrieving the allowed headers, we will try again next time
   */
   async preflight (path) {
     const allowedHeadersCached = allowedHeadersCache.get(this.hostname)

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -96,11 +96,11 @@ export default class RequestClient {
     does not support those headers. In which case, the default preflight would lead to CORS.
     So to avoid those errors, we do preflight ourselves, to see what headers the Companion server
     we are communicating with allows. And based on that, companion-client knows what headers to
-    send and what headers to not send
+    send and what headers to not send.
 
-    the preflight only happens once throughout the life-cycle of a certain
+    The preflight only happens once throughout the life-cycle of a certain
     Companion-client <-> Companion-server pair (allowedHeadersCache).
-    Subsequent requests use the cached result of the preflight
+    Subsequent requests use the cached result of the preflight.
   */
   async preflight (path) {
     const allowedHeaders = allowedHeadersCache.get(this.hostname)
@@ -115,7 +115,9 @@ export default class RequestClient {
 
         this.uppy.log(`[CompanionClient] adding allowed preflight headers to companion cache: ${this.hostname} ${header}`)
 
-        return header.split(',').map((headerName) => headerName.trim().toLowerCase())
+        const allowedHeaders = header.split(',').map((headerName) => headerName.trim().toLowerCase())
+        allowedHeadersCache.set(this.hostname, allowedHeaders)
+        return allowedHeaders
       } catch (err) {
         this.uppy.log(`[CompanionClient] unable to make preflight request ${err}`, 'warning')
         return undefined
@@ -126,13 +128,13 @@ export default class RequestClient {
 
     const allowedHeadersNew = await promise
     const fallbackAllowedHeaders = ['accept', 'content-type', 'uppy-auth-token']
-    return allowedHeadersNew != null ? allowedHeadersNew : fallbackAllowedHeaders
+    return allowedHeadersNew ?? fallbackAllowedHeaders
   }
 
   async preflightAndHeaders (path) {
     const [allowedHeaders, headers] = await Promise.all([this.preflight(path), this.headers()])
     // filter to keep only allowed Headers
-    Object.fromEntries(Object.entries(headers).filter(([header]) => {
+    return Object.fromEntries(Object.entries(headers).filter(([header]) => {
       if (!allowedHeaders.includes(header.toLowerCase())) {
         this.uppy.log(`[CompanionClient] excluding disallowed header ${header}`)
         return false

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -115,9 +115,7 @@ export default class RequestClient {
 
         this.uppy.log(`[CompanionClient] adding allowed preflight headers to companion cache: ${this.hostname} ${header}`)
 
-        const allowedHeaders = header.split(',').map((headerName) => headerName.trim().toLowerCase())
-        allowedHeadersCache.set(this.hostname, allowedHeaders)
-        return allowedHeaders
+        return header.split(',').map((headerName) => headerName.trim().toLowerCase())
       } catch (err) {
         this.uppy.log(`[CompanionClient] unable to make preflight request ${err}`, 'warning')
         return undefined
@@ -125,8 +123,11 @@ export default class RequestClient {
     })()
 
     allowedHeadersCache.set(this.hostname, promise)
-
     const allowedHeadersNew = await promise
+    // If the user gets a network error or similar, we should try preflight again next time,
+    // or else we might get incorrect behaviour
+    allowedHeadersCache.set(this.hostname, allowedHeadersNew)
+
     const fallbackAllowedHeaders = ['accept', 'content-type', 'uppy-auth-token']
     return allowedHeadersNew ?? fallbackAllowedHeaders
   }

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -103,8 +103,8 @@ export default class RequestClient {
     Subsequent requests use the cached result of the preflight.
   */
   async preflight (path) {
-    const allowedHeaders = allowedHeadersCache.get(this.hostname)
-    if (allowedHeaders != null) return allowedHeaders
+    const allowedHeadersCached = allowedHeadersCache.get(this.hostname)
+    if (allowedHeadersCached != null) return allowedHeadersCached
 
     const promise = (async () => {
       try {
@@ -141,8 +141,6 @@ export default class RequestClient {
       }
       return true
     }))
-
-    return headers
   }
 
   get = async (path, skipPostResponse) => this.#request({ path, skipPostResponse })


### PR DESCRIPTION
...that caused double OPTIONS to be sent for each inital reqeust

Also simplify, deduplicate and async/awaitify code and fix lint.

This race condition caused the RequestClient to send X redundant OPTIONS requests immediately when starting an upload, where X is the number of files uploaded. This affected all Companion-related uploads: s3, s3-multipart, google drive etc. Note that after the initial requests, it would not send double OPTIONS (such as multipart uploading individual parts, because it would be cached by then).
This cache would be cleared for every upload "session".

After this PR, we only send OPTIONS once, then wait for the response before continuing. We globally cache the allowed headers based on `companionUrl`, so even in subsequent upload sessions, it will not send any more of these extraneous OPTIONS requests

tip for easier review: ignore whitespace