### PR TITLE
@uppy/aws-s3-multipart: retry signature request

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -112,7 +112,7 @@ class HTTPCommunicationQueue {
       this.#sendCompletionRequest = requests.wrapPromiseFunction(options.completeMultipartUpload, { priority:1 })
     }
     if ('retryDelays' in options) {
-      this.#retryDelays = options.retryDelays
+      this.#retryDelays = options.retryDelays ?? []
     }
     if ('uploadPartBytes' in options) {
       this.#uploadPartBytes = requests.wrapPromiseFunction(options.uploadPartBytes, { priority:Infinity })

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -348,7 +348,6 @@ class HTTPCommunicationQueue {
   async uploadChunk (file, partNumber, chunk, signal) {
     throwIfAborted(signal)
     const { uploadId, key } = await this.getUploadId(file, signal)
-    throwIfAborted(signal)
 
     const signatureRetryIterator = this.#retryDelays.values()
     const chunkRetryIterator = this.#retryDelays.values()

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -370,7 +370,7 @@ class HTTPCommunicationQueue {
           uploadId, key, partNumber, body: chunkData, signal,
         }).abortOn(signal)
       } catch (err) {
-        const timeout = shouldRetrySignature(err)
+        const timeout = shouldRetrySignature()
         if (timeout == null || signal.aborted) {
           throw err
         }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import BasePlugin from '@uppy/core/lib/BasePlugin.js'
 import { Provider, RequestClient } from '@uppy/companion-client'
 import EventManager from '@uppy/utils/lib/EventManager'
@@ -76,7 +77,7 @@ class HTTPCommunicationQueue {
 
   #requests
 
-  #retryDelayIterator
+  #retryDelays
 
   #sendCompletionRequest
 
@@ -112,7 +113,7 @@ class HTTPCommunicationQueue {
       this.#sendCompletionRequest = requests.wrapPromiseFunction(options.completeMultipartUpload, { priority:1 })
     }
     if ('retryDelays' in options) {
-      this.#retryDelayIterator = options.retryDelays?.values()
+      this.#retryDelays = options.retryDelays
     }
     if ('uploadPartBytes' in options) {
       this.#uploadPartBytes = requests.wrapPromiseFunction(options.uploadPartBytes, { priority:Infinity })
@@ -122,7 +123,7 @@ class HTTPCommunicationQueue {
     }
   }
 
-  async #shouldRetry (err) {
+  async #shouldRetry (err, retryDelayIterator) {
     const requests = this.#requests
     const status = err?.source?.status
 
@@ -137,7 +138,7 @@ class HTTPCommunicationQueue {
         // more than one request in parallel, to give slower connection a chance
         // to catch up with the expiry set in Companion.
         if (requests.limit === 1 || this.#previousRetryDelay == null) {
-          const next = this.#retryDelayIterator?.next()
+          const next = retryDelayIterator.next()
           if (next == null || next.done) {
             return false
           }
@@ -156,7 +157,7 @@ class HTTPCommunicationQueue {
     } else if (status === 429) {
       // HTTP 429 Too Many Requests => to avoid the whole download to fail, pause all requests.
       if (!requests.isPaused) {
-        const next = this.#retryDelayIterator?.next()
+        const next = retryDelayIterator.next()
         if (next == null || next.done) {
           return false
         }
@@ -175,7 +176,7 @@ class HTTPCommunicationQueue {
       }
     } else {
       // Other error code means the request can be retried later.
-      const next = this.#retryDelayIterator?.next()
+      const next = retryDelayIterator.next()
       if (next == null || next.done) {
         return false
       }
@@ -349,13 +350,37 @@ class HTTPCommunicationQueue {
     throwIfAborted(signal)
     const { uploadId, key } = await this.getUploadId(file, signal)
     throwIfAborted(signal)
+
+    const signatureRetryIterator = this.#retryDelays.values()
+    const chunkRetryIterator = this.#retryDelays.values()
+    const shouldRetrySignature = () => {
+      const next = signatureRetryIterator.next()
+      if (next == null || next.done) {
+        return null
+      }
+      return next.value
+    }
+
     for (;;) {
       const chunkData = chunk.getData()
       const { onProgress, onComplete } = chunk
+      let signature
 
-      const signature = await this.#fetchSignature(this.#getFile(file), {
-        uploadId, key, partNumber, body: chunkData, signal,
-      }).abortOn(signal)
+      try {
+        signature = await this.#fetchSignature(this.#getFile(file), {
+          uploadId, key, partNumber, body: chunkData, signal,
+        }).abortOn(signal)
+      } catch (err) {
+        const timeout = shouldRetrySignature(err)
+        if (timeout == null) {
+          throw err
+        }
+        // TODO: we don't listen for cancel-all to stop these operations it seems
+        // so it might continue in the background even after pressing cancel in the UI
+        await new Promise(resolve => setTimeout(resolve, timeout))
+        // eslint-disable-next-line no-continue
+        continue
+      }
 
       throwIfAborted(signal)
       try {
@@ -366,7 +391,7 @@ class HTTPCommunicationQueue {
           }).abortOn(signal),
         }
       } catch (err) {
-        if (!await this.#shouldRetry(err)) throw err
+        if (!await this.#shouldRetry(err, chunkRetryIterator)) throw err
       }
     }
   }

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 import BasePlugin from '@uppy/core/lib/BasePlugin.js'
 import { Provider, RequestClient } from '@uppy/companion-client'
 import EventManager from '@uppy/utils/lib/EventManager'

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -361,6 +361,7 @@ class HTTPCommunicationQueue {
     }
 
     for (;;) {
+      throwIfAborted(signal)
       const chunkData = chunk.getData()
       const { onProgress, onComplete } = chunk
       let signature
@@ -371,11 +372,9 @@ class HTTPCommunicationQueue {
         }).abortOn(signal)
       } catch (err) {
         const timeout = shouldRetrySignature(err)
-        if (timeout == null) {
+        if (timeout == null || signal.aborted) {
           throw err
         }
-        // TODO: we don't listen for cancel-all to stop these operations it seems
-        // so it might continue in the background even after pressing cancel in the UI
         await new Promise(resolve => setTimeout(resolve, timeout))
         // eslint-disable-next-line no-continue
         continue

--- a/packages/@uppy/aws-s3-multipart/src/index.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.js
@@ -390,7 +390,7 @@ describe('AwsS3Multipart', () => {
 
       await expect(core.upload()).rejects.toEqual({ source: { status: 500 } })
 
-      expect(awsS3Multipart.opts.uploadPartBytes.mock.calls.length).toEqual(2)
+      expect(awsS3Multipart.opts.uploadPartBytes.mock.calls.length).toEqual(3)
       expect(mock.mock.calls.length).toEqual(1)
     })
   })


### PR DESCRIPTION
This is a tricky one. Using `RateLimitedQueue` is complex and unintuitive. We also duplicate this logic between tus and S3. We can not reuse the existing `#shouldRetry` as it's very tightly coupled and full of side-effects.  It's also odd that there is a global retry iterator, which takes the default or user provided `retryDelays` and turns it into an iterator, as this seems to unnecessarily share the retry interval between all requests.

There is an open issue about all of this: https://github.com/transloadit/uppy/issues/4173.

For now this fix is fine. 