### PR TITLE
@uppy/aws-s3-multipart: fix `getUploadParameters` option

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -41,8 +41,6 @@ function throwIfAborted (signal) {
 class HTTPCommunicationQueue {
   #abortMultipartUpload
 
-  #allowedMetaFields
-
   #cache = new WeakMap()
 
   #createMultipartUpload
@@ -76,9 +74,6 @@ class HTTPCommunicationQueue {
 
     if ('abortMultipartUpload' in options) {
       this.#abortMultipartUpload = requests.wrapPromiseFunction(options.abortMultipartUpload)
-    }
-    if ('allowedMetaFields' in options) {
-      this.#allowedMetaFields = options.allowedMetaFields
     }
     if ('createMultipartUpload' in options) {
       this.#createMultipartUpload = requests.wrapPromiseFunction(options.createMultipartUpload, { priority:-1 })
@@ -217,17 +212,12 @@ class HTTPCommunicationQueue {
   }
 
   async #nonMultipartUpload (file, chunk, signal) {
-    const { meta } = file
-    const { type, name: filename } = meta
-    const metadata = getAllowedMetadata({ meta, allowedMetaFields: this.#allowedMetaFields, querify: true })
-
-    const query = new URLSearchParams({ filename, type, ...metadata })
     const {
       method = 'post',
       url,
       fields,
       headers,
-    } = await this.#getUploadParameters(`s3/params?${query}`, { signal }).abortOn(signal)
+    } = await this.#getUploadParameters(file, { signal }).abortOn(signal)
 
     const formData = new FormData()
     Object.entries(fields).forEach(([key, value]) => formData.set(key, value))
@@ -344,7 +334,15 @@ export default class AwsS3Multipart extends BasePlugin {
       completeMultipartUpload: this.completeMultipartUpload.bind(this),
       signPart: this.signPart.bind(this),
       uploadPartBytes: AwsS3Multipart.uploadPartBytes,
-      getUploadParameters: (...args) => this.#client.get(...args),
+      getUploadParameters: (file, options) => {
+        const { meta } = file
+        const { type, name: filename } = meta
+        const metadata = getAllowedMetadata({ meta, allowedMetaFields: this.opts.allowedMetaFields, querify: true })
+
+        const query = new URLSearchParams({ filename, type, ...metadata })
+
+        return this.#client.get(`s3/params?${query}`, options)
+      },
       companionHeaders: {},
     }
 
@@ -462,7 +460,7 @@ export default class AwsS3Multipart extends BasePlugin {
       .then(assertServerError)
   }
 
-  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'PUT' }, body, size = body.size, onProgress, onComplete, signal }) {
+  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'POST' }, body, size = body.size, onProgress, onComplete, signal }) {
     throwIfAborted(signal)
 
     if (url == null) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -334,15 +334,7 @@ export default class AwsS3Multipart extends BasePlugin {
       completeMultipartUpload: this.completeMultipartUpload.bind(this),
       signPart: this.signPart.bind(this),
       uploadPartBytes: AwsS3Multipart.uploadPartBytes,
-      getUploadParameters: (file, options) => {
-        const { meta } = file
-        const { type, name: filename } = meta
-        const metadata = getAllowedMetadata({ meta, allowedMetaFields: this.opts.allowedMetaFields, querify: true })
-
-        const query = new URLSearchParams({ filename, type, ...metadata })
-
-        return this.#client.get(`s3/params?${query}`, options)
-      },
+      getUploadParameters: this.getUploadParameters.bind(this),
       companionHeaders: {},
     }
 
@@ -458,6 +450,16 @@ export default class AwsS3Multipart extends BasePlugin {
     const uploadIdEnc = encodeURIComponent(uploadId)
     return this.#client.delete(`s3/multipart/${uploadIdEnc}?key=${filename}`, undefined, { signal })
       .then(assertServerError)
+  }
+
+  getUploadParameters (file, options) {
+    const { meta } = file
+    const { type, name: filename } = meta
+    const metadata = getAllowedMetadata({ meta, allowedMetaFields: this.opts.allowedMetaFields, querify: true })
+
+    const query = new URLSearchParams({ filename, type, ...metadata })
+
+    return this.#client.get(`s3/params?${query}`, options)
   }
 
   static async uploadPartBytes ({ signature: { url, expires, headers, method = 'POST' }, body, size = body.size, onProgress, onComplete, signal }) {

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -462,7 +462,7 @@ export default class AwsS3Multipart extends BasePlugin {
     return this.#client.get(`s3/params?${query}`, options)
   }
 
-  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'POST' }, body, size = body.size, onProgress, onComplete, signal }) {
+  static async uploadPartBytes ({ signature: { url, expires, headers, method = 'PUT' }, body, size = body.size, onProgress, onComplete, signal }) {
     throwIfAborted(signal)
 
     if (url == null) {


### PR DESCRIPTION
The intent was to match the `@uppy/aws-s3` plugin option, and that's what we are documenting as well, however  the implementation was using a different API signature, which would make migrating to the future aggregated S3 plugin more complicated than necessary.