### PR TITLE
@uppy/core: fix `sideEffects` declaration

### DIFF
--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -7,7 +7,9 @@
   "style": "dist/style.min.css",
   "types": "types/index.d.ts",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "keywords": [
     "file uploader",
     "uppy",


### PR DESCRIPTION
CSS files do contain some side effects, as some Uppy plugins rely on some CSS class being styled by core.