### PR TITLE
meta: upgrade to Vite 4 and ESBuild 0.16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ VITE_UPLOADER=tus
 
 VITE_COMPANION_URL=http://localhost:3020
 # See also Transloadit.COMPANION_PATTERN
-VITE_COMPANION_ALLOWED_HOSTS=/\.transloadit\.com$/
+VITE_COMPANION_ALLOWED_HOSTS="/\.transloadit\.com\$/"
 VITE_TUS_ENDPOINT=https://tusd.tusdemo.net/files/
 VITE_XHR_ENDPOINT=https://xhr-server.herokuapp.com/upload
 

--- a/examples/aws-companion/package.json
+++ b/examples/aws-companion/package.json
@@ -18,7 +18,7 @@
     "express": "^4.18.1",
     "express-session": "^1.17.3",
     "npm-run-all": "^4.1.5",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "engines": {

--- a/examples/aws-php/package.json
+++ b/examples/aws-php/package.json
@@ -8,7 +8,7 @@
     "uppy": "workspace:*"
   },
   "devDependencies": {
-    "esbuild": "^0.15.1"
+    "esbuild": "^0.16.1"
   },
   "private": true,
   "type": "module",

--- a/examples/custom-provider/package.json
+++ b/examples/custom-provider/package.json
@@ -21,7 +21,7 @@
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "npm-run-all": "^4.1.2",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/digitalocean-spaces/package.json
+++ b/examples/digitalocean-spaces/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "dotenv": "^16.0.1",
     "express": "^4.16.2",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/multiple-instances/package.json
+++ b/examples/multiple-instances/package.json
@@ -8,7 +8,7 @@
     "@uppy/golden-retriever": "workspace:*"
   },
   "devDependencies": {
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/node-xhr/package.json
+++ b/examples/node-xhr/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.3",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/php-xhr/package.json
+++ b/examples/php-xhr/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.3",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/python-xhr/package.json
+++ b/examples/python-xhr/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.3",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^2.0.0",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   }
 }

--- a/examples/transloadit-markdown-bin/package.json
+++ b/examples/transloadit-markdown-bin/package.json
@@ -13,7 +13,7 @@
     "marked": "^4.0.18"
   },
   "devDependencies": {
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/examples/transloadit/package.json
+++ b/examples/transloadit/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "devDependencies": {
     "npm-run-all": "^4.1.5",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "dependencies": {
     "@uppy/core": "workspace:*",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -17,7 +17,7 @@
     "vue": "^2.6.14"
   },
   "devDependencies": {
-    "vite": "^3.0.0",
+    "vite": "^4.0.0",
     "vite-plugin-vue2": "^2.0.1",
     "vue-template-compiler": "^2.6.14"
   }

--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^3.0.0",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   }
 }

--- a/examples/xhr-bundle/package.json
+++ b/examples/xhr-bundle/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "core-js": "~3.24.0",
     "cssnano": "^5.0.6",
     "dotenv": "^16.0.0",
-    "esbuild": "^0.15.1",
+    "esbuild": "^0.16.1",
     "esbuild-plugin-babel": "^0.2.3",
     "eslint": "^8.0.0",
     "eslint-config-transloadit": "^2.0.0",

--- a/private/dev/package.json
+++ b/private/dev/package.json
@@ -13,7 +13,7 @@
     "autoprefixer": "^10.2.6",
     "postcss-dir-pseudo-class": "^6.0.0",
     "postcss-logical": "^5.0.0",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   },
   "private": true,
   "type": "module",

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "chalk": "2.4.2",
     "cssnano": "^5.0.6",
     "drag-drop": "^4.2.0",
-    "esbuild": "^0.15.3",
+    "esbuild": "^0.16.1",
     "esbuild-plugin-alias": "^0.2.1",
     "esbuild-plugin-babel": "^0.2.3",
     "glob": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,6 +2741,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/android-arm64@npm:0.16.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/android-arm@npm:0.16.3"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/android-x64@npm:0.16.3"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/darwin-arm64@npm:0.16.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/darwin-x64@npm:0.16.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/freebsd-arm64@npm:0.16.3"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/freebsd-x64@npm:0.16.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-arm64@npm:0.16.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-arm@npm:0.16.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-ia32@npm:0.16.3"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.14.54":
   version: 0.14.54
   resolution: "@esbuild/linux-loong64@npm:0.14.54"
@@ -2755,10 +2825,87 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "@esbuild/linux-loong64@npm:0.15.6"
+"@esbuild/linux-loong64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-loong64@npm:0.16.3"
   conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-mips64el@npm:0.16.3"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-ppc64@npm:0.16.3"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-riscv64@npm:0.16.3"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-s390x@npm:0.16.3"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/linux-x64@npm:0.16.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/netbsd-x64@npm:0.16.3"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/openbsd-x64@npm:0.16.3"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/sunos-x64@npm:0.16.3"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/win32-arm64@npm:0.16.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/win32-ia32@npm:0.16.3"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@esbuild/win32-x64@npm:0.16.3"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -7777,7 +7924,7 @@ __metadata:
     core-js: ~3.24.0
     cssnano: ^5.0.6
     dotenv: ^16.0.0
-    esbuild: ^0.15.1
+    esbuild: ^0.16.1
     esbuild-plugin-babel: ^0.2.3
     eslint: ^8.0.0
     eslint-config-transloadit: ^2.0.0
@@ -7832,7 +7979,7 @@ __metadata:
     autoprefixer: ^10.2.6
     postcss-dir-pseudo-class: ^6.0.0
     postcss-logical: ^5.0.0
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -7955,7 +8102,7 @@ __metadata:
     express: ^4.18.1
     express-session: ^1.17.3
     npm-run-all: ^4.1.5
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -7977,7 +8124,7 @@ __metadata:
     "@uppy/aws-s3": "workspace:*"
     "@uppy/core": "workspace:*"
     "@uppy/dashboard": "workspace:*"
-    esbuild: ^0.15.1
+    esbuild: ^0.16.1
     uppy: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -8020,7 +8167,7 @@ __metadata:
     express-session: ^1.15.6
     npm-run-all: ^4.1.2
     preact: ^10.5.13
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8035,7 +8182,7 @@ __metadata:
     cors: ^2.8.5
     dotenv: ^16.0.1
     express: ^4.16.2
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8046,7 +8193,7 @@ __metadata:
     "@uppy/core": "workspace:*"
     "@uppy/dashboard": "workspace:*"
     "@uppy/golden-retriever": "workspace:*"
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8060,7 +8207,7 @@ __metadata:
     "@uppy/xhr-upload": "workspace:*"
     formidable: ^3.2.4
     npm-run-all: ^4.1.3
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8073,7 +8220,7 @@ __metadata:
     "@uppy/webcam": "workspace:*"
     "@uppy/xhr-upload": "workspace:*"
     npm-run-all: ^4.1.3
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8086,7 +8233,7 @@ __metadata:
     "@uppy/webcam": "workspace:*"
     "@uppy/xhr-upload": "workspace:*"
     npm-run-all: ^4.1.3
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8125,7 +8272,7 @@ __metadata:
     "@vitejs/plugin-react": ^2.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8189,7 +8336,7 @@ __metadata:
     "@uppy/transloadit": "workspace:*"
     "@uppy/webcam": "workspace:*"
     marked: ^4.0.18
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8209,7 +8356,7 @@ __metadata:
     express: ^4.16.4
     he: ^1.2.0
     npm-run-all: ^4.1.5
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8236,7 +8383,7 @@ __metadata:
     "@uppy/progress-bar": "workspace:*"
     "@uppy/transloadit": "workspace:*"
     "@uppy/vue": "workspace:*"
-    vite: ^3.0.0
+    vite: ^4.0.0
     vite-plugin-vue2: ^2.0.1
     vue: ^2.6.14
     vue-template-compiler: ^2.6.14
@@ -8254,7 +8401,7 @@ __metadata:
     "@uppy/tus": "workspace:*"
     "@uppy/vue": "workspace:*"
     "@vitejs/plugin-vue": ^3.0.0
-    vite: ^3.0.0
+    vite: ^4.0.0
     vue: ^3.2.33
   languageName: unknown
   linkType: soft
@@ -8270,7 +8417,7 @@ __metadata:
     express: ^4.16.4
     multer: ^1.4.1
     npm-run-all: ^4.1.5
-    vite: ^3.0.0
+    vite: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -15659,13 +15806,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-android-64@npm:0.15.6"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-android-arm64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-android-arm64@npm:0.14.54"
@@ -15676,13 +15816,6 @@ __metadata:
 "esbuild-android-arm64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-android-arm64@npm:0.15.5"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-android-arm64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-android-arm64@npm:0.15.6"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -15701,13 +15834,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-darwin-64@npm:0.15.6"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-darwin-arm64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-darwin-arm64@npm:0.14.54"
@@ -15718,13 +15844,6 @@ __metadata:
 "esbuild-darwin-arm64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-darwin-arm64@npm:0.15.5"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-darwin-arm64@npm:0.15.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -15743,13 +15862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-freebsd-64@npm:0.15.6"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-freebsd-arm64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-freebsd-arm64@npm:0.14.54"
@@ -15760,13 +15872,6 @@ __metadata:
 "esbuild-freebsd-arm64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-freebsd-arm64@npm:0.15.5"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-freebsd-arm64@npm:0.15.6"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -15785,13 +15890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-32@npm:0.15.6"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "esbuild-linux-64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-linux-64@npm:0.14.54"
@@ -15802,13 +15900,6 @@ __metadata:
 "esbuild-linux-64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-linux-64@npm:0.15.5"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-64@npm:0.15.6"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -15827,13 +15918,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-arm64@npm:0.15.6"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "esbuild-linux-arm@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-linux-arm@npm:0.14.54"
@@ -15844,13 +15928,6 @@ __metadata:
 "esbuild-linux-arm@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-linux-arm@npm:0.15.5"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-arm@npm:0.15.6"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -15869,13 +15946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-mips64le@npm:0.15.6"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
 "esbuild-linux-ppc64le@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-linux-ppc64le@npm:0.14.54"
@@ -15886,13 +15956,6 @@ __metadata:
 "esbuild-linux-ppc64le@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-linux-ppc64le@npm:0.15.5"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-ppc64le@npm:0.15.6"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -15911,13 +15974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-riscv64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-riscv64@npm:0.15.6"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
 "esbuild-linux-s390x@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-linux-s390x@npm:0.14.54"
@@ -15928,13 +15984,6 @@ __metadata:
 "esbuild-linux-s390x@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-linux-s390x@npm:0.15.5"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-s390x@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-linux-s390x@npm:0.15.6"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -15953,13 +16002,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-netbsd-64@npm:0.15.6"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-openbsd-64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-openbsd-64@npm:0.14.54"
@@ -15970,13 +16012,6 @@ __metadata:
 "esbuild-openbsd-64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-openbsd-64@npm:0.15.5"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-openbsd-64@npm:0.15.6"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -16007,13 +16042,6 @@ __metadata:
 "esbuild-sunos-64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-sunos-64@npm:0.15.5"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-sunos-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-sunos-64@npm:0.15.6"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -16050,13 +16078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-windows-32@npm:0.15.6"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "esbuild-windows-64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-windows-64@npm:0.14.54"
@@ -16071,13 +16092,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-windows-64@npm:0.15.6"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-windows-arm64@npm:0.14.54":
   version: 0.14.54
   resolution: "esbuild-windows-arm64@npm:0.14.54"
@@ -16088,13 +16102,6 @@ __metadata:
 "esbuild-windows-arm64@npm:0.15.5":
   version: 0.15.5
   resolution: "esbuild-windows-arm64@npm:0.15.5"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.15.6":
-  version: 0.15.6
-  resolution: "esbuild-windows-arm64@npm:0.15.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -16173,7 +16180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.14.0, esbuild@npm:^0.14.47":
+"esbuild@npm:^0.14.0":
   version: 0.14.54
   resolution: "esbuild@npm:0.14.54"
   dependencies:
@@ -16247,77 +16254,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.15.1, esbuild@npm:^0.15.3":
-  version: 0.15.6
-  resolution: "esbuild@npm:0.15.6"
+"esbuild@npm:^0.16.1, esbuild@npm:^0.16.3":
+  version: 0.16.3
+  resolution: "esbuild@npm:0.16.3"
   dependencies:
-    "@esbuild/linux-loong64": 0.15.6
-    esbuild-android-64: 0.15.6
-    esbuild-android-arm64: 0.15.6
-    esbuild-darwin-64: 0.15.6
-    esbuild-darwin-arm64: 0.15.6
-    esbuild-freebsd-64: 0.15.6
-    esbuild-freebsd-arm64: 0.15.6
-    esbuild-linux-32: 0.15.6
-    esbuild-linux-64: 0.15.6
-    esbuild-linux-arm: 0.15.6
-    esbuild-linux-arm64: 0.15.6
-    esbuild-linux-mips64le: 0.15.6
-    esbuild-linux-ppc64le: 0.15.6
-    esbuild-linux-riscv64: 0.15.6
-    esbuild-linux-s390x: 0.15.6
-    esbuild-netbsd-64: 0.15.6
-    esbuild-openbsd-64: 0.15.6
-    esbuild-sunos-64: 0.15.6
-    esbuild-windows-32: 0.15.6
-    esbuild-windows-64: 0.15.6
-    esbuild-windows-arm64: 0.15.6
+    "@esbuild/android-arm": 0.16.3
+    "@esbuild/android-arm64": 0.16.3
+    "@esbuild/android-x64": 0.16.3
+    "@esbuild/darwin-arm64": 0.16.3
+    "@esbuild/darwin-x64": 0.16.3
+    "@esbuild/freebsd-arm64": 0.16.3
+    "@esbuild/freebsd-x64": 0.16.3
+    "@esbuild/linux-arm": 0.16.3
+    "@esbuild/linux-arm64": 0.16.3
+    "@esbuild/linux-ia32": 0.16.3
+    "@esbuild/linux-loong64": 0.16.3
+    "@esbuild/linux-mips64el": 0.16.3
+    "@esbuild/linux-ppc64": 0.16.3
+    "@esbuild/linux-riscv64": 0.16.3
+    "@esbuild/linux-s390x": 0.16.3
+    "@esbuild/linux-x64": 0.16.3
+    "@esbuild/netbsd-x64": 0.16.3
+    "@esbuild/openbsd-x64": 0.16.3
+    "@esbuild/sunos-x64": 0.16.3
+    "@esbuild/win32-arm64": 0.16.3
+    "@esbuild/win32-ia32": 0.16.3
+    "@esbuild/win32-x64": 0.16.3
   dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
     "@esbuild/linux-loong64":
       optional: true
-    esbuild-android-64:
+    "@esbuild/linux-mips64el":
       optional: true
-    esbuild-android-arm64:
+    "@esbuild/linux-ppc64":
       optional: true
-    esbuild-darwin-64:
+    "@esbuild/linux-riscv64":
       optional: true
-    esbuild-darwin-arm64:
+    "@esbuild/linux-s390x":
       optional: true
-    esbuild-freebsd-64:
+    "@esbuild/linux-x64":
       optional: true
-    esbuild-freebsd-arm64:
+    "@esbuild/netbsd-x64":
       optional: true
-    esbuild-linux-32:
+    "@esbuild/openbsd-x64":
       optional: true
-    esbuild-linux-64:
+    "@esbuild/sunos-x64":
       optional: true
-    esbuild-linux-arm:
+    "@esbuild/win32-arm64":
       optional: true
-    esbuild-linux-arm64:
+    "@esbuild/win32-ia32":
       optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-linux-riscv64:
-      optional: true
-    esbuild-linux-s390x:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
+    "@esbuild/win32-x64":
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: e351cd5647311aa857fa30fb3fa7055b39d7c82ebd96a7abd2657e42e62b5960aeb1dd9466ba97699ab1a1fbc0f0217b26b266fe5e9301590855c53b3133282f
+  checksum: c2986b0433c6048b917c185067ea42427413ef4136c45012e180e48fc24e6f01af9c94ca7e9bc6dd29ac529af45d26c9d4eb5b8639c9a79f68f337d24aeda2af
   languageName: node
   linkType: hard
 
@@ -29073,6 +29083,17 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 62782723a385f92b7525f66d29614624de7c5643855423db3a5efd9287e677650300192749adddbbb6734cea9b1d5f5fd4f6ea00ca3f9a95dbbb88f835f5ca64
+  languageName: node
+  linkType: hard
+
 "posthtml-parser@npm:^0.10.1":
   version: 0.10.2
   resolution: "posthtml-parser@npm:0.10.2"
@@ -31436,20 +31457,6 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"rollup@npm:>=2.75.6 <2.77.0 || ~2.77.0":
-  version: 2.77.3
-  resolution: "rollup@npm:2.77.3"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: b179c68249584565ddb5664a241e8e48c293b2207718d885b08ee25797d98857a383f06b544bb89819407da5a71557f4713309a278f61c4778bb32b1d3321a1c
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^2.45.1, rollup@npm:^2.60.2, rollup@npm:^2.70.2":
   version: 2.78.1
   resolution: "rollup@npm:2.78.1"
@@ -31461,6 +31468,20 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   bin:
     rollup: dist/bin/rollup
   checksum: 9034814383ca5bdb4bea6d499270aeb31cdb0bb884f81b0c6a1d19c63cc973f040e6ee09b7af8a7169dd231c090f4b44ef8b99c4bfdf884aceeb3dcefb8cfa14
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "rollup@npm:3.7.0"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 9a407469cd25e1255fb5a5956eff53ff963c90ffba949ec81ea8104d1271e1ce377c28231078d96c2d14a8a9727a06d1d2421f3db4d11b74d46cbcc2a02c3768
   languageName: node
   linkType: hard
 
@@ -35745,7 +35766,7 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
     chalk: 2.4.2
     cssnano: ^5.0.6
     drag-drop: ^4.2.0
-    esbuild: ^0.15.3
+    esbuild: ^0.16.1
     esbuild-plugin-alias: ^0.2.1
     esbuild-plugin-babel: ^0.2.3
     glob: ^7.2.0
@@ -36289,35 +36310,41 @@ hexo-filter-github-emojis@arturi/hexo-filter-github-emojis:
   languageName: node
   linkType: hard
 
-"vite@npm:^3.0.0":
-  version: 3.0.9
-  resolution: "vite@npm:3.0.9"
+"vite@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "vite@npm:4.0.0"
   dependencies:
-    esbuild: ^0.14.47
+    esbuild: ^0.16.3
     fsevents: ~2.3.2
-    postcss: ^8.4.16
+    postcss: ^8.4.19
     resolve: ^1.22.1
-    rollup: ">=2.75.6 <2.77.0 || ~2.77.0"
+    rollup: ^3.7.0
   peerDependencies:
+    "@types/node": ">= 14"
     less: "*"
     sass: "*"
     stylus: "*"
+    sugarss: "*"
     terser: ^5.4.0
   dependenciesMeta:
     fsevents:
       optional: true
   peerDependenciesMeta:
+    "@types/node":
+      optional: true
     less:
       optional: true
     sass:
       optional: true
     stylus:
       optional: true
+    sugarss:
+      optional: true
     terser:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 6341aa43579ae45f8a383bdc0c5041dea3dff98f14e0a546d6d884a864134b00082246a28d1de8adff0ce0dd92b468c7ade8f972ffe1ed97258671d63e0f16f7
+  checksum: 83099d5033fa5580714641df3cda16579ec104b9f3d447c2cf3208105ef2e6f8573267fbe3bdc93c0e51a70830d4d30bc166767c9f8805b1075a405625471930
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Note that Uppy devs will probably have to update their `.env` file to escape `$` chars.