### PR TITLE
@uppy/transloadit: do not rely on deprecated options

### DIFF
--- a/packages/@uppy/transloadit/src/AssemblyOptions.js
+++ b/packages/@uppy/transloadit/src/AssemblyOptions.js
@@ -48,7 +48,7 @@ function dedupe (list) {
   }))
 }
 
-async function getAssemblyOptions (file, options) {
+export async function getAssemblyOptions (file, options) {
   const assemblyOptions = typeof options.assemblyOptions === 'function'
     ? await options.assemblyOptions(file, options)
     : options.assemblyOptions

--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -5,7 +5,7 @@ import BasePlugin from '@uppy/core/lib/BasePlugin.js'
 import Tus from '@uppy/tus'
 import Assembly from './Assembly.js'
 import Client from './Client.js'
-import AssemblyOptions, { validateParams } from './AssemblyOptions.js'
+import AssemblyOptions, { validateParams, getAssemblyOptions } from './AssemblyOptions.js'
 import AssemblyWatcher from './AssemblyWatcher.js'
 
 import locale from './locale.js'
@@ -191,12 +191,8 @@ export default class Transloadit extends BasePlugin {
   #createAssembly (fileIDs, uploadID, options) {
     this.uppy.log('[Transloadit] Create Assembly')
 
-    return this.client.createAssembly({
-      params: options.params,
-      fields: options.fields,
-      expectedFiles: fileIDs.length,
-      signature: options.signature,
-    }).then(async (newAssembly) => {
+    const createAssembly = assemblyOptions => this.client.createAssembly(assemblyOptions)
+    return getAssemblyOptions(fileIDs, options).then(createAssembly).then(async (newAssembly) => {
       const files = this.uppy.getFiles().filter(({ id }) => fileIDs.includes(id))
       if (files.length !== fileIDs.length) {
         if (files.length === 0) {


### PR DESCRIPTION
Our API currently assumes there's going to be one file per assembly, which is a bit unfortunate (not sure what we are suppose to pass when grouping several files. Previously, the plugin was ignoring the `getAssemblyOptions` option, only accepting the individual options, maybe we should keep doing that? That sounds hard to document.
Or we could pass `undefined` for the `file` attribute (downside is it could create TypeError possibly hard to understand for the user)
Currently in this PR, I'm passing the array of file IDs, but I don't know if the right thing to do.

Refs: https://github.com/transloadit/uppy/pull/4059