### PR TITLE
remove transpilation of companion

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 lib
+/packages/@uppy/companion/types
 dist
 coverage
 test/lib/**

--- a/packages/@uppy/companion/.gitignore
+++ b/packages/@uppy/companion/.gitignore
@@ -38,6 +38,6 @@ test/output/*
 .DS_Store
 
 # Transpiled
-lib/
+types/
 infra/kube/companion/uppy-env.yaml
 scripts/.tl-deploy-hosts-danger.txt

--- a/packages/@uppy/companion/bin/companion
+++ b/packages/@uppy/companion/bin/companion
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/standalone/start-server')
+require('../src/standalone/start-server')

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -2,8 +2,8 @@
   "name": "@uppy/companion",
   "version": "4.8.2",
   "description": "OAuth helper and remote fetcher for Uppy's (https://uppy.io) extensible file upload widget with support for drag&drop, resumable uploads, previews, restrictions, file processing/encoding, remote providers like Dropbox and Google Drive, S3 and more :dog:",
-  "main": "lib/companion.js",
-  "types": "lib/companion.d.ts",
+  "main": "src/companion.js",
+  "types": "types/companion.d.ts",
   "author": "Transloadit.com",
   "license": "MIT",
   "homepage": "https://github.com/transloadit/uppy#readme",
@@ -93,7 +93,8 @@
   },
   "files": [
     "bin/",
-    "lib/"
+    "src/",
+    "types/"
   ],
   "jest": {
     "testEnvironment": "node",
@@ -109,7 +110,7 @@
     "build": "tsc -p .",
     "deploy": "kubectl apply -f infra/kube/companion-kube.yml",
     "prepublishOnly": "yarn run build",
-    "start": "node ./lib/standalone/start-server.js",
+    "start": "node ./src/standalone/start-server.js",
     "test": "jest"
   },
   "engines": {

--- a/packages/@uppy/companion/tsconfig.json
+++ b/packages/@uppy/companion/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
-    "outDir": "./lib",
-    "module": "commonjs",
+    "module": "Node16",
     "moduleResolution": "node16",
     "declaration": true,
-    "target": "es6",
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "target": "es2019",
     "noImplicitAny": false,
     "sourceMap": false,
     "allowJs": true,


### PR DESCRIPTION
this was discussed before but we never got to it:

why? transpilation adds junk to the source code making it hard to debug issues and stack traces in production because line numbers become messed up also we don't need to transpile because we are targeting relatively recent node versions so stuff like generator-runtime isn't needed anymore.

example: https://www.unpkg.com/@uppy/companion@4.5.1/lib/server/provider/credentials.js

alternatively close this PR and instead merge #4670