### PR TITLE
Include uppy id when emitting cancel-all event

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -807,7 +807,7 @@ class Uppy {
   }
 
   cancelAll ({ reason = 'user' } = {}) {
-    this.emit('cancel-all', { reason })
+    this.emit('cancel-all', { id: this.opts['id'], reason })
 
     // Only remove existing uploads if user is canceling
     if (reason === 'user') {

--- a/website/src/docs/core.md
+++ b/website/src/docs/core.md
@@ -1004,6 +1004,13 @@ Fired when “info” message should be hidden in the UI. See [`info-visible`](#
 
 Fired when [`uppy.cancelAll()`]() is called, all uploads are canceled, files removed and progress is reset.
 
+```javascript
+uppy.on('cancel-all', (event) => {
+  const { id, reason } = event
+  console.log(`uppy id: ${id}, reason: ${reason}`)
+})
+```
+
 ### `restriction-failed`
 
 Fired when a file violates certain restrictions when added. This event is providing another choice for those who want to customize the behavior of file upload restrictions.


### PR DESCRIPTION
When using multiple Uppy instances on a page, sometimes you need to know which Uppy emitted the `cancel-all` event. Include the Uppy `id` in the object that is emitted for this event.