### PR TITLE
@uppy/companion: fix part listing in s3

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -159,7 +159,7 @@ module.exports = function s3 (config) {
       return
     }
 
-    let parts = []
+    const parts = []
 
     function listPartsPage (startAt) {
       client.send(new ListPartsCommand({
@@ -167,18 +167,18 @@ module.exports = function s3 (config) {
         Key: key,
         UploadId: uploadId,
         PartNumberMarker: startAt,
-      })).then(data => {
-        parts = parts.concat(data.Parts)
+      })).then(({ Parts, IsTruncated, NextPartNumberMarker }) => {
+        if (Parts) parts.push(...Parts)
 
-        if (data.IsTruncated) {
+        if (IsTruncated) {
           // Get the next page.
-          listPartsPage(data.NextPartNumberMarker)
+          listPartsPage(NextPartNumberMarker)
         } else {
           res.json(parts)
         }
       }, next)
     }
-    listPartsPage(0)
+    listPartsPage()
   }
 
   /**


### PR DESCRIPTION
Attempting to list a multipart upload with 0 uploaded parts would return an empty array with AWS SDK v2, and returns `undefined` with AWS SDK v3.

It's broken since #4285, I think.