### PR TITLE
@uppy/thumbnail-generator: don't enlarge already small thumbnails

### DIFF
--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -183,17 +183,25 @@ export default class ThumbnailGenerator extends UIPlugin {
       aspect = img.height / img.width
     }
 
+    let targetWidth = width
+    let targetHeight = height
+
+    // Thumbnail shouldn’t be enlarged / upscaled, only reduced.
+    // If img is already smaller than width/height, leave it as is.
+    if (img.width < width) targetWidth = img.width
+    if (img.height < height) targetHeight = img.height
+
     if (width != null) {
       return {
-        width,
-        height: Math.round(width / aspect),
+        width: targetWidth,
+        height: Math.round(targetWidth / aspect),
       }
     }
 
     if (height != null) {
       return {
-        width: Math.round(height * aspect),
-        height,
+        width: Math.round(targetHeight * aspect),
+        height: targetHeight,
       }
     }
 

--- a/packages/@uppy/thumbnail-generator/src/index.js
+++ b/packages/@uppy/thumbnail-generator/src/index.js
@@ -161,6 +161,9 @@ export default class ThumbnailGenerator extends UIPlugin {
 
     return Promise.all([onload, orientationPromise])
       .then(([image, orientation]) => {
+        const originalImageDimensions = { width: image.width, height: image.height }
+        this.uppy.setFileMeta(file.id, { dimensions: originalImageDimensions })
+
         const dimensions = this.getProportionalDimensions(image, targetWidth, targetHeight, orientation.deg)
         const rotatedImage = rotateImage(image, orientation)
         const resizedImage = this.resizeImage(rotatedImage, dimensions.width, dimensions.height)


### PR DESCRIPTION
- Thumbnail shouldn’t be enlarged / upscaled, only reduced. If img is already smaller than width/height, leave it as is. @nqst reported this in https://github.com/transloadit/uppy/pull/4374#pullrequestreview-1361065165
- We have image width/height when we resize for thumbnail, might as well set it as file.meta for Uppy users and us to use in the UI?