### PR TITLE
Add missing translations to de_DE

### DIFF
--- a/packages/@uppy/locales/src/de_DE.ts
+++ b/packages/@uppy/locales/src/de_DE.ts
@@ -137,6 +137,7 @@ de_DE.strings = {
   recordingLength: 'Aufnahmedauer %{recording_length}',
   recordingStoppedMaxSize:
     'Die Aufnahme wurde gestoppt, weil die Dateigröße das Limit überschritten hat',
+  recordVideoBtn: 'Video aufnehmen',
   recoveredAllFiles:
     'Wir haben alle Dateien wiederhergestellt. Sie können mit dem Hochladen fortfahren.',
   recoveredXFiles: {
@@ -168,7 +169,8 @@ de_DE.strings = {
   streamActive: 'Stream aktiv',
   streamPassive: 'Stream passiv',
   submitRecordedFile: 'Aufgezeichnete Datei verwenden',
-  takePicture: 'Ein Foto machen',
+  takePicture: 'Ein Foto aufnehmen',
+  takePictureBtn: 'Foto aufnehmen',
   timedOut: 'Upload für %{seconds} Sekunden stehen geblieben, breche ab.',
   upload: 'Hochladen',
   uploadComplete: 'Hochladen abgeschlossen',


### PR DESCRIPTION
Follow up to https://github.com/transloadit/uppy/pull/4797 with new translation structure

Original text:

> Thanks for making uppy! I appreciate the hard work and versatility.
> 
> When integrating this for a mobile PWA, I noticed two translation strings are missing which I've added to this PR. I hope you find this useful, too.
> 
> Thanks,
> Leo

Thanks for the initial review @Acconut!