### PR TITLE
@uppy/aws-s3,@uppy/aws-s3-multipart: update types

### DIFF
--- a/e2e/cypress/integration/dashboard-transloadit.spec.ts
+++ b/e2e/cypress/integration/dashboard-transloadit.spec.ts
@@ -364,7 +364,6 @@ describe('Dashboard with Transloadit', () => {
 
   it('should complete on retry', () => {
     cy.get('@file-input').selectFile(['cypress/fixtures/images/cat.jpg', 'cypress/fixtures/images/traffic.jpg'], { force: true })
-    cy.get('.uppy-StatusBar-actionBtn--upload').click()
 
     cy.intercept('POST', 'https://transloaditstatus.com/client_error', {
       statusCode: 200,
@@ -376,7 +375,9 @@ describe('Dashboard with Transloadit', () => {
       { statusCode: 500, body: {} },
     ).as('failedAssemblyCreation')
 
+    cy.get('.uppy-StatusBar-actionBtn--upload').click()
     cy.wait('@failedAssemblyCreation')
+
     cy.get('button[data-cy=retry]').click()
 
     cy.wait(['@assemblies', '@resumable'])

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -5,13 +5,13 @@ type MaybePromise<T> = T | Promise<T>
 export type AwsS3UploadParameters = {
   method: 'POST'
   url: string
-  fields?: Record<string, string>
+  fields: Record<string, string>
   expires?: number
   headers?: Record<string, string>
 } | {
   method?: 'PUT'
   url: string
-  fields: never
+  fields?: never
   expires?: number
   headers?: Record<string, string>
 }
@@ -40,7 +40,7 @@ export interface AwsS3STSResponse {
 }
 
 type AWSS3NonMultipartWithCompanionMandatory = {
-  getUploadParameters: never
+  getUploadParameters?: never
 }
 
 type AWSS3NonMultipartWithoutCompanionMandatory = {
@@ -52,21 +52,31 @@ type AWSS3NonMultipartWithCompanion = AWSS3WithCompanion &
                                       AWSS3NonMultipartWithCompanionMandatory &
                                       {
                                         shouldUseMultipart: false
+                                        createMultipartUpload?: never
+                                        listParts?: never
+                                        signPart?: never
+                                        abortMultipartUpload?: never
+                                        completeMultipartUpload?: never
                                       }
 
 type AWSS3NonMultipartWithoutCompanion = AWSS3WithoutCompanion &
                                          AWSS3NonMultipartWithoutCompanionMandatory &
                                          {
                                            shouldUseMultipart: false
+                                           createMultipartUpload?: never
+                                           listParts?: never
+                                           signPart?: never
+                                           abortMultipartUpload?: never
+                                           completeMultipartUpload?: never
                                          }
 
 type AWSS3MultipartWithCompanionMandatory = {
   getChunkSize?: (file: UppyFile) => number
-  createMultipartUpload: never
-  listParts: never
-  signPart: never
-  abortMultipartUpload: never
-  completeMultipartUpload: never
+  createMultipartUpload?: never
+  listParts?: never
+  signPart?: never
+  abortMultipartUpload?: never
+  completeMultipartUpload?: never
 }
 type AWSS3MultipartWithoutCompanionMandatory = {
   getChunkSize?: (file: UppyFile) => number
@@ -93,15 +103,15 @@ type AWSS3MultipartWithoutCompanionMandatory = {
 type AWSS3MultipartWithoutCompanion = AWSS3WithoutCompanion &
                                       AWSS3MultipartWithoutCompanionMandatory &
                                       {
-                                        shouldUseMultipart: true
-                                        getUploadParameters: never
+                                        shouldUseMultipart?: true
+                                        getUploadParameters?: never
                                       }
 
 type AWSS3MultipartWithCompanion = AWSS3WithCompanion &
                                    AWSS3MultipartWithCompanionMandatory &
                                    {
-                                     shouldUseMultipart: true
-                                     getUploadParameters: never
+                                     shouldUseMultipart?: true
+                                     getUploadParameters?: never
                                    }
 
 type AWSS3MaybeMultipartWithCompanion = AWSS3WithCompanion &
@@ -125,9 +135,9 @@ type AWSS3WithCompanion = {
   getTemporarySecurityCredentials?: true
 }
 type AWSS3WithoutCompanion = {
-  companionUrl: never
-  companionHeaders: never
-  companionCookiesRule: never
+  companionUrl?: never
+  companionHeaders?: never
+  companionCookiesRule?: never
   getTemporarySecurityCredentials?: (options?: {signal?: AbortSignal}) => MaybePromise<AwsS3STSResponse>
 }
 
@@ -135,6 +145,11 @@ interface _AwsS3MultipartOptions extends PluginOptions {
     allowedMetaFields?: string[] | null
     limit?: number
     retryDelays?: number[] | null
+    /** @deprecated Use signPart instead */
+    prepareUploadParts?: (
+      file: UppyFile,
+      partData: { uploadId: string; key: string; parts: [{ number: number, chunk: Blob }] }
+    ) => MaybePromise<{ presignedUrls: Record<number, string>, headers?: Record<number, Record<string, string>> }>
 }
 
 export type AwsS3MultipartOptions = _AwsS3MultipartOptions & (AWSS3NonMultipartWithCompanion |

--- a/packages/@uppy/aws-s3-multipart/types/index.d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.d.ts
@@ -2,11 +2,28 @@ import type { BasePlugin, PluginOptions, UppyFile } from '@uppy/core'
 
 type MaybePromise<T> = T | Promise<T>
 
+export type AwsS3UploadParameters = {
+  method: 'POST'
+  url: string
+  fields?: Record<string, string>
+  expires?: number
+  headers?: Record<string, string>
+} | {
+  method?: 'PUT'
+  url: string
+  fields: never
+  expires?: number
+  headers?: Record<string, string>
+}
+
 export interface AwsS3Part {
   PartNumber?: number
   Size?: number
   ETag?: string
 }
+/**
+ * @deprecated use {@link AwsS3UploadParameters} instead
+ */
 export interface AwsS3SignedPart {
   url: string
   headers?: Record<string, string>
@@ -22,43 +39,110 @@ export interface AwsS3STSResponse {
   region: string
 }
 
-export interface AwsS3MultipartOptions extends PluginOptions {
-    companionHeaders?: { [type: string]: string }
-    companionUrl?: string
-    companionCookiesRule?: string
-    allowedMetaFields?: string[] | null
-    getChunkSize?: (file: UppyFile) => number
-    createMultipartUpload?: (
-      file: UppyFile
-    ) => MaybePromise<{ uploadId: string; key: string }>
-    listParts?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; signal: AbortSignal }
-    ) => MaybePromise<AwsS3Part[]>
-    signPart?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; partNumber: number; body: Blob; signal: AbortSignal }
-    ) => MaybePromise<AwsS3SignedPart>
-    /** @deprecated Use signPart instead */
-    prepareUploadParts?: (
-      file: UppyFile,
-      partData: { uploadId: string; key: string; parts: [{ number: number, chunk: Blob }] }
-    ) => MaybePromise<{ presignedUrls: Record<number, string>, headers?: Record<number, Record<string, string>> }>
-    abortMultipartUpload?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; signal: AbortSignal }
-    ) => MaybePromise<void>
-    completeMultipartUpload?: (
-      file: UppyFile,
-      opts: { uploadId: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
-    ) => MaybePromise<{ location?: string }>
-    limit?: number
-    shouldUseMultipart?: boolean | ((file: UppyFile) => boolean)
-    retryDelays?: number[] | null
-    getUploadParameters?: (
-      file: UppyFile
-    ) => MaybePromise<{ url: string }>
+type AWSS3NonMultipartWithCompanionMandatory = {
+  getUploadParameters: never
 }
+
+type AWSS3NonMultipartWithoutCompanionMandatory = {
+  getUploadParameters: (
+    file: UppyFile
+  ) => MaybePromise<AwsS3UploadParameters>
+}
+type AWSS3NonMultipartWithCompanion = AWSS3WithCompanion &
+                                      AWSS3NonMultipartWithCompanionMandatory &
+                                      {
+                                        shouldUseMultipart: false
+                                      }
+
+type AWSS3NonMultipartWithoutCompanion = AWSS3WithoutCompanion &
+                                         AWSS3NonMultipartWithoutCompanionMandatory &
+                                         {
+                                           shouldUseMultipart: false
+                                         }
+
+type AWSS3MultipartWithCompanionMandatory = {
+  getChunkSize?: (file: UppyFile) => number
+  createMultipartUpload: never
+  listParts: never
+  signPart: never
+  abortMultipartUpload: never
+  completeMultipartUpload: never
+}
+type AWSS3MultipartWithoutCompanionMandatory = {
+  getChunkSize?: (file: UppyFile) => number
+  createMultipartUpload: (
+    file: UppyFile
+  ) => MaybePromise<{ uploadId: string; key: string }>
+  listParts: (
+    file: UppyFile,
+    opts: { uploadId: string; key: string; signal: AbortSignal }
+  ) => MaybePromise<AwsS3Part[]>
+  signPart: (
+    file: UppyFile,
+    opts: { uploadId: string; key: string; partNumber: number; body: Blob; signal: AbortSignal }
+  ) => MaybePromise<AwsS3UploadParameters>
+  abortMultipartUpload: (
+    file: UppyFile,
+    opts: { uploadId: string; key: string; signal: AbortSignal }
+  ) => MaybePromise<void>
+  completeMultipartUpload: (
+    file: UppyFile,
+    opts: { uploadId: string; key: string; parts: AwsS3Part[]; signal: AbortSignal }
+  ) => MaybePromise<{ location?: string }>
+}
+type AWSS3MultipartWithoutCompanion = AWSS3WithoutCompanion &
+                                      AWSS3MultipartWithoutCompanionMandatory &
+                                      {
+                                        shouldUseMultipart: true
+                                        getUploadParameters: never
+                                      }
+
+type AWSS3MultipartWithCompanion = AWSS3WithCompanion &
+                                   AWSS3MultipartWithCompanionMandatory &
+                                   {
+                                     shouldUseMultipart: true
+                                     getUploadParameters: never
+                                   }
+
+type AWSS3MaybeMultipartWithCompanion = AWSS3WithCompanion &
+                                        AWSS3MultipartWithCompanionMandatory &
+                                        AWSS3NonMultipartWithCompanionMandatory &
+                                        {
+                                          shouldUseMultipart: ((file: UppyFile) => boolean)
+                                        }
+
+type AWSS3MaybeMultipartWithoutCompanion = AWSS3WithoutCompanion &
+                                           AWSS3MultipartWithoutCompanionMandatory &
+                                           AWSS3NonMultipartWithoutCompanionMandatory &
+                                           {
+                                             shouldUseMultipart: ((file: UppyFile) => boolean)
+                                           }
+
+type AWSS3WithCompanion = {
+  companionUrl: string
+  companionHeaders?: Record<string, string>
+  companionCookiesRule?: string
+  getTemporarySecurityCredentials?: true
+}
+type AWSS3WithoutCompanion = {
+  companionUrl: never
+  companionHeaders: never
+  companionCookiesRule: never
+  getTemporarySecurityCredentials?: (options?: {signal?: AbortSignal}) => MaybePromise<AwsS3STSResponse>
+}
+
+interface _AwsS3MultipartOptions extends PluginOptions {
+    allowedMetaFields?: string[] | null
+    limit?: number
+    retryDelays?: number[] | null
+}
+
+export type AwsS3MultipartOptions = _AwsS3MultipartOptions & (AWSS3NonMultipartWithCompanion |
+                                                              AWSS3NonMultipartWithoutCompanion |
+                                                              AWSS3MultipartWithCompanion |
+                                                              AWSS3MultipartWithoutCompanion |
+                                                              AWSS3MaybeMultipartWithCompanion |
+                                                              AWSS3MaybeMultipartWithoutCompanion)
 
 declare class AwsS3Multipart extends BasePlugin<
   AwsS3MultipartOptions

--- a/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
@@ -7,6 +7,7 @@ import type { AwsS3Part } from '..'
 {
   const uppy = new Uppy()
   uppy.use(AwsS3Multipart, {
+    shouldUseMultipart: true,
     createMultipartUpload (file) {
       expectType<UppyFile>(file)
       return { uploadId: '', key: '' }
@@ -17,12 +18,13 @@ import type { AwsS3Part } from '..'
       expectType<string>(opts.key)
       return []
     },
-    prepareUploadParts (file, partData) {
+    signPart (file, opts) {
       expectType<UppyFile>(file)
-      expectType<string>(partData.uploadId)
-      expectType<string>(partData.key)
-      expectType<[{number: number, chunk: Blob}]>(partData.parts)
-      return { presignedUrls: {} }
+      expectType<string>(opts.uploadId)
+      expectType<string>(opts.key)
+      expectType<Blob>(opts.body)
+      expectType<AbortSignal>(opts.signal)
+      return { url: '' }
     },
     abortMultipartUpload (file, opts) {
       expectType<UppyFile>(file)
@@ -41,8 +43,8 @@ import type { AwsS3Part } from '..'
 
 {
   const uppy = new Uppy()
-  expectError(uppy.use(AwsS3Multipart, { getChunkSize: 100 }))
-  expectError(uppy.use(AwsS3Multipart, { getChunkSize: () => 'not a number' }))
-  uppy.use(AwsS3Multipart, { getChunkSize: () => 100 })
-  uppy.use(AwsS3Multipart, { getChunkSize: (file) => file.size })
+  expectError(uppy.use(AwsS3Multipart, { companionUrl: '', getChunkSize: 100 }))
+  expectError(uppy.use(AwsS3Multipart, { companionUrl: '', getChunkSize: () => 'not a number' }))
+  uppy.use(AwsS3Multipart, { companionUrl: '', getChunkSize: () => 100 })
+  uppy.use(AwsS3Multipart, { companionUrl: '', getChunkSize: (file) => file.size })
 }

--- a/packages/@uppy/aws-s3/types/index.d.ts
+++ b/packages/@uppy/aws-s3/types/index.d.ts
@@ -12,13 +12,13 @@ export type AwsS3UploadParameters = {
 } | {
   method: 'PUT'
   url: string
-  fields: never
+  fields?: never
   expires?: number
   headers?: Record<string, string>
 }
 
 interface LegacyAwsS3Options extends PluginOptions {
-  shouldUseMultipart: never
+    shouldUseMultipart?: never
     companionUrl?: string | null
     companionHeaders?: Record<string, string>
     allowedMetaFields?: Array<string> | null

--- a/packages/@uppy/aws-s3/types/index.d.ts
+++ b/packages/@uppy/aws-s3/types/index.d.ts
@@ -1,35 +1,36 @@
+import { AwsS3MultipartOptions } from '@uppy/aws-s3-multipart'
 import type { BasePlugin, Locale, PluginOptions, UppyFile } from '@uppy/core'
 
 type MaybePromise<T> = T | Promise<T>
 
-export interface AwsS3UploadParameters {
-    method?: string
-    url: string
-    fields?: { [type: string]: string }
-    headers?: { [type: string]: string }
+export type AwsS3UploadParameters = {
+  method?: 'POST'
+  url: string
+  fields?: Record<string, string>
+  expires?: number
+  headers?: Record<string, string>
+} | {
+  method: 'PUT'
+  url: string
+  fields: never
+  expires?: number
+  headers?: Record<string, string>
 }
 
-export interface AwsS3Options extends PluginOptions {
+interface LegacyAwsS3Options extends PluginOptions {
+  shouldUseMultipart: never
     companionUrl?: string | null
     companionHeaders?: Record<string, string>
     allowedMetaFields?: Array<string> | null
-    getUploadParameters?: (file: UppyFile) => MaybePromise<{
-      method?: 'POST'
-      url: string
-      fields?: Record<string, string>
-      headers?: Record<string, string>
-    } | {
-      method: 'PUT'
-      url: string
-      fields: never
-      headers?: Record<string, string>
-    }>
+    getUploadParameters?: (file: UppyFile) => MaybePromise<AwsS3UploadParameters>
     limit?: number
     /** @deprecated this option will not be supported in future versions of this plugin */
     getResponseData?: (responseText: string, response: XMLHttpRequest) => void
     locale?: Locale,
     timeout?: number
-}
+  }
+
+export type AwsS3Options = LegacyAwsS3Options | AwsS3MultipartOptions;
 
 declare class AwsS3 extends BasePlugin<AwsS3Options> {}
 

--- a/packages/@uppy/aws-s3/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import { Uppy, UppyFile } from '@uppy/core'
-import { expectType } from 'tsd'
+import { expectType, expectError } from 'tsd'
 import AwsS3 from '..'
 
 {
@@ -7,7 +7,21 @@ import AwsS3 from '..'
   uppy.use(AwsS3, {
     getUploadParameters (file) {
       expectType<UppyFile>(file)
-      return { method: 'POST', url: '', fields: {}, headers: {} }
+      return { method: 'POST', url: '' }
+    },
+  })
+  expectError(uppy.use(AwsS3, {
+    shouldUseMultipart: false,
+    getUploadParameters (file) {
+      expectType<UppyFile>(file)
+      return { method: 'POST', url: '' }
+    },
+  }))
+  uppy.use(AwsS3, {
+    shouldUseMultipart: false,
+    getUploadParameters (file) {
+      expectType<UppyFile>(file)
+      return { method: 'POST', url: '', fields: {} }
     },
   })
 }

--- a/packages/@uppy/aws-s3/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3/types/index.test-d.ts
@@ -1,5 +1,6 @@
 import { Uppy, UppyFile } from '@uppy/core'
 import { expectType, expectError } from 'tsd'
+import type { AwsS3Part } from '@uppy/aws-s3-multipart'
 import AwsS3 from '..'
 
 {
@@ -22,6 +23,50 @@ import AwsS3 from '..'
     getUploadParameters (file) {
       expectType<UppyFile>(file)
       return { method: 'POST', url: '', fields: {} }
+    },
+  })
+  expectError(uppy.use(AwsS3, {
+    shouldUseMultipart: true,
+    getUploadParameters (file) {
+      expectType<UppyFile>(file)
+      return { method: 'PUT', url: '' }
+    },
+  }))
+  uppy.use(AwsS3, {
+    shouldUseMultipart: () => Math.random() > 0.5,
+    getUploadParameters (file) {
+      expectType<UppyFile>(file)
+      return { method: 'PUT', url: '' }
+    },
+    createMultipartUpload (file) {
+      expectType<UppyFile>(file)
+      return { uploadId: '', key: '' }
+    },
+    listParts (file, opts) {
+      expectType<UppyFile>(file)
+      expectType<string>(opts.uploadId)
+      expectType<string>(opts.key)
+      return []
+    },
+    signPart (file, opts) {
+      expectType<UppyFile>(file)
+      expectType<string>(opts.uploadId)
+      expectType<string>(opts.key)
+      expectType<Blob>(opts.body)
+      expectType<AbortSignal>(opts.signal)
+      return { url: '' }
+    },
+    abortMultipartUpload (file, opts) {
+      expectType<UppyFile>(file)
+      expectType<string>(opts.uploadId)
+      expectType<string>(opts.key)
+    },
+    completeMultipartUpload (file, opts) {
+      expectType<UppyFile>(file)
+      expectType<string>(opts.uploadId)
+      expectType<string>(opts.key)
+      expectType<AwsS3Part>(opts.parts[0])
+      return {}
     },
   })
 }


### PR DESCRIPTION
Attempt at making `@uppy/aws-s3` types more useful for consumers. 