### PR TITLE
@uppy/core: allow duplicate files with onBeforeFileAdded

### DIFF
--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -547,7 +547,6 @@ class Uppy {
           this.log(`Replaced the blob in the restored ghost file: ${newFile.name}, ${newFile.id}`)
         }
 
-        console.log('HELLO')
         const onBeforeFileAddedResult = this.opts.onBeforeFileAdded(newFile, nextFilesState)
 
         if (!onBeforeFileAddedResult && this.checkIfFileAlreadyExists(newFile.id)) {

--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -59,7 +59,7 @@ class Uppy {
       debug: false,
       restrictions: defaultRestrictionOptions,
       meta: {},
-      onBeforeFileAdded: (file, files) => !(file.id in files),
+      onBeforeFileAdded: (file, files) => !Object.hasOwn(files, file.id),
       onBeforeUpload: (files) => files,
       store: new DefaultStore(),
       logger: justErrorsLogger,

--- a/packages/@uppy/core/src/Uppy.js
+++ b/packages/@uppy/core/src/Uppy.js
@@ -59,7 +59,7 @@ class Uppy {
       debug: false,
       restrictions: defaultRestrictionOptions,
       meta: {},
-      onBeforeFileAdded: (currentFile) => currentFile,
+      onBeforeFileAdded: (file, files) => !(file.id in files),
       onBeforeUpload: (files) => files,
       store: new DefaultStore(),
       logger: justErrorsLogger,
@@ -547,11 +547,12 @@ class Uppy {
           this.log(`Replaced the blob in the restored ghost file: ${newFile.name}, ${newFile.id}`)
         }
 
-        if (this.checkIfFileAlreadyExists(newFile.id)) {
+        console.log('HELLO')
+        const onBeforeFileAddedResult = this.opts.onBeforeFileAdded(newFile, nextFilesState)
+
+        if (!onBeforeFileAddedResult && this.checkIfFileAlreadyExists(newFile.id)) {
           throw new RestrictionError(this.i18n('noDuplicates', { fileName: newFile.name }), { file: fileToAdd })
         }
-
-        const onBeforeFileAddedResult = this.opts.onBeforeFileAdded(newFile, nextFilesState)
 
         if (onBeforeFileAddedResult === false) {
           // Don’t show UI info for this error, as it should be done by the developer

--- a/packages/@uppy/core/src/Uppy.test.js
+++ b/packages/@uppy/core/src/Uppy.test.js
@@ -702,6 +702,29 @@ describe('src/Core', () => {
       expect(onBeforeFileAdded.mock.calls[0][1]).toEqual({})
     })
 
+    it('should allow uploading duplicate file if explicitly allowed in onBeforeFileAdded', async () => {
+      const core = new Core({ onBeforeFileAdded: () => true })
+      const sameFileBlob = new File([sampleImage], { type: 'image/jpeg' })
+
+      core.addFile({
+        source: 'jest',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: sameFileBlob,
+      })
+
+      await core.upload()
+
+      expect(() => {
+        core.addFile({
+          source: 'jest',
+          name: 'foo.jpg',
+          type: 'image/jpeg',
+          data: sameFileBlob,
+        })
+      }).not.toThrow()
+    })
+
     it('should add a file', () => {
       const fileData = new File([sampleImage], { type: 'image/jpeg' })
       const fileAddedEventMock = jest.fn()

--- a/packages/@uppy/core/src/Uppy.test.js
+++ b/packages/@uppy/core/src/Uppy.test.js
@@ -713,16 +713,12 @@ describe('src/Core', () => {
         data: sameFileBlob,
       })
 
-      await core.upload()
-
-      expect(() => {
-        core.addFile({
-          source: 'jest',
-          name: 'foo.jpg',
-          type: 'image/jpeg',
-          data: sameFileBlob,
-        })
-      }).not.toThrow()
+      core.addFile({
+        source: 'jest',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: sameFileBlob,
+      })
     })
 
     it('should add a file', () => {


### PR DESCRIPTION
Closes #4470

- Change default signature of `onBeforeFileAdded` to check for duplicate files to not make this a breaking change.
- Swap order of `checkIfFileAlreadyExists` and `onBeforeFileAdded`.

This means:
- If you add the same file again before uploading, it will override it.
- If you add the same file after uploading, you can upload it again. Depending on your uploader and backend this may or may not override the file. Tus for instance always generates unique IDs so it wouldn't override it. But people should be able to handle it the way they want.

Needs docs PR too.