### PR TITLE
Dashboard: Single file mode

### DIFF
--- a/packages/@uppy/dashboard/src/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/Dashboard.jsx
@@ -783,6 +783,9 @@ export default class Dashboard extends UIPlugin {
     this.uppy.off('file-editor:complete', this.hideAllPanels)
     this.uppy.off('complete', this.handleComplete)
 
+    this.uppy.off('files-added', this.#generateLargeThumbnailIfSingleFile)
+    this.uppy.off('file-removed', this.#generateLargeThumbnailIfSingleFile)
+
     document.removeEventListener('focus', this.recordIfFocusedOnUppyRecently)
     document.removeEventListener('click', this.recordIfFocusedOnUppyRecently)
 

--- a/packages/@uppy/dashboard/src/components/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/components/Dashboard.jsx
@@ -138,6 +138,7 @@ export default function Dashboard (props) {
             <FileList
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...props}
+              singleFile={singleFile}
               itemsPerRow={itemsPerRow}
             />
           ) : (

--- a/packages/@uppy/dashboard/src/components/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/components/Dashboard.jsx
@@ -20,6 +20,8 @@ const HEIGHT_MD = 400
 
 export default function Dashboard (props) {
   const noFiles = props.totalFileCount === 0
+  const singleFile = props.totalFileCount === 1
+
   const isSizeMD = props.containerWidth > WIDTH_MD
 
   const dashboardClassName = classNames({
@@ -35,6 +37,7 @@ export default function Dashboard (props) {
     'uppy-size--height-md': props.containerHeight > HEIGHT_MD,
     'uppy-Dashboard--isAddFilesPanelVisible': props.showAddFilesPanel,
     'uppy-Dashboard--isInnerWrapVisible': props.areInsidesReadyToBeVisible,
+    'uppy-Dashboard--singleFile': singleFile,
   })
 
   // Important: keep these in sync with the percent width values in `src/components/FileItem/index.scss`.

--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.jsx
@@ -15,7 +15,7 @@ function EditButton ({
   ) {
     return (
       <button
-        className="uppy-u-reset uppy-Dashboard-Item-action uppy-Dashboard-Item-action--edit"
+        className="uppy-u-reset uppy-c-btn uppy-Dashboard-Item-action uppy-Dashboard-Item-action--edit"
         type="button"
         aria-label={i18n('editFileWithFilename', { file: file.meta.name })}
         title={i18n('editFileWithFilename', { file: file.meta.name })}

--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.scss
@@ -30,6 +30,21 @@
     opacity: 1;
   }
 
+  .uppy-size--md &,
+  .uppy-Dashboard--singleFile & {
+    position: absolute;
+    top: -8px;
+    z-index: $zIndex-3;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    inset-inline-end: -8px;
+
+    &:focus {
+      border-radius: 50%;
+    }
+  }
+
   [data-uppy-theme="dark"] & {
     color: $gray-700;
   }
@@ -40,7 +55,7 @@
 }
 
 // Only for mobile screens
-.uppy-Dashboard:not(.uppy-size--md) {
+.uppy-Dashboard:not(.uppy-size--md):not(.uppy-Dashboard--singleFile) {
   // Vertically center Edit&Remove buttons on mobile
   .uppy-Dashboard-Item-actionWrapper {
     display: flex;
@@ -69,20 +84,6 @@
 
     &:focus {
       border-radius: 3px;
-    }
-  }
-  // Remove button is in the top right corner
-  .uppy-Dashboard-Item-action--remove {
-    position: absolute;
-    top: -8px;
-    z-index: $zIndex-3;
-    width: 18px;
-    height: 18px;
-    padding: 0;
-    inset-inline-end: -8px;
-
-    &:focus {
-      border-radius: 50%;
     }
   }
 }

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.jsx
@@ -7,6 +7,9 @@ const renderFileName = (props) => {
   const { author, name } = props.file.meta
 
   function getMaxNameLength () {
+    if (props.singleFile) {
+      return 200
+    }
     if (props.containerWidth <= 352) {
       return 35
     }

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.jsx
@@ -78,7 +78,7 @@ const ErrorButton = ({ file, onClick }) => {
   if (file.error) {
     return (
       <button
-        className="uppy-u-reset uppy-Dashboard-Item-errorDetails"
+        className="uppy-u-reset uppy-c-btn uppy-Dashboard-Item-errorDetails"
         aria-label={file.error}
         data-microtip-position="bottom"
         data-microtip-size="medium"

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
@@ -15,6 +15,11 @@
   [data-uppy-theme="dark"] & {
     color: $gray-200;
   }
+
+  .uppy-size--md.uppy-Dashboard--singleFile & {
+    font-size: 14px;
+    line-height: 1.4;
+  }
 }
 
 .uppy-Dashboard-Item-fileName {

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.scss
@@ -1,5 +1,13 @@
 .uppy-Dashboard-Item-fileInfo {
   padding-inline-end: 5px;
+
+  .uppy-Dashboard--singleFile & {
+    padding-inline-end: 10px;
+  }
+
+  .uppy-size--md.uppy-Dashboard--singleFile & {
+    padding-inline-end: 15px;
+  }
 }
 
 .uppy-Dashboard-Item-name {

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.jsx
@@ -40,7 +40,7 @@ function ProgressIndicatorButton (props) {
   return (
     <div className="uppy-Dashboard-Item-progress">
       <button
-        className="uppy-u-reset uppy-Dashboard-Item-progressIndicator"
+        className="uppy-u-reset uppy-c-btn uppy-Dashboard-Item-progressIndicator"
         type="button"
         aria-label={progressIndicatorTitle(props)}
         title={progressIndicatorTitle(props)}

--- a/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileProgress/index.scss
@@ -15,6 +15,7 @@
   width: 38px;
   height: 38px;
   opacity: 0.9;
+  color: $white;
 
   .uppy-size--md & {
     width: 55px;

--- a/packages/@uppy/dashboard/src/components/FileItem/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.jsx
@@ -106,6 +106,7 @@ export default class FileItem extends Component {
             toggleAddFilesPanel={this.props.toggleAddFilesPanel}
             toggleFileCard={this.props.toggleFileCard}
             metaFields={this.props.metaFields}
+            singleFile={this.props.singleFile}
           />
           <Buttons
             file={file}

--- a/packages/@uppy/dashboard/src/components/FileItem/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.scss
@@ -55,6 +55,9 @@
     max-width: 400px;
     height: auto;
     border-bottom: 0;
+    position: relative;
+    padding: 0;
+    margin: 10px;
   }
 }
 
@@ -114,7 +117,7 @@
 
   .uppy-Dashboard--singleFile & {
     width: 100%;
-    height: 300px;
+    height: 270px;
   }
 }
 

--- a/packages/@uppy/dashboard/src/components/FileItem/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.scss
@@ -8,7 +8,10 @@
   align-items: center;
   padding: 10px;
   border-bottom: 1px solid $gray-200;
-  padding-inline-end: 0;
+
+  .uppy-Dashboard:not(.uppy-Dashboard--singleFile) & {
+    padding-inline-end: 0;
+  }
 
   [data-uppy-theme="dark"] & {
     border-bottom: 1px solid $gray-800;
@@ -36,12 +39,22 @@
     width: calc(25% - #{$rl-margin} - #{$rl-margin});
     height: 190px;
     margin: 5px $rl-margin;
+    padding: 0;
   }
 
   .uppy-size--xl & {
     /* When changing width: also update `itemsPerRow` values in `src/components/Dashboard.js`. */
     width: calc(20% - #{$rl-margin} - #{$rl-margin});
     height: 210px;
+    padding: 0;
+  }
+
+  .uppy-Dashboard--singleFile & {
+    display: block;
+    width: 100%;
+    max-width: 400px;
+    height: auto;
+    border-bottom: 0;
   }
 }
 
@@ -78,12 +91,13 @@
   position: relative;
 
   // @media only mobile
-  .uppy-Dashboard:not(.uppy-size--md) & {
+  .uppy-Dashboard:not(.uppy-size--md):not(.uppy-Dashboard--singleFile) & {
     flex-grow: 0;
     flex-shrink: 0;
     width: 50px;
     height: 50px;
   }
+
   // @media bigger than .md
   .uppy-size--md & {
     width: 100%;
@@ -97,6 +111,11 @@
   .uppy-size--xl & {
     height: 140px;
   }
+
+  .uppy-Dashboard--singleFile & {
+    width: 100%;
+    height: 300px;
+  }
 }
 
 .uppy-Dashboard-Item-fileInfoAndButtons {
@@ -107,7 +126,8 @@
   padding-inline-end: 8px;
   padding-inline-start: 12px;
 
-  .uppy-size--md & {
+  .uppy-size--md &,
+  .uppy-Dashboard--singleFile & {
     align-items: flex-start;
     width: 100%;
     padding: 0;

--- a/packages/@uppy/dashboard/src/components/FileList.jsx
+++ b/packages/@uppy/dashboard/src/components/FileList.jsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { h } from 'preact'
 import FileItem from './FileItem/index.jsx'
 import VirtualList from './VirtualList.jsx'
@@ -19,14 +18,6 @@ function chunks (list, size) {
 }
 
 export default (props) => {
-  const noFiles = props.totalFileCount === 0
-  const singleFile = props.totalFileCount === 1
-
-  const dashboardFilesClass = classNames(
-    'uppy-Dashboard-files',
-    { 'uppy-Dashboard-files--noFiles': noFiles },
-  )
-
   // It's not great that this is hardcoded!
   // It's ESPECIALLY not great that this is checking against `itemsPerRow`!
   const rowHeight = props.itemsPerRow === 1
@@ -55,7 +46,7 @@ export default (props) => {
     isWide: props.isWide,
     metaFields: props.metaFields,
     recoveredState: props.recoveredState,
-    singleFile,
+    singleFile: props.singleFile,
     // callbacks
     toggleFileCard: props.toggleFileCard,
     handleRequestThumbnail: props.handleRequestThumbnail,
@@ -91,9 +82,9 @@ export default (props) => {
     </div>
   )
 
-  if (singleFile) {
+  if (props.singleFile) {
     return (
-      <div class={dashboardFilesClass}>
+      <div class="uppy-Dashboard-files">
         {renderRow(rows[0])}
       </div>
     )
@@ -101,7 +92,7 @@ export default (props) => {
 
   return (
     <VirtualList
-      class={dashboardFilesClass}
+      class="uppy-Dashboard-files"
       role="list"
       data={rows}
       renderRow={renderRow}

--- a/packages/@uppy/dashboard/src/components/FileList.jsx
+++ b/packages/@uppy/dashboard/src/components/FileList.jsx
@@ -20,6 +20,8 @@ function chunks (list, size) {
 
 export default (props) => {
   const noFiles = props.totalFileCount === 0
+  const singleFile = props.totalFileCount === 1
+
   const dashboardFilesClass = classNames(
     'uppy-Dashboard-files',
     { 'uppy-Dashboard-files--noFiles': noFiles },
@@ -72,7 +74,7 @@ export default (props) => {
     // The `role="presentation` attribute ensures that the list items are properly
     // associated with the `VirtualList` element.
     // We use the first file ID as the key—this should not change across scroll rerenders
-    <div role="presentation" key={row[0]}>
+    <div class="uppy-Dashboard-filesInner" role="presentation" key={row[0]}>
       {row.map((fileID) => (
         <FileItem
           key={fileID}
@@ -87,6 +89,14 @@ export default (props) => {
       ))}
     </div>
   )
+
+  if (singleFile) {
+    return (
+      <div class={dashboardFilesClass}>
+        {renderRow(rows[0])}
+      </div>
+    )
+  }
 
   return (
     <VirtualList

--- a/packages/@uppy/dashboard/src/components/FileList.jsx
+++ b/packages/@uppy/dashboard/src/components/FileList.jsx
@@ -55,6 +55,7 @@ export default (props) => {
     isWide: props.isWide,
     metaFields: props.metaFields,
     recoveredState: props.recoveredState,
+    singleFile,
     // callbacks
     toggleFileCard: props.toggleFileCard,
     handleRequestThumbnail: props.handleRequestThumbnail,

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -727,6 +727,13 @@
   }
 }
 
+.uppy-Dashboard--singleFile .uppy-Dashboard-filesInner  {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
 .uppy-Dashboard-dropFilesHereHint {
   position: absolute;
   top: 7px;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -874,12 +874,21 @@ a.uppy-Dashboard-poweredBy {
     width: 100%;
     height: 100%;
   }
+
+  .uppy-Dashboard--singleFile & {
+    width: 90px;
+    height: 90px;
+  }
 }
 
 .uppy-Dashboard-Item-previewIconWrap {
   position: relative;
   height: 76px;
   max-height: 75%;
+
+  .uppy-Dashboard--singleFile & {
+    height: 176px;
+  }
 }
 
 .uppy-Dashboard-Item-previewIconBg {


### PR DESCRIPTION
With only one file / image selected, display it large and centered, and re-generate image preview so it's `600px` large.

![Screen Shot 2022-11-04 at 17 02 24](https://user-images.githubusercontent.com/1199054/200039014-d9d66aeb-a585-42f7-b345-64ac147dae52.png)

![Screen Shot 2022-11-04 at 16 48 43](https://user-images.githubusercontent.com/1199054/200031579-ab9a6820-159a-4663-a34b-a9dcc242e729.png)

![Screen Shot 2022-11-04 at 16 50 51](https://user-images.githubusercontent.com/1199054/200031556-b480be18-6ccb-4030-ad81-f55664eb8284.png)

![Screen Shot 2022-11-04 at 16 49 16](https://user-images.githubusercontent.com/1199054/200031560-9d1b01aa-bd87-4d95-a114-59316cc39908.png)

Fixes #3970.

