### PR TITLE
@uppy/companion: fix Redis key default TTL

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -411,7 +411,6 @@ class Uploader {
     // https://github.com/transloadit/uppy/issues/3748
     const keyExpirySec = 60 * 60 * 24
     const redisKey = `${Uploader.STORAGE_PREFIX}:${this.token}`
-    // this.storage.set(redisKey, jsonStringify(state), 'EX', keyExpirySec)
     this.storage.set(redisKey, jsonStringify(state), {
     EX: keyExpirySec,
     })

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -411,7 +411,10 @@ class Uploader {
     // https://github.com/transloadit/uppy/issues/3748
     const keyExpirySec = 60 * 60 * 24
     const redisKey = `${Uploader.STORAGE_PREFIX}:${this.token}`
-    this.storage.set(redisKey, jsonStringify(state), 'EX', keyExpirySec)
+    // this.storage.set(redisKey, jsonStringify(state), 'EX', keyExpirySec)
+    this.storage.set(redisKey, jsonStringify(state), {
+    EX: keyExpirySec,
+    })
   }
 
   throttledEmitProgress = throttle((dataToEmit) => {

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -412,7 +412,7 @@ class Uploader {
     const keyExpirySec = 60 * 60 * 24
     const redisKey = `${Uploader.STORAGE_PREFIX}:${this.token}`
     this.storage.set(redisKey, jsonStringify(state), {
-    EX: keyExpirySec,
+      EX: keyExpirySec,
     })
   }
 


### PR DESCRIPTION
This PR fixes redis default ttl 

prev was in version v3 but in https://github.com/transloadit/uppy/pull/3589 updated to v4 but we need to update the syntax also to set redis url

https://github.com/transloadit/uppy/issues/3748#ref-commit-3387b84

**code changes** 
`this.storage.set(redisKey, jsonStringify(state), 'EX', keyExpirySec)` has been updated to 

` this.storage.set(redisKey, jsonStringify(state), {
    EX: keyExpirySec,
    })
 `
 
 file `packages/@uppy/companion/src/server/Uploader.js`
