### PR TITLE
Warn more instead of erroring

### DIFF
--- a/packages/@uppy/audio/src/Audio.jsx
+++ b/packages/@uppy/audio/src/Audio.jsx
@@ -215,7 +215,7 @@ export default class Audio extends UIPlugin {
     } catch (err) {
       // Logging the error, exept restrictions, which is handled in Core
       if (!err.isRestriction) {
-        this.uppy.log(err, 'error')
+        this.uppy.log(err, 'warning')
       }
     }
   }

--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -372,7 +372,7 @@ class Uppy {
       this.emit('error', error)
     }
     this.info({ message, details }, 'error', this.opts.infoTimeout)
-    this.log(`${message} ${details}`.trim(), 'error')
+    this.log(error, 'warning')
   }
 
   validateRestrictions (file, files = this.getFiles()) {

--- a/packages/@uppy/dashboard/src/Dashboard.jsx
+++ b/packages/@uppy/dashboard/src/Dashboard.jsx
@@ -407,10 +407,7 @@ export default class Dashboard extends UIPlugin {
     // Emits first event on initialization.
     this.resizeObserver = new ResizeObserver((entries) => {
       const uppyDashboardInnerEl = entries[0]
-
       const { width, height } = uppyDashboardInnerEl.contentRect
-
-      this.uppy.log(`[Dashboard] resized: ${width} / ${height}`, 'debug')
 
       this.setPluginState({
         containerWidth: width,
@@ -430,7 +427,7 @@ export default class Dashboard extends UIPlugin {
         // and it's not due to the modal being closed
         && !isModalAndClosed
       ) {
-        this.uppy.log("[Dashboard] resize event didn't fire on time: defaulted to mobile layout", 'debug')
+        this.uppy.log('[Dashboard] resize event didn’t fire on time: defaulted to mobile layout', 'warning')
 
         this.setPluginState({
           areInsidesReadyToBeVisible: true,

--- a/packages/@uppy/screen-capture/src/ScreenCapture.jsx
+++ b/packages/@uppy/screen-capture/src/ScreenCapture.jsx
@@ -85,7 +85,7 @@ export default class ScreenCapture extends UIPlugin {
 
   install () {
     if (!isScreenRecordingSupported()) {
-      this.uppy.log('Screen recorder access is not supported', 'error')
+      this.uppy.log('Screen recorder access is not supported', 'warning')
       return null
     }
 
@@ -192,8 +192,8 @@ export default class ScreenCapture extends UIPlugin {
       .catch((err) => {
         if (err.name === 'NotAllowedError') {
           this.uppy.info(this.i18n('micDisabled'), 'error', 5000)
+          this.uppy.log(this.i18n('micDisabled'), 'warning')
         }
-
         return false
       })
   }
@@ -316,7 +316,7 @@ export default class ScreenCapture extends UIPlugin {
     } catch (err) {
       // Logging the error, exept restrictions, which is handled in Core
       if (!err.isRestriction) {
-        this.uppy.log(err, 'error')
+        this.uppy.log(err, 'warning')
       }
     }
   }


### PR DESCRIPTION
On Transloadit, we see a ton of errors such as “Screen recorder access is not supported”, which should actually be warnings.

Also because we were sometimes not logging the original error, but `{ message, details }`, the stack trace was lost.

![image](https://user-images.githubusercontent.com/1199054/216726978-0e0ee4d6-6be1-4141-a950-193014404df6.png)
