### PR TITLE
@uppy/companion-client: treat `*` the same as missing header

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -115,7 +115,7 @@ export default class RequestClient {
         const response = await fetch(this.#getUrl(path), { method: 'OPTIONS' })
 
         const header = response.headers.get('access-control-allow-headers')
-        if (header == null) {
+        if (header == null || header === '*') {
           allowedHeadersCache.set(this.hostname, fallbackAllowedHeaders)
           return fallbackAllowedHeaders
         }


### PR DESCRIPTION
Setting `Access-Control-Allow-Headers: *` should be interpreted as when that header is missing, for backward compat.