### PR TITLE
@uppy/core: mark the package as side-effect free

### DIFF
--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -7,6 +7,7 @@
   "style": "dist/style.min.css",
   "types": "types/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "keywords": [
     "file uploader",
     "uppy",


### PR DESCRIPTION
This should allow bundler to not include Preact when no UIPlugin is used.