### PR TITLE
@uppy/companion: fix infinite recursion in uploader test

### DIFF
--- a/packages/@uppy/companion/test/__tests__/uploader.js
+++ b/packages/@uppy/companion/test/__tests__/uploader.js
@@ -149,13 +149,12 @@ describe('uploader with tus protocol', () => {
       // emulate socket connection
       socketClient.connect(uploadToken)
       socketClient.onProgress(uploadToken, (message) => {
-        if (firstReceivedProgress == null) firstReceivedProgress = message.payload.bytesUploaded
+        if (firstReceivedProgress == null) firstReceivedProgress = message.payload
       })
       socketClient.onUploadSuccess(uploadToken, (message) => {
         try {
-          expect(message.payload.bytesTotal).toBe(fileContent.length)
+          expect(firstReceivedProgress.bytesUploaded).toBe(8192)
 
-          expect(firstReceivedProgress).toBe(8192)
           // see __mocks__/tus-js-client.js
           expect(message.payload.url).toBe('https://tus.endpoint/files/foo-bar')
         } catch (err) {

--- a/packages/@uppy/companion/test/__tests__/uploader.js
+++ b/packages/@uppy/companion/test/__tests__/uploader.js
@@ -118,6 +118,7 @@ describe('uploader with tus protocol', () => {
     }
 
     const uploader = new Uploader(opts)
+    const originalTryDeleteTmpPath = uploader.tryDeleteTmpPath.bind(uploader)
     uploader.tryDeleteTmpPath = async () => {
       // validate that the tmp file has been downloaded and saved into the file path
       // must do it before it gets deleted
@@ -125,7 +126,7 @@ describe('uploader with tus protocol', () => {
       expect(fileInfo.isFile()).toBe(true)
       expect(fileInfo.size).toBe(fileContent.length)
 
-      return uploader.tryDeleteTmpPath()
+      return originalTryDeleteTmpPath()
     }
     const uploadToken = uploader.token
     expect(uploadToken).toBeTruthy()


### PR DESCRIPTION
and [remove invalid assertion](https://github.com/transloadit/uppy/commit/26417630b6654e121e5418c4a8cf2d6db8f549cb) 

success event never seems to have included "bytesTotal" in payload
this assertion was mistakenly moved from onProgress to success in https://github.com/transloadit/uppy/commit/1b5c0d7d4b6ac2f387ac5699d587e281f6579afe