### PR TITLE
@uppy/xhr-upload: allow to upload multiple files in metaData

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -171,7 +171,9 @@ export default class XHRUpload extends BasePlugin {
       : Object.keys(meta) // Send along all fields by default.
 
     allowedMetaFields.forEach((item) => {
-      formData.append(item, meta[item])
+      Array.isArray(meta[item]) 
+        ? meta[item].forEach(subItem => formData.append(item, subItem)) 
+        : formData.append(item, meta[item]);
     })
   }
 

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -172,8 +172,8 @@ export default class XHRUpload extends BasePlugin {
 
     allowedMetaFields.forEach((item) => {
       if (Array.isArray(meta[item])) {
-        // In this case we don't need to transform `item` as a form value name,
-        // because it is already an array-like variable, for example `item[]` and it won't be overrided
+        // In this case we don't transform `item` to add brackets, it's up to
+        // the user to add the brackets so it won't be overridden.
         meta[item].forEach(subItem => formData.append(item, subItem))
       } else {
         formData.append(item, meta[item])

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -171,9 +171,11 @@ export default class XHRUpload extends BasePlugin {
       : Object.keys(meta) // Send along all fields by default.
 
     allowedMetaFields.forEach((item) => {
-      Array.isArray(meta[item]) 
-        ? meta[item].forEach(subItem => formData.append(item, subItem)) 
-        : formData.append(item, meta[item]);
+      if (Array.isArray(meta[item])) {
+        meta[item].forEach(subItem => formData.append(item, subItem))
+      } else {
+        formData.append(item, meta[item])
+      }
     })
   }
 

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -172,6 +172,8 @@ export default class XHRUpload extends BasePlugin {
 
     allowedMetaFields.forEach((item) => {
       if (Array.isArray(meta[item])) {
+        // In this case we don't need to transform `item` as a form value name,
+        // because it is already an array-like variable, for example `item[]` and it won't be overrided
         meta[item].forEach(subItem => formData.append(item, subItem))
       } else {
         formData.append(item, meta[item])


### PR DESCRIPTION
Currently multiple files send as 
```
field_from_form_for_files[]: [object File],[object File],[object File]
``` 
and it breaks default form behaviour, with this fix it works properly, like
```
field_from_form_for_files[]: (binary)
field_from_form_for_files[]: (binary)
field_from_form_for_files[]: (binary)
```