### PR TITLE
@uppy/aws-s3-multipart: fix crash on pause/resume

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -374,7 +374,7 @@ class HTTPCommunicationQueue {
     for (;;) {
       throwIfAborted(signal)
       if (chunk == null) {
-        return;
+        break;
       }
       
       const chunkData = chunk.getData()

--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -373,6 +373,10 @@ class HTTPCommunicationQueue {
 
     for (;;) {
       throwIfAborted(signal)
+      if (chunk == null) {
+        return;
+      }
+      
       const chunkData = chunk.getData()
       const { onProgress, onComplete } = chunk
       let signature


### PR DESCRIPTION
Fixes: https://github.com/transloadit/uppy/issues/4648

This bug occurs when we attempt to press the pause/resume button after the first batch of chunks has been uploaded. When the second batch starts the upload process, we end up with an array of chunks in the multipart upload package that looks like this: `[null, null, null, null, chunk, chunk]` As a result, when we resume, we continue to attempt to retrieve data from the null chunks. This is why I added a check to skip them.

Before fix we have error:
```
[Uppy] [11:22:52] TypeError: Cannot read properties of null (reading 'getData')
    at index.js:333:31
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (asyncToGenerator.js:3:1)
    at _next (asyncToGenerator.js:25:1)
    at _ZoneDelegate.invoke (zone.js:372:26)
    at Object.onInvoke (core.mjs:26291:33)
    at _ZoneDelegate.invoke (zone.js:371:52)
    at Zone.run (zone.js:134:43)
    at zone.js:1275:36
    at _ZoneDelegate.invokeTask (zone.js:406:31)
```

After fix - resume successfull