### PR TITLE
meta: use `corepack yarn` instead of `npm` to launch E2E

### DIFF
--- a/.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch
+++ b/.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch
@@ -1,0 +1,13 @@
+diff --git a/src/utils.js b/src/utils.js
+index 1f636c6617a71a68318dc587a1c9e6081020f9aa..b28e840ed08f26a4eadd242a6f541fbaefea0eda 100644
+--- a/src/utils.js
++++ b/src/utils.js
+@@ -112,7 +112,7 @@ const getArguments = cliArgs => {
+ }
+ 
+ function normalizeCommand (command) {
+-  return UTILS.isPackageScriptName(command) ? `npm run ${command}` : command
++  return UTILS.isPackageScriptName(command) ? `corepack yarn ${command}` : command
+ }
+ 
+ /**

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@types/react": "^17",
     "@types/webpack-dev-server": "^4",
     "preact": "patch:preact@npm:10.10.0#.yarn/patches/preact-npm-10.10.0-dd04de05e8.patch",
-    "pre-commit": "patch:pre-commit@npm:1.2.2#.yarn/patches/pre-commit-npm-1.2.2-f30af83877.patch"
+    "pre-commit": "patch:pre-commit@npm:1.2.2#.yarn/patches/pre-commit-npm-1.2.2-f30af83877.patch",
+    "start-server-and-test": "patch:start-server-and-test@npm:1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33343,7 +33343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"start-server-and-test@npm:^1.14.0":
+"start-server-and-test@npm:1.14.0":
   version: 1.14.0
   resolution: "start-server-and-test@npm:1.14.0"
   dependencies:
@@ -33359,6 +33359,25 @@ __metadata:
     start-server-and-test: src/bin/start.js
     start-test: src/bin/start.js
   checksum: 8437f5fc39bb47dd684b94023bab654703abc4890d08f005c3d86df620b2cdaac03f6e3bb21792a93209f1a70c8bb500d82fe4025a356da45fc060f2a80374e1
+  languageName: node
+  linkType: hard
+
+"start-server-and-test@patch:start-server-and-test@npm:1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
+  version: 1.14.0
+  resolution: "start-server-and-test@patch:start-server-and-test@npm%3A1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch::version=1.14.0&hash=2add03&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  dependencies:
+    bluebird: 3.7.2
+    check-more-types: 2.24.0
+    debug: 4.3.2
+    execa: 5.1.1
+    lazy-ass: 1.6.0
+    ps-tree: 1.2.0
+    wait-on: 6.0.0
+  bin:
+    server-test: src/bin/start.js
+    start-server-and-test: src/bin/start.js
+    start-test: src/bin/start.js
+  checksum: f69c82aa8fe842e9b36856ba8a350f031c8b1cf4617ac3353a710669cd6555122eac34de4cc73701550f0e498dbaef234d58f022f43509146d9f8fde0878bf4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I was getting locally `npm command not found` when trying to run `yarn e2e:ci` locally.