### PR TITLE
@uppy/companion: deprecate `RequestClient` options

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.test.js
+++ b/packages/@uppy/companion-client/src/RequestClient.test.js
@@ -4,8 +4,8 @@ import RequestClient from './RequestClient.js'
 describe('RequestClient', () => {
   it('has a hostname without trailing slash', () => {
     const mockCore = { getState: () => ({}) }
-    const a = new RequestClient(mockCore, { companionUrl: 'http://companion.uppy.io' })
-    const b = new RequestClient(mockCore, { companionUrl: 'http://companion.uppy.io/' })
+    const a = new RequestClient(mockCore, { backendURL: 'http://companion.uppy.io' })
+    const b = new RequestClient(mockCore, { backendURL: 'http://companion.uppy.io/' })
 
     expect(a.hostname).toBe('http://companion.uppy.io')
     expect(b.hostname).toBe('http://companion.uppy.io')

--- a/packages/@uppy/companion-client/types/index.d.ts
+++ b/packages/@uppy/companion-client/types/index.d.ts
@@ -13,9 +13,16 @@ export interface TokenStorage {
 type CompanionHeaders = Record<string, string>
 
 export interface RequestClientOptions {
+  /** @deprecated use `backendURL` instead. */
   companionUrl: string
+  /** @deprecated use `backendHeaders` instead. */
   companionHeaders?: CompanionHeaders
+  /** @deprecated use `backendCookiesRule` instead. */
   companionCookiesRule?: RequestCredentials
+
+  backendURL: string
+  backendHeaders?: CompanionHeaders
+  backendCookiesRule?: RequestCredentials
 }
 
 type RequestOptions = {


### PR DESCRIPTION
Deprecate `RequestClient` options in favor of less Companion-centered ones so this class can be reused in non-Companion setup.