### PR TITLE
ImageEditor.jsx - remove 1px black lines

### DIFF
--- a/packages/@uppy/image-editor/src/ImageEditor.jsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.jsx
@@ -91,6 +91,17 @@ export default class ImageEditor extends UIPlugin {
 
     const { currentImage } = this.getPluginState()
 
+    // Fixes black 1px lines on odd-width images.
+    // This should be removed when cropperjs fixes this issue.
+    // (See https://github.com/transloadit/uppy/issues/4305 and https://github.com/fengyuanchen/cropperjs/issues/551).
+    const croppedCanvas = this.cropper.getCroppedCanvas({})
+    if (croppedCanvas.width % 2 !== 0) {
+      this.cropper.setData({ width: croppedCanvas.width - 1 })
+    }
+    if (croppedCanvas.height % 2 !== 0) {
+      this.cropper.setData({ height: croppedCanvas.height - 1 })
+    }
+
     this.cropper.getCroppedCanvas(this.opts.cropperOptions.croppedCanvasOptions).toBlob(
       saveBlobCallback,
       currentImage.type,


### PR DESCRIPTION
Didn't overthink the solution, it's taken from https://github.com/fengyuanchen/cropperjs/issues/551#issuecomment-1642138810, we'll want to go for cropperjs's solution when they implement it.

See https://github.com/transloadit/uppy/issues/4305#issuecomment-1717170265 for details.
___

Note for the reviewers: the obvious solution would be to just return the original image if user didn't do any transformations with the image, however this is a separate issue. A black line will appear even if we rotate the image.

___

Fixes #4305