### PR TITLE
@uppy/companion: fix 500 when file name contains non-ASCII chars

### DIFF
--- a/e2e/cypress/fixtures/images/١٠ كم мест для Нью-Йорке.pdf
+++ b/e2e/cypress/fixtures/images/١٠ كم мест для Нью-Йорке.pdf
@@ -1,0 +1,5 @@
+%PDF-1.
+1 0 obj<</Pages 2 0 R>>endobj
+2 0 obj<</Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Parent 2 0 R>>endobj
+trailer <</Root 1 0 R>>

--- a/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
+++ b/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
@@ -14,6 +14,15 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
     cy.wait(['@post', '@get', '@put'])
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
   })
+  it.only('should upload Russian poem image successfully', () => {
+    const fileName = '١٠ كم мест для Нью-Йорке.pdf'
+    cy.get('@file-input').selectFile(`cypress/fixtures/images/${fileName}`, { force:true })
+
+    cy.get('.uppy-StatusBar-actionBtn--upload').click()
+    cy.wait(['@post', '@get', '@put'])
+    cy.get('.uppy-Dashboard-Item-name').should('contain', fileName)
+    cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
+  })
 
   it('should handle retry request gracefully',  () => {
     cy.get('@file-input').selectFile('cypress/fixtures/images/cat.jpg', { force:true })

--- a/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
+++ b/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
@@ -14,7 +14,7 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
     cy.wait(['@post', '@get', '@put'])
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
   })
-  it.only('should upload Russian poem image successfully', () => {
+  it('should upload Russian poem image successfully', () => {
     const fileName = '١٠ كم мест для Нью-Йорке.pdf'
     cy.get('@file-input').selectFile(`cypress/fixtures/images/${fileName}`, { force:true })
 

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -1,5 +1,13 @@
 const express = require('express')
 
+function rfc2047Encode (data) {
+  // eslint-disable-next-line no-param-reassign
+  data = `${data}`
+  // eslint-disable-next-line no-control-regex
+  if (/^[\x00-\x7F]*$/.test(data)) return data // we return ASCII as is
+  return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encore non-ASCII strings
+}
+
 module.exports = function s3 (config) {
   if (typeof config.acl !== 'string' && config.acl != null) {
     throw new TypeError('s3: The `acl` option must be a string or null')
@@ -102,7 +110,7 @@ module.exports = function s3 (config) {
       Bucket: config.bucket,
       Key: key,
       ContentType: type,
-      Metadata: metadata,
+      Metadata: Object.fromEntries(Object.entries(metadata).map(entry => entry.map(rfc2047Encode))),
     }
 
     if (config.acl != null) params.ACL = config.acl

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -5,7 +5,7 @@ function rfc2047Encode (data) {
   data = `${data}`
   // eslint-disable-next-line no-control-regex
   if (/^[\x00-\x7F]*$/.test(data)) return data // we return ASCII as is
-  return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encore non-ASCII strings
+  return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encode non-ASCII strings
 }
 
 module.exports = function s3 (config) {

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -145,7 +145,7 @@ module.exports.decrypt = (encrypted, secret) => {
   return decrypted
 }
 
-module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename}`
+module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename.replace(/[^.-\w]/g, '_')}`
 
 module.exports.prepareStream = async (stream) => new Promise((resolve, reject) => (
   stream

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -145,7 +145,7 @@ module.exports.decrypt = (encrypted, secret) => {
   return decrypted
 }
 
-module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename.replace(/[^.-\w]/g, '_')}`
+module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename}`
 
 module.exports.prepareStream = async (stream) => new Promise((resolve, reject) => (
   stream


### PR DESCRIPTION
For some reason, the AWS SDK doesn't encode those for us and crashes when a metadata contains non-ASCII chars. ~There was another issue when the key contains non-ASCII char, so now the default key generator now filters those out.~