### PR TITLE
Don't close socket while upload is still in progress

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -734,7 +734,7 @@ export default class AwsS3Multipart extends BasePlugin {
           queuedRequest = this.requests.run(() => {
             socket.open()
             socket.send('resume', {})
-            return () => socket.close()
+            return () => {}
           })
         }
       })
@@ -762,7 +762,7 @@ export default class AwsS3Multipart extends BasePlugin {
           socket.open()
           socket.send('resume', {})
 
-          return () => socket.close()
+          return () => {}
         })
       })
 
@@ -790,6 +790,7 @@ export default class AwsS3Multipart extends BasePlugin {
         this.uppy.emit('upload-error', file, new Error(errData.error))
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
+        socket.close()
         reject(new Error(errData.error))
       })
 
@@ -801,6 +802,7 @@ export default class AwsS3Multipart extends BasePlugin {
         this.uppy.emit('upload-success', file, uploadResp)
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
+        socket.close()
         resolve()
       })
 
@@ -811,7 +813,7 @@ export default class AwsS3Multipart extends BasePlugin {
           socket.open()
         }
 
-        return () => socket.close()
+        return () => {}
       })
     })
   }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -498,8 +498,8 @@ export default class Tus extends BasePlugin {
       let queuedRequest
 
       this.onFileRemove(file.id, () => {
-        queuedRequest.abort()
         socket.send('cancel', {})
+        queuedRequest.abort()
         this.resetUploaderReferences(file.id)
         resolve(`upload ${file.id} was removed`)
       })
@@ -507,8 +507,8 @@ export default class Tus extends BasePlugin {
       this.onPause(file.id, (isPaused) => {
         if (isPaused) {
           // Remove this file from the queue so another file can start in its place.
-          queuedRequest.abort()
           socket.send('pause', {})
+          queuedRequest.abort()
         } else {
           // Resuming an upload should be queued, else you could pause and then
           // resume a queued upload to make it skip the queue.
@@ -523,14 +523,14 @@ export default class Tus extends BasePlugin {
       })
 
       this.onPauseAll(file.id, () => {
-        queuedRequest.abort()
         socket.send('pause', {})
+        queuedRequest.abort()
       })
 
       this.onCancelAll(file.id, ({ reason } = {}) => {
         if (reason === 'user') {
-          queuedRequest.abort()
           socket.send('cancel', {})
+          queuedRequest.abort()
           this.resetUploaderReferences(file.id)
         }
         resolve(`upload ${file.id} was canceled`)

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -517,7 +517,7 @@ export default class Tus extends BasePlugin {
             socket.open()
             socket.send('resume', {})
 
-            return () => socket.close()
+            return () => {}
           })
         }
       })
@@ -545,7 +545,7 @@ export default class Tus extends BasePlugin {
           socket.open()
           socket.send('resume', {})
 
-          return () => socket.close()
+          return () => {}
         })
       })
 
@@ -616,7 +616,7 @@ export default class Tus extends BasePlugin {
         // that point this cancellation function is not going to be called.
         // Also, we need to remove the request from the queue _without_ destroying everything
         // related to this upload to handle pauses.
-        return () => socket.close()
+        return () => {}
       })
     })
   }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -599,7 +599,7 @@ export default class Tus extends BasePlugin {
         this.uppy.emit('upload-success', file, uploadResp)
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
-
+        socket.close()
         resolve()
       })
 


### PR DESCRIPTION
- Fixed tus `pause`/`resume`/`cancel` being ignored on Companion — don't close sockets after pause/resume events are sent
- Close sockets on error and complete

Fixes #4409

:warning: ** Note:**
`pause`/`resume`/`cancel` works in tus, but only `cancel` works in S3 Multipart for remote uploads. For local uploads you can `pause`/`resume` them. @mifi says pause/resuming remote uploads could be complicated because of streaming.

Related:

- https://github.com/transloadit/uppy/pull/4368