### PR TITLE
@uppy/companion: Fix Uploader.js metadata normalisation

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -51,7 +51,6 @@ function rfc2047Encode (data) {
   return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encode non-ASCII strings
 }
 
-
 // TODO remove once we migrate away from form-data
 function sanitizeMetadata (inputMetadata) {
   if (inputMetadata == null) return {}
@@ -138,7 +137,6 @@ function validateOptions (options) {
   }
 }
 
-
 class Uploader {
   /**
    * Uploads file to destination based on the supplied protocol (tus, s3-multipart, multipart)
@@ -218,8 +216,6 @@ class Uploader {
     this.uploadStopped = true
     if (this.readStream) this.readStream.destroy(err)
   }
-
- 
 
   async _uploadByProtocol () {
     // todo a default protocol should not be set. We should ensure that the user specifies their protocol.
@@ -666,7 +662,7 @@ class Uploader {
       Bucket: options.bucket,
       Key: options.getKey(null, filename, this.options.metadata),
       ContentType: this.options.metadata.type,
-      Metadata:  Object.fromEntries(Object.entries(this.options.metadata).map(entry => entry.map(rfc2047Encode))),
+      Metadata: Object.fromEntries(Object.entries(this.options.metadata).map(entry => entry.map(rfc2047Encode))),
       Body: stream,
     }
 

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -14,13 +14,7 @@ const {
 const { createPresignedPost } = require('@aws-sdk/s3-presigned-post')
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner')
 
-function rfc2047Encode (data) {
-  // eslint-disable-next-line no-param-reassign
-  data = `${data}`
-  // eslint-disable-next-line no-control-regex
-  if (/^[\x00-\x7F]*$/.test(data)) return data // we return ASCII as is
-  return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encode non-ASCII strings
-}
+const { rfc2047EncodeMetadata } = require('../helpers/utils')
 
 module.exports = function s3 (config) {
   if (typeof config.acl !== 'string' && config.acl != null) {
@@ -138,7 +132,7 @@ module.exports = function s3 (config) {
       Bucket: bucket,
       Key: key,
       ContentType: type,
-      Metadata: Object.fromEntries(Object.entries(metadata).map(entry => entry.map(rfc2047Encode))),
+      Metadata: rfc2047EncodeMetadata(metadata),
     }
 
     if (config.acl != null) params.ACL = config.acl

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -174,3 +174,14 @@ module.exports.getBasicAuthHeader = (key, secret) => {
   const base64 = Buffer.from(`${key}:${secret}`, 'binary').toString('base64')
   return `Basic ${base64}`
 }
+
+const rfc2047Encode = (dataIn) => {
+  const data = `${dataIn}`
+  // eslint-disable-next-line no-control-regex
+  if (/^[\x00-\x7F]*$/.test(data)) return data // we return ASCII as is
+  return `=?UTF-8?B?${Buffer.from(data).toString('base64')}?=` // We encode non-ASCII strings
+}
+
+module.exports.rfc2047EncodeMetadata = (metadata) => (
+  Object.fromEntries(Object.entries(metadata).map((entry) => entry.map(rfc2047Encode)))
+)


### PR DESCRIPTION
While uploading from Box, Gdrive or any other companion provider, if the file name is something like `Joe Rogan’s Shortest Podcasts.mp4` so `Rogan’s` which is not url safe. the upload got 500 error.

so updated the Metadata to use `rfc2047Encode` function. in file `packages/@uppy/companion/src/server/Uploader.js`

Please advice if needed any more changes 
