### PR TITLE
Add missing pt-BR locales for ImageEditor plugin

### DIFF
--- a/packages/@uppy/locales/src/pt_BR.js
+++ b/packages/@uppy/locales/src/pt_BR.js
@@ -13,6 +13,9 @@ pt_BR.strings = {
   addingMoreFiles: 'Adicionando mais arquivos',
   allowAccessDescription:
     'Para poder tirar fotos e gravar vídeos com sua câmera, por favor permita o acesso a câmera para esse site.',
+  aspectRatioSquare: 'Recortar quadrado',
+  aspectRatioLandscape: 'Recortar paisagem (16:9)',
+  aspectRatioPortrait: 'Recortar retrato (9:16)',
   allowAccessTitle: 'Por favor permita o acesso a sua câmera',
   authenticateWith: 'Conectar com %{pluginName}',
   authenticateWithTitle:
@@ -63,6 +66,7 @@ pt_BR.strings = {
   },
   filter: 'Filtrar',
   finishEditingFile: 'Finalizar edição de arquivo',
+  flipHorizontal: 'Inverter',
   folderAdded: {
     '0': 'Adicionado %{smart_count} arquivo de %{folder}',
     '1': 'Adicionado %{smart_count} arquivos de %{folder}',
@@ -88,6 +92,9 @@ pt_BR.strings = {
   resumeUpload: 'Retomar envio de arquivos',
   retry: 'Tentar novamente',
   retryUpload: 'Tentar enviar novamente',
+  revert: 'Reverter',
+  rotate: 'Girar',
+  save: 'Salvar',
   saveChanges: 'Salvar alterações',
   selectX: {
     '0': 'Selecionar %{smart_count}',
@@ -133,6 +140,8 @@ pt_BR.strings = {
     '0': 'Você precisa selecionar pelo menos %{smart_count} arquivo',
     '1': 'Você precisa selecionar pelo menos %{smart_count} arquivos',
   },
+  zoomIn: 'Aumentar o zoom',
+  zoomOut: 'Diminuir o zoom',
   selectFileNamed: 'Selecione o arquivo %{name}',
   unselectFileNamed: 'Deselecionar arquivo %{name}',
   openFolderNamed: 'Pasta aberta %{name}',


### PR DESCRIPTION
Upon testing multiple locales, I realized some options are falling back to English for the editor plugin. I did some digging and found out that the locales are missing in pt-BR. This should do it. 
I am a native Brazilian Portuguese speaker therefore I'm confident the translations are correct but please feel free to have someone review this translations if necessary. Hope this helps!