### PR TITLE
Fix: Utilize user-defined onSuccess, onError, and onProgress callbacks in @uppy/tus

### DIFF
--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -258,7 +258,7 @@ export default class Tus extends BasePlugin {
 
       uploadOptions.onProgress = (bytesUploaded, bytesTotal) => {
         this.onReceiveUploadUrl(file, upload.url)
-        if (typeof opts.onProgress === 'function'){
+        if (typeof opts.onProgress === 'function') {
           opts.onProgress(bytesUploaded, bytesTotal)
         }
         this.uppy.emit('upload-progress', file, {

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -250,12 +250,14 @@ export default class Tus extends BasePlugin {
         queuedRequest?.abort()
 
         this.uppy.emit('upload-error', file, err)
-
+        if (typeof opts.onError === 'function') opts.onError(err);
         reject(err)
       }
 
       uploadOptions.onProgress = (bytesUploaded, bytesTotal) => {
         this.onReceiveUploadUrl(file, upload.url)
+        if (typeof opts.onProgress === 'function')
+        opts.onProgress(bytesUploaded, bytesTotal);
         this.uppy.emit('upload-progress', file, {
           uploader: this,
           bytesUploaded,
@@ -276,6 +278,7 @@ export default class Tus extends BasePlugin {
         if (upload.url) {
           this.uppy.log(`Download ${upload.file.name} from ${upload.url}`)
         }
+        if (typeof opts.onSuccess === 'function') opts.onSuccess();
 
         resolve(upload)
       }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -250,14 +250,17 @@ export default class Tus extends BasePlugin {
         queuedRequest?.abort()
 
         this.uppy.emit('upload-error', file, err)
-        if (typeof opts.onError === 'function') opts.onError(err);
+        if (typeof opts.onError === 'function') {
+          opts.onError(err);
+        }
         reject(err)
       }
 
       uploadOptions.onProgress = (bytesUploaded, bytesTotal) => {
         this.onReceiveUploadUrl(file, upload.url)
-        if (typeof opts.onProgress === 'function')
-        opts.onProgress(bytesUploaded, bytesTotal);
+        if (typeof opts.onProgress === 'function'){
+          opts.onProgress(bytesUploaded, bytesTotal);
+        }
         this.uppy.emit('upload-progress', file, {
           uploader: this,
           bytesUploaded,
@@ -278,7 +281,9 @@ export default class Tus extends BasePlugin {
         if (upload.url) {
           this.uppy.log(`Download ${upload.file.name} from ${upload.url}`)
         }
-        if (typeof opts.onSuccess === 'function') opts.onSuccess();
+        if (typeof opts.onSuccess === 'function') {
+          opts.onSuccess();
+        }
 
         resolve(upload)
       }

--- a/packages/@uppy/tus/src/index.js
+++ b/packages/@uppy/tus/src/index.js
@@ -251,7 +251,7 @@ export default class Tus extends BasePlugin {
 
         this.uppy.emit('upload-error', file, err)
         if (typeof opts.onError === 'function') {
-          opts.onError(err);
+          opts.onError(err)
         }
         reject(err)
       }
@@ -259,7 +259,7 @@ export default class Tus extends BasePlugin {
       uploadOptions.onProgress = (bytesUploaded, bytesTotal) => {
         this.onReceiveUploadUrl(file, upload.url)
         if (typeof opts.onProgress === 'function'){
-          opts.onProgress(bytesUploaded, bytesTotal);
+          opts.onProgress(bytesUploaded, bytesTotal)
         }
         this.uppy.emit('upload-progress', file, {
           uploader: this,
@@ -282,7 +282,7 @@ export default class Tus extends BasePlugin {
           this.uppy.log(`Download ${upload.file.name} from ${upload.url}`)
         }
         if (typeof opts.onSuccess === 'function') {
-          opts.onSuccess();
+          opts.onSuccess()
         }
 
         resolve(upload)


### PR DESCRIPTION
This PR fixes the issue where user-defined `onSuccess`, `onError`, and `onProgress` callbacks were being ignored in the Tus plugin. While these options were accepted during initialization, they were not being called in the respective events.

This change ensures that if a user has provided any of these callbacks, they will be called in addition to the internal handlers.

### Changes Made
- Utilized user-defined `onSuccess`, `onError`, and `onProgress` callbacks in the Tus plugin.
- Updated the code to check for and invoke user-defined callbacks if provided.
