### PR TITLE
run type checks also for companion and add files to docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .git
 website
 assets
+private
+e2e

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ website
 assets
 private
 e2e
+.env

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -48,3 +48,19 @@ jobs:
         run: corepack yarn run test:companion
       - name: Run type checks in focused workspace
         run: corepack yarn run build:companion
+
+  docker:
+    name: Build docker
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 0
+      COMPOSE_DOCKER_CLI_BUILD: 0
+    steps:
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -56,6 +56,8 @@ jobs:
       DOCKER_BUILDKIT: 0
       COMPOSE_DOCKER_CLI_BUILD: 0
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Build docker image

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -49,20 +49,3 @@ jobs:
       - name: Run type checks in focused workspace
         run: corepack yarn run build:companion
 
-  docker:
-    name: Build docker
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - name: Build docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -46,4 +46,5 @@ jobs:
         run: corepack yarn workspaces focus @uppy/companion
       - name: Run tests
         run: corepack yarn run test:companion
-
+      - name: Run type checks in focused workspace
+        run: corepack yarn run build:companion

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then mkdir -p /usr/local/sbin/ && ln -s /
 
 WORKDIR /app
 
-COPY * /app/
+COPY . /app/
 
 RUN apk --update add  --virtual native-dep \
   make gcc g++ python3 libgcc libstdc++ git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then mkdir -p /usr/local/sbin/ && ln -s /
 
 WORKDIR /app
 
-COPY package.json .yarnrc.yml /app/
-COPY .yarn /app/.yarn
-COPY packages/@uppy/companion /app/packages/@uppy/companion
+COPY * /app/
 
 RUN apk --update add  --virtual native-dep \
   make gcc g++ python3 libgcc libstdc++ git && \


### PR DESCRIPTION
theory: this PR's build should fail with

```
#23 22.96 node_modules/@szmarczak/http-timer/dist/source/index.d.ts(25,18): error TS2430: Interface 'ClientRequestWithTimings' incorrectly extends interface 'ClientRequest'.
#23 22.96   The types returned by 'setTimeout(...)' are incompatible between these types.
#23 22.96     Type 'ClientRequest' is not assignable to type 'this'.
#23 22.96       'ClientRequest' is assignable to the constraint of type 'this', but 'this' could be instantiated with a different subtype of constraint 'ClientRequest'.
#23 ERROR: process "/bin/sh -c cd /app && corepack yarn workspace @uppy/companion build" did not complete successfully: exit code: 1

#22 [linux/arm64 build 7/9] RUN apk --update add  --virtual native-dep   make gcc g++ python3 libgcc libstdc++ git &&   (cd /app && corepack yarn workspaces focus @uppy/companion) &&   apk del native-dep
#22 CANCELED
------
 > [linux/amd64 build 8/9] RUN cd /app && corepack yarn workspace @uppy/companion build:
22.96 node_modules/@szmarczak/http-timer/dist/source/index.d.ts(25,18): error TS2430: Interface 'ClientRequestWithTimings' incorrectly extends interface 'ClientRequest'.
22.96   The types returned by 'setTimeout(...)' are incompatible between these types.
22.96     Type 'ClientRequest' is not assignable to type 'this'.
22.96       'ClientRequest' is assignable to the constraint of type 'this', but 'this' could be instantiated with a different subtype of constraint 'ClientRequest'.
```