### PR TITLE
Prevent submitting outer form when enter is pressed in Url/Unsplash plugin 

### DIFF
--- a/packages/@uppy/provider-views/src/SearchProviderView/InputView.jsx
+++ b/packages/@uppy/provider-views/src/SearchProviderView/InputView.jsx
@@ -9,6 +9,7 @@ export default ({ i18n, search }) => {
   }
   const handleKeyPress = (ev) => {
     if (ev.keyCode === 13) {
+      ev.preventDefault()
       validateAndSearch()
     }
   }
@@ -20,7 +21,7 @@ export default ({ i18n, search }) => {
         type="search"
         aria-label={i18n('enterTextToSearch')}
         placeholder={i18n('enterTextToSearch')}
-        onKeyUp={handleKeyPress}
+        onKeyDown={handleKeyPress}
         ref={(input_) => { input = input_ }}
         data-uppy-super-focusable
       />

--- a/packages/@uppy/url/src/UrlUI.jsx
+++ b/packages/@uppy/url/src/UrlUI.jsx
@@ -7,6 +7,7 @@ class UrlUI extends Component {
 
   #handleKeyPress = (ev) => {
     if (ev.keyCode === 13) {
+      ev.preventDefault()
       this.#handleSubmit()
     }
   }
@@ -26,7 +27,7 @@ class UrlUI extends Component {
           type="text"
           aria-label={i18n('enterUrlToImport')}
           placeholder={i18n('enterUrlToImport')}
-          onKeyUp={this.#handleKeyPress}
+          onKeyDown={this.#handleKeyPress}
           ref={(input) => { this.input = input }}
           data-uppy-super-focusable
         />


### PR DESCRIPTION
Related: https://github.com/transloadit/uppy.io/issues/51

Problem: when Uppy Dashboard is wrapped in an outer `<form>`, pressing `enter` on inputs inside Uppy submits that outer form, instead of confirming the input inside Uppy. This PR seems to resolve it in my tests.

Is there some use case where actual form and submit event would be better, does handling `enter` key not cut it?