### PR TITLE
ci: make sure Yarn's global cache is disabled

### DIFF
--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   isolate_uppy:
-    name: Isolate Uppy package
+    name: Isolate Uppy packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -15,6 +15,9 @@ on:
       - '.github/**'
       - '!.github/workflows/bundlers.yml'
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   isolate_uppy:
     name: Isolate Uppy package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ on:
       - '.github/**'
       - '!.github/workflows/ci.yml'
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   unit_tests:
     name: Unit tests

--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -11,6 +11,9 @@ on:
       - 'packages/@uppy/companion/**'
       - '.github/workflows/companion-deploy.yml'
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   npm:
     name: Generate npm tarball

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -14,6 +14,9 @@ on:
       - 'packages/@uppy/companion/**'
       - '.github/workflows/companion.yml'
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   test:
     name: Unit tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,9 @@ on:
 
 concurrency: ${{ github.workflow }}--${{ github.ref }}
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   e2e:
     if: ${{ !github.event.pull_request || (contains(github.event.pull_request.labels.*.name, 'safe to test') && github.event.pull_request.state == 'open') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.event_name != 'labeled') }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,9 @@ on:
       - '.github/**'
       - '!.github/workflows/linters.yml'
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   lint_js:
     name: Lint JavaScript/TypeScript

--- a/.github/workflows/lockile_check.yml
+++ b/.github/workflows/lockile_check.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - yarn.lock
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   lint_lockfile:
     name: Lint yarn.lock

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -7,6 +7,9 @@ on:
         required: true
         default: "uppy"
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: release
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   prepare-release:
     name: Prepare release candidate Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   release:
     name: Publish releases
@@ -43,10 +46,10 @@ jobs:
         run: corepack yarn run build
       - name: Hack to allow the publish of the Angular package
         run: corepack yarn workspace @uppy/angular prepublishOnly
-      - name: Login to NPM
-        run: corepack yarn config set npmAuthToken ${{ toJSON(secrets.NPM_TOKEN) }}
-      - name: Publish to NPM
+      - name: Publish to the npm registry
         run: corepack yarn workspaces foreach --no-private npm publish --access public --tolerate-republish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Merge PR
         id: merge
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/website.yml'
   workflow_dispatch:
 
+env:
+  YARN_ENABLE_GLOBAL_CACHE: false
+
 jobs:
   deploy:
     name: Deploy


### PR DESCRIPTION
Yarn v4 enables global caching by default, using a local cache simplifies the use of @actions/cache.
Also simplifies the publish to npm step.