### PR TITLE
image-editor: add checkered background

### DIFF
--- a/packages/@uppy/image-editor/src/cropper.scss
+++ b/packages/@uppy/image-editor/src/cropper.scss
@@ -66,6 +66,7 @@
   overflow: hidden;
   outline: 1px solid #39f;
   outline-color: rgba(51, 153, 255, 0.75);
+  background: repeating-conic-gradient(rgba(0, 0, 0, 0.5) 0% 25%, rgba(255, 255, 255, 0.5) 0% 50%) 50% / 16px 16px;
 }
 
 .cropper-dashed {


### PR DESCRIPTION
Add checkered background to cropper viewbox to indicate transparent parts of image.

Before:
![cropper_main](https://user-images.githubusercontent.com/74449973/200111108-dded0f46-b5e1-49b3-9d3c-05e3814c01f1.png)
After:
![cropper_checkered](https://user-images.githubusercontent.com/74449973/200111113-e7d53406-405c-43d8-89ae-c44ba18d4dfa.png)
