### PR TITLE
Hide upload button when state is recovered if hideUploadButton is true

### DIFF
--- a/packages/@uppy/status-bar/src/StatusBarUI.jsx
+++ b/packages/@uppy/status-bar/src/StatusBarUI.jsx
@@ -122,12 +122,11 @@ export default function StatusBar (props) {
 
   const width = progressValue ?? 100
 
-  const showUploadBtn = !error
-    && newFiles
-    && !isUploadInProgress
-    && !isAllPaused
-    && allowNewUpload
-    && !hideUploadButton
+  const showUploadBtn = !hideUploadButton
+    && (
+      (!error && newFiles && !isUploadInProgress && !isAllPaused && allowNewUpload)
+      || recoveredState
+    )
 
   const showCancelBtn = !hideCancelButton
     && uploadState !== STATE_WAITING
@@ -140,6 +139,14 @@ export default function StatusBar (props) {
   const showRetryBtn = error && !isAllComplete && !hideRetryButton
 
   const showDoneBtn = doneButtonHandler && uploadState === STATE_COMPLETE
+
+  const hasActions = (
+    showUploadBtn
+    || showCancelBtn
+    || showPauseResumeBtn
+    || showRetryBtn
+    || showDoneBtn
+  )
 
   const progressClassNames = classNames('uppy-StatusBar-progress', {
     'is-indeterminate': getIsIndeterminate(),
@@ -204,37 +211,39 @@ export default function StatusBar (props) {
         }
       })()}
 
-      <div className="uppy-StatusBar-actions">
-        {recoveredState || showUploadBtn ? (
-          <UploadBtn
-            newFiles={newFiles}
-            isUploadStarted={isUploadStarted}
-            recoveredState={recoveredState}
-            i18n={i18n}
-            isSomeGhost={isSomeGhost}
-            startUpload={startUpload}
-            uploadState={uploadState}
-          />
-        ) : null}
+      {hasActions ? (
+        <div className="uppy-StatusBar-actions">
+          {showUploadBtn ? (
+            <UploadBtn
+              newFiles={newFiles}
+              isUploadStarted={isUploadStarted}
+              recoveredState={recoveredState}
+              i18n={i18n}
+              isSomeGhost={isSomeGhost}
+              startUpload={startUpload}
+              uploadState={uploadState}
+            />
+          ) : null}
 
-        {showRetryBtn ? <RetryBtn i18n={i18n} uppy={uppy} /> : null}
+          {showRetryBtn ? <RetryBtn i18n={i18n} uppy={uppy} /> : null}
 
-        {showPauseResumeBtn ? (
-          <PauseResumeButton
-            isAllPaused={isAllPaused}
-            i18n={i18n}
-            isAllComplete={isAllComplete}
-            resumableUploads={resumableUploads}
-            uppy={uppy}
-          />
-        ) : null}
+          {showPauseResumeBtn ? (
+            <PauseResumeButton
+              isAllPaused={isAllPaused}
+              i18n={i18n}
+              isAllComplete={isAllComplete}
+              resumableUploads={resumableUploads}
+              uppy={uppy}
+            />
+          ) : null}
 
-        {showCancelBtn ? <CancelBtn i18n={i18n} uppy={uppy} /> : null}
+          {showCancelBtn ? <CancelBtn i18n={i18n} uppy={uppy} /> : null}
 
-        {showDoneBtn ? (
-          <DoneBtn i18n={i18n} doneButtonHandler={doneButtonHandler} />
-        ) : null}
-      </div>
+          {showDoneBtn ? (
+            <DoneBtn i18n={i18n} doneButtonHandler={doneButtonHandler} />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
This is a draft of a change for [the behavior documented in this community forum post](https://community.transloadit.com/t/statusbar-does-not-respect-hideuploadbutton-when-state-is-recovered-with-golden-retriever/16760). When Golden Retriever is used, recovered state overrides the user-supplied option for `hideUploadButton`; this change makes the status bar not render the button if state has been recovered.

There may be a bit of styling changes required if the direction of this PR is acceptable. If the button is not rendered and the progress bar has `display: none`, the container is still not hidden and has the same height as if it had contents.

Alternatively, I understand if the current behavior is intended and developers are responsible for hiding the button and container via our own CSS. That seems perfectly reasonable.

I will be unavailable for the next week but appreciate any feedback on this PR. Thank you!