### PR TITLE
Improve Contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,18 +14,8 @@ Corepack comes pre-installed with Node.js >=16.x, or can be installed through `n
 
 ```sh
 corepack -v || npm i -g corepack
-```
-
-You can either run `corepack enable` to install a `yarn` executable in your `$PATH`, and run all `yarn` commands in this guide as they are written:
-
-```sh
 corepack enable
-# e.g. `yarn install`
 ```
-
-or prefix all `yarn` commands in this guide with `corepack yarn` (e.g.
-`corepack yarn install` instead of `yarn install`).
-
 
 [Corepack]: https://nodejs.org/api/corepack.html
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,8 @@ corepack enable
 # e.g. `yarn install`
 ```
 
-or prefix all `yarn` commands in this guide with `corepack yarn`:
+or prefix all `yarn` commands in this guide with `corepack yarn` (e.g.
+`corepack yarn install` instead of `yarn install`).
 
 ```sh
 corepack yarn install

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,7 +44,7 @@ yarn install
 To run a basic development version of Uppy, run:
 
 ```bash
-yarn run dev
+yarn dev
 ```
 
 and go to http://localhost:5174 (or whatever link the yarn command outputted).\

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/transloadit/uppy.git
 cd uppy
 ```
 
-We are using [Corepack][] to manage versions of [Yarn][].\
+We are using [Corepack][] to manage versions of [Yarn][].
 Corepack comes pre-installed with Node.js >=16.x, or can be installed through `npm`:
 
 ```sh

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Now you should be able to test the Instagram integration.
 Unit tests are using Jest and can be run with:
 
 ```bash
-yarn run test:unit
+yarn test:unit
 ```
 
 ### End-to-End tests

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,12 +9,24 @@ git clone https://github.com/transloadit/uppy.git
 cd uppy
 ```
 
-We are using [Corepack][] to manage version of [Yarn][]. Corepack comes pre-installed with Node.js >=16.x, or can be installed through `npm`. You can run `corepack enable` to install a `yarn` executable in your `$PATH`, or prefix all yarn commands with `corepack yarn`.
+We are using [Corepack][] to manage versions of [Yarn][].\
+Corepack comes pre-installed with Node.js >=16.x, or can be installed through `npm`:
 
 ```sh
 corepack -v || npm i -g corepack
-yarn -v || corepack enable
-yarn install || corepack yarn install
+```
+
+You can either run `corepack enable` to install a `yarn` executable in your `$PATH`, and run all `yarn` commands in this guide as they are written:
+
+```sh
+corepack enable
+# e.g. `yarn install`
+```
+
+or prefix all `yarn` commands in this guide with `corepack yarn`:
+
+```sh
+# e.g. `corepack yarn install`
 ```
 
 [Corepack]: https://nodejs.org/api/corepack.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,9 +26,6 @@ corepack enable
 or prefix all `yarn` commands in this guide with `corepack yarn` (e.g.
 `corepack yarn install` instead of `yarn install`).
 
-```sh
-corepack yarn install
-```
 
 [Corepack]: https://nodejs.org/api/corepack.html
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Uppy development
+## Contributing to Uppy
 
 Fork the repository into your own account first. See the [GitHub Help](https://help.github.com/articles/fork-a-repo/) article for instructions.
 
@@ -33,52 +33,34 @@ or prefix all `yarn` commands in this guide with `corepack yarn`:
 
 [Yarn]: https://yarnpkg.com/
 
-### Requiring files
+## Development
 
-* If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (for example to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).
-* But if we want to `require()` some file from another subpackage - we should use global @uppy requires, and they should always be in the form of `@uppy/:packageName/(lib instead of src)/(same path).js`
-
-## Tests
-
-### Unit tests
-
-Unit tests are using Jest and can be run with:
+First of all, install Uppy dependencies:
 
 ```bash
-yarn run test:unit
+yarn install
 ```
 
-### End-to-End tests
+### Basic
 
-We use [Cypress](https://www.cypress.io/) for our e2e test suite. Be sure to checkout “[Writing your first test](https://docs.cypress.io/guides/getting-started/writing-your-first-test#Add-a-test-file)” and the “[Introduction to Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Cypress-Can-Be-Simple-Sometimes)”. You should also be aware of the “[Best Practices](https://docs.cypress.io/guides/references/best-practices)”.
+To run a basic development version of Uppy, run:
 
-To get started make sure you have your `.env` set up. Copy the contents of `.env.example` to a file named `.env` and add the values relevant for the test(s) you are trying to run.
+```bash
+yarn run dev
+```
 
-To start the testing suite run:
-
-    yarn e2e
-
-This will run Cypress in watch-mode, and it will pick up and rebuild any changes to JS files. If you need to change other files (like CSS for example), you need to run the respective `yarn build:*` scripts.
-
-Alternatively the following command is the same as the above, except it doesn’t run `build` first:
-
-    yarn e2e:skip-build
-
-To generate the boilerplate for a new test run:
-
-    yarn e2e:generate
-
-## Development
+and go to http://localhost:5174 (or whatever link the yarn command outputted).\
+As you edit Uppy code, the browser will live reload the changes.
 
 ### Companion
 
-To start the Companion server along with Uppy, run:
+If you’d like to work on features that the basic development version of Uppy doesn’t support, such as Uppy integrations with Instagram/Google Drive/Facebook etc., you need to set up your `.env` file (copy the contents of `.env.example` and adjust them based on what you need to work on), and run:
 
 ```bash
 yarn run dev:with-companion
 ```
 
-or if you only want to run Companion
+Or, if you only want to run the Companion server:
 
 ```bash
 yarn run start:companion
@@ -147,6 +129,41 @@ Go to your instagram account at <https://www.instagram.com/accounts/manage_acces
 Tester invites -> Accept
 
 Now you should be able to test the Instagram integration.
+
+### Requiring files
+
+* If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (for example to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).
+* But if we want to `require()` some file from another subpackage - we should use global @uppy requires, and they should always be in the form of `@uppy/:packageName/(lib instead of src)/(same path).js`
+
+## Tests
+
+### Unit tests
+
+Unit tests are using Jest and can be run with:
+
+```bash
+yarn run test:unit
+```
+
+### End-to-End tests
+
+We use [Cypress](https://www.cypress.io/) for our e2e test suite. Be sure to checkout “[Writing your first test](https://docs.cypress.io/guides/getting-started/writing-your-first-test#Add-a-test-file)” and the “[Introduction to Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Cypress-Can-Be-Simple-Sometimes)”. You should also be aware of the “[Best Practices](https://docs.cypress.io/guides/references/best-practices)”.
+
+To get started make sure you have your `.env` set up. Copy the contents of `.env.example` to a file named `.env` and add the values relevant for the test(s) you are trying to run.
+
+To start the testing suite run:
+
+    yarn e2e
+
+This will run Cypress in watch-mode, and it will pick up and rebuild any changes to JS files. If you need to change other files (like CSS for example), you need to run the respective `yarn build:*` scripts.
+
+Alternatively the following command is the same as the above, except it doesn’t run `build` first:
+
+    yarn e2e:skip-build
+
+To generate the boilerplate for a new test run:
+
+    yarn e2e:generate
 
 ## Zoom
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,8 +21,6 @@ yarn install || corepack yarn install
 
 [Yarn]: https://yarnpkg.com/
 
-Our website’s examples section is also our playground, please read the [Local Previews](#Local-previews) section to get up and running.
-
 ### Requiring files
 
 * If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (for example to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).
@@ -148,19 +146,6 @@ To test recording a meeting, you need to sign up for a Zoom Pro trial (can be ca
 
 ## Releases
 
-Before doing a release, check that the examples on the website work:
-
-```bash
-yarn start
-open http://localhost:4000/examples/dashboard
-```
-
-Also check the other examples:
-
-```bash
-yarn workspace <example-name> start
-```
-
 Releases are managed by GitHub Actions, here’s an overview of the process to release a new Uppy version:
 
 * Run `yarn release` on your local machine.
@@ -175,31 +160,6 @@ Releases are managed by GitHub Actions, here’s an overview of the process to r
   * the demos on the homepage work and can import from Google Drive, Instagram, Dropbox, etc.
 
 If you don’t have access to the transloadit.com source code ping @arturi or @goto-bus-stop and we’ll pick it up. :sparkles:
-
-## Website development
-
-We keep the [uppy.io](http://uppy.io) website in `./website` to keep docs and code in sync as we are still iterating at high velocity.
-
-The site is built with [Hexo](http://hexo.io/), and Travis automatically deploys this onto GitHub Pages (it overwrites the `gh-pages` branch with Hexo’s build at every change to `main`). The content is written in Markdown and located in `./website/src`. Feel free to fork & hack!
-
-Even though bundled in this repo, the website is regarded as a separate project. As such, it has its own `package.json` and we aim to keep the surface where the two projects interface as small as possible. `./website/update.js` is called during website builds to inject the Uppy knowledge into the site.
-
-### Local previews
-
-1. `yarn install`
-2. `yarn start`
-3. Go to http://localhost:4000. Your changes in `/website` and `/packages/@uppy` will be watched, your browser will refresh as files change.
-
-Then, to work on, for instance, the XHRUpload example, you would edit the following files:
-
-```bash
-${EDITOR} packages/@uppy/core/src/index.js \
-  packages/@uppy/core/src/Plugin.js \
-  packages/@uppy/xhr-upload/src/index.js \
-  website/src/examples/xhrupload/app.es6
-```
-
-And open <http://localhost:4000/examples/xhrupload/> in your web browser.
 
 ## CSS guidelines
 
@@ -378,7 +338,7 @@ order: 0
 category: "Other Integrations"
 ```
 
-This data is used to generate Uppy’s website. Refer to [the section about running the website locally](#website-previews) if you’d like to see how the docs look on the website.
+This data is used to generate Uppy’s website.
 
 Any change of the documentation that involves a security best practice must substantiated with an external reference. See [#3565](https://github.com/transloadit/uppy/issues/3565).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ corepack enable
 or prefix all `yarn` commands in this guide with `corepack yarn`:
 
 ```sh
-# e.g. `corepack yarn install`
+corepack yarn install
 ```
 
 [Corepack]: https://nodejs.org/api/corepack.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To run a basic development version of Uppy, run:
 yarn dev
 ```
 
-and go to http://localhost:5174 (or whatever link the yarn command outputted).\
+and go to http://localhost:5174 (or whatever link the yarn command outputted).
 As you edit Uppy code, the browser will live reload the changes.
 
 ### Companion


### PR DESCRIPTION
- Moved **#Development** section above the **#Tests** section
Because people develop first and test second, especially since tests fail by default without the correct env file.

- Removed mentions of **Uppy.io**
Looks like we moved the website to https://github.com/transloadit/uppy.io.

- Clarified **corepack** usage
  Previous instructions would always be doing `yarn install` for me (with my old version of yarn) because I already had yarn installed.
  ```sh
  #previous instructions
  corepack -v || npm i -g corepack
  yarn -v || corepack enable
  yarn install || corepack yarn install
  ```

- Added a section for the command beginner contributors probably most want, `yarn run dev` 