### PR TITLE
update to node-18.17.0-alpine, 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0-alpine as build
+FROM node:18.17.0-alpine as build
 
 # Create link to node on amd64 so that corepack can find it
 RUN if [ "$(uname -m)" == "aarch64" ]; then mkdir -p /usr/local/sbin/ && ln -s /usr/local/bin/node /usr/local/sbin/node; fi
@@ -19,7 +19,7 @@ RUN cd /app && corepack yarn workspace @uppy/companion build
 # Now remove all non-prod dependencies for a leaner image
 RUN cd /app && corepack yarn workspaces focus @uppy/companion --production
 
-FROM node:16.13.0-alpine
+FROM node:18.17.0-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:16.13.0-alpine
+FROM node:18.17.0-alpine
 
 COPY package.json /app/package.json
 


### PR DESCRIPTION
update to node-18.17.0-alpine as node 16 have 1 high security issue https://nodejs.org/en/blog/vulnerability/february-2023-security-releases#nodejs-permissions-policies-can-be-bypassed-via-processmainmodule-high-cve-2023-23918