### PR TITLE
@uppy/aws-s3-multipart: pass `signal` as separate arg for backward compat

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -301,6 +301,7 @@ class HTTPCommunicationQueue {
       return await this.#sendCompletionRequest(
         this.#getFile(file),
         { key, uploadId, parts, signal },
+        signal,
       ).abortOn(signal)
     } catch (err) {
       if (err?.cause !== pausingUploadReason && err?.name !== 'AbortError') {
@@ -327,6 +328,7 @@ class HTTPCommunicationQueue {
     const alreadyUploadedParts = await this.#listParts(
       this.#getFile(file),
       { uploadId, key, signal },
+      signal,
     ).abortOn(signal)
     throwIfAborted(signal)
     const parts = await Promise.all(
@@ -346,6 +348,7 @@ class HTTPCommunicationQueue {
     return this.#sendCompletionRequest(
       this.#getFile(file),
       { key, uploadId, parts, signal },
+      signal,
     ).abortOn(signal)
   }
 


### PR DESCRIPTION
Not ideal design, but better than making a breaking change. Some of our methods are expecting the `signal` to be a separate argument instead of being in the options bag. It shouldn't be a problem to pass the same `AbortSignal` twice, hopefully that's something we can fix in a future major.