### PR TITLE
Fix getSpeed type (referenced `bytesTotal` instead of `uploadStarted`)

### DIFF
--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -189,8 +189,8 @@ declare module '@uppy/utils/lib/getSocketHost' {
 
 declare module '@uppy/utils/lib/getSpeed' {
   function getSpeed (progress: {
-    bytesTotal: number
     bytesUploaded: number
+    uploadStarted: number
   }): number
   export default getSpeed
 }


### PR DESCRIPTION
Was pulling my hair out while passing `bytesTotal` (as requested by the type definition) and was getting `NaN` back as a result 😅 (see https://github.com/transloadit/uppy/blob/b8e1f9c995a365fd8ee042fe66944a3f425091b7/packages/%40uppy/utils/src/getSpeed.test.js for correct usage)