### PR TITLE
Suggestion on Rationality of Setting setAspectRatio upon “reset” Action

### DIFF
--- a/packages/@uppy/image-editor/src/Editor.jsx
+++ b/packages/@uppy/image-editor/src/Editor.jsx
@@ -127,7 +127,7 @@ export default class Editor extends Component {
   }
 
   renderRevert () {
-    const { i18n } = this.props
+    const { i18n, opts } = this.props
 
     return (
       <label
@@ -140,7 +140,11 @@ export default class Editor extends Component {
           className="uppy-u-reset uppy-c-btn"
           onClick={() => {
             this.cropper.reset()
-            this.cropper.setAspectRatio(0)
+            if (opts.cropperOptions.initialAspectRatio) {
+              this.cropper.setAspectRatio(opts.cropperOptions.initialAspectRatio);
+            } else {
+              this.cropper.setAspectRatio(0);
+            }
             this.setState({ angle90Deg: 0, angleGranular: 0 })
           }}
         >


### PR DESCRIPTION
Problem Description:
When using the "reset" to reset the image, we believe that setAspectRatio should be set to the initialAspectRatio of cropperOptions, instead of 0. The rationality of this behavior is questionable.

Use Case:
In the scenario of uploading a profile picture using Uppy's imageEditor, the initial aspect ratio of Uppy is set to 1/1. Within this setting, we only retained the three buttons: "reset", "zoomIn", and "zoomOut". However, after clicking the "revert" button on the image, the aspect ratio becomes ineffective.

Suggested Improvement:
To maintain the stability of the aspect ratio after the "reset" operation, we suggest setting setAspectRatio to the initialAspectRatio of cropperOptions, so as to maintain the aspect ratio in its initial state instead of setting it to 0. This way, the image can maintain its original aspect ratio after the "revert" operation, which aligns better with user expectations.