### PR TITLE
@uppy/companion: only body parse when needed & increased body size for s3

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -1,4 +1,4 @@
-const router = require('express').Router
+const express = require('express')
 
 module.exports = function s3 (config) {
   if (typeof config.acl !== 'string' && config.acl != null) {
@@ -342,13 +342,13 @@ module.exports = function s3 (config) {
     })
   }
 
-  return router()
+  return express.Router()
     .get('/params', getUploadParameters)
-    .post('/multipart', createMultipartUpload)
+    .post('/multipart', express.json(), createMultipartUpload)
     .get('/multipart/:uploadId', getUploadedParts)
     .get('/multipart/:uploadId/batch', batchSignPartsUpload)
     .get('/multipart/:uploadId/:partNumber', signPartUpload)
-    .post('/multipart/:uploadId/complete', completeMultipartUpload)
+    .post('/multipart/:uploadId/complete', express.json(), completeMultipartUpload)
     .delete('/multipart/:uploadId', abortMultipartUpload)
 }
 

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -348,7 +348,8 @@ module.exports = function s3 (config) {
     .get('/multipart/:uploadId', getUploadedParts)
     .get('/multipart/:uploadId/batch', batchSignPartsUpload)
     .get('/multipart/:uploadId/:partNumber', signPartUpload)
-    .post('/multipart/:uploadId/complete', express.json(), completeMultipartUpload)
+    // limit 1mb because maybe large upload with a lot of parts, see https://github.com/transloadit/uppy/issues/1945
+    .post('/multipart/:uploadId/complete', express.json({ limit: '1mb' }), completeMultipartUpload)
     .delete('/multipart/:uploadId', abortMultipartUpload)
 }
 

--- a/packages/@uppy/companion/src/server/controllers/url.js
+++ b/packages/@uppy/companion/src/server/controllers/url.js
@@ -1,4 +1,4 @@
-const router = require('express').Router
+const express = require('express')
 const validator = require('validator')
 
 const { startDownUpload } = require('../helpers/upload')
@@ -112,6 +112,6 @@ const get = async (req, res) => {
   startDownUpload({ req, res, getSize, download, onUnhandledError })
 }
 
-module.exports = () => router()
-  .post('/meta', meta)
-  .post('/get', get)
+module.exports = () => express.Router()
+  .post('/meta', express.json(), meta)
+  .post('/get', express.json(), get)

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -9,13 +9,22 @@ const getS3Client = require('./s3-client')
 const { getURLBuilder } = require('./helpers/utils')
 
 exports.hasSessionAndProvider = (req, res, next) => {
-  if (!req.session || !req.body) {
-    logger.debug('No session/body attached to req object. Exiting dispatcher.', null, req.id)
+  if (!req.session) {
+    logger.debug('No session attached to req object. Exiting dispatcher.', null, req.id)
     return res.sendStatus(400)
   }
 
   if (!req.companion.provider) {
     logger.debug('No provider/provider-handler found. Exiting dispatcher.', null, req.id)
+    return res.sendStatus(400)
+  }
+
+  return next()
+}
+
+exports.hasBody = (req, res, next) => {
+  if (!req.body) {
+    logger.debug('No body attached to req object. Exiting dispatcher.', null, req.id)
     return res.sendStatus(400)
   }
 

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -2,7 +2,6 @@ const express = require('express')
 const qs = require('node:querystring')
 const helmet = require('helmet')
 const morgan = require('morgan')
-const bodyParser = require('body-parser')
 const { URL } = require('node:url')
 const session = require('express-session')
 const addRequestId = require('express-request-id')()
@@ -95,9 +94,6 @@ module.exports = function server (inputCompanionOptions) {
     }
     return undefined
   })
-
-  router.use(bodyParser.json())
-  router.use(bodyParser.urlencoded({ extended: false }))
 
   // Use helmet to secure Express headers
   router.use(helmet.frameguard())


### PR DESCRIPTION
increase body size for s3 complete endpoint

fixes #1945

also:
[refine body parsers](https://github.com/transloadit/uppy/commit/cc26ecc50242735fa70b43b5c2b54f966227503b) 

to make it possible to adjust them individually, also improves security and speed, because we don't have to parse all body types (and all sizes) for all endpoints