### PR TITLE
@uppy/companion: add parent folder path in onedrive provider

### DIFF
--- a/packages/@uppy/companion/src/server/provider/onedrive/adapter.js
+++ b/packages/@uppy/companion/src/server/provider/onedrive/adapter.js
@@ -40,11 +40,18 @@ const getItemId = (item) => {
 }
 
 const getItemRequestPath = (item) => {
+  // consists of the item id and the drive id if given
   let query = `?driveId=${item.parentReference.driveId}`
   if (item.remoteItem) {
     query = `?driveId=${item.remoteItem.parentReference.driveId}`
   }
   return getItemId(item) + query
+}
+
+const getDirectoryPath = (item) => {
+  // absolute path to the directory the item is located in
+  const strippedPath = item.parentReference?.path?.replace(/^\/drive\/root:/, '')
+  return strippedPath === '' ? '/' : strippedPath
 }
 
 const getItemModifiedDate = (item) => {
@@ -74,6 +81,7 @@ module.exports = (res, username) => {
       requestPath: getItemRequestPath(item),
       modifiedDate: getItemModifiedDate(item),
       size: getItemSize(item),
+      directoryPath: getDirectoryPath(item),
     })
   })
 

--- a/packages/@uppy/companion/test/__tests__/providers.js
+++ b/packages/@uppy/companion/test/__tests__/providers.js
@@ -85,6 +85,10 @@ describe('list provider files', () => {
         expect(item.size).toBe(thisOrThat(providerFixtures.itemSize, defaults.FILE_SIZE))
         expect(item.requestPath).toBe(providerFixtures.itemRequestPath || defaults.ITEM_ID)
         expect(item.icon).toBe(providerFixtures.itemIcon || defaults.THUMBNAIL_URL)
+
+        if (providerName === 'onedrive') {
+          expect(item.directoryPath).toBe(providerFixtures.directoryPath)
+        }
       })
   }
 

--- a/packages/@uppy/companion/test/fixtures/onedrive.js
+++ b/packages/@uppy/companion/test/fixtures/onedrive.js
@@ -2,4 +2,5 @@ const defaults = require('./constants')
 
 module.exports.expects = {
   itemRequestPath: `${defaults.ITEM_ID}?driveId=DUMMY-DRIVE-ID`,
+  directoryPath: '/',
 }


### PR DESCRIPTION
Adds the parent folder path to the OneDrive provider. This can be used to determine and distinguish different source locations of files.

Relates to https://github.com/transloadit/uppy/issues/4034 (although it doesn't fix it completely because other providers are still missing).