### PR TITLE
Invoke headers function for remote uploads

### DIFF
--- a/packages/@uppy/aws-s3/src/index.js
+++ b/packages/@uppy/aws-s3/src/index.js
@@ -276,7 +276,7 @@ export default class AwsS3 extends UploaderPlugin {
       metadata: Object.fromEntries(allowedMetaFields.map(name => [name, file.meta[name]])),
       httpMethod: opts.method,
       useFormData: opts.formData,
-      headers: opts.headers,
+      headers: typeof opts.headers === 'function' ? opts.headers(file) : opts.headers,
     })
     return res.token
   }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -447,7 +447,7 @@ export default class Tus extends UploaderPlugin {
       uploadUrl: opts.uploadUrl,
       protocol: 'tus',
       size: file.data.size,
-      headers: opts.headers,
+      headers: (typeof opts.headers === 'function') ? opts.headers(file) : opts.headers,
       metadata: file.meta,
     }, options)
     return res.token

--- a/packages/@uppy/xhr-upload/src/index.js
+++ b/packages/@uppy/xhr-upload/src/index.js
@@ -366,7 +366,7 @@ export default class XHRUpload extends UploaderPlugin {
       metadata: Object.fromEntries(allowedMetaFields.map(name => [name, file.meta[name]])),
       httpMethod: opts.method,
       useFormData: opts.formData,
-      headers: opts.headers,
+      headers: typeof opts.headers === 'function' ? opts.headers(file) : opts.headers,
     }, options)
     return res.token
   }


### PR DESCRIPTION
Streamline the behavior of local and remote uploads - currently when `headers` is a function it's serialized to `undefined` (or rather it's skipped) .

c.f. 
https://github.com/transloadit/uppy/blob/514690781a40b7204cd2c3750bb4b9cfbe473adb/packages/%40uppy/tus/src/index.js#L197-L199

https://github.com/transloadit/uppy/blob/514690781a40b7204cd2c3750bb4b9cfbe473adb/packages/%40uppy/xhr-upload/src/index.js#L149-L153


There is also 
https://github.com/transloadit/uppy/blob/514690781a40b7204cd2c3750bb4b9cfbe473adb/packages/%40uppy/aws-s3/src/index.js#L224-L226

Which looks like it should do the same, but the code is a little different and I don't want to touch it if I don't have to