### PR TITLE
Uppy Mini

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -252,6 +252,7 @@ module.exports = {
         'packages/@uppy/webcam/src/**/*.js',
         'packages/@uppy/xhr-upload/src/**/*.js',
         'packages/@uppy/zoom/src/**/*.js',
+        'packages/@uppy/mini/src/**/*.js',
         'website/src/examples/*/*.es6',
       ],
       parser: 'espree',

--- a/packages/@uppy/dashboard/src/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/Dashboard.jsx
@@ -170,6 +170,8 @@ export default class Dashboard extends UIPlugin {
     }
 
     this.setPluginState(update)
+
+    this.uppy.emit('dashboard:hide-all-panels')
   }
 
   showPanel = (id) => {
@@ -727,6 +729,7 @@ export default class Dashboard extends UIPlugin {
     const firstFile = files[0]
     if (this.canEditFile(firstFile)) {
       this.openFileEditor(firstFile)
+      setTimeout(this.openModal, 4)
     }
   }
 

--- a/packages/@uppy/mini/LICENSE
+++ b/packages/@uppy/mini/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Transloadit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@uppy/mini/README.md
+++ b/packages/@uppy/mini/README.md
@@ -1,0 +1,3 @@
+# @uppy/mini
+
+<img src="https://uppy.io/images/logos/uppy-dog-head-arrow.svg" width="120" alt="Uppy logo: a superman puppy in a pink suit" align="right">

--- a/packages/@uppy/mini/package.json
+++ b/packages/@uppy/mini/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@uppy/mini",
+  "description": "Dashboard mini",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "style": "dist/style.min.css",
+  "type": "module",
+  "types": "types/index.d.ts",
+  "keywords": [
+    "file uploader",
+    "uppy",
+    "uppy-plugin",
+    "drag-drop",
+    "drag",
+    "drop",
+    "dropzone",
+    "upload"
+  ],
+  "homepage": "https://uppy.io",
+  "bugs": {
+    "url": "https://github.com/transloadit/uppy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/transloadit/uppy.git"
+  },
+  "dependencies": {
+    "@uppy/utils": "workspace:^",
+    "preact": "^10.5.13"
+  },
+  "peerDependencies": {
+    "@uppy/core": "workspace:^"
+  }
+}

--- a/packages/@uppy/mini/package.json
+++ b/packages/@uppy/mini/package.json
@@ -30,6 +30,7 @@
     "preact": "^10.5.13"
   },
   "peerDependencies": {
-    "@uppy/core": "workspace:^"
+    "@uppy/core": "workspace:^",
+    "@uppy/dashboard": "workspace:^"
   }
 }

--- a/packages/@uppy/mini/src/Mini.jsx
+++ b/packages/@uppy/mini/src/Mini.jsx
@@ -1,0 +1,341 @@
+import { h, Fragment } from 'preact'
+import { UIPlugin } from '@uppy/core'
+import toArray from '@uppy/utils/lib/toArray'
+import getDroppedFiles from '@uppy/utils/lib/getDroppedFiles'
+
+import packageJson from '../package.json'
+import locale from './locale.js'
+
+const myDeviceIcon = (
+  <svg aria-hidden="true" focusable="false" width="32" height="32" viewBox="0 0 32 32">
+    <g fill="none" fillRule="evenodd">
+      <rect className="uppy-ProviderIconBg" width="32" height="32" rx="16" fill="#2275D7" />
+      <path d="M21.973 21.152H9.863l-1.108-5.087h14.464l-1.246 5.087zM9.935 11.37h3.958l.886 1.444a.673.673 0 0 0 .585.316h6.506v1.37H9.935v-3.13zm14.898 3.44a.793.793 0 0 0-.616-.31h-.978v-2.126c0-.379-.275-.613-.653-.613H15.75l-.886-1.445a.673.673 0 0 0-.585-.316H9.232c-.378 0-.667.209-.667.587V14.5h-.782a.793.793 0 0 0-.61.303.795.795 0 0 0-.155.663l1.45 6.633c.078.36.396.618.764.618h13.354c.36 0 .674-.246.76-.595l1.631-6.636a.795.795 0 0 0-.144-.675z" fill="#FFF" />
+    </g>
+  </svg>
+)
+
+export default class DragDrop extends UIPlugin {
+  static VERSION = packageJson.version
+
+  constructor (uppy, opts) {
+    super(uppy, opts)
+    this.type = 'acquirer'
+    this.id = this.opts.id || 'DashboardMini'
+    this.title = 'Dashboard Mini'
+
+    this.defaultLocale = locale
+
+    // Default options, must be kept in sync with @uppy/react/src/DragDrop.js.
+    const defaultOpts = {
+
+    }
+
+    // Merge default options with the ones set by user
+    this.opts = { ...defaultOpts, ...opts }
+
+    this.i18nInit()
+  }
+
+  addFiles = (files) => {
+    const descriptors = files.map(file => ({
+      source: this.id,
+      name: file.name,
+      type: file.type,
+      data: file,
+      meta: {
+        // path of the file relative to the ancestor directory the user selected.
+        // e.g. 'docs/Old Prague/airbnb.pdf'
+        relativePath: file.relativePath || null,
+      },
+    }))
+
+    try {
+      this.uppy.addFiles(descriptors)
+    } catch (err) {
+      this.uppy.log(err)
+    }
+  }
+
+  onInputChange = (event) => {
+    const files = toArray(event.target.files)
+    if (files.length > 0) {
+      this.uppy.log('[DragDrop] Files selected through input')
+      this.addFiles(files)
+    }
+
+    // We clear the input after a file is selected, because otherwise
+    // change event is not fired in Chrome and Safari when a file
+    // with the same name is selected.
+    // ___Why not use value="" on <input/> instead?
+    //    Because if we use that method of clearing the input,
+    //    Chrome will not trigger change if we drop the same file twice (Issue #768).
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = null
+  }
+
+  handleDragOver = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    // Check if the "type" of the datatransfer object includes files. If not, deny drop.
+    const { types } = event.dataTransfer
+    const hasFiles = types.some(type => type === 'Files')
+    const { allowNewUpload } = this.uppy.getState()
+    if (!hasFiles || !allowNewUpload) {
+      // eslint-disable-next-line no-param-reassign
+      event.dataTransfer.dropEffect = 'none'
+      clearTimeout(this.removeDragOverClassTimeout)
+      return
+    }
+
+    // Add a small (+) icon on drop
+    // (and prevent browsers from interpreting this as files being _moved_ into the browser
+    // https://github.com/transloadit/uppy/issues/1978)
+    //
+    // eslint-disable-next-line no-param-reassign
+    event.dataTransfer.dropEffect = 'copy'
+
+    clearTimeout(this.removeDragOverClassTimeout)
+    this.setPluginState({ isDraggingOver: true })
+
+    this.opts.onDragOver?.(event)
+  }
+
+  handleDragLeave = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    clearTimeout(this.removeDragOverClassTimeout)
+    // Timeout against flickering, this solution is taken from drag-drop library.
+    // Solution with 'pointer-events: none' didn't work across browsers.
+    this.removeDragOverClassTimeout = setTimeout(() => {
+      this.setPluginState({ isDraggingOver: false })
+    }, 50)
+
+    this.opts.onDragLeave?.(event)
+  }
+
+  handleDrop = async (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    clearTimeout(this.removeDragOverClassTimeout)
+
+    // Remove dragover class
+    this.setPluginState({ isDraggingOver: false })
+
+    const logDropError = (error) => {
+      this.uppy.log(error, 'error')
+    }
+
+    // Add all dropped files
+    const files = await getDroppedFiles(event.dataTransfer, { logDropError })
+    if (files.length > 0) {
+      this.uppy.log('[Mini] Files dropped')
+      this.addFiles(files)
+    }
+
+    this.opts.onDrop?.(event)
+  }
+
+  renderHiddenFileInput () {
+    const { restrictions } = this.uppy.opts
+    return (
+      <input
+        className="uppy-mini-hiddenInput"
+        type="file"
+        hidden
+        ref={(ref) => { this.fileInputRef = ref }}
+        name={this.opts.inputName}
+        multiple={restrictions.maxNumberOfFiles !== 1}
+        accept={restrictions.allowedFileTypes}
+        onChange={this.onInputChange}
+      />
+    )
+  }
+
+  handleSelectChange = (ev) => {
+    const selected = ev.target.value
+    if (selected === 'myDevice') {
+      this.fileInputRef.click()
+      return
+    }
+    const dashboard = this.uppy.getPlugin('Dashboard')
+    dashboard.showPanel(selected)
+    dashboard.openModal()
+  }
+
+  toggleSourcesDropdown = () => {
+    this.sourcesDropdown.toggleAttribute('hidden')
+    this.sourcesDropdown.toggleAttribute('aria-expanded')
+  }
+
+  renderSelectControl = () => {
+    return (
+      <>
+        Drag & drop or
+        {' '}
+        <button
+          type="button"
+          class="uppy-u-reset uppy-Mini-browse"
+          onClick={this.toggleSourcesDropdown}
+        >
+          Browse...
+        </button>
+      </>
+    )
+  }
+
+  renderSourcesDropdown () {
+    const dashboard = this.uppy.getPlugin('Dashboard')
+    const dashboardPlugins = dashboard
+      .getPluginState().targets
+      .filter(plugin => plugin.type === 'acquirer')
+      .map(plugin => {
+        const { icon } = this.uppy.getPlugin(plugin.id)
+        return {
+          ...plugin,
+          icon: icon || dashboard.opts.defaultPickerIcon,
+        }
+      })
+
+    return (
+      <div
+        class="uppy-Mini-sources"
+        hidden="true"
+        aria-haspopup="true"
+        ref={(dom) => { this.sourcesDropdown = dom }}
+      >
+        <ul class="uppy-u-reset uppy-Mini-sourcesList">
+          <li class="uppy-u-reset">
+            <button
+              class="uppy-u-reset"
+              type="button"
+              value="myDevice"
+              onClick={this.handleSelectChange}
+            >
+              {myDeviceIcon}
+              My Device
+            </button>
+          </li>
+          {dashboardPlugins.map(plugin => {
+            return (
+              <li class="uppy-u-reset">
+                <button
+                  class="uppy-u-reset"
+                  type="button"
+                  value={plugin.id}
+                  onClick={this.handleSelectChange}
+                >
+                  {plugin.icon()}
+                  {plugin.name}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    )
+  }
+
+  renderSelected (files, complete) {
+    const singleFile = () => {
+      const file = files[0]
+      return (
+        <>
+          {/* eslint-disable-next-line jsx-a11y/alt-text */}
+          <img src={file.preview} width="40" />
+          <span class="uppy-Mini-selectedName">{file.name}</span>
+        </>
+      )
+    }
+
+    const multipleFiles = () => {
+      const fileNames = files.map(file => file.name.substring(0, 15)).join(', ')
+      const filesWithPreviewElements = files.map(file => {
+        /* eslint-disable-next-line jsx-a11y/alt-text */
+        return <img src={file.preview} width="40" />
+      })
+      return (
+        <>
+          {filesWithPreviewElements}
+          <span class="uppy-Mini-selectedName">{files.length} files: {fileNames}</span>
+        </>
+      )
+    }
+
+    return (
+      <div class="uppy-Mini-selected">
+        {files.length === 1
+          ? singleFile()
+          : multipleFiles()}
+        {' '}
+        {!complete && (
+          <button
+            type="button"
+            class="uppy-u-reset btn-close uppy-Mini-remove"
+            onClick={() => this.uppy.cancelAll()}
+          >
+            Remove
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  renderProgress = (totalProgress) => {
+    const complete = totalProgress === 100
+    return (
+      <div
+        class={`uppy-Mini-progress ${complete ? 'uppy-Mini-progress--complete' : ''}`}
+        style={{ width: `${totalProgress}%` }}
+      />
+    )
+  }
+
+  render = () => {
+    const files = this.uppy.getFiles()
+    const { totalProgress } = this.uppy.getState()
+    const complete = totalProgress === 100
+
+    return (
+      <div
+        onDragOver={this.handleDragOver}
+        onDragLeave={this.handleDragLeave}
+        onDrop={this.handleDrop}
+        class={`uppy-Mini ${complete ? 'uppy-Mini--complete' : ''}`}
+      >
+        <div class="uppy-Mini-bar">
+          {files.length === 0 && this.renderSelectControl()}
+          {this.renderHiddenFileInput()}
+          {files.length !== 0 && this.renderSelected(files, complete)}
+          {this.renderProgress(totalProgress)}
+        </div>
+        {files.length === 0 && this.renderSourcesDropdown()}
+      </div>
+    )
+  }
+
+  install () {
+    const { target } = this.opts
+
+    if (target) {
+      this.mount(target, this)
+    }
+
+    // document.addEventListener('click', (ev) => {
+    //   if (ev.target !== this.sourcesDropdown && !this.sourcesDropdown.hidden) {
+    //     this.toggleSourcesDropdown()
+    //   }
+    // })
+
+    this.uppy.on('dashboard:hide-all-panels', () => {
+      const dashboard = this.uppy.getPlugin('Dashboard')
+      dashboard.closeModal()
+    })
+  }
+
+  uninstall () {
+    this.unmount()
+  }
+}

--- a/packages/@uppy/mini/src/index.js
+++ b/packages/@uppy/mini/src/index.js
@@ -1,0 +1,1 @@
+export { default } from './Mini.jsx'

--- a/packages/@uppy/mini/src/locale.js
+++ b/packages/@uppy/mini/src/locale.js
@@ -1,0 +1,5 @@
+export default {
+  strings: {
+
+  },
+}

--- a/packages/@uppy/mini/src/style.scss
+++ b/packages/@uppy/mini/src/style.scss
@@ -1,0 +1,161 @@
+@import '@uppy/core/src/_utils.scss';
+@import '@uppy/core/src/_variables.scss';
+
+.uppy-Mini {
+  position: relative;
+  display: inline-block;
+}
+
+  .uppy-Mini--complete .uppy-Mini-bar {
+    color: #fff;
+    border: 1px solid transparent;
+  }
+
+.uppy-Mini-bar {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgb(224, 224, 224);
+  padding: 9px 14px;
+  border-radius: 10px;
+  display: inline-block;
+}
+
+.uppy-Mini-progress {
+  position: absolute;
+  height: 100%;
+  top: 0;
+  left: 0;
+  transition: all .2s;
+  background: linear-gradient(-15deg, #0974f1 0%, #9fccfa 100% );  
+  opacity: 0.7;
+  z-index: 5;
+}
+
+  .uppy-Mini-progress--complete {
+    // background: linear-gradient(-15deg, #ccff33 0%, #004b23 100%);
+    background: #65A30D;
+  }
+
+.uppy-Mini-browse {
+  display: inline-block;
+  color: inherit;
+  cursor: pointer;
+  border-bottom: 1px solid #ccc;
+}
+
+.uppy-Mini-remove {
+  cursor: pointer;
+  position: relative;
+  left: 5px;
+}
+
+.uppy-Mini-selected {
+  display: flex;
+  align-items: center;
+  position: relative;
+  z-index: 10;
+}
+
+.uppy-Mini-selected img {
+  margin-right: 8px;
+  border-radius: 5px;
+  height: 30px;
+  object-fit: cover;
+}
+
+.uppy-Mini-selectedName {
+  font-size: 0.8em;
+  line-height: 1.3;
+  max-width: 320px;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 6px;
+}
+
+.uppy-Mini-sources {
+  display: block;
+  width: 180px;
+  height: 250px;
+  overflow: hidden;
+  background-color: $white;
+  border-radius: 10px;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  position: absolute;
+  top: 35px;
+  left: 50%;
+  font-size: 12px;
+  z-index: 15;
+}
+
+.uppy-Mini-sources li {
+  display: block;
+  font-size: 10px;
+}
+
+.uppy-Mini-sourcesList {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.uppy-Mini-sourcesList::-webkit-scrollbar {
+  display: none;
+}
+
+.uppy-Mini-sources li:hover {
+  background-color: rgb(226, 226, 226);
+}
+
+.uppy-Mini-sources button {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  padding: 8px;
+}
+
+.uppy-Mini-sources svg {
+  width: 15px;
+  height: 15px;
+  margin-right: 5px;
+}
+
+.btn-close {
+	overflow: hidden;
+	position: relative;
+	border: none;
+	padding: 0;
+	width: 1em; 
+  height: 1em;
+	border-radius: 50%;
+	background: rgb(0, 0, 0, 0.8);
+	color: #fff;
+	font: inherit;
+	text-indent: 100%;
+	cursor: pointer;
+	
+	&:focus {
+		outline: solid 0 transparent;
+		box-shadow: 0 0 0 2px #8ed0f9;
+	}
+	
+	&:hover {
+    background: rgb(0, 0, 0, 1);
+	}
+	
+	&:before, &:after {
+		position: absolute;
+		top: 18%; 
+    left: calc(50% - .05em);
+		width: .085em; 
+    height: 60%;
+		border-radius: .125em;
+		transform: rotate(45deg);
+		background: currentcolor;
+		content: ''
+	}
+	
+	&:after { transform: rotate(-45deg); }
+}

--- a/packages/uppy/src/style.scss
+++ b/packages/uppy/src/style.scss
@@ -12,3 +12,5 @@
 @import '@uppy/screen-capture/src/style.scss';
 @import '@uppy/image-editor/src/style.scss';
 @import '@uppy/drop-target/src/style.scss';
+@import '@uppy/mini/src/style.scss';
+

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -16,6 +16,8 @@ import ImageEditor from '@uppy/image-editor'
 import DropTarget from '@uppy/drop-target'
 import Audio from '@uppy/audio'
 import Compressor from '@uppy/compressor'
+import Mini from '@uppy/mini'
+
 /* eslint-enable import/no-extraneous-dependencies */
 
 import generateSignatureIfSecret from './generateSignatureIfSecret.js'
@@ -41,7 +43,7 @@ console.log(import.meta.env)
 
 const RESTORE = false
 
-async function getAssemblyOptions () {
+async function getAssemblyOptions (file) {
   return generateSignatureIfSecret(TRANSLOADIT_SECRET, {
     auth: {
       key: TRANSLOADIT_KEY,
@@ -49,6 +51,9 @@ async function getAssemblyOptions () {
     // It's more secure to use a template_id and enable
     // Signature Authentication
     template_id: TRANSLOADIT_TEMPLATE,
+    fields: {
+      id: file.id,
+    },
   })
 }
 
@@ -75,6 +80,10 @@ export default () => {
       showProgressDetails: true,
       proudlyDisplayPoweredByUppy: true,
       note: '2 files, images and video only',
+      autoOpenFileEditor: true,
+    })
+    .use(Mini, {
+      target: '#mini-here',
     })
     // .use(GoogleDrive, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
     // .use(Instagram, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
@@ -171,6 +180,6 @@ export default () => {
     }
   })
 
-  const modalTrigger = document.querySelector('#pick-files')
-  if (modalTrigger) modalTrigger.click()
+  // const modalTrigger = document.querySelector('#pick-files')
+  // if (modalTrigger) modalTrigger.click()
 }

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -1,20 +1,20 @@
 // The @uppy/ dependencies are resolved from source
 /* eslint-disable import/no-extraneous-dependencies */
 import Uppy, { debugLogger } from '@uppy/core'
-import Dashboard from '@uppy/dashboard'
-import RemoteSources from '@uppy/remote-sources'
-import Webcam from '@uppy/webcam'
-import ScreenCapture from '@uppy/screen-capture'
+// import Dashboard from '@uppy/dashboard'
+// import RemoteSources from '@uppy/remote-sources'
+// import Webcam from '@uppy/webcam'
+// import ScreenCapture from '@uppy/screen-capture'
 import GoldenRetriever from '@uppy/golden-retriever'
 import Tus from '@uppy/tus'
 import AwsS3 from '@uppy/aws-s3'
 import AwsS3Multipart from '@uppy/aws-s3-multipart'
 import XHRUpload from '@uppy/xhr-upload'
 import Transloadit from '@uppy/transloadit'
-import Form from '@uppy/form'
-import ImageEditor from '@uppy/image-editor'
+// import Form from '@uppy/form'
+// import ImageEditor from '@uppy/image-editor'
 import DropTarget from '@uppy/drop-target'
-import Audio from '@uppy/audio'
+// import Audio from '@uppy/audio'
 import Compressor from '@uppy/compressor'
 import Mini from '@uppy/mini'
 
@@ -26,7 +26,7 @@ import generateSignatureIfSecret from './generateSignatureIfSecret.js'
 const {
   VITE_UPLOADER : UPLOADER,
   VITE_COMPANION_URL : COMPANION_URL,
-  VITE_COMPANION_ALLOWED_HOSTS : companionAllowedHosts,
+  // VITE_COMPANION_ALLOWED_HOSTS : companionAllowedHosts,
   VITE_TUS_ENDPOINT : TUS_ENDPOINT,
   VITE_XHR_ENDPOINT : XHR_ENDPOINT,
   VITE_TRANSLOADIT_KEY : TRANSLOADIT_KEY,
@@ -69,21 +69,22 @@ export default () => {
     allowMultipleUploadBatches: false,
     // restrictions: { requiredMetaFields: ['caption'] },
   })
-    .use(Dashboard, {
-      trigger: '#pick-files',
-      // inline: true,
-      target: '.foo',
-      metaFields: [
-        { id: 'license', name: 'License', placeholder: 'specify license' },
-        { id: 'caption', name: 'Caption', placeholder: 'add caption' },
-      ],
-      showProgressDetails: true,
-      proudlyDisplayPoweredByUppy: true,
-      note: '2 files, images and video only',
-      autoOpenFileEditor: true,
-    })
+    // .use(Dashboard, {
+    //   trigger: '#pick-files',
+    //   // inline: true,
+    //   target: '.foo',
+    //   metaFields: [
+    //     { id: 'license', name: 'License', placeholder: 'specify license' },
+    //     { id: 'caption', name: 'Caption', placeholder: 'add caption' },
+    //   ],
+    //   showProgressDetails: true,
+    //   proudlyDisplayPoweredByUppy: true,
+    //   note: '2 files, images and video only',
+    //   autoOpenFileEditor: true,
+    // })
     .use(Mini, {
       target: '#mini-here',
+      sources: ['Audio'],
     })
     // .use(GoogleDrive, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
     // .use(Instagram, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
@@ -94,23 +95,23 @@ export default () => {
     // .use(Zoom, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
     // .use(Url, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
     // .use(Unsplash, { target: Dashboard, companionUrl: COMPANION_URL, companionAllowedHosts })
-    .use(RemoteSources, {
-      companionUrl: COMPANION_URL,
-      sources: ['Box', 'Dropbox', 'Facebook', 'GoogleDrive', 'Instagram', 'OneDrive', 'Unsplash', 'Zoom', 'Url'],
-      companionAllowedHosts,
-    })
-    .use(Webcam, {
-      target: Dashboard,
-      showVideoSourceDropdown: true,
-      showRecordingLength: true,
-    })
-    .use(Audio, {
-      target: Dashboard,
-      showRecordingLength: true,
-    })
-    .use(ScreenCapture, { target: Dashboard })
-    .use(Form, { target: '#upload-form' })
-    .use(ImageEditor, { target: Dashboard })
+    // .use(RemoteSources, {
+    //   companionUrl: COMPANION_URL,
+    //   sources: ['Box', 'Dropbox', 'Facebook', 'GoogleDrive', 'Instagram', 'OneDrive', 'Unsplash', 'Zoom', 'Url'],
+    //   companionAllowedHosts,
+    // })
+    // .use(Webcam, {
+    //   target: Dashboard,
+    //   showVideoSourceDropdown: true,
+    //   showRecordingLength: true,
+    // })
+    // .use(Audio, {
+    //   target: Dashboard,
+    //   showRecordingLength: true,
+    // })
+    // .use(ScreenCapture, { target: Dashboard })
+    // .use(Form, { target: '#upload-form' })
+    // .use(ImageEditor, { target: Dashboard })
     .use(DropTarget, {
       target: document.body,
     })

--- a/private/dev/index.html
+++ b/private/dev/index.html
@@ -4,51 +4,80 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Dashboard</title>
-    <style>
-      main {
-        padding-top: 100px;
-        text-align: center;
-      }
-
-      #upload-form {
-        max-width: 400px;
-        text-align: left;
-        margin: auto;
-      }
-
-      button,
-      input {
-        color: green;
-        font-size: 30px;
-        text-align: right;
-        border: 2px solid purple;
-      }
-
-      /* css to make sure that Dashboard's css overrides page css */
-      ul {
-        margin: 60px;
-      }
-      li {
-        margin: 60px;
-      }
-      a {
-        color: purple;
-      }
-    </style>
+    <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
   </head>
 
   <body>
-    <main class="foo">
-      <h1>Dashboard is here</h1>
+    <main class="foo" style="max-width: 800px; margin: 50px auto;">
+    <div>
+      <div class="md:grid md:grid-cols-3 md:gap-6">
+        <div class="md:col-span-1">
+          <div class="px-4 sm:px-0">
+            <h3 class="text-lg font-medium leading-6 text-gray-900"><h1>Mars Ares 8 Application</h1></h3>
+            <p class="mt-1 text-sm text-gray-600">This information will be displayed publicly so be careful what you share.</p>
+          </div>
+          <img style="margin-top: 30px;" src="https://images.unsplash.com/photo-1614935981447-893ce3858657?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=80">
+        </div>
+        <div class="mt-5 md:col-span-2 md:mt-0">
+          <form action="#" method="POST">
+            <div class="shadow sm:overflow-hidden sm:rounded-md">
+              <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
+                <div>
+                  <label for="about" class="block text-sm font-medium text-gray-700">About</label>
+                  <div class="mt-1">
+                    <textarea id="about" name="about" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" placeholder="you@example.com"></textarea>
+                  </div>
+                  <p class="mt-2 text-sm text-gray-500">In a few paragraphs, explain why you would be the best fit to explore Mars</p>
+                </div>
 
+                <div>
+                  <label class="block text-sm font-medium text-gray-700">Photo</label>
+                  <div class="mt-1 flex items-center">
+                    <div id="mini-here"></div>
+                  </div>
+                </div>
+
+                <div>
+                  <label class="block text-sm font-medium text-gray-700">Cover photo</label>
+                  <div class="mt-1 flex justify-center rounded-md border-2 border-dashed border-gray-300 px-6 pt-5 pb-6">
+                    <div class="space-y-1 text-center">
+                      <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                        <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                      <div class="flex text-sm text-gray-600">
+                        <label for="file-upload" class="relative cursor-pointer rounded-md bg-white font-medium text-indigo-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:text-indigo-500">
+                          <span>Upload a file</span>
+                          <input id="file-upload" name="file-upload" type="file" class="sr-only">
+                        </label>
+                        <p class="pl-1">or drag and drop</p>
+                      </div>
+                      <p class="text-xs text-gray-500">PNG, JPG, GIF up to 10MB</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="bg-gray-50 px-4 py-3 text-right sm:px-6">
+                <button 
+                  type="button" 
+                  class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                  onclick="window.uppy.upload()">Save</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+   
       <!-- some inputs in a form to check focus management in Dashboard -->
-      <form id="upload-form" action="/">
+      <!-- <form id="upload-form" action="/">
         <button type="button" id="pick-files">Pick Files</button><br>
         True ? <input type="checkbox" name="check_test" value="1" checked><br>
         Something: <input type="text" name="yo" value="1"><br>
         <input type="hidden" name="bla" value="12333"><br>
         <button type="submit">Submit</button>
-      </form>
+      </form> -->
     </main>
 
     <script src="./index.js" type="module"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8611,6 +8611,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@uppy/mini@workspace:packages/@uppy/mini":
+  version: 0.0.0-use.local
+  resolution: "@uppy/mini@workspace:packages/@uppy/mini"
+  dependencies:
+    "@uppy/utils": "workspace:^"
+    preact: ^10.5.13
+  peerDependencies:
+    "@uppy/core": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@uppy/onedrive@workspace:^, @uppy/onedrive@workspace:packages/@uppy/onedrive":
   version: 0.0.0-use.local
   resolution: "@uppy/onedrive@workspace:packages/@uppy/onedrive"


### PR DESCRIPTION
A prototype for a new plugin that acts as (a replacement for) file input + drag-drop, allows direct access to Dashboard’s sources (Webcam, Instagram) shows selected file names/sizes/previews and simple progress. Mini does not require Dashboard, it can act as plain drag and drop + local file picker. If Dashboard is present, Mini dropdown will show all of it’s sources as a tidy list and jump directly to the plugin you select.

(Cover photo area in the form is unrelated, just part of the demo form).

![Screenshot from 2022-11-18 15-16-40](https://user-images.githubusercontent.com/1199054/202773126-550f7c72-ce81-4d50-9bba-f2212cdf4342.png)

![Screenshot from 2022-11-18 15-17-43](https://user-images.githubusercontent.com/1199054/202773168-245e329b-4d5c-4d21-89b1-5fc3c491a8b2.png)

[Screencast from 2022-11-18 14-39-24.webm](https://user-images.githubusercontent.com/1199054/202773199-345692f7-2fb8-444b-b290-5113992a6a1c.webm)

[Screencast from 2022-11-18 15-15-39.webm](https://user-images.githubusercontent.com/1199054/202773327-e5bf0856-7791-4c69-abe1-7c162ab63136.webm)

Test locally:

```sh
git checkout uppy-mini
yarn && yarn dev
```
