### PR TITLE
Make file-editor:cancel event fire when the Image Editor “cancel” button is pressed

### DIFF
--- a/packages/@uppy/dashboard/src/components/EditorPanel.jsx
+++ b/packages/@uppy/dashboard/src/components/EditorPanel.jsx
@@ -4,6 +4,11 @@ import classNames from 'classnames'
 function EditorPanel (props) {
   const file = props.files[props.fileCardFor]
 
+  const handleCancel = () => {
+    props.uppy.emit('file-editor:cancel', file)
+    props.hideAllPanels()
+  }
+
   return (
     <div
       className={classNames('uppy-DashboardContent-panel', props.className)}
@@ -20,7 +25,7 @@ function EditorPanel (props) {
         <button
           className="uppy-DashboardContent-back"
           type="button"
-          onClick={props.hideAllPanels}
+          onClick={handleCancel}
         >
           {props.i18n('cancel')}
         </button>

--- a/packages/@uppy/dashboard/src/components/FileCard/index.jsx
+++ b/packages/@uppy/dashboard/src/components/FileCard/index.jsx
@@ -9,7 +9,6 @@ import RenderMetaFields from './RenderMetaFields.jsx'
 
 export default function FileCard (props) {
   const {
-    uppy,
     files,
     fileCardFor,
     toggleFileCard,
@@ -53,7 +52,6 @@ export default function FileCard (props) {
   }
 
   const handleCancel = () => {
-    uppy.emit('file-editor:cancel', file)
     toggleFileCard(false)
   }
 


### PR DESCRIPTION
Fixes #4045

This makes both “cancel” buttons firing this event though. Probably only the image editor neends to fire it?