### PR TITLE
@uppy/companion: use deferred length for tus streams

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -514,9 +514,9 @@ class Uploader {
       this.tus = new tus.Upload(stream, {
         endpoint: this.options.endpoint,
         uploadUrl: this.options.uploadUrl,
-        uploadLengthDeferred: false,
+        uploadLengthDeferred: !isFileStream,
         retryDelays: [0, 1000, 3000, 5000],
-        uploadSize: this.size,
+        uploadSize: isFileStream ? this.size : undefined,
         chunkSize,
         headers: headerSanitize(this.options.headers),
         addRequestId: true,


### PR DESCRIPTION
with tus
as recommended in https://github.com/tus/tus-js-client/pull/606

because sometimes HEAD reports an incorrect size