### PR TITLE
@uppy/aws-s3-multipart: fix upload retry using an outdated ID

### DIFF
--- a/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
+++ b/e2e/cypress/integration/dashboard-aws-multipart.spec.ts
@@ -34,7 +34,7 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
 
     cy.intercept('POST', '/s3/multipart', { statusCode: 200, times: 1, body: JSON.stringify({ key:'mocked-key-attempt1', uploadId:'mocked-uploadId-attempt1' }) }).as('createMultipartUpload-attempt1')
     cy.intercept('GET', '/s3/multipart/mocked-uploadId-attempt1/1?key=mocked-key-attempt1', { forceNetworkError: true }).as('signPart-fails')
-    cy.intercept('DELETE', '/s3/multipart/mocked-uploadId-attempt1?key=mocked-key-attempt1', { statusCode: 204 }).as('abortAttempt-1')
+    cy.intercept('DELETE', '/s3/multipart/mocked-uploadId-attempt1?key=mocked-key-attempt1', { statusCode: 200, body: '{}' }).as('abortAttempt-1')
     cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
     cy.wait(['@createMultipartUpload-attempt1', '@signPart-fails', '@abortAttempt-1'])
     cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Upload failed')
@@ -47,7 +47,7 @@ describe('Dashboard with @uppy/aws-s3-multipart', () => {
       },
       body: JSON.stringify({ url:'/put-fail', expires:8 }),
     }).as('signPart-toFail')
-    cy.intercept('DELETE', '/s3/multipart/mocked-uploadId-attempt2?key=mocked-key-attempt2', { statusCode: 204 }).as('abortAttempt-2')
+    cy.intercept('DELETE', '/s3/multipart/mocked-uploadId-attempt2?key=mocked-key-attempt2', { statusCode: 200, body: '{}' }).as('abortAttempt-2')
     cy.intercept('PUT', '/put-fail', { forceNetworkError: true }).as('put-fails')
     cy.get('.uppy-StatusBar-actions > .uppy-c-btn').click()
     cy.wait(['@createMultipartUpload-attempt2', '@signPart-toFail', ...Array(5).fill('@put-fails'), '@abortAttempt-2'], { timeout: 10_000 })

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -86,10 +86,10 @@ class MultipartUploader {
     this.#onError = this.options.onError
     this.#shouldUseMultipart = this.options.shouldUseMultipart
 
-    // When we are restoring an upload, we already have an uploadId. Otherwise
-    // we need to call `createMultipartUpload` to get an `uploadId`.
+    // When we are restoring an upload, we already have an UploadId and a Key. Otherwise
+    // we need to call `createMultipartUpload` to get an `uploadId` and a `key`.
     // Non-multipart uploads are not restorable.
-    this.#isRestoring = 'uploadId' in options
+    this.#isRestoring = options.uploadFile && options.key
 
     this.#initChunks()
   }

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.js
@@ -89,7 +89,7 @@ class MultipartUploader {
     // When we are restoring an upload, we already have an UploadId and a Key. Otherwise
     // we need to call `createMultipartUpload` to get an `uploadId` and a `key`.
     // Non-multipart uploads are not restorable.
-    this.#isRestoring = options.uploadFile && options.key
+    this.#isRestoring = options.uploadId && options.key
 
     this.#initChunks()
   }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -204,6 +204,7 @@ class HTTPCommunicationQueue {
     // Remove the cache entry right away for follow-up requests do not try to
     // use the soon-to-be aborted chached values.
     this.#cache.delete(file.data)
+    this.#setS3MultipartState(file, Object.create(null))
     let awaitedResult
     try {
       awaitedResult = await result
@@ -258,7 +259,7 @@ class HTTPCommunicationQueue {
       return await this.#sendCompletionRequest(file, { key, uploadId, parts, signal }).abortOn(signal)
     } catch (err) {
       if (err?.cause !== pausingUploadReason && err?.name !== 'AbortError') {
-        this.abortFileUpload(file).catch(() => {})
+        this.abortFileUpload(file).catch(console.warn)
       }
       throw err
     }


### PR DESCRIPTION
https://github.com/transloadit/uppy/pull/4526 introduced a regression causing already aborted UploadId to be reused.