### PR TITLE
@aws-s3-multipart: remove unused `timeout` option

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -32,7 +32,6 @@ export default class AwsS3Multipart extends BasePlugin {
     this.#client = new RequestClient(uppy, opts)
 
     const defaultOptions = {
-      timeout: 30 * 1000,
       limit: 0,
       retryDelays: [0, 1000, 3000, 5000],
       createMultipartUpload: this.createMultipartUpload.bind(this),

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -32,7 +32,6 @@ export interface AwsS3MultipartOptions extends PluginOptions {
       file: UppyFile,
       opts: { uploadId: string; key: string; parts: AwsS3Part[] }
     ) => MaybePromise<{ location?: string }>
-    timeout?: number
     limit?: number
     retryDelays?: number[] | null
 }


### PR DESCRIPTION
We have never used this option.