### PR TITLE
@uppy/aws-s3-multipart: add types to internal fields

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -27,11 +27,11 @@ function ensureInt (value) {
 export const pausingUploadReason = Symbol('pausing upload, not an actual error')
 
 /**
-* A MultipartUploader instance is used per file upload to manage the chunk splitting,
-* the S3 multipart upload phase: create, sign, upload, finish, and handling pause/resume.
-* It also determines whether a upload should be done as multipart (`shouldUseMultipart`)
-* or as a regular S3 upload.
-*/
+ * A MultipartUploader instance is used per file upload to determine whether a
+ * upload should be done as multipart or as a regular S3 upload
+ * (based on the user-provided `shouldUseMultipart` option value) and to manage
+ * the chunk splitting.
+ */
 class MultipartUploader {
   #abortController = new AbortController()
 

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -26,6 +26,12 @@ function ensureInt (value) {
 
 export const pausingUploadReason = Symbol('pausing upload, not an actual error')
 
+/**
+* A MultipartUploader instance is used per file upload to manage the chunk splitting,
+* the S3 multipart upload phase: create, sign, upload, finish, and handling pause/resume.
+* It also determines whether a upload should be done as multipart (`shouldUseMultipart`)
+* or as a regular S3 upload.
+*/
 class MultipartUploader {
   #abortController = new AbortController()
 
@@ -48,10 +54,10 @@ class MultipartUploader {
   /** @type {boolean} */
   #uploadHasStarted = false
 
-  /** @type {(err?: Error | any) => any} */
+  /** @type {(err?: Error | any) => void} */
   #onError
 
-  /** @type {() => any} */
+  /** @type {() => void} */
   #onSuccess
 
   /** @type {typeof import('../types/index').AwsS3MultipartOptions["shouldUseMultipart"]} */

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -239,6 +239,12 @@ class HTTPCommunicationQueue {
     }).abortOn(signal)
   }
 
+  /**
+   * @param {import("@uppy/core").UppyFile} file
+   * @param {import("../types/chunk").Chunk[]} chunks
+   * @param {AbortSignal} signal
+   * @returns {Promise<void>}
+   */
   async uploadFile (file, chunks, signal) {
     throwIfAborted(signal)
     if (chunks.length === 1 && !chunks[0].shouldUseMultipart) {
@@ -281,6 +287,14 @@ class HTTPCommunicationQueue {
     return this.#sendCompletionRequest(file, { key, uploadId, parts, signal }).abortOn(signal)
   }
 
+  /**
+   *
+   * @param {import("@uppy/core").UppyFile} file
+   * @param {number} partNumber
+   * @param {import("../types/chunk").Chunk} chunk
+   * @param {AbortSignal} signal
+   * @returns {Promise<object>}
+   */
   async uploadChunk (file, partNumber, chunk, signal) {
     throwIfAborted(signal)
     const { uploadId, key } = await this.getUploadId(file, signal)

--- a/packages/@uppy/aws-s3-multipart/types/chunk.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/chunk.d.ts
@@ -1,0 +1,6 @@
+export interface Chunk {
+    getData: () => Blob
+    onProgress: (ev: ProgressEvent) => void
+    onComplete: (etag: string) => void
+    shouldUseMultipart: boolean
+}


### PR DESCRIPTION
We could certainly benefit from a full TS overwrite, but adding a few JSDoc comment already goes a long way so that's what this PR is doing.