### PR TITLE
@uppy/aws-s3-multipart: Aligning singPart with doc

### DIFF
--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -7,6 +7,10 @@ export interface AwsS3Part {
   Size?: number
   ETag?: string
 }
+export interface AwsS3SignedPart {
+  url: string
+  headers?: Record<string, string>
+}
 
 export interface AwsS3MultipartOptions extends PluginOptions {
     companionHeaders?: { [type: string]: string }
@@ -23,7 +27,7 @@ export interface AwsS3MultipartOptions extends PluginOptions {
     signPart?: (
       file: UppyFile,
       opts: { uploadId: string; key: string; partNumber: number; body: Blob, signal: AbortSignal }
-    ) => MaybePromise<AwsS3Part>
+    ) => MaybePromise<AwsS3SignedPart>
     /** @deprecated Use signPart instead */
     prepareUploadParts?: (
       file: UppyFile,


### PR DESCRIPTION
The typing here is not aligned with the docs. Minor thing

```
...
An example of what the return value should look like:
{
  "url": "https://bucket.region.amazonaws.com/path/to/file.jpg?partNumber=1&...",
  "headers": { "Content-MD5": "foo" }
}
```

https://uppy.io/docs/aws-s3-multipart/#signPart-file-partData