### PR TITLE
RateLimitedQueue: fix ‘cannot mark request as done’

### DIFF
--- a/packages/@uppy/companion-client/src/Socket.js
+++ b/packages/@uppy/companion-client/src/Socket.js
@@ -24,6 +24,8 @@ export default class UppySocket {
   [Symbol.for('uppy test: getQueued')] () { return this.#queued }
 
   open () {
+    if (this.#socket != null) return
+
     this.#socket = new WebSocket(this.opts.target)
 
     this.#socket.onopen = () => {
@@ -37,6 +39,7 @@ export default class UppySocket {
 
     this.#socket.onclose = () => {
       this.#isOpen = false
+      this.#socket = null
     }
 
     this.#socket.onmessage = this.#handleMessage

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -496,7 +496,7 @@ export default class Tus extends BasePlugin {
     return new Promise((resolve, reject) => {
       const token = file.serverToken
       const host = getSocketHost(file.remote.companionUrl)
-      const socket = new Socket({ target: `${host}/api/${token}` })
+      const socket = new Socket({ target: `${host}/api/${token}`, autoOpen: false })
       this.uploaderSockets[file.id] = socket
       this.uploaderEvents[file.id] = new EventTracker(this.uppy)
 
@@ -519,8 +519,10 @@ export default class Tus extends BasePlugin {
           // resume a queued upload to make it skip the queue.
           queuedRequest.abort()
           queuedRequest = this.requests.run(() => {
+            socket.open()
             socket.send('resume', {})
-            return () => {}
+
+            return () => socket.close()
           })
         }
       })
@@ -545,8 +547,10 @@ export default class Tus extends BasePlugin {
           socket.send('pause', {})
         }
         queuedRequest = this.requests.run(() => {
+          socket.open()
           socket.send('resume', {})
-          return () => {}
+
+          return () => socket.close()
         })
       })
 
@@ -607,15 +611,17 @@ export default class Tus extends BasePlugin {
       queuedRequest = this.requests.run(() => {
         if (file.isPaused) {
           socket.send('pause', {})
+        } else {
+          socket.open()
         }
 
-        // Don't do anything here, the caller will take care of cancelling the upload itself
+        // Just close the socket here, the caller will take care of cancelling the upload itself
         // using resetUploaderReferences(). This is because resetUploaderReferences() has to be
         // called when this request is still in the queue, and has not been started yet, too. At
         // that point this cancellation function is not going to be called.
         // Also, we need to remove the request from the queue _without_ destroying everything
         // related to this upload to handle pauses.
-        return () => {}
+        return () => socket.close()
       })
     })
   }


### PR DESCRIPTION
- Don’t auto-open socket when adding to the queue; cleanup on abort
- Socket: don't open if already opened

Co-authored-by: Antoine du Hamel <duhamelantoine1995@gmail.com>