### PR TITLE
@uppy/provider-views: Fix range selection not resetting and computing correctly

### DIFF
--- a/packages/@uppy/provider-views/src/Item/components/GridLi.jsx
+++ b/packages/@uppy/provider-views/src/Item/components/GridLi.jsx
@@ -33,6 +33,7 @@ function GridListItem (props) {
         className={checkBoxClassName}
         onChange={toggleCheckbox}
         onKeyDown={recordShiftKeyPress}
+        onMouseDown={recordShiftKeyPress}
         name="listitem"
         id={id}
         checked={isChecked}

--- a/packages/@uppy/provider-views/src/Item/components/ListLi.jsx
+++ b/packages/@uppy/provider-views/src/Item/components/ListLi.jsx
@@ -36,6 +36,7 @@ function ListItem (props) {
           className={`uppy-u-reset uppy-ProviderBrowserItem-checkbox ${isChecked ? 'uppy-ProviderBrowserItem-checkbox--is-checked' : ''}`}
           onChange={toggleCheckbox}
           onKeyDown={recordShiftKeyPress}
+          onMouseDown={recordShiftKeyPress}
           // for the <label/>
           name="listitem"
           id={id}

--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.jsx
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.jsx
@@ -122,6 +122,7 @@ export default class ProviderView extends View {
       this.username = res.username || this.username
       this.#updateFilesAndFolders(res, files, folders)
       this.plugin.setPluginState({ directories: updatedDirectories, filterInput: '' })
+      this.lastCheckbox = undefined
     } catch (err) {
       this.handleError(err)
     } finally {

--- a/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.jsx
+++ b/packages/@uppy/provider-views/src/SearchProviderView/SearchProviderView.jsx
@@ -138,12 +138,13 @@ export default class SearchProviderView extends View {
 
     const targetViewOptions = { ...this.opts, ...viewOptions }
     const { files, folders, filterInput, loading, currentSelection } = this.plugin.getPluginState()
-    const { isChecked, toggleCheckbox, filterItems } = this
+    const { isChecked, toggleCheckbox, filterItems, recordShiftKeyPress } = this
     const hasInput = filterInput !== ''
 
     const browserProps = {
       isChecked,
       toggleCheckbox,
+      recordShiftKeyPress,
       currentSelection,
       files: hasInput ? filterItems(files) : files,
       folders: hasInput ? filterItems(folders) : folders,

--- a/packages/@uppy/provider-views/src/View.js
+++ b/packages/@uppy/provider-views/src/View.js
@@ -123,7 +123,7 @@ export default class View {
     const { folders, files } = this.plugin.getPluginState()
     const items = this.filterItems(folders.concat(files))
     // Shift-clicking selects a single consecutive list of items
-    // starting at the previous click and deselects everything else.
+    // starting at the previous click.
     if (this.lastCheckbox && this.isShiftKeyPressed) {
       const { currentSelection } = this.plugin.getPluginState()
       const prevIndex = items.indexOf(this.lastCheckbox)

--- a/packages/@uppy/provider-views/src/View.js
+++ b/packages/@uppy/provider-views/src/View.js
@@ -125,29 +125,30 @@ export default class View {
     // Shift-clicking selects a single consecutive list of items
     // starting at the previous click and deselects everything else.
     if (this.lastCheckbox && this.isShiftKeyPressed) {
+      const { currentSelection } = this.plugin.getPluginState()
       const prevIndex = items.indexOf(this.lastCheckbox)
       const currentIndex = items.indexOf(file)
-      const currentSelection = (prevIndex < currentIndex)
+      const newSelection = (prevIndex < currentIndex)
         ? items.slice(prevIndex, currentIndex + 1)
         : items.slice(currentIndex, prevIndex + 1)
-      const reducedCurrentSelection = []
+      const reducedNewSelection = []
 
       // Check restrictions on each file in currentSelection,
       // reduce it to only contain files that pass restrictions
-      for (const item of currentSelection) {
+      for (const item of newSelection) {
         const { uppy } = this.plugin
         const restrictionError = uppy.validateRestrictions(
           remoteFileObjToLocal(item),
-          [...uppy.getFiles(), ...reducedCurrentSelection],
+          [...uppy.getFiles(), ...reducedNewSelection],
         )
 
         if (!restrictionError) {
-          reducedCurrentSelection.push(item)
+          reducedNewSelection.push(item)
         } else {
           uppy.info({ message: restrictionError.message }, 'error', uppy.opts.infoTimeout)
         }
       }
-      this.plugin.setPluginState({ currentSelection: reducedCurrentSelection })
+      this.plugin.setPluginState({ currentSelection: [...new Set([...currentSelection, ...reducedNewSelection])] })
       return
     }
 


### PR DESCRIPTION
This PR changes a few things:
- Adds `recordShiftKeyPress` callback to the `mousedown` event in list and grid list items. This currently only tracks the `keydown` event, so when checkboxes receive mouse events (e.g. a click) even without the shift key, the shift key state isn't updated.
- Resets `lastCheckbox` when switching folders. We don't want to track the last checkbox clicked between folders because no range of folders can be computed from that, and that causes shift-clicking on a file in a different folder to fail. 
- Combine existing selection with new selected range. The existing range selection resets any previously selected files, and therefore doesn't support selecting multiple non-overlapping ranges. This concatenates the existing selections with the new range, and removes any duplicates.
- These changes should fix #4322 .