### PR TITLE
@uppy/companion: add missing env variable for standalone option

### DIFF
--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -143,6 +143,7 @@ const getConfigFromEnv = () => {
       ? parseInt(process.env.COMPANION_PERIODIC_PING_COUNT, 10) : undefined,
     filePath: process.env.COMPANION_DATADIR,
     redisUrl: process.env.COMPANION_REDIS_URL,
+    redisPubSubScope: process.env.COMPANION_REDIS_PUBSUB_SCOPE,
     // adding redisOptions to keep all companion options easily visible
     //  redisOptions refers to https://www.npmjs.com/package/redis#options-object-properties
     redisOptions: {},


### PR DESCRIPTION
COMPANION_REDIS_PUBSUB_SCOPE -> redisPubSubScope
docs: https://github.com/transloadit/uppy.io/pull/88