### PR TITLE
Update @uppy/audio Readme

### DIFF
--- a/packages/@uppy/audio/README.md
+++ b/packages/@uppy/audio/README.md
@@ -12,7 +12,7 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 
 ```js
 import Uppy from '@uppy/core'
-import Webcam from '@uppy/audio'
+import Audio from '@uppy/audio'
 
 const uppy = new Uppy()
 uppy.use(Audio)


### PR DESCRIPTION
Export should be named `Audio`, reflecting later usage