### PR TITLE
@uppy/xhr-upload: add `'upload-stalled'` event

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -972,6 +972,19 @@ class Uppy {
       }
     })
 
+    let uploadStalledWarningRecentlyEmitted
+    this.on('upload-stalled', (error, files) => {
+      const { message } = error
+      const details = files.map(file => file.meta.name).join(', ')
+      if (!uploadStalledWarningRecentlyEmitted) {
+        this.info({ message, details }, 'warning', this.opts.infoTimeout)
+        uploadStalledWarningRecentlyEmitted = setTimeout(() => {
+          uploadStalledWarningRecentlyEmitted = null
+        }, this.opts.infoTimeout)
+      }
+      this.log(`${message} ${details}`.trim(), 'warning')
+    })
+
     this.on('upload', () => {
       this.setState({ error: null })
     })

--- a/packages/@uppy/locales/src/fr_FR.js
+++ b/packages/@uppy/locales/src/fr_FR.js
@@ -125,6 +125,7 @@ fr_FR.strings = {
   uploadComplete: 'Téléchargement terminé',
   uploadFailed: 'Le téléchargement a échoué',
   uploadPaused: 'Téléchargement mis en pause',
+  uploadStalled: 'Téléchargement bloqué depuis %{seconds} secondes. Il est peut-être nécessaire de recommencer l\'opération.',
   uploadXFiles: {
     '0': 'Télécharger %{smart_count} fichier',
     '1': 'Télécharger %{smart_count} fichiers',

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -230,8 +230,8 @@ export default class XHRUpload extends BasePlugin {
       let queuedRequest
 
       const timer = new ProgressTimeout(opts.timeout, () => {
-        const error = new Error(this.i18n('timedOut', { seconds: Math.ceil(opts.timeout / 1000) }))
-        this.uppy.emit('upload-stalled', file, error)
+        const error = new Error(this.i18n('uploadStalled', { seconds: Math.ceil(opts.timeout / 1000) }))
+        this.uppy.emit('upload-stalled', error, file)
       })
 
       const id = nanoid()
@@ -513,10 +513,8 @@ export default class XHRUpload extends BasePlugin {
       }
 
       const timer = new ProgressTimeout(this.opts.timeout, () => {
-        xhr.abort()
-        const error = new Error(this.i18n('timedOut', { seconds: Math.ceil(this.opts.timeout / 1000) }))
-        emitError(error)
-        reject(error)
+        const error = new Error(this.i18n('uploadStalled', { seconds: Math.ceil(this.opts.timeout / 1000) }))
+        this.uppy.emit('upload-stalled', error)
       })
 
       xhr.upload.addEventListener('loadstart', () => {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -231,7 +231,7 @@ export default class XHRUpload extends BasePlugin {
 
       const timer = new ProgressTimeout(opts.timeout, () => {
         const error = new Error(this.i18n('uploadStalled', { seconds: Math.ceil(opts.timeout / 1000) }))
-        this.uppy.emit('upload-stalled', error, file)
+        this.uppy.emit('upload-stalled', error, [file])
       })
 
       const id = nanoid()
@@ -514,7 +514,7 @@ export default class XHRUpload extends BasePlugin {
 
       const timer = new ProgressTimeout(this.opts.timeout, () => {
         const error = new Error(this.i18n('uploadStalled', { seconds: Math.ceil(this.opts.timeout / 1000) }))
-        this.uppy.emit('upload-stalled', error)
+        this.uppy.emit('upload-stalled', error, files)
       })
 
       xhr.upload.addEventListener('loadstart', () => {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -230,11 +230,8 @@ export default class XHRUpload extends BasePlugin {
       let queuedRequest
 
       const timer = new ProgressTimeout(opts.timeout, () => {
-        xhr.abort()
-        queuedRequest.done()
         const error = new Error(this.i18n('timedOut', { seconds: Math.ceil(opts.timeout / 1000) }))
-        this.uppy.emit('upload-error', file, error)
-        reject(error)
+        this.uppy.emit('upload-stalled', file, error)
       })
 
       const id = nanoid()

--- a/packages/@uppy/xhr-upload/src/locale.js
+++ b/packages/@uppy/xhr-upload/src/locale.js
@@ -1,6 +1,6 @@
 export default {
   strings: {
     // Shown in the Informer if an upload is being canceled because it stalled for too long.
-    timedOut: 'Upload stalled for %{seconds} seconds, aborting.',
+    uploadStalled: 'Upload has not made any progress for %{seconds} seconds. You may want to retry it.',
   },
 }

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -946,6 +946,11 @@ uppy.on('upload-error', (file, error, response) => {
 })
 ```
 
+### `upload-stalled`
+
+Fired when an upload is seemingly stalled. Use this event to display a message
+on the UI to tell the user they might want to retry the upload.
+
 ### `upload-retry`
 
 Fired when an upload has been retried (after an error, for example).

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -954,7 +954,7 @@ Fired when an upload is seemingly stalled. Use this event to display a message o
 uppy.on('upload-stalled', () => {
   uppy.info(`Your upload "${file.meta.name}" has not made any progress for ${timeout} seconds. You may want to retry it.`, 'warning')
   uppy.once('progress', () => {
-    stallWarning.hidden = true
+    uppy.info('The upload is no longer stalled')
   })
 })
 ```

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -952,14 +952,14 @@ Fired when an upload has not received any progress in some time (in `@uppy/xhr-u
 
 ```js
 uppy.on('upload-stalled', (error, files) => {
-  console.log(error, files)
-  const uploadProgressHandler = (file) => {
+  console.log('upload seems stalled', error, files)
+  const noLongerStalledEventHandler = (file) => {
     if (files.includes(file)) {
-      uppy.info('The upload is no longer stalled')
-      uppy.off('upload-progress', uploadProgressHandler)
+      console.log('upload is no longer stalled')
+      uppy.off('upload-progress', noLongerStalledEventHandler)
     }
   }
-  uppy.on('upload-progress', uploadProgressHandler)
+  uppy.on('upload-progress', noLongerStalledEventHandler)
 })
 ```
 

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -952,7 +952,7 @@ Fired when an upload is seemingly stalled. Use this event to display a message o
 
 ```js
 uppy.on('upload-stalled', () => {
-  stallWarning.hidden = false
+  uppy.info(`Your upload "${file.meta.name}" has not made any progress for ${timeout} seconds. You may want to retry it.`, 'warning')
   uppy.once('progress', () => {
     stallWarning.hidden = true
   })

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -950,6 +950,15 @@ uppy.on('upload-error', (file, error, response) => {
 
 Fired when an upload is seemingly stalled. Use this event to display a message on the UI to tell the user they might want to retry the upload.
 
+```js
+uppy.on('upload-stalled', () => {
+  stallWarning.hidden = false
+  uppy.once('progress', () => {
+    stallWarning.hidden = true
+  })
+})
+```
+
 ### `upload-retry`
 
 Fired when an upload has been retried (after an error, for example).

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -948,8 +948,7 @@ uppy.on('upload-error', (file, error, response) => {
 
 ### `upload-stalled`
 
-Fired when an upload is seemingly stalled. Use this event to display a message
-on the UI to tell the user they might want to retry the upload.
+Fired when an upload is seemingly stalled. Use this event to display a message on the UI to tell the user they might want to retry the upload.
 
 ### `upload-retry`
 

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -951,11 +951,15 @@ uppy.on('upload-error', (file, error, response) => {
 Fired when an upload is seemingly stalled. Use this event to display a message on the UI to tell the user they might want to retry the upload.
 
 ```js
-uppy.on('upload-stalled', () => {
-  uppy.info(`Your upload "${file.meta.name}" has not made any progress for ${timeout} seconds. You may want to retry it.`, 'warning')
-  uppy.once('progress', () => {
-    uppy.info('The upload is no longer stalled')
-  })
+uppy.on('upload-stalled', (error, files) => {
+  console.log(error, files)
+  const uploadProgressHandler = (file) => {
+    if (files.includes(file)) {
+      uppy.info('The upload is no longer stalled')
+      uppy.off('upload-progress', uploadProgressHandler)
+    }
+  }
+  uppy.on('upload-progress', uploadProgressHandler)
 })
 ```
 

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -948,7 +948,7 @@ uppy.on('upload-error', (file, error, response) => {
 
 ### `upload-stalled`
 
-Fired when an upload is seemingly stalled. Use this event to display a message on the UI to tell the user they might want to retry the upload.
+Fired when an upload has not received any progress in some time (in `@uppy/xhr-upload`, the delay is defined by the `timeout` option). Use this event to display a message on the UI to tell the user they might want to retry the upload.
 
 ```js
 uppy.on('upload-stalled', (error, files) => {

--- a/website/src/docs/xhr-upload.md
+++ b/website/src/docs/xhr-upload.md
@@ -209,10 +209,12 @@ function getResponseError (responseText, response) {
 
 The field name containing a publically accessible location of the uploaded file in the response data returned by [`getResponseData()`](#getResponseData-responseText-response).
 
-### `timeout: 30 * 1000`
+### `timeout: 30_000`
 
-When no upload progress events have been received for this amount of milliseconds, assume the connection has an issue and abort the upload.
-Note that unlike the [`XMLHttpRequest.timeout`][XHR.timeout] property, this is a timer between progress events: the total upload can take longer than this value.
+When no upload progress events have been received for this amount of
+milliseconds, send a `'upload-stalled'` event.
+Note that unlike the [`XMLHttpRequest.timeout`][XHR.timeout] property, this is a
+timer between progress events: the total upload can take longer than this value.
 Set to `0` to disable this check.
 
 The default for the timeout is 30 seconds.

--- a/website/src/docs/xhr-upload.md
+++ b/website/src/docs/xhr-upload.md
@@ -211,10 +211,8 @@ The field name containing a publically accessible location of the uploaded file 
 
 ### `timeout: 30_000`
 
-When no upload progress events have been received for this amount of
-milliseconds, send a `'upload-stalled'` event.
-Note that unlike the [`XMLHttpRequest.timeout`][XHR.timeout] property, this is a
-timer between progress events: the total upload can take longer than this value.
+When no upload progress events have been received for this amount of milliseconds, send a `'upload-stalled'` event.
+Note that unlike the [`XMLHttpRequest.timeout`][XHR.timeout] property, this is a timer between progress events: the total upload can take longer than this value.
 Set to `0` to disable this check.
 
 The default for the timeout is 30 seconds.


### PR DESCRIPTION
Instead of cancelling the upload, let's give the user control over what to do when a stalling is detected.

The stall detection was added in https://github.com/transloadit/uppy/pull/378, but using a hard-coded time limit is probably not a good idea.