### PR TITLE
fix instagram/facebook auth error regression

### DIFF
--- a/packages/@uppy/companion/src/server/provider/facebook/index.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/index.js
@@ -91,7 +91,7 @@ class Facebook extends Provider {
       fn,
       tag,
       providerName: this.authProvider,
-      isAuthError: (response) => response.statusCode === 190, // Invalid OAuth 2.0 Access Token
+      isAuthError: (response) => typeof response.body === 'object' && response.body?.error?.code === 190, // Invalid OAuth 2.0 Access Token
       getJsonErrorMessage: (body) => body?.error?.message,
     })
   }

--- a/packages/@uppy/companion/src/server/provider/instagram/graph/index.js
+++ b/packages/@uppy/companion/src/server/provider/instagram/graph/index.js
@@ -91,7 +91,7 @@ class Instagram extends Provider {
       fn,
       tag,
       providerName: this.authProvider,
-      isAuthError: (response) => response.statusCode === 190, // Invalid OAuth 2.0 Access Token
+      isAuthError: (response) => typeof response.body === 'object' && response.body?.error?.code === 190, // Invalid OAuth 2.0 Access Token
       getJsonErrorMessage: (body) => body?.error?.message,
     })
   }


### PR DESCRIPTION
was accidentally introduced here:
https://github.com/transloadit/uppy/commit/35812ca378b9b02290a2ab51261ddaeff8211fda#diff-48004ff4f8ca0268432082f97fc45b2443ceb2e5936284b7985b8aa68494dbbcR94

How to reproduce the error with facebook (before this PR):

- Log into your facebook account in Uppy and list files
- Go to facebook settings and privacy https://www.facebook.com/privacy/checkup/?source=settings_and_privacy
- Remove the Transloadit app
- now reload uppy and click facebook again and abserve the error

I've tested the fix with facebook and it works. 
