### PR TITLE
@uppy/aws-s3-multipart: fix the chunk size calculation

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -72,11 +72,11 @@ class MultipartUploader {
 
     if (shouldUseMultipart) {
       const desiredChunkSize = this.options.getChunkSize(this.#data)
-      // at least 5MB per request, at most 10k requests
-      const minChunkSize = Math.max(5 * MB, Math.ceil(fileSize / 10000))
-      const chunkSize = Math.max(desiredChunkSize, minChunkSize)
+      // At least 5MB per request:
+      const chunkSize = Math.max(desiredChunkSize, 5 * MB)
 
-      const arraySize = Math.ceil(fileSize / chunkSize)
+      // At most 10k requests per file:
+      const arraySize = Math.min(Math.floor(fileSize / chunkSize), 10_000)
       this.#chunks = Array(arraySize)
 
       for (let i = 0, j = 0; i < fileSize; i += chunkSize, j++) {

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -74,7 +74,7 @@ class MultipartUploader {
       let arraySize, chunkSize
       if (fileSize < 5 * MB) {
         // At least 5MB per request:
-        chunkSize = 5 * MB;
+        chunkSize = 5 * MB
         arraySize = 1
       } else {
         chunkSize = Math.max(this.options.getChunkSize(this.#data), 5 * MB)

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -70,21 +70,15 @@ class MultipartUploader {
       ? this.#shouldUseMultipart(this.#file)
       : Boolean(this.#shouldUseMultipart)
 
-    if (shouldUseMultipart) {
-      let arraySize, chunkSize
-      if (fileSize < 5 * MB) {
-        // At least 5MB per request:
-        chunkSize = 5 * MB
-        arraySize = 1
-      } else {
-        chunkSize = Math.max(this.options.getChunkSize(this.#data), 5 * MB)
-        arraySize = Math.floor(fileSize / chunkSize)
+    if (shouldUseMultipart && fileSize > 5 * MB) {
+      // At least 5MB per request:
+      let chunkSize = Math.max(this.options.getChunkSize(this.#data), 5 * MB)
+      let arraySize = Math.floor(fileSize / chunkSize)
 
-        // At most 10k requests per file:
-        if (arraySize > 10_000) {
-          arraySize = 10_000
-          chunkSize = fileSize / 10_000
-        }
+      // At most 10k requests per file:
+      if (arraySize > 10_000) {
+        arraySize = 10_000
+        chunkSize = fileSize / 10_000
       }
       this.#chunks = Array(arraySize)
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -47,9 +47,9 @@ class MultipartUploader {
 
   #onReject = (err) => (err?.cause === pausingUploadReason ? null : this.#onError(err))
 
-  maxMultipartParts = 10000
+  #maxMultipartParts = 10000
 
-  minPartSize = 5 * MB
+  #minPartSize = 5 * MB
 
   constructor (data, options) {
     this.options = {
@@ -78,15 +78,15 @@ class MultipartUploader {
       ? this.#shouldUseMultipart(this.#file)
       : Boolean(this.#shouldUseMultipart)
 
-    if (shouldUseMultipart && fileSize > this.minPartSize) {
+    if (shouldUseMultipart && fileSize > this.#minPartSize) {
       // At least 5MB per request:
-      let chunkSize = Math.max(this.options.getChunkSize(this.#data), this.minPartSize)
+      let chunkSize = Math.max(this.options.getChunkSize(this.#data), this.#minPartSize)
       let arraySize = Math.floor(fileSize / chunkSize)
 
       // At most 10k requests per file:
-      if (arraySize > this.maxMultipartParts) {
-        arraySize = this.maxMultipartParts
-        chunkSize = fileSize / this.maxMultipartParts
+      if (arraySize > this.#maxMultipartParts) {
+        arraySize = this.#maxMultipartParts
+        chunkSize = fileSize / this.#maxMultipartParts
       }
       this.#chunks = Array(arraySize)
 


### PR DESCRIPTION
We were using `Math.ceil` instead of `Math.floor` which ended up creating always one part too many.