### PR TITLE
@uppy/provider-views: Implement Load All button for viewType: list providers, with loading progress

### DIFF
--- a/packages/@uppy/core/src/locale.js
+++ b/packages/@uppy/core/src/locale.js
@@ -42,8 +42,9 @@ export default {
     filter: 'Filter',
     resetFilter: 'Reset filter',
     loading: 'Loading...',
-    authenticateWithTitle:
-      'Please authenticate with %{pluginName} to select files',
+    loadingX: 'Loading (%{numFiles})...',
+    loadAllFilesFolders: 'Load all files and folders',
+    authenticateWithTitle: 'Please authenticate with %{pluginName} to select files',
     authenticateWith: 'Connect to %{pluginName}',
     signInWithGoogle: 'Sign in with Google',
     searchImages: 'Search for images',

--- a/packages/@uppy/provider-views/src/Browser.jsx
+++ b/packages/@uppy/provider-views/src/Browser.jsx
@@ -21,6 +21,9 @@ function Browser (props) {
     toggleCheckbox,
     recordShiftKeyPress,
     handleScroll,
+    loadAllPages,
+    loadedItemsProgress,
+    hasMorePages,
     showTitles,
     i18n,
     validateRestrictions,
@@ -40,6 +43,7 @@ function Browser (props) {
   } = props
 
   const selected = currentSelection.length
+  const showFooter = selected > 0 || hasMorePages
 
   return (
     <div
@@ -148,12 +152,15 @@ function Browser (props) {
         )
       })()}
 
-      {selected > 0 && (
+      {showFooter && (
         <FooterActions
           selected={selected}
           done={done}
           cancel={cancel}
           i18n={i18n}
+          loadAllPages={loadAllPages}
+          loadedItemsProgress={loadedItemsProgress}
+          viewType={viewType}
         />
       )}
     </div>

--- a/packages/@uppy/provider-views/src/FooterActions.jsx
+++ b/packages/@uppy/provider-views/src/FooterActions.jsx
@@ -1,16 +1,70 @@
 import { h } from 'preact'
 
-export default ({ cancel, done, i18n, selected }) => {
+function LoadingProgress (props) {
+  const { i18n, loadedItemsProgress } = props
+
   return (
-    <div className="uppy-ProviderBrowser-footer">
-      <button className="uppy-u-reset uppy-c-btn uppy-c-btn-primary" onClick={done} type="button">
-        {i18n('selectX', {
-          smart_count: selected,
-        })}
-      </button>
-      <button className="uppy-u-reset uppy-c-btn uppy-c-btn-link" onClick={cancel} type="button">
-        {i18n('cancel')}
+    <div className="uppy-ProviderBrowser-footer uppy-ProviderBrowser-footer--centered">
+      <div data-uppy-super-focusable>
+        <svg
+          className="uppy-ProviderBrowser-spinner"
+          aria-hidden="true"
+          focusable="false"
+          width="14"
+          height="14"
+        >
+          <path
+            d="M13.983 6.547c-.12-2.509-1.64-4.893-3.939-5.936-2.48-1.127-5.488-.656-7.556 1.094C.524 3.367-.398 6.048.162 8.562c.556 2.495 2.46 4.52 4.94 5.183 2.932.784 5.61-.602 7.256-3.015-1.493 1.993-3.745 3.309-6.298 2.868-2.514-.434-4.578-2.349-5.153-4.84a6.226 6.226 0 0 1 2.98-6.778C6.34.586 9.74 1.1 11.373 3.493c.407.596.693 1.282.842 1.988.127.598.073 1.197.161 1.794.078.525.543 1.257 1.15.864.525-.341.49-1.05.456-1.592-.007-.15.02.3 0 0"
+            fillRule="evenodd"
+          />
+        </svg>
+        {i18n('loadingX', { numFiles:  loadedItemsProgress })}
+      </div>
+    </div>
+  )
+}
+
+function LoadAllButton (props) {
+  const { i18n, loadAllPages } = props
+  return (
+    <div className="uppy-ProviderBrowser-footer uppy-ProviderBrowser-footer--centered">
+      <button
+        className="uppy-u-reset uppy-c-btn uppy-c-btn-link"
+        type="button"
+        onClick={loadAllPages}
+      >
+        {i18n('loadAllFilesFolders')}
       </button>
     </div>
   )
+}
+
+export default (props) => {
+  const { cancel, done, i18n, selected, loadedItemsProgress, viewType } = props
+  const shouldShowLoadAll = viewType === 'list'
+
+  if (selected === 0 && loadedItemsProgress && shouldShowLoadAll) {
+    return LoadingProgress(props)
+  }
+
+  if (selected === 0 && shouldShowLoadAll) {
+    return LoadAllButton(props)
+  }
+
+  if (selected > 0) {
+    return (
+      <div className="uppy-ProviderBrowser-footer">
+        <button className="uppy-u-reset uppy-c-btn uppy-c-btn-primary" onClick={done} type="button">
+          {i18n('selectX', {
+            smart_count: selected,
+          })}
+        </button>
+        <button className="uppy-u-reset uppy-c-btn uppy-c-btn-link" onClick={cancel} type="button">
+          {i18n('cancel')}
+        </button>
+      </div>
+    )
+  }
+
+  return null
 }

--- a/packages/@uppy/provider-views/src/View.js
+++ b/packages/@uppy/provider-views/src/View.js
@@ -8,6 +8,7 @@ export default class View {
     this.provider = opts.provider
 
     this.isHandlingScroll = false
+    this.isLoadingAllPages = false
 
     this.preFirstRender = this.preFirstRender.bind(this)
     this.handleError = this.handleError.bind(this)
@@ -29,7 +30,11 @@ export default class View {
   }
 
   clearSelection () {
-    this.plugin.setPluginState({ currentSelection: [], filterInput: '' })
+    this.plugin.setPluginState({
+      currentSelection: [],
+      filterInput: '',
+    })
+    this.isLoadingAllPages = false
   }
 
   cancelPicking () {

--- a/packages/@uppy/provider-views/src/style.scss
+++ b/packages/@uppy/provider-views/src/style.scss
@@ -360,3 +360,28 @@
     border-top: 1px solid $gray-800;
   }
 }
+
+.uppy-ProviderBrowser-footer--centered {
+  justify-content: center;
+}
+
+.uppy-ProviderBrowser-spinner {
+  animation-name: uppy-ProviderBrowser-spinnerAnimation;
+  animation-duration: 1s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  fill: $blue;
+  margin-inline-end: 10px;
+  position: relative;
+  top: 2px;
+}
+
+@keyframes uppy-ProviderBrowser-spinnerAnimation {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Adds Load All Files and Folders to compliment lazy loading long lists of files.

The main intention was to solve an issue when folders are lazy-loaded to the top of the list, when you scroll down a long list of files and folders.

![image](https://github.com/transloadit/uppy/assets/1199054/723da905-8f64-4843-82b7-df65b05a5ec0)

![image](https://github.com/transloadit/uppy/assets/1199054/a3d3ffbc-441b-4f0e-b824-487d1383ba1d)
