### PR TITLE
@uppy/aws-s3-multipart: fix `TypeError`

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -319,7 +319,7 @@ class HTTPCommunicationQueue {
 
   async resumeUploadFile (file, chunks, signal) {
     throwIfAborted(signal)
-    if (chunks.length === 1 && !chunks[0].shouldUseMultipart) {
+    if (chunks.length === 1 && chunks[0] != null && !chunks[0].shouldUseMultipart) {
       return this.#nonMultipartUpload(file, chunks[0], signal)
     }
     const { uploadId, key } = await this.getUploadId(file, signal)


### PR DESCRIPTION
When chunks have already been uploaded, they are removed from memory. If the user resume an upload whose first chunk has been uploaded, they were getting a `TypeError` back.