### PR TITLE
@uppy/aws-s3-multipart: add `shouldUseMultipart ` option

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -92,7 +92,7 @@ class MultipartUploader {
           getData,
           onProgress: this.#onPartProgress(j),
           onComplete: this.#onPartComplete(j),
-          shouldUseMultipart: false,
+          shouldUseMultipart,
         }
       }
     } else {
@@ -100,7 +100,7 @@ class MultipartUploader {
         getData: () => this.#data,
         onProgress: this.#onPartProgress(0),
         onComplete: this.#onPartComplete(0),
-        shouldUseMultipart: true,
+        shouldUseMultipart,
       }]
     }
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -119,8 +119,10 @@ class MultipartUploader {
       .then(this.#onSuccess, this.#onReject)
   }
 
-  #onPartProgress = (index) => (bytes) => {
-    this.#chunkState[index].uploaded = ensureInt(bytes)
+  #onPartProgress = (index) => (ev) => {
+    if (!ev.lengthComputable) return
+
+    this.#chunkState[index].uploaded = ensureInt(ev.loaded)
 
     const totalUploaded = this.#chunkState.reduce((n, c) => n + c.uploaded, 0)
     this.options.onProgress(totalUploaded, this.#data.size)

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -62,20 +62,21 @@ class MultipartUploader {
   }
 
   #initChunks () {
-    const desiredChunkSize = this.options.getChunkSize(this.#data)
-    // at least 5MB per request, at most 10k requests
     const fileSize = this.#data.size
-    const minChunkSize = Math.max(5 * MB, Math.ceil(fileSize / 10000))
-    const chunkSize = Math.max(desiredChunkSize, minChunkSize)
 
     // Upload zero-sized files in one zero-sized chunk
-    if (this.#data.size === 0) {
+    if (this.#data.size === 0 || fileSize >> 10 >> 10 < 100) {
       this.#chunks = [{
         getData: () => this.#data,
         onProgress: this.#onPartProgress(0),
         onComplete: this.#onPartComplete(0),
       }]
     } else {
+      const desiredChunkSize = this.options.getChunkSize(this.#data)
+      // at least 5MB per request, at most 10k requests
+      const minChunkSize = Math.max(5 * MB, Math.ceil(fileSize / 10000))
+      const chunkSize = Math.max(desiredChunkSize, minChunkSize)
+
       const arraySize = Math.ceil(fileSize / chunkSize)
       this.#chunks = Array(arraySize)
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -92,12 +92,16 @@ class MultipartUploader {
           getData,
           onProgress: this.#onPartProgress(j),
           onComplete: this.#onPartComplete(j),
+          shouldUseMultipart: false,
         }
       }
     } else {
-      this.#chunks = [this.#data]
-      this.#data.onProgress = this.#onPartProgress(0)
-      this.#data.onComplete = this.#onPartComplete(0)
+      this.#chunks = [{
+        getData: () => this.#data,
+        onProgress: this.#onPartProgress(0),
+        onComplete: this.#onPartComplete(0),
+        shouldUseMultipart: true,
+      }]
     }
 
     this.#chunkState = this.#chunks.map(() => ({ uploaded: 0 }))

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -119,11 +119,8 @@ class MultipartUploader {
       .then(this.#onSuccess, this.#onReject)
   }
 
-  #onPartProgress = (index) => (ev) => {
-    if (!ev.lengthComputable) return
-
-    const sent = ev.loaded
-    this.#chunkState[index].uploaded = ensureInt(sent)
+  #onPartProgress = (index) => (bytes) => {
+    this.#chunkState[index].uploaded = ensureInt(bytes)
 
     const totalUploaded = this.#chunkState.reduce((n, c) => n + c.uploaded, 0)
     this.options.onProgress(totalUploaded, this.#data.size)

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -67,7 +67,7 @@ class MultipartUploader {
   #initChunks () {
     const fileSize = this.#data.size
     const shouldUseMultipart = typeof this.#shouldUseMultipart === 'function'
-      ? this.#shouldUseMultipart(this.#file, fileSize)
+      ? this.#shouldUseMultipart(this.#file)
       : Boolean(this.#shouldUseMultipart)
 
     if (shouldUseMultipart) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -300,6 +300,8 @@ export default class AwsS3Multipart extends BasePlugin {
       // TODO: this is currently opt-in for backward compat, switch to opt-out in the next major
       allowedMetaFields: null,
       limit: 6,
+      // eslint-disable-next-line no-bitwise
+      shouldUseMultipart: (file, fileSize) => fileSize >> 10 >> 10 > 100,
       retryDelays: [0, 1000, 3000, 5000],
       createMultipartUpload: this.createMultipartUpload.bind(this),
       listParts: this.listParts.bind(this),
@@ -582,6 +584,7 @@ export default class AwsS3Multipart extends BasePlugin {
         onPartComplete,
 
         file,
+        shouldUseMultipart: this.opts.shouldUseMultipart,
 
         ...file.s3Multipart,
       })

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -312,7 +312,7 @@ export default class AwsS3Multipart extends BasePlugin {
       // TODO: this is currently opt-in for backward compat, switch to opt-out in the next major
       allowedMetaFields: null,
       limit: 6,
-      shouldUseMultipart: true, // In the next major, the default should be switched as the following:
+      shouldUseMultipart: (file, fileSize) => fileSize !== 0, // TODO: Switch default to:
       // eslint-disable-next-line no-bitwise
       // shouldUseMultipart: (file, fileSize) => fileSize >> 10 >> 10 > 100,
       retryDelays: [0, 1000, 3000, 5000],

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -227,7 +227,7 @@ class HTTPCommunicationQueue {
 
   async uploadFile (file, chunks, signal) {
     throwIfAborted(signal)
-    if (chunks.length === 1 && chunks[0].shouldUseMultipart) {
+    if (chunks.length === 1 && !chunks[0].shouldUseMultipart) {
       return this.#nonMultipartUpload(file, chunks[0], signal)
     }
     const { uploadId, key } = await this.getUploadId(file, signal)

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -444,7 +444,7 @@ export default class AwsS3Multipart extends BasePlugin {
       .then(assertServerError)
   }
 
-  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'PUT' }, body, size, onProgress, onComplete, signal }) {
+  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'PUT' }, body, size = body.size, onProgress, onComplete, signal }) {
     throwIfAborted(signal)
 
     if (url == null) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -35,7 +35,7 @@ function throwIfAborted (signal) {
 class HTTPCommunicationQueue {
   #abortMultipartUpload
 
-  #options
+  #allowedMetaFields
 
   #cache = new WeakMap()
 
@@ -66,12 +66,13 @@ class HTTPCommunicationQueue {
   }
 
   setOptions (options) {
-    this.#options = options ?? {}
-
     const requests = this.#requests
 
     if ('abortMultipartUpload' in options) {
       this.#abortMultipartUpload = requests.wrapPromiseFunction(options.abortMultipartUpload)
+    }
+    if ('allowedMetaFields' in options) {
+      this.#allowedMetaFields = options.allowedMetaFields
     }
     if ('createMultipartUpload' in options) {
       this.#createMultipartUpload = requests.wrapPromiseFunction(options.createMultipartUpload, { priority:-1 })
@@ -210,9 +211,9 @@ class HTTPCommunicationQueue {
   }
 
   async #nonMultipartUpload (file, chunk, signal) {
-    const filename = file.meta.name
-    const { type } = file.meta
-    const metadata = getMetadata({ meta: file.meta, allowedMetaFields: this.#options.allowedMetaFields })
+    const { meta } = file
+    const { type, name: filename } = meta
+    const metadata = getMetadata({ meta, allowedMetaFields: this.#allowedMetaFields })
 
     const query = new URLSearchParams({ filename, type, ...metadata })
     const {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -21,6 +21,8 @@ function assertServerError (res) {
 function getAllowedMetadata ({ meta, allowedMetaFields, querify = false }) {
   const metaFields = allowedMetaFields ?? Object.keys(meta)
 
+  console.log(metaFields)
+
   if (!meta) return {}
 
   return Object.fromEntries(
@@ -333,9 +335,9 @@ export default class AwsS3Multipart extends BasePlugin {
       // TODO: this is currently opt-in for backward compat, switch to opt-out in the next major
       allowedMetaFields: null,
       limit: 6,
-      shouldUseMultipart: (file, fileSize) => fileSize !== 0, // TODO: Switch default to:
+      shouldUseMultipart: (file) => file.size !== 0, // TODO: Switch default to:
       // eslint-disable-next-line no-bitwise
-      // shouldUseMultipart: (file, fileSize) => fileSize >> 10 >> 10 > 100,
+      // shouldUseMultipart: (file) => file.size >> 10 >> 10 > 100,
       retryDelays: [0, 1000, 3000, 5000],
       createMultipartUpload: this.createMultipartUpload.bind(this),
       listParts: this.listParts.bind(this),

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -214,7 +214,13 @@ class HTTPCommunicationQueue {
 
     const { onProgress, onComplete } = chunk
 
-    return this.#uploadPartBytes({ signature: { url, headers, method }, body: data, onProgress, onComplete, signal }).abortOn(signal)
+    return this.#uploadPartBytes({
+      signature: { url, headers, method },
+      body: data,
+      onProgress,
+      onComplete,
+      signal,
+    }).abortOn(signal)
   }
 
   async uploadFile (file, chunks, signal) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -300,8 +300,9 @@ export default class AwsS3Multipart extends BasePlugin {
       // TODO: this is currently opt-in for backward compat, switch to opt-out in the next major
       allowedMetaFields: null,
       limit: 6,
+      shouldUseMultipart: true, // In the next major, the default should be switched as the following:
       // eslint-disable-next-line no-bitwise
-      shouldUseMultipart: (file, fileSize) => fileSize >> 10 >> 10 > 100,
+      // shouldUseMultipart: (file, fileSize) => fileSize >> 10 >> 10 > 100,
       retryDelays: [0, 1000, 3000, 5000],
       createMultipartUpload: this.createMultipartUpload.bind(this),
       listParts: this.listParts.bind(this),

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -21,8 +21,6 @@ function assertServerError (res) {
 function getAllowedMetadata ({ meta, allowedMetaFields, querify = false }) {
   const metaFields = allowedMetaFields ?? Object.keys(meta)
 
-  console.log(metaFields)
-
   if (!meta) return {}
 
   return Object.fromEntries(

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -43,7 +43,7 @@ export interface AwsS3MultipartOptions extends PluginOptions {
       opts: { uploadId: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
     ) => MaybePromise<{ location?: string }>
     limit?: number
-    shouldUseMultipart?: boolean | ((file: UppyFile, fileSize: number) => boolean)
+    shouldUseMultipart?: boolean | ((file: UppyFile) => boolean)
     retryDelays?: number[] | null
 }
 

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -43,6 +43,7 @@ export interface AwsS3MultipartOptions extends PluginOptions {
       opts: { uploadId: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
     ) => MaybePromise<{ location?: string }>
     limit?: number
+    shouldUseMultipart?: boolean | ((file: UppyFile, fileSize: number) => boolean)
     retryDelays?: number[] | null
 }
 

--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -101,6 +101,7 @@ function defaultGetResponseError (content, xhr) {
 // warning deduplication flag: see `getResponseData()` XHRUpload option definition
 let warnedSuccessActionStatus = false
 
+// TODO deprecate this, will use s3-multipart instead
 export default class AwsS3 extends BasePlugin {
   static VERSION = packageJson.version
 


### PR DESCRIPTION
When uploading small files (e.g. ≤100MiB), using multipart can decrease the upload performance as it introduces more overhead for uploading just one part.
This can be solved without too much difficulty by hitting the non-multipart endpoint for files with only one chunk.