### PR TITLE
uppy/image-editor: Fix TypeScript error in image-editor types

### DIFF
--- a/packages/@uppy/image-editor/types/index.d.ts
+++ b/packages/@uppy/image-editor/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { PluginOptions, UIPlugin, PluginTarget, UppyFile } from '@uppy/core'
+import type { PluginOptions, UIPlugin, PluginTarget, UppyFile, IndexedObject } from '@uppy/core'
 import type Cropper from 'cropperjs'
 import ImageEditorLocale from './generatedLocale'
 
@@ -32,12 +32,12 @@ export default ImageEditor
 
 // Events
 
-export type FileEditorStartCallback<TMeta> = (file: UppyFile<TMeta>) => void;
-export type FileEditorCompleteCallback<TMeta> = (updatedFile: UppyFile<TMeta>) => void;
-export type FileEditorCancelCallback<TMeta> = (file: UppyFile<TMeta>) => void;
+export type FileEditorStartCallback<TMeta extends IndexedObject<any>> = (file: UppyFile<TMeta>) => void;
+export type FileEditorCompleteCallback<TMeta extends IndexedObject<any>> = (updatedFile: UppyFile<TMeta>) => void;
+export type FileEditorCancelCallback<TMeta extends IndexedObject<any>> = (file: UppyFile<TMeta>) => void;
 
 declare module '@uppy/core' {
-  export interface UppyEventMap<TMeta> {
+  export interface UppyEventMap<TMeta extends IndexedObject<any>> {
     'file-editor:start' : FileEditorStartCallback<TMeta>
     'file-editor:complete': FileEditorCompleteCallback<TMeta>
     'file-editor:cancel': FileEditorCancelCallback<TMeta>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16807587/221374036-32bca682-2703-4ece-963f-0e325e92f89d.png)

Reported by TypeScript >= 4.8, see [TypeScript 4.8 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#unconstrained-generics-no-longer-assignable-to-).

Currently using `skipLibCheck` as a workaround.

Amends issue #4053 and PR #4048.