### PR TITLE
@uppy/dashboard: Fix low-contrast hover styles

### DIFF
--- a/packages/@uppy/core/src/_variables.scss
+++ b/packages/@uppy/core/src/_variables.scss
@@ -19,8 +19,8 @@ $beige: #edd4b9 !default;
 
 $gray-50: #fafafa !default;
 $gray-100: #f4f4f4 !default;
-$gray-100--highlighted: #f1f3f6 !default;
 $gray-200: #eaeaea !default;
+$gray-200--highlighted: #e9ecef !default;
 $gray-250: #dfdfdf !default;
 $gray-300: #cfcfcf !default;
 $gray-400: #bbb !default;

--- a/packages/@uppy/dashboard/src/style.scss
+++ b/packages/@uppy/dashboard/src/style.scss
@@ -470,7 +470,7 @@
 }
 
 .uppy-DashboardTab-btn:hover {
-  background-color: $gray-100--highlighted;
+  background-color: $gray-200--highlighted;
 
   [data-uppy-theme="dark"] & {
     background-color: $gray-800;


### PR DESCRIPTION
After modifying the dashboard background, the icon hover styles became barely visible. Fixing it here:

**Before:**

![Screenshot 07-03-2023 at 11 45 30](https://user-images.githubusercontent.com/375537/223400723-00f9dfe7-1cf2-4353-838c-7eacc5bad4dc.gif)

**After:**

![Screenshot 07-03-2023 at 11 45 49](https://user-images.githubusercontent.com/375537/223400731-63106daf-6995-4127-9d61-f0cc8f77cb12.gif)

Full preview:

https://user-images.githubusercontent.com/375537/223401003-1f3ff9ad-1ebd-454d-be38-de82b00fc142.mp4


