### PR TITLE
@uppy/aws-s3-multipart: make retries more robust

### DIFF
--- a/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
+++ b/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
@@ -14,4 +14,60 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
     cy.wait(['@post', '@get', '@put'])
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
   })
+
+  it('should handle error gracefully',  () => {
+    cy.get('@file-input').selectFile('cypress/fixtures/images/cat.jpg', { force:true })
+
+    cy.intercept('POST', '/s3/multipart', { forceNetworkError: true, times: 1 }).as('post-fails')
+    cy.get('.uppy-StatusBar-actionBtn--upload').click()
+    cy.wait(['@post-fails'])
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')
+
+    cy.intercept('POST', '/s3/multipart', { statusCode: 200, times: 1, body: JSON.stringify({ key:'mocked-key-example', uploadId:'mocked-uploadId-example' }) }).as('post1')
+    cy.intercept('GET', '/s3/multipart/mocked-uploadId-example/1?key=mocked-key-example', { forceNetworkError: true }).as('get-fails')
+    cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
+    cy.wait(['@post1', '@get-fails'])
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')
+
+    cy.intercept('POST', '/s3/multipart', { statusCode: 200, times: 1, body: JSON.stringify({ key:'mocked-key-example', uploadId:'mocked-new-uploadId-example' }) }).as('post2')
+    cy.intercept('GET', '/s3/multipart/mocked-new-uploadId-example/1?key=mocked-key-example', {
+      statusCode: 200,
+      headers: {
+        ETag: 'W/"222-GXE2wLoMKDihw3wxZFH1APdUjHM"',
+      },
+      body: JSON.stringify({ url:'/fail-put', expires:8 }),
+    }).as('get2')
+    cy.intercept('PUT', '/fail-put', { forceNetworkError: true }).as('put-fails')
+    cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
+    cy.wait(['@post2', '@get2', ...Array(5).fill('@put-fails')], { timeout: 10_000 })
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')
+
+    cy.intercept('GET', '/s3/multipart/mocked-new-uploadId-example/1?key=mocked-key-example', {
+      statusCode: 200,
+      headers: {
+        ETag: 'W/"222-GXE2wLoMKDihw3wxZFH1APdUjHM"',
+      },
+      body: JSON.stringify({ url:'/fail-success', expires:8 }),
+    }).as('get3')
+    cy.intercept('PUT', '/fail-success', {
+      statusCode: 200,
+      headers: {
+        ETag: 'W/"222-GXE2wLoMKDihw3wxZFH1APdUjHM"',
+      },
+    }).as('put3')
+    cy.intercept('POST', '/s3/multipart/mocked-new-uploadId-example/complete?key=mocked-key-example', { forceNetworkError: true}).as('post3')
+    cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
+    cy.wait(['@post2', '@get3', '@put3', '@post3'])
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')
+
+    cy.intercept('POST', '/s3/multipart/mocked-new-uploadId-example/complete?key=mocked-key-example', {
+      statusCode: 200,
+      body: JSON.stringify({
+        location: 'someLocation',
+      }),
+    }).as('post4')
+    cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
+    cy.wait(['@post2', '@get3', '@put3', '@post4'])
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
+  })
 })

--- a/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
+++ b/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
@@ -55,7 +55,7 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
         ETag: 'W/"222-GXE2wLoMKDihw3wxZFH1APdUjHM"',
       },
     }).as('put3')
-    cy.intercept('POST', '/s3/multipart/mocked-new-uploadId-example/complete?key=mocked-key-example', { forceNetworkError: true}).as('post3')
+    cy.intercept('POST', '/s3/multipart/mocked-new-uploadId-example/complete?key=mocked-key-example', { forceNetworkError: true }).as('post3')
     cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
     cy.wait(['@post2', '@get3', '@put3', '@post3'])
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')

--- a/e2e/cypress/support/e2e.ts
+++ b/e2e/cypress/support/e2e.ts
@@ -24,9 +24,3 @@ import './commands'
 import installLogsCollector from  'cypress-terminal-report/src/installLogsCollector.js'
 
 installLogsCollector()
-
-Cypress.on('uncaught:exception', () => {
-  // returning false here prevents Cypress from
-  // failing the test
-  return false
-})

--- a/e2e/cypress/support/e2e.ts
+++ b/e2e/cypress/support/e2e.ts
@@ -26,7 +26,7 @@ import installLogsCollector from  'cypress-terminal-report/src/installLogsCollec
 installLogsCollector()
 
 Cypress.on('uncaught:exception', () => {
-    // returning false here prevents Cypress from
-    // failing the test
-    return false
-  })
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})

--- a/e2e/cypress/support/e2e.ts
+++ b/e2e/cypress/support/e2e.ts
@@ -24,3 +24,9 @@ import './commands'
 import installLogsCollector from  'cypress-terminal-report/src/installLogsCollector.js'
 
 installLogsCollector()
+
+Cypress.on('uncaught:exception', () => {
+    // returning false here prevents Cypress from
+    // failing the test
+    return false
+  })

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -141,6 +141,9 @@ class HTTPCommunicationQueue {
 
   async getUploadId (file, signal) {
     let cachedResult
+    // As the cache is updated asynchronously, there could be a race condition
+    // where we just miss a new result so we loop here until we get nothing back,
+    // at which point it's out turn to create a new cache entry.
     while ((cachedResult = this.#cache.get(file.data)) != null) {
       try {
         return await cachedResult

--- a/packages/@uppy/status-bar/src/Components.jsx
+++ b/packages/@uppy/status-bar/src/Components.jsx
@@ -57,7 +57,7 @@ function RetryBtn (props) {
       type="button"
       className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--retry"
       aria-label={i18n('retryUpload')}
-      onClick={() => uppy.retryAll()}
+      onClick={() => uppy.retryAll().catch(() => { /* Error reported and handled via an event */ })}
       data-uppy-super-focusable
     >
       <svg


### PR DESCRIPTION
When the user clicks retries, we need to have cleared up all the cache regarding the file to retry, otherwise we are likely to target an already expired ID.

Fixes: https://github.com/transloadit/uppy/issues/4366