### PR TITLE
@uppy/aws-s3-multipart: fix metadata shape

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -318,7 +318,7 @@ export default class AwsS3Multipart extends BasePlugin {
     const metadata = file.meta ? Object.fromEntries(
       (this.opts.allowedMetaFields ?? Object.keys(file.meta))
         .filter(key => file.meta[key] != null)
-        .map(key => [`metadata[${key}]`, String(file.meta[key])]),
+        .map(key => [key, String(file.meta[key])]),
     ) : {}
 
     return this.#client.post('s3/multipart', {


### PR DESCRIPTION
Currently, the shape of the metadata property makes Companion crash.