### PR TITLE
@uppy/companion: increase max limits for remote file list operations

### DIFF
--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -85,7 +85,14 @@ class Drive extends Provider {
           // pageSize: The maximum number of files to return per page.
           // Partial or empty result pages are possible even before the end of the files list has been reached.
           // Acceptable values are 1 to 1000, inclusive. (Default: 100)
-          pageSize: 1000,
+          //
+          // @TODO:
+          // SAD WARNING: doesn’t work if you have multiple `fields`, defaults to 100 anyway.
+          // Works if we remove `permissions(role,emailAddress)`, which we use to set the email address
+          // of logged in user in the Provider View header on the frontend.
+          // See https://stackoverflow.com/questions/42592125/list-request-page-size-being-ignored
+          //
+          // pageSize: 1000,
           // pageSize: 10, // can be used for testing pagination if you don't have many files
           orderBy: 'folder,name',
           includeItemsFromAllDrives: true,

--- a/packages/@uppy/companion/src/server/provider/drive/index.js
+++ b/packages/@uppy/companion/src/server/provider/drive/index.js
@@ -82,6 +82,10 @@ class Drive extends Provider {
           fields: DRIVE_FILES_FIELDS,
           pageToken: query.cursor,
           q,
+          // pageSize: The maximum number of files to return per page.
+          // Partial or empty result pages are possible even before the end of the files list has been reached.
+          // Acceptable values are 1 to 1000, inclusive. (Default: 100)
+          pageSize: 1000,
           // pageSize: 10, // can be used for testing pagination if you don't have many files
           orderBy: 'folder,name',
           includeItemsFromAllDrives: true,

--- a/packages/@uppy/companion/src/server/provider/dropbox/index.js
+++ b/packages/@uppy/companion/src/server/provider/dropbox/index.js
@@ -29,7 +29,16 @@ async function list ({ directory, query, token }) {
     return getClient({ token }).post('files/list_folder/continue', { json: { cursor: query.cursor }, responseType: 'json' }).json()
   }
 
-  return getClient({ token }).post('files/list_folder', { searchParams: query, json: { path: `${directory || ''}`, include_non_downloadable_files: false }, responseType: 'json' }).json()
+  return getClient({ token }).post('files/list_folder', {
+    searchParams: query,
+    json: {
+      path: `${directory || ''}`,
+      include_non_downloadable_files: false,
+      // min=1, max=2000 (default: 500): The maximum number of results to return per request.
+      limit: 2000,
+    },
+    responseType: 'json',
+  }).json()
 }
 
 async function userInfo ({ token }) {

--- a/packages/@uppy/companion/test/__tests__/providers.js
+++ b/packages/@uppy/companion/test/__tests__/providers.js
@@ -157,7 +157,7 @@ describe('list provider files', () => {
       kind: 'drive#driveList', drives: [],
     })
 
-    nock('https://www.googleapis.com').get('/drive/v3/files?fields=kind%2CnextPageToken%2CincompleteSearch%2Cfiles%28kind%2Cid%2CimageMediaMetadata%2Cname%2CmimeType%2CownedByMe%2Cpermissions%28role%2CemailAddress%29%2Csize%2CmodifiedTime%2CiconLink%2CthumbnailLink%2CteamDriveId%2CvideoMediaMetadata%2CshortcutDetails%28targetId%2CtargetMimeType%29%29&q=%28%27root%27+in+parents%29+and+trashed%3Dfalse&orderBy=folder%2Cname&includeItemsFromAllDrives=true&supportsAllDrives=true').reply(200, {
+    nock('https://www.googleapis.com').get('/drive/v3/files?fields=kind%2CnextPageToken%2CincompleteSearch%2Cfiles%28kind%2Cid%2CimageMediaMetadata%2Cname%2CmimeType%2CownedByMe%2Cpermissions%28role%2CemailAddress%29%2Csize%2CmodifiedTime%2CiconLink%2CthumbnailLink%2CteamDriveId%2CvideoMediaMetadata%2CshortcutDetails%28targetId%2CtargetMimeType%29%29&q=%28%27root%27+in+parents%29+and+trashed%3Dfalse&pageSize=1000&orderBy=folder%2Cname&includeItemsFromAllDrives=true&supportsAllDrives=true').reply(200, {
       kind: 'drive#fileList',
       nextPageToken: defaults.NEXT_PAGE_TOKEN,
       files: [

--- a/packages/@uppy/companion/test/__tests__/providers.js
+++ b/packages/@uppy/companion/test/__tests__/providers.js
@@ -157,7 +157,7 @@ describe('list provider files', () => {
       kind: 'drive#driveList', drives: [],
     })
 
-    nock('https://www.googleapis.com').get('/drive/v3/files?fields=kind%2CnextPageToken%2CincompleteSearch%2Cfiles%28kind%2Cid%2CimageMediaMetadata%2Cname%2CmimeType%2CownedByMe%2Cpermissions%28role%2CemailAddress%29%2Csize%2CmodifiedTime%2CiconLink%2CthumbnailLink%2CteamDriveId%2CvideoMediaMetadata%2CshortcutDetails%28targetId%2CtargetMimeType%29%29&q=%28%27root%27+in+parents%29+and+trashed%3Dfalse&pageSize=1000&orderBy=folder%2Cname&includeItemsFromAllDrives=true&supportsAllDrives=true').reply(200, {
+    nock('https://www.googleapis.com').get('/drive/v3/files?fields=kind%2CnextPageToken%2CincompleteSearch%2Cfiles%28kind%2Cid%2CimageMediaMetadata%2Cname%2CmimeType%2CownedByMe%2Cpermissions%28role%2CemailAddress%29%2Csize%2CmodifiedTime%2CiconLink%2CthumbnailLink%2CteamDriveId%2CvideoMediaMetadata%2CshortcutDetails%28targetId%2CtargetMimeType%29%29&q=%28%27root%27+in+parents%29+and+trashed%3Dfalse&orderBy=folder%2Cname&includeItemsFromAllDrives=true&supportsAllDrives=true').reply(200, {
       kind: 'drive#fileList',
       nextPageToken: defaults.NEXT_PAGE_TOKEN,
       files: [


### PR DESCRIPTION
...because adding 10k files still takes about 5 minutes (to paginate all files), see discussion here: #4389

advantages:
- adding huge folder as much faster
- listing files is faster when scrolling (when a lot of files), because less `/list` API calls

disadvantages:
- it takes longer to show the user the first list (when a lot of files) and more data will be used (e.g. mobile)

## TODO

- [ ] All other providers?