### PR TITLE
meta: use latest Node.js version for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         # todo put back?
-        node-version: [16.x, 18.16.0, 20.4.0]
+        node-version: [16.x, 18.16.0, 20.6.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Opening as draft as we probably want to remove 16.x next week, we might as well do that in the same commit.