### PR TITLE
@uppy/utils: rename `EventTracker` -> `EventManager`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -1,6 +1,6 @@
 import BasePlugin from '@uppy/core/lib/BasePlugin.js'
 import { Socket, Provider, RequestClient } from '@uppy/companion-client'
-import EventTracker from '@uppy/utils/lib/EventTracker'
+import EventManager from '@uppy/utils/lib/EventManager'
 import emitSocketProgress from '@uppy/utils/lib/emitSocketProgress'
 import getSocketHost from '@uppy/utils/lib/getSocketHost'
 import { RateLimitedQueue } from '@uppy/utils/lib/RateLimitedQueue'
@@ -624,7 +624,7 @@ export default class AwsS3Multipart extends BasePlugin {
       })
 
       this.uploaders[file.id] = upload
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       this.onFileRemove(file.id, (removed) => {
         upload.abort()
@@ -713,7 +713,7 @@ export default class AwsS3Multipart extends BasePlugin {
       const host = getSocketHost(file.remote.companionUrl)
       const socket = new Socket({ target: `${host}/api/${token}`, autoOpen: false })
       this.uploaderSockets[file.id] = socket
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       this.onFileRemove(file.id, () => {
         queuedRequest.abort()

--- a/packages/@uppy/aws-s3/src/MiniXHRUpload.js
+++ b/packages/@uppy/aws-s3/src/MiniXHRUpload.js
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid/non-secure'
 import { Provider, RequestClient, Socket } from '@uppy/companion-client'
 import emitSocketProgress from '@uppy/utils/lib/emitSocketProgress'
 import getSocketHost from '@uppy/utils/lib/getSocketHost'
-import EventTracker from '@uppy/utils/lib/EventTracker'
+import EventManager from '@uppy/utils/lib/EventManager'
 import ProgressTimeout from '@uppy/utils/lib/ProgressTimeout'
 import ErrorWithCause from '@uppy/utils/lib/ErrorWithCause'
 import NetworkError from '@uppy/utils/lib/NetworkError'
@@ -128,7 +128,7 @@ export default class MiniXHRUpload {
         : createBareUpload(file, opts)
 
       const xhr = new XMLHttpRequest()
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       const timer = new ProgressTimeout(opts.timeout, () => {
         xhr.abort()
@@ -349,7 +349,7 @@ export default class MiniXHRUpload {
           reject(error)
         })
       }
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       let queuedRequest = this.requests.run(() => {
         if (file.isPaused) {

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -3,7 +3,7 @@ import * as tus from 'tus-js-client'
 import { Provider, RequestClient, Socket } from '@uppy/companion-client'
 import emitSocketProgress from '@uppy/utils/lib/emitSocketProgress'
 import getSocketHost from '@uppy/utils/lib/getSocketHost'
-import EventTracker from '@uppy/utils/lib/EventTracker'
+import EventManager from '@uppy/utils/lib/EventManager'
 import NetworkError from '@uppy/utils/lib/NetworkError'
 import isNetworkError from '@uppy/utils/lib/isNetworkError'
 import { RateLimitedQueue } from '@uppy/utils/lib/RateLimitedQueue'
@@ -153,22 +153,22 @@ export default class Tus extends BasePlugin {
    * A lot can happen during an upload, so this is quite hard to follow!
    * - First, the upload is started. If the file was already paused by the time the upload starts, nothing should happen.
    *   If the `limit` option is used, the upload must be queued onto the `this.requests` queue.
-   *   When an upload starts, we store the tus.Upload instance, and an EventTracker instance that manages the event listeners
+   *   When an upload starts, we store the tus.Upload instance, and an EventManager instance that manages the event listeners
    *   for pausing, cancellation, removal, etc.
    * - While the upload is in progress, it may be paused or cancelled.
    *   Pausing aborts the underlying tus.Upload, and removes the upload from the `this.requests` queue. All other state is
    *   maintained.
    *   Cancelling removes the upload from the `this.requests` queue, and completely aborts the upload-- the `tus.Upload`
-   *   instance is aborted and discarded, the EventTracker instance is destroyed (removing all listeners).
+   *   instance is aborted and discarded, the EventManager instance is destroyed (removing all listeners).
    *   Resuming the upload uses the `this.requests` queue as well, to prevent selectively pausing and resuming uploads from
    *   bypassing the limit.
-   * - After completing an upload, the tus.Upload and EventTracker instances are cleaned up, and the upload is marked as done
+   * - After completing an upload, the tus.Upload and EventManager instances are cleaned up, and the upload is marked as done
    *   in the `this.requests` queue.
    * - When an upload completed with an error, the same happens as on successful completion, but the `upload()` promise is
    *   rejected.
    *
    * When working on this function, keep in mind:
-   *  - When an upload is completed or cancelled for any reason, the tus.Upload and EventTracker instances need to be cleaned
+   *  - When an upload is completed or cancelled for any reason, the tus.Upload and EventManager instances need to be cleaned
    *    up using this.resetUploaderReferences().
    *  - When an upload is cancelled or paused, for any reason, it needs to be removed from the `this.requests` queue using
    *    `queuedRequest.abort()`.
@@ -361,7 +361,7 @@ export default class Tus extends BasePlugin {
 
       upload = new tus.Upload(file.data, uploadOptions)
       this.uploaders[file.id] = upload
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       // eslint-disable-next-line prefer-const
       qRequest = () => {
@@ -493,7 +493,7 @@ export default class Tus extends BasePlugin {
       const host = getSocketHost(file.remote.companionUrl)
       const socket = new Socket({ target: `${host}/api/${token}`, autoOpen: false })
       this.uploaderSockets[file.id] = socket
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       let queuedRequest
 

--- a/packages/@uppy/utils/package.json
+++ b/packages/@uppy/utils/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     "./lib/Translator": "./lib/Translator.js",
+    "./lib/EventTracker": "./lib/EventManager.js",
     "./lib/EventManager": "./lib/EventManager.js",
     "./lib/ProgressTimeout": "./lib/ProgressTimeout.js",
     "./lib/RateLimitedQueue": "./lib/RateLimitedQueue.js",

--- a/packages/@uppy/utils/package.json
+++ b/packages/@uppy/utils/package.json
@@ -20,7 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     "./lib/Translator": "./lib/Translator.js",
-    "./lib/EventTracker": "./lib/EventTracker.js",
+    "./lib/EventManager": "./lib/EventManager.js",
     "./lib/ProgressTimeout": "./lib/ProgressTimeout.js",
     "./lib/RateLimitedQueue": "./lib/RateLimitedQueue.js",
     "./lib/canvasToBlob": "./lib/canvasToBlob.js",

--- a/packages/@uppy/utils/src/EventManager.js
+++ b/packages/@uppy/utils/src/EventManager.js
@@ -2,7 +2,7 @@
  * Create a wrapper around an event emitter with a `remove` method to remove
  * all events that were added using the wrapped emitter.
  */
-export default class EventTracker {
+export default class EventManager {
   #emitter
 
   #events = []

--- a/packages/@uppy/utils/types/index.d.ts
+++ b/packages/@uppy/utils/types/index.d.ts
@@ -19,8 +19,8 @@ declare module '@uppy/utils/lib/Translator' {
   export default Translator
 }
 
-declare module '@uppy/utils/lib/EventTracker' {
-  namespace EventTracker {
+declare module '@uppy/utils/lib/EventManager' {
+  namespace EventManager {
     export type EventHandler = (...args: any[]) => void
     export interface Emitter {
       on: (event: string, handler: EventHandler) => void
@@ -28,15 +28,15 @@ declare module '@uppy/utils/lib/EventTracker' {
     }
   }
 
-  class EventTracker {
-    constructor (emitter: EventTracker.Emitter)
+  class EventManager {
+    constructor (emitter: EventManager.Emitter)
 
-    on (event: string, handler: EventTracker.EventHandler): void
+    on (event: string, handler: EventManager.EventHandler): void
 
     remove (): void
   }
 
-  export default EventTracker
+  export default EventManager
 }
 
 declare module '@uppy/utils/lib/ProgressTimeout' {

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid/non-secure'
 import { Provider, RequestClient, Socket } from '@uppy/companion-client'
 import emitSocketProgress from '@uppy/utils/lib/emitSocketProgress'
 import getSocketHost from '@uppy/utils/lib/getSocketHost'
-import EventTracker from '@uppy/utils/lib/EventTracker'
+import EventManager from '@uppy/utils/lib/EventManager'
 import ProgressTimeout from '@uppy/utils/lib/ProgressTimeout'
 import { RateLimitedQueue, internalRateLimitedQueue } from '@uppy/utils/lib/RateLimitedQueue'
 import NetworkError from '@uppy/utils/lib/NetworkError'
@@ -228,7 +228,7 @@ export default class XHRUpload extends BasePlugin {
         : file.data
 
       const xhr = new XMLHttpRequest()
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
       let queuedRequest
 
       const timer = new ProgressTimeout(opts.timeout, () => {
@@ -442,7 +442,7 @@ export default class XHRUpload extends BasePlugin {
           reject(error)
         })
       }
-      this.uploaderEvents[file.id] = new EventTracker(this.uppy)
+      this.uploaderEvents[file.id] = new EventManager(this.uppy)
 
       let queuedRequest = this.requests.run(() => {
         if (file.isPaused) {


### PR DESCRIPTION
See original issue: https://github.com/transloadit/uppy/issues/4446

Not actually sure how to test this locally, this was a simple global find & replace.