### PR TITLE
@uppy/aws-s3-multipart: Fix typo in url check

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -568,7 +568,7 @@ export default class AwsS3Multipart extends BasePlugin {
       Object.assign(opts, file.tus)
     }
 
-    if (file.remove.url == null) {
+    if (file.remote.url == null) {
       throw new Error('Cannot connect to an undefined URL')
     }
 


### PR DESCRIPTION
The newly introduced check contains a typo. It should check `file.remote.url` not `file.remove.url`.