### PR TITLE
upgrade ts target

### DIFF
--- a/packages/@uppy/companion/tsconfig.json
+++ b/packages/@uppy/companion/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "module": "commonjs",
+    "module": "Node16",
     "moduleResolution": "node16",
     "declaration": true,
-    "target": "es6",
+    "target": "es2019",
     "noImplicitAny": false,
     "sourceMap": false,
     "allowJs": true,


### PR DESCRIPTION
and fix ts error in tsconfig ("module")

because stuff like generator-runtime isn't needed anymore. example: https://www.unpkg.com/@uppy/companion@4.5.1/lib/server/provider/credentials.js

alternatively close this PR and instead merge #4669