### PR TITLE
e2e: increase `requestTimeout` to 16s

### DIFF
--- a/e2e/cypress.config.mjs
+++ b/e2e/cypress.config.mjs
@@ -3,7 +3,8 @@ import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter.j
 import startMockServer from './mock-server.mjs'
 
 export default defineConfig({
-  defaultCommandTimeout: 16000,
+  defaultCommandTimeout: 16_000,
+  requestTimeout: 16_000,
 
   e2e: {
     baseUrl: 'http://localhost:1234',


### PR DESCRIPTION
The default value was 5s, causing a lot of flakiness.