### PR TITLE
@uppy/core: remove `state` getter from types

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -284,8 +284,6 @@ export class Uppy {
 
   getState<TMeta extends IndexedObject<any> = Record<string, unknown>>(): State<TMeta>
 
-  readonly state: State
-
   setFileState(fileID: string, state: Record<string, unknown>): void
 
   resetProgress(): void


### PR DESCRIPTION
The `state` getter was removed a while back, and we forgot to fix the types.

Refs: https://github.com/transloadit/uppy/commit/c042f0220b7637c8294d673c24b2c73e9a089681
Fixes: https://github.com/transloadit/uppy/issues/4090