### PR TITLE
Improve image rotation

### DIFF
--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -1,6 +1,30 @@
 import Cropper from 'cropperjs'
 import { h, Component } from 'preact'
 
+// See this cropperjs image to understand how container/image/canavas/cropbox relate to each other.
+// (https://github.com/fengyuanchen/cropperjs/blob/9b528a8baeaae876dc090085e37992a1683c6f34/docs/images/layers.jpg)
+function getCanvasDataThatFitsPerfectlyIntoContainer (containerData, imageData) {
+  const widthRatio = containerData.width / imageData.naturalWidth
+  const heightRatio = containerData.height / imageData.naturalHeight
+
+  const scaleFactor = Math.min(widthRatio, heightRatio)
+
+  const newWidth = imageData.naturalWidth * scaleFactor
+  const newHeight = imageData.naturalHeight * scaleFactor
+
+  const left = (containerData.width - newWidth) / 2
+  const top = (containerData.height - newHeight) / 2
+
+  return {
+    naturalWidth: imageData.naturalWidth,
+    naturalHeight: imageData.naturalHeight,
+    width: newWidth,
+    height: newHeight,
+    left,
+    top,
+  }
+}
+
 export default class Editor extends Component {
   constructor (props) {
     super(props)
@@ -98,7 +122,16 @@ export default class Editor extends Component {
       <button
         type="button"
         className="uppy-u-reset uppy-c-btn"
-        onClick={() => this.cropper.rotate(-90)}
+        onClick={() => {
+          this.cropper.rotate(-90)
+
+          const canvasData = this.cropper.getCanvasData()
+          const containerData = this.cropper.getContainerData()
+
+          const newCanvasData = getCanvasDataThatFitsPerfectlyIntoContainer(containerData, canvasData)
+          this.cropper.setCanvasData(newCanvasData)
+          this.cropper.setCropBoxData(newCanvasData)
+        }}
         aria-label={i18n('rotate')}
         data-microtip-position="top"
       >

--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -3,25 +3,24 @@ import { h, Component } from 'preact'
 
 // See this cropperjs image to understand how container/image/canavas/cropbox relate to each other.
 // (https://github.com/fengyuanchen/cropperjs/blob/9b528a8baeaae876dc090085e37992a1683c6f34/docs/images/layers.jpg)
-function getCanvasDataThatFitsPerfectlyIntoContainer (containerData, imageData) {
-  const widthRatio = containerData.width / imageData.naturalWidth
-  const heightRatio = containerData.height / imageData.naturalHeight
-
+function getCanvasDataThatFitsPerfectlyIntoContainer (containerData, canvasData) {
+  // 1. Scale our canvas as much as possible
+  const widthRatio = containerData.width / canvasData.width
+  const heightRatio = containerData.height / canvasData.height
   const scaleFactor = Math.min(widthRatio, heightRatio)
 
-  const newWidth = imageData.naturalWidth * scaleFactor
-  const newHeight = imageData.naturalHeight * scaleFactor
+  const newWidth = canvasData.width * scaleFactor
+  const newHeight = canvasData.height * scaleFactor
 
-  const left = (containerData.width - newWidth) / 2
-  const top = (containerData.height - newHeight) / 2
+  // 2. Center our canvas
+  const newLeft = (containerData.width - newWidth) / 2
+  const newTop = (containerData.height - newHeight) / 2
 
   return {
-    naturalWidth: imageData.naturalWidth,
-    naturalHeight: imageData.naturalHeight,
     width: newWidth,
     height: newHeight,
-    left,
-    top,
+    left: newLeft,
+    top: newTop,
   }
 }
 

--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -1,28 +1,7 @@
 import Cropper from 'cropperjs'
 import { h, Component } from 'preact'
-
-// See this cropperjs image to understand how container/image/canavas/cropbox relate to each other.
-// (https://github.com/fengyuanchen/cropperjs/blob/9b528a8baeaae876dc090085e37992a1683c6f34/docs/images/layers.jpg)
-function getCanvasDataThatFitsPerfectlyIntoContainer (containerData, canvasData) {
-  // 1. Scale our canvas as much as possible
-  const widthRatio = containerData.width / canvasData.width
-  const heightRatio = containerData.height / canvasData.height
-  const scaleFactor = Math.min(widthRatio, heightRatio)
-
-  const newWidth = canvasData.width * scaleFactor
-  const newHeight = canvasData.height * scaleFactor
-
-  // 2. Center our canvas
-  const newLeft = (containerData.width - newWidth) / 2
-  const newTop = (containerData.height - newHeight) / 2
-
-  return {
-    width: newWidth,
-    height: newHeight,
-    left: newLeft,
-    top: newTop,
-  }
-}
+import getCanvasDataThatFitsPerfectlyIntoContainer from './utils/getCanvasDataThatFitsPerfectlyIntoContainer.js'
+import getScaleFactorThatRemovesDarkCorners from './utils/getScaleFactorThatRemovesDarkCorners.js'
 
 export default class Editor extends Component {
   constructor (props) {
@@ -62,6 +41,10 @@ export default class Editor extends Component {
       const pendingRotationAngle = rotationAngle + pendingRotationDelta
       this.granularRotateOnInputNextFrame = requestAnimationFrame(() => {
         this.cropper.rotateTo(pendingRotationAngle)
+
+        const imageData = this.cropper.getImageData()
+        const scaleFactor = getScaleFactorThatRemovesDarkCorners(imageData)
+        this.cropper.scale(scaleFactor)
       })
     }
   }

--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import Cropper from 'cropperjs'
 import { h, Component } from 'preact'
 import getCanvasDataThatFitsPerfectlyIntoContainer from './utils/getCanvasDataThatFitsPerfectlyIntoContainer.js'
@@ -27,44 +26,40 @@ export default class Editor extends Component {
   }
 
   onRotate90Deg = () => {
-    const newAngle = this.state.angle90Deg - 90
-
-    const mod = newAngle % 360
-    const normalizedObjectiveAngle = mod < 0 ? mod + 360 : mod
-
-    // Important to reset scale here, or cropper will get confused on further rotations
-    this.cropper.scale(1)
+    // 1. Set state
+    const { angle90Deg } = this.state
+    const newAngle = angle90Deg - 90
     this.setState({
-      angle90Deg: normalizedObjectiveAngle,
+      angle90Deg: newAngle,
       angleGranular: 0,
     })
 
-    console.info({ normalizedObjectiveAngle });
+    // 2. Rotate the image
+    // Important to reset scale here, or cropper will get confused on further rotations
+    this.cropper.scale(1)
+    this.cropper.rotateTo(newAngle)
 
-    this.cropper.rotateTo(normalizedObjectiveAngle)
-
-    // Fit into view
+    // 3. Fit the rotated image into the view
     const canvasData = this.cropper.getCanvasData()
     const containerData = this.cropper.getContainerData()
     const newCanvasData = getCanvasDataThatFitsPerfectlyIntoContainer(containerData, canvasData)
     this.cropper.setCanvasData(newCanvasData)
+
+    // 4. Make cropbox fully wrap the image
     this.cropper.setCropBoxData(newCanvasData)
   }
 
   onRotateGranular = (ev) => {
+    //  1. Set stsate
     const newGranularAngle = Number(ev.target.value)
     this.setState({ angleGranular: newGranularAngle })
 
-    const newObjectiveAngle = this.state.angle90Deg + newGranularAngle
+    // 2. Rotate the image
+    const { angle90Deg } = this.state
+    const newAngle = angle90Deg + newGranularAngle
+    this.cropper.rotateTo(newAngle)
 
-    // Place the value between [0, 360]
-    const mod = newObjectiveAngle % 360
-    const normalizedObjectiveAngle = mod < 0 ? mod + 360 : mod
-
-    console.info({ normalizedObjectiveAngle });
-
-    this.cropper.rotateTo(normalizedObjectiveAngle)
-    // const imageData = this.cropper.getImageData()
+    // 3. Scale the image so that it fits into the cropbox
     const cropboxData = this.cropper.getCropBoxData()
     const scaleFactor = getScaleFactorThatRemovesDarkCorners(cropboxData, newGranularAngle)
     this.cropper.scale(scaleFactor)

--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -62,7 +62,9 @@ export default class Editor extends Component {
     // 3. Scale the image so that it fits into the cropbox
     const cropboxData = this.cropper.getCropBoxData()
     const scaleFactor = getScaleFactorThatRemovesDarkCorners(cropboxData, newGranularAngle)
-    this.cropper.scale(scaleFactor)
+    // Preserve flip
+    const scaleFactorX = this.cropper.getImageData().scaleX < 0 ? -scaleFactor : scaleFactor
+    this.cropper.scale(scaleFactorX, scaleFactor)
   }
 
   renderGranularRotate () {

--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -28,12 +28,20 @@ export default class Editor extends Component {
 
   onRotate90Deg = () => {
     const newAngle = this.state.angle90Deg - 90
+
+    const mod = newAngle % 360
+    const normalizedObjectiveAngle = mod < 0 ? mod + 360 : mod
+
+    // Important to reset scale here, or cropper will get confused on further rotations
+    this.cropper.scale(1)
     this.setState({
-      angle90Deg: newAngle,
+      angle90Deg: normalizedObjectiveAngle,
       angleGranular: 0,
     })
 
-    this.cropper.rotateTo(newAngle)
+    console.info({ normalizedObjectiveAngle });
+
+    this.cropper.rotateTo(normalizedObjectiveAngle)
 
     // Fit into view
     const canvasData = this.cropper.getCanvasData()
@@ -49,9 +57,16 @@ export default class Editor extends Component {
 
     const newObjectiveAngle = this.state.angle90Deg + newGranularAngle
 
-    this.cropper.rotateTo(newObjectiveAngle)
-    const imageData = this.cropper.getImageData()
-    const scaleFactor = getScaleFactorThatRemovesDarkCorners(imageData)
+    // Place the value between [0, 360]
+    const mod = newObjectiveAngle % 360
+    const normalizedObjectiveAngle = mod < 0 ? mod + 360 : mod
+
+    console.info({ normalizedObjectiveAngle });
+
+    this.cropper.rotateTo(normalizedObjectiveAngle)
+    // const imageData = this.cropper.getImageData()
+    const cropboxData = this.cropper.getCropBoxData()
+    const scaleFactor = getScaleFactorThatRemovesDarkCorners(cropboxData, newGranularAngle)
     this.cropper.scale(scaleFactor)
   }
 
@@ -70,7 +85,6 @@ export default class Editor extends Component {
         <input
           className="uppy-ImageCropper-range uppy-u-reset"
           type="range"
-          // TODO do we need both of these events
           onInput={this.onRotateGranular}
           onChange={this.onRotateGranular}
           value={angleGranular}

--- a/packages/@uppy/image-editor/src/ImageEditor.jsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.jsx
@@ -17,7 +17,7 @@ export default class ImageEditor extends UIPlugin {
     this.defaultLocale = locale
 
     const defaultCropperOptions = {
-      viewMode: 1,
+      viewMode: 0,
       background: false,
       autoCropArea: 1,
       responsive: true,

--- a/packages/@uppy/image-editor/src/style.scss
+++ b/packages/@uppy/image-editor/src/style.scss
@@ -14,11 +14,13 @@
   flex-grow: 1;
 }
 
-// Note that exactly these styles are demanded by cropper
-// (https: //github.com/fengyuanchen/cropperjs#example)
 .uppy-ImageCropper-image {
+  // Note that exactly these styles are demanded by cropperjs
+  // (https: //github.com/fengyuanchen/cropperjs#example)
   display: block;
   max-width: 100%;
+  // And this style is required for rendering tall and narrow images
+  max-height: 400px;
 }
 
 .uppy-ImageCropper-controls {

--- a/packages/@uppy/image-editor/src/style.scss
+++ b/packages/@uppy/image-editor/src/style.scss
@@ -14,9 +14,11 @@
   flex-grow: 1;
 }
 
+// Note that exactly these styles are demanded by cropper
+// (https: //github.com/fengyuanchen/cropperjs#example)
 .uppy-ImageCropper-image {
   display: block;
-  max-height: 400px;
+  max-width: 100%;
 }
 
 .uppy-ImageCropper-controls {

--- a/packages/@uppy/image-editor/src/utils/getCanvasDataThatFitsPerfectlyIntoContainer.js
+++ b/packages/@uppy/image-editor/src/utils/getCanvasDataThatFitsPerfectlyIntoContainer.js
@@ -1,0 +1,24 @@
+// See this cropperjs image to understand how container/image/canavas/cropbox relate to each other.
+// (https://github.com/fengyuanchen/cropperjs/blob/9b528a8baeaae876dc090085e37992a1683c6f34/docs/images/layers.jpg)
+function getCanvasDataThatFitsPerfectlyIntoContainer (containerData, canvasData) {
+  // 1. Scale our canvas as much as possible
+  const widthRatio = containerData.width / canvasData.width
+  const heightRatio = containerData.height / canvasData.height
+  const scaleFactor = Math.min(widthRatio, heightRatio)
+
+  const newWidth = canvasData.width * scaleFactor
+  const newHeight = canvasData.height * scaleFactor
+
+  // 2. Center our canvas
+  const newLeft = (containerData.width - newWidth) / 2
+  const newTop = (containerData.height - newHeight) / 2
+
+  return {
+    width: newWidth,
+    height: newHeight,
+    left: newLeft,
+    top: newTop,
+  }
+}
+
+export default getCanvasDataThatFitsPerfectlyIntoContainer

--- a/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
+++ b/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
@@ -2,19 +2,15 @@ function toRadians (angle) {
   return angle * (Math.PI / 180)
 }
 
-function getScaleFactorThatRemovesDarkCorners (imageData) {
-  let rotation = toRadians(imageData.rotate)
+function getScaleFactorThatRemovesDarkCorners (cropboxData, newGranularAngle) {
+  const rotation = toRadians(newGranularAngle)
 
-  if (rotation < 0) {
-    rotation = 2 * Math.PI - rotation
-  }
-
-  const a = imageData.width
-  const b = imageData.height
+  const a = cropboxData.width
+  const b = cropboxData.height
 
   const scaleFactor = Math.max(
-    (Math.sin(rotation) * a + Math.cos(rotation) * b) / b,
-    (Math.sin(rotation) * b + Math.cos(rotation) * a) / a,
+    (Math.abs(Math.sin(rotation)) * a + Math.abs(Math.cos(rotation)) * b) / b,
+    (Math.abs(Math.sin(rotation)) * b + Math.abs(Math.cos(rotation)) * a) / a,
   )
 
   return scaleFactor

--- a/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
+++ b/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
@@ -2,15 +2,15 @@ function toRadians (angle) {
   return angle * (Math.PI / 180)
 }
 
-function getScaleFactorThatRemovesDarkCorners (cropboxData, newGranularAngle) {
-  const rotation = toRadians(newGranularAngle)
+function getScaleFactorThatRemovesDarkCorners (cropboxData, granularAngle) {
+  const α = Math.abs(toRadians(granularAngle))
 
-  const a = cropboxData.width
-  const b = cropboxData.height
+  const w = cropboxData.width
+  const h = cropboxData.height
 
   const scaleFactor = Math.max(
-    (Math.abs(Math.sin(rotation)) * a + Math.abs(Math.cos(rotation)) * b) / b,
-    (Math.abs(Math.sin(rotation)) * b + Math.abs(Math.cos(rotation)) * a) / a,
+    (Math.sin(α) * w + Math.cos(α) * h) / h,
+    (Math.sin(α) * h + Math.cos(α) * w) / w,
   )
 
   return scaleFactor

--- a/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
+++ b/packages/@uppy/image-editor/src/utils/getScaleFactorThatRemovesDarkCorners.js
@@ -1,0 +1,23 @@
+function toRadians (angle) {
+  return angle * (Math.PI / 180)
+}
+
+function getScaleFactorThatRemovesDarkCorners (imageData) {
+  let rotation = toRadians(imageData.rotate)
+
+  if (rotation < 0) {
+    rotation = 2 * Math.PI - rotation
+  }
+
+  const a = imageData.width
+  const b = imageData.height
+
+  const scaleFactor = Math.max(
+    (Math.sin(rotation) * a + Math.cos(rotation) * b) / b,
+    (Math.sin(rotation) * b + Math.cos(rotation) * a) / a,
+  )
+
+  return scaleFactor
+}
+
+export default getScaleFactorThatRemovesDarkCorners


### PR DESCRIPTION
### This PR
- on 90deg rotations, the image now fits fully into the view, and cropbox wraps it entirely (fixes https://github.com/transloadit/uppy/issues/4380)
- on granular rotations, the image scales like on android
- on granular rotations, we always see `[-45°, 45°]` range (previously we saw values such as `-59°`)
  <img width="437" alt="image" src="https://github.com/transloadit/uppy/assets/7578559/0a7c34ca-418e-438a-8163-8b289fb5942f">

### Notes

- I removed `requestAnimationFrame` code temporarily while developing. Should we add it back, is there some issue/use case that it helps solve that we can observe in action?

### Further ideas (notes for myself)
- make "granular rotation" and "90 deg rotation" work around the cropbox center instead of image center (cropper 1 doesn't support this https://github.com/fengyuanchen/cropperjs/issues/580, but we can do it manually)
- disable scale-on-rotation if the cropbox doesn't exactly match the original-nonrotated-image-position
- prohibit cropbox movement to the empty corners
- on double click - make the cropbox fit the full image again
- readd labels on hover over buttons
- on `<input type="range">` data-microtip-position should follow the user mouse if possible
- "Revert everything" button should be on top/more easily discernable from "rotate 90deg"
- aspect ratio should be a select

___

https://github.com/transloadit/uppy/assets/7578559/9d2b21d6-93f5-4d55-8c47-62c27b148f3e