### PR TITLE
@uppy/companion: Use filename from content-disposition instead of relying on url, with fallback

### DIFF
--- a/e2e/cypress.config.mjs
+++ b/e2e/cypress.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter.js'
+import startMockServer from './mock-server.mjs'
 
 export default defineConfig({
   defaultCommandTimeout: 16000,
@@ -11,6 +12,8 @@ export default defineConfig({
     setupNodeEvents (on) {
       // implement node event listeners here
       installLogsPrinter(on)
+
+      startMockServer('localhost', 4678)
     },
   },
 })

--- a/e2e/cypress/integration/dashboard-xhr.spec.ts
+++ b/e2e/cypress/integration/dashboard-xhr.spec.ts
@@ -1,7 +1,5 @@
 import { interceptCompanionUrlRequest, interceptCompanionUnsplashRequest, runRemoteUrlImageUploadTest, runRemoteUnsplashUploadTest } from './reusable-tests'
 
-const interceptCompanionUrlRequest = () => cy.intercept('http://localhost:3020/url/*').as('url')
-
 describe('Dashboard with XHR', () => {
   beforeEach(() => {
     cy.visit('/dashboard-xhr')

--- a/e2e/cypress/integration/dashboard-xhr.spec.ts
+++ b/e2e/cypress/integration/dashboard-xhr.spec.ts
@@ -35,8 +35,6 @@ describe('Dashboard with XHR', () => {
   })
 
   it('should return correct file name even when Companion doesnt supply it', () => {
-    // cy.intercept('http://localhost:3020/url/*').as('url')
-
     cy.intercept('POST', 'http://localhost:3020/url/meta', {
       statusCode: 200,
       headers: {},

--- a/e2e/cypress/integration/dashboard-xhr.spec.ts
+++ b/e2e/cypress/integration/dashboard-xhr.spec.ts
@@ -1,5 +1,7 @@
 import { interceptCompanionUrlRequest, interceptCompanionUnsplashRequest, runRemoteUrlImageUploadTest, runRemoteUnsplashUploadTest } from './reusable-tests'
 
+const interceptCompanionUrlRequest = () => cy.intercept('http://localhost:3020/url/*').as('url')
+
 describe('Dashboard with XHR', () => {
   beforeEach(() => {
     cy.visit('/dashboard-xhr')
@@ -9,6 +11,45 @@ describe('Dashboard with XHR', () => {
 
   it('should upload remote image with URL plugin', () => {
     runRemoteUrlImageUploadTest()
+  })
+
+  it('should return correct file name with URL plugin from remote image with Content-Disposition', () => {
+    const fileName = `DALL·E IMG_9078 - 学中文 🤑`
+    cy.get('[data-cy="Url"]').click()
+    cy.get('.uppy-Url-input').type('http://localhost:4678/file-with-content-disposition')
+    cy.get('.uppy-Url-importButton').click()
+    cy.wait('@url').then(() => {
+      cy.get('.uppy-Dashboard-Item-name').should('contain', fileName)
+      cy.get('.uppy-Dashboard-Item-status').should('contain', '84 KB')
+    })
+  })
+
+  it('should return correct file name with URL plugin from remote image without Content-Disposition', () => {
+    cy.get('[data-cy="Url"]').click()
+    cy.get('.uppy-Url-input').type('http://localhost:4678/file-no-headers')
+    cy.get('.uppy-Url-importButton').click()
+    cy.wait('@url').then(() => {
+      cy.get('.uppy-Dashboard-Item-name').should('contain', 'file-no')
+      cy.get('.uppy-Dashboard-Item-status').should('contain', '0')
+    })
+  })
+
+  it('should return correct file name even when Companion doesnt supply it', () => {
+    // cy.intercept('http://localhost:3020/url/*').as('url')
+
+    cy.intercept('POST', 'http://localhost:3020/url/meta', {
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({ size: 123, type: 'image/jpeg' }),
+    }).as('url')
+
+    cy.get('[data-cy="Url"]').click()
+    cy.get('.uppy-Url-input').type('http://localhost:4678/file-with-content-disposition')
+    cy.get('.uppy-Url-importButton').click()
+    cy.wait('@url').then(() => {
+      cy.get('.uppy-Dashboard-Item-name').should('contain', 'file-with')
+      cy.get('.uppy-Dashboard-Item-status').should('contain', '123 B')
+    })
   })
 
   it('should upload remote image with Unsplash plugin', () => {

--- a/e2e/mock-server.mjs
+++ b/e2e/mock-server.mjs
@@ -1,0 +1,30 @@
+import http from 'node:http'
+
+const fileName = `DALL·E IMG_9078 - 学中文 🤑`
+
+const requestListener = (req, res) => {
+  const endpoint = req.url
+
+  switch (endpoint) {
+    case '/file-with-content-disposition':
+      res.setHeader('Content-Disposition', `attachment; filename="ASCII-name.zip"; filename*=UTF-8''${encodeURIComponent(fileName)}`)
+      res.setHeader('Content-Type', 'image/jpeg')
+      res.setHeader('Content-Length', '86500')
+      break
+    case '/file-no-headers':
+      break
+    default:
+      res.end('My first server!')
+  }
+
+  res.end()
+}
+
+export default function startMockServer (host, port) {
+  const server = http.createServer(requestListener)
+  server.listen(port, host, () => {
+    console.log(`Server is running on http://${host}:${port}`)
+  })
+}
+
+// startMockServer('localhost', 4678)

--- a/e2e/mock-server.mjs
+++ b/e2e/mock-server.mjs
@@ -14,7 +14,7 @@ const requestListener = (req, res) => {
     case '/file-no-headers':
       break
     default:
-      res.end('My first server!')
+      response.writeHead(404).end('Unhandled request')
   }
 
   res.end()

--- a/e2e/mock-server.mjs
+++ b/e2e/mock-server.mjs
@@ -1,16 +1,16 @@
 import http from 'node:http'
 
-const fileName = `DALL·E IMG_9078 - 学中文 🤑`
-
 const requestListener = (req, res) => {
   const endpoint = req.url
 
   switch (endpoint) {
-    case '/file-with-content-disposition':
+    case '/file-with-content-disposition': {
+      const fileName = `DALL·E IMG_9078 - 学中文 🤑`
       res.setHeader('Content-Disposition', `attachment; filename="ASCII-name.zip"; filename*=UTF-8''${encodeURIComponent(fileName)}`)
       res.setHeader('Content-Type', 'image/jpeg')
       res.setHeader('Content-Length', '86500')
       break
+    }
     case '/file-no-headers':
       break
     default:

--- a/e2e/mock-server.mjs
+++ b/e2e/mock-server.mjs
@@ -14,7 +14,7 @@ const requestListener = (req, res) => {
     case '/file-no-headers':
       break
     default:
-      response.writeHead(404).end('Unhandled request')
+      res.writeHead(404).end('Unhandled request')
   }
 
   res.end()

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "aws-sdk": "^2.1038.0",
     "babel-jest": "^29.0.0",
     "babel-plugin-inline-package-json": "^2.0.0",
+    "buffer": "^5.5.0",
     "chalk": "^5.0.0",
     "concat-stream": "^2.0.0",
     "core-js": "~3.24.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "aws-sdk": "^2.1038.0",
     "babel-jest": "^29.0.0",
     "babel-plugin-inline-package-json": "^2.0.0",
-    "buffer": "^5.5.0",
     "chalk": "^5.0.0",
     "concat-stream": "^2.0.0",
     "core-js": "~3.24.0",

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -34,6 +34,7 @@
     "chalk": "4.1.2",
     "common-tags": "1.8.2",
     "connect-redis": "6.1.3",
+    "content-disposition": "^0.5.4",
     "cookie-parser": "1.4.6",
     "cors": "^2.8.5",
     "escape-goat": "3.0.0",

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -132,7 +132,6 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
       stream
         .on('response', (response) => {
           // Can be undefined for unknown length URLs, e.g. transfer-encoding: chunked
-          console.log(response.request)
           const contentLength = parseInt(response.headers['content-length'], 10)
           const filename = response.headers['content-disposition']
             ? contentDisposition.parse(response.headers['content-disposition']).parameters.filename

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -173,6 +173,6 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
     throw new Error(`URL server responded with status: ${urlMeta.statusCode}`)
   }
 
-  const { name, size, type  } = urlMeta
+  const { name, size, type } = urlMeta
   return { name, size, type }
 }

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -6,6 +6,7 @@ const dns = require('node:dns')
 const ipaddr = require('ipaddr.js')
 const got = require('got').default
 const path = require('node:path')
+const { randomUUID } = require('node:crypto')
 const contentDisposition = require('content-disposition')
 
 const logger = require('../logger')
@@ -135,7 +136,7 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
           const contentLength = parseInt(response.headers['content-length'], 10)
           const filename = response.headers['content-disposition']
             ? contentDisposition.parse(response.headers['content-disposition']).parameters.filename
-            : path.basename(response.request.requestUrl)
+            : `${path.basename(response.request.requestUrl)}-${randomUUID()}`
 
           // No need to get the rest of the response, as we only want header (not really relevant for HEAD, but why not)
           stream.destroy()

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -5,6 +5,8 @@ const { URL } = require('node:url')
 const dns = require('node:dns')
 const ipaddr = require('ipaddr.js')
 const got = require('got').default
+const path = require('node:path')
+const contentDisposition = require('content-disposition')
 
 const logger = require('../logger')
 
@@ -119,7 +121,7 @@ module.exports.getProtectedGot = getProtectedGot
  *
  * @param {string} url
  * @param {boolean} blockLocalIPs
- * @returns {Promise<{type: string, size: number}>}
+ * @returns {Promise<{name: string, type: string, size: number}>}
  */
 exports.getURLMeta = async (url, blockLocalIPs = false) => {
   async function requestWithMethod (method) {
@@ -130,12 +132,17 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
       stream
         .on('response', (response) => {
           // Can be undefined for unknown length URLs, e.g. transfer-encoding: chunked
+          console.log(response.request)
           const contentLength = parseInt(response.headers['content-length'], 10)
+          const filename = response.headers['content-disposition']
+            ? contentDisposition.parse(response.headers['content-disposition']).parameters.filename
+            : path.basename(response.request.requestUrl)
 
           // No need to get the rest of the response, as we only want header (not really relevant for HEAD, but why not)
           stream.destroy()
 
           resolve({
+            name: filename,
             type: response.headers['content-type'],
             size: Number.isNaN(contentLength) ? null : contentLength,
             statusCode: response.statusCode,
@@ -167,6 +174,6 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
     throw new Error(`URL server responded with status: ${urlMeta.statusCode}`)
   }
 
-  const { size, type } = urlMeta
-  return { size, type }
+  const { name, size, type  } = urlMeta
+  return { name, size, type }
 }

--- a/packages/@uppy/companion/src/server/helpers/request.js
+++ b/packages/@uppy/companion/src/server/helpers/request.js
@@ -134,6 +134,9 @@ exports.getURLMeta = async (url, blockLocalIPs = false) => {
         .on('response', (response) => {
           // Can be undefined for unknown length URLs, e.g. transfer-encoding: chunked
           const contentLength = parseInt(response.headers['content-length'], 10)
+          // If Content-Disposition with file name is missing, fallback to the URL path for the name,
+          // but if multiple files are served via query params like foo.com?file=file-1, foo.com?file=file-2,
+          // we add random string to avoid duplicate files
           const filename = response.headers['content-disposition']
             ? contentDisposition.parse(response.headers['content-disposition']).parameters.filename
             : `${path.basename(response.request.requestUrl)}-${randomUUID()}`

--- a/packages/@uppy/url/src/Url.jsx
+++ b/packages/@uppy/url/src/Url.jsx
@@ -116,7 +116,7 @@ export default class Url extends UIPlugin {
       const tagFile = {
         meta: optionalMeta,
         source: this.id,
-        name: getFileNameFromUrl(url),
+        name: meta.name || getFileNameFromUrl(url),
         type: meta.type,
         data: {
           size: meta.size,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,7 +8764,6 @@ __metadata:
     aws-sdk: ^2.1038.0
     babel-jest: ^29.0.0
     babel-plugin-inline-package-json: ^2.0.0
-    buffer: ^5.5.0
     chalk: ^5.0.0
     concat-stream: ^2.0.0
     core-js: ~3.24.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -9374,6 +9374,7 @@ __metadata:
     chalk: 4.1.2
     common-tags: 1.8.2
     connect-redis: 6.1.3
+    content-disposition: ^0.5.4
     cookie-parser: 1.4.6
     cors: ^2.8.5
     escape-goat: 3.0.0
@@ -13851,7 +13852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4":
+"content-disposition@npm:0.5.4, content-disposition@npm:^0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,6 +8764,7 @@ __metadata:
     aws-sdk: ^2.1038.0
     babel-jest: ^29.0.0
     babel-plugin-inline-package-json: ^2.0.0
+    buffer: ^5.5.0
     chalk: ^5.0.0
     concat-stream: ^2.0.0
     core-js: ~3.24.0


### PR DESCRIPTION
- We should make sure it works for old Companion as well, so `name: meta.name || getFileNameFromUrl(url)`
- Is `response.request.requestUrl` a good original url source for the fallback?

Before:
![Screen Shot 2023-06-06 at 20 23 42](https://github.com/transloadit/uppy/assets/1199054/0920396d-4726-415f-9b15-7c57cf5a59d4)

After:
![Screen Shot 2023-06-06 at 20 24 31](https://github.com/transloadit/uppy/assets/1199054/f8579f14-1820-4c54-92fa-551aa49633ad)
