### PR TITLE
The use of a dynamic bucket is allowed

### DIFF
--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -13,45 +13,51 @@ export interface AwsS3SignedPart {
 }
 
 export interface AwsS3MultipartOptions extends PluginOptions {
-    companionHeaders?: { [type: string]: string }
-    companionUrl?: string
-    companionCookiesRule?: string
-    allowedMetaFields?: string[] | null
-    getChunkSize?: (file: UppyFile) => number
-    createMultipartUpload?: (
-      file: UppyFile
-    ) => MaybePromise<{ uploadId: string; key: string }>
-    listParts?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; signal: AbortSignal }
-    ) => MaybePromise<AwsS3Part[]>
-    signPart?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; partNumber: number; body: Blob, signal: AbortSignal }
-    ) => MaybePromise<AwsS3SignedPart>
-    /** @deprecated Use signPart instead */
-    prepareUploadParts?: (
-      file: UppyFile,
-      partData: { uploadId: string; key: string; parts: [{ number: number, chunk: Blob }], signal: AbortSignal }
-    ) => MaybePromise<{ presignedUrls: { [k: number]: string }, headers?: { [k: string]: string } }>
-    abortMultipartUpload?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; signal: AbortSignal }
-    ) => MaybePromise<void>
-    completeMultipartUpload?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
-    ) => MaybePromise<{ location?: string }>
-    limit?: number
-    shouldUseMultipart?: boolean | ((file: UppyFile) => boolean)
-    retryDelays?: number[] | null
-    getUploadParameters?: (
-      file: UppyFile
-    ) => MaybePromise<{ url: string }>
+  companionHeaders?: { [type: string]: string }
+  companionUrl?: string
+  companionCookiesRule?: string
+  allowedMetaFields?: string[] | null
+  getChunkSize?: (file: UppyFile) => number
+  createMultipartUpload?: (
+    file: UppyFile
+  ) => MaybePromise<{ uploadId: string; bucket?: string; key: string }>
+  listParts?: (
+    file: UppyFile,
+    opts: { uploadId: string; bucket?: string; key: string; signal: AbortSignal }
+  ) => MaybePromise<AwsS3Part[]>
+  signPart?: (
+    file: UppyFile,
+    opts: { uploadId: string; bucket?: string; key: string; partNumber: number; body: Blob, signal: AbortSignal }
+  ) => MaybePromise<AwsS3SignedPart>
+  /** @deprecated Use signPart instead */
+  prepareUploadParts?: (
+    file: UppyFile,
+    partData: {
+      uploadId: string;
+      bucket?: string;
+      key: string;
+      parts: [{ number: number, chunk: Blob }],
+      signal: AbortSignal,
+    }
+  ) => MaybePromise<{ presignedUrls: { [k: number]: string }, headers?: { [k: string]: string } }>
+  abortMultipartUpload?: (
+    file: UppyFile,
+    opts: { uploadId: string; bucket?: string; key: string; signal: AbortSignal }
+  ) => MaybePromise<void>
+  completeMultipartUpload?: (
+    file: UppyFile,
+    opts: { uploadId: string; bucket?: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
+  ) => MaybePromise<{ location?: string }>
+  limit?: number
+  shouldUseMultipart?: boolean | ((file: UppyFile) => boolean)
+  retryDelays?: number[] | null
+  getUploadParameters?: (
+    file: UppyFile
+  ) => MaybePromise<{ url: string }>
 }
 
 declare class AwsS3Multipart extends BasePlugin<
   AwsS3MultipartOptions
-> {}
+> { }
 
 export default AwsS3Multipart

--- a/packages/@uppy/companion/src/config/companion.js
+++ b/packages/@uppy/companion/src/config/companion.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs')
 const { isURL } = require('validator')
 const logger = require('../server/logger')
-const { defaultGetKey } = require('../server/helpers/utils')
+const { defaultGetKey, defaultGetBucket } = require('../server/helpers/utils')
 
 const defaultOptions = {
   server: {
@@ -14,6 +14,7 @@ const defaultOptions = {
     conditions: [],
     useAccelerateEndpoint: false,
     getKey: defaultGetKey,
+    getBucket: defaultGetBucket,
     expires: 800, // seconds
   },
   allowLocalUrls: false,

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -651,7 +651,7 @@ class Uploader {
     const { client, options } = s3Options
 
     const params = {
-      Bucket: options.bucket,
+      Bucket: options.getBucket(null, this.options.metadata) ?? options.bucket,
       Key: options.getKey(null, filename, this.options.metadata),
       ContentType: this.options.metadata.type,
       Metadata: this.options.metadata,

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -147,7 +147,7 @@ module.exports.decrypt = (encrypted, secret) => {
 
 module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename}`
 
-module.exports.defaultGetBucket = () => null
+module.exports.defaultGetBucket = (_) => null
 
 module.exports.prepareStream = async (stream) => new Promise((resolve, reject) => (
   stream

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -147,6 +147,8 @@ module.exports.decrypt = (encrypted, secret) => {
 
 module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename}`
 
+module.exports.defaultGetBucket = () => null
+
 module.exports.prepareStream = async (stream) => new Promise((resolve, reject) => (
   stream
     .on('response', () => {

--- a/packages/@uppy/companion/src/server/middlewares.js
+++ b/packages/@uppy/companion/src/server/middlewares.js
@@ -194,7 +194,7 @@ exports.getCompanionMiddleware = (options) => {
     const versionFromQuery = req.query.uppyVersions ? decodeURIComponent(req.query.uppyVersions) : null
     req.companion = {
       options,
-      s3Client: getS3Client(options),
+      s3Client: getS3Client(req, options),
       authToken: req.header('uppy-auth-token') || req.query.uppyAuthToken,
       clientVersion: req.header('uppy-versions') || versionFromQuery || '1.0.0',
       buildURL: getURLBuilder(options),

--- a/packages/@uppy/companion/src/server/s3-client.js
+++ b/packages/@uppy/companion/src/server/s3-client.js
@@ -3,9 +3,10 @@ const { S3Client } = require('@aws-sdk/client-s3')
 /**
  * instantiates the aws-sdk s3 client that will be used for s3 uploads.
  *
+ * @param {object} req the request object
  * @param {object} companionOptions the companion options object
  */
-module.exports = (companionOptions) => {
+module.exports = (req, companionOptions) => {
   let s3Client = null
   if (companionOptions.s3) {
     const { s3 } = companionOptions
@@ -28,14 +29,15 @@ module.exports = (companionOptions) => {
       s3ClientOptions.endpoint = s3.endpoint.replace(/{service}/, 's3').replace(/{region}/, s3.region)
     }
 
-    if (s3.useAccelerateEndpoint && s3.bucket != null) {
+    const bucket = s3.getBucket(req, {}) ?? s3.bucket
+    if (s3.useAccelerateEndpoint && bucket != null) {
       s3ClientOptions = {
         ...s3ClientOptions,
         useAccelerateEndpoint: true,
         bucketEndpoint: true,
         // This is a workaround for lacking support for useAccelerateEndpoint in createPresignedPost
         // See https://github.com/transloadit/uppy/issues/4135#issuecomment-1276450023
-        endpoint: `https://${s3.bucket}.s3-accelerate.amazonaws.com/`,
+        endpoint: `https://${bucket}.s3-accelerate.amazonaws.com/`,
       }
     }
 

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -65,6 +65,13 @@ const s3Prefix = process.env.COMPANION_AWS_PREFIX || ''
 const defaultStandaloneGetKey = (...args) => `${s3Prefix}${utils.defaultGetKey(...args)}`
 
 /**
+ * Default getBucket for Companion standalone variant
+ *
+ * @returns {string|null}
+ */
+const defaultStandaloneGetBucket = (...args) => `${utils.defaultGetBucket(...args)}`
+
+/**
  * Loads the config from environment variables
  *
  * @returns {object}
@@ -119,6 +126,7 @@ const getConfigFromEnv = () => {
     s3: {
       key: process.env.COMPANION_AWS_KEY,
       getKey: defaultStandaloneGetKey,
+      getBucket: defaultStandaloneGetBucket,
       secret: getSecret('COMPANION_AWS_SECRET'),
       bucket: process.env.COMPANION_AWS_BUCKET,
       endpoint: process.env.COMPANION_AWS_ENDPOINT,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8871,7 +8871,7 @@ __metadata:
 
 "@types/connect-redis@patch:@types/connect-redis@npm:0.0.18#.yarn/patches/@types-connect-redis-npm-0.0.18-4fd2b614d3::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
   version: 0.0.18
-  resolution: "@types/connect-redis@patch:@types/connect-redis@npm%3A0.0.18#.yarn/patches/@types-connect-redis-npm-0.0.18-4fd2b614d3::version=0.0.18&hash=df5a6e&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  resolution: "@types/connect-redis@patch:@types/connect-redis@npm%3A0.0.18#.yarn/patches/@types-connect-redis-npm-0.0.18-4fd2b614d3::version=0.0.18&hash=060147&locator=%40uppy-dev%2Fbuild%40workspace%3A."
   dependencies:
     "@types/express": "*"
     "@types/express-session": "*"
@@ -19856,7 +19856,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^1.2.7#~builtin<compat/fsevents>":
   version: 1.2.13
-  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=d11327"
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
@@ -19866,7 +19866,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -29763,7 +29763,7 @@ __metadata:
 
 "pre-commit@patch:pre-commit@npm:1.2.2#.yarn/patches/pre-commit-npm-1.2.2-f30af83877.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
   version: 1.2.2
-  resolution: "pre-commit@patch:pre-commit@npm%3A1.2.2#.yarn/patches/pre-commit-npm-1.2.2-f30af83877.patch::version=1.2.2&hash=b54a30&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  resolution: "pre-commit@patch:pre-commit@npm%3A1.2.2#.yarn/patches/pre-commit-npm-1.2.2-f30af83877.patch::version=1.2.2&hash=41c00a&locator=%40uppy-dev%2Fbuild%40workspace%3A."
   dependencies:
     cross-spawn: ^5.0.1
     spawn-sync: ^1.0.15
@@ -29792,7 +29792,7 @@ __metadata:
 
 "preact@patch:preact@npm:10.10.0#.yarn/patches/preact-npm-10.10.0-dd04de05e8.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
   version: 10.10.0
-  resolution: "preact@patch:preact@npm%3A10.10.0#.yarn/patches/preact-npm-10.10.0-dd04de05e8.patch::version=10.10.0&hash=e9860f&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  resolution: "preact@patch:preact@npm%3A10.10.0#.yarn/patches/preact-npm-10.10.0-dd04de05e8.patch::version=10.10.0&hash=513c63&locator=%40uppy-dev%2Fbuild%40workspace%3A."
   checksum: 8fefec89ac68b5bd8fc0c4f1672beb7585c878663f9e929de85ff0f5c6d12dc49d9910867d7c9ef2bc449ec09512241574e08cb0546bdb3a34600891db5e0a96
   languageName: node
   linkType: hard
@@ -31672,14 +31672,14 @@ __metadata:
 
 "resolve@patch:resolve@1.1.7#~builtin<compat/resolve>":
   version: 1.1.7
-  resolution: "resolve@patch:resolve@npm%3A1.1.7#~builtin<compat/resolve>::version=1.1.7&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.1.7#~builtin<compat/resolve>::version=1.1.7&hash=3bafbf"
   checksum: e9dbca78600ae56835c43a09f1276876c883e4b4bbd43e2683fa140671519d2bdebeb1c1576ca87c8c508ae2987b3ec481645ac5d3054b0f23254cfc1ce49942
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.5#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -31692,7 +31692,7 @@ __metadata:
 
 "resolve@patch:resolve@^2.0.0-next.4#~builtin<compat/resolve>":
   version: 2.0.0-next.4
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -33364,7 +33364,7 @@ __metadata:
 
 "start-server-and-test@patch:start-server-and-test@npm:1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
   version: 1.14.0
-  resolution: "start-server-and-test@patch:start-server-and-test@npm%3A1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch::version=1.14.0&hash=2add03&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  resolution: "start-server-and-test@patch:start-server-and-test@npm%3A1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch::version=1.14.0&hash=1ef69f&locator=%40uppy-dev%2Fbuild%40workspace%3A."
   dependencies:
     bluebird: 3.7.2
     check-more-types: 2.24.0
@@ -35257,11 +35257,11 @@ __metadata:
 
 "typescript@patch:typescript@*#~builtin<compat/typescript>, typescript@patch:typescript@^4.0.3#~builtin<compat/typescript>, typescript@patch:typescript@~4.8#~builtin<compat/typescript>":
   version: 4.8.2
-  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=f456af"
+  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=3b564f"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
+  checksum: 28e130a49d9330b64b8229ad336247bf980e9a705c5850f30a859a68c051e8e68e367b3275f119da4a825dca71ad0fe315964a1315d4a381c0021bca5eeeb62e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The use of a dynamic bucket is allowed, by using `s3.getBucket` in the companion configuration.
Eg:
	s3: {
		getBucket: (req, metadata) {
			return req.user.id;
		}
	}