### PR TITLE
@uppy/companion: catch "invalid initialization vector" instead of crashing

### DIFF
--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -126,6 +126,7 @@ module.exports.decrypt = (encrypted, secret) => {
     throw new Error('Invalid encrypted value. Maybe it was generated with an old Companion version?')
   }
 
+  // NOTE: The first 32 characters are the iv, in hex format. The rest is the encrypted string, in base64 format.
   const iv = Buffer.from(encrypted.slice(0, 32), 'hex')
   const encryptionWithoutIv = encrypted.slice(32)
 


### PR DESCRIPTION
when async function rejects promise unhandled

prevents `Invalid initialization vector` from crashing companion in prod.