### PR TITLE
meta: Don't use triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,5 +1,5 @@
 name: 🐛 Bug report
-labels: Bug, Triage
+labels: Bug
 description: Describe a bug with a project
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,5 +1,5 @@
 name: 🚀 Feature request
-labels: Feature, Triage
+labels: Feature
 description: Suggest an idea
 body:
   - type: checkboxes


### PR DESCRIPTION
We sort new issues between bug and feature automatically