### PR TITLE
@uppy/companion: fix double tus uploads

### DIFF
--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -87,7 +87,7 @@ export default class RequestClient {
     return stripSlash(companion && companion[host] ? companion[host] : host)
   }
 
-  async headers (emptyBody = false) {
+  async headers(emptyBody = false) {
     const defaultHeaders = {
       Accept: 'application/json',
       ...(emptyBody ? undefined : {
@@ -397,15 +397,6 @@ export default class RequestClient {
 
           isPaused = newPausedState
           if (socket) sendState()
-
-          if (newPausedState) {
-            // Remove this file from the queue so another file can start in its place.
-            socketAbortController?.abort?.() // close socket to free up the request for other uploads
-          } else {
-            // Resuming an upload should be queued, else you could pause and then
-            // resume a queued upload to make it skip the queue.
-            createWebsocket()
-          }
         }
 
         const onFileRemove = (targetFile) => {

--- a/packages/@uppy/companion-client/src/RequestClient.js
+++ b/packages/@uppy/companion-client/src/RequestClient.js
@@ -87,7 +87,7 @@ export default class RequestClient {
     return stripSlash(companion && companion[host] ? companion[host] : host)
   }
 
-  async headers(emptyBody = false) {
+  async headers (emptyBody = false) {
     const defaultHeaders = {
       Accept: 'application/json',
       ...(emptyBody ? undefined : {
@@ -397,6 +397,15 @@ export default class RequestClient {
 
           isPaused = newPausedState
           if (socket) sendState()
+
+          if (newPausedState) {
+            // Remove this file from the queue so another file can start in its place.
+            socketAbortController?.abort?.() // close socket to free up the request for other uploads
+          } else {
+            // Resuming an upload should be queued, else you could pause and then
+            // resume a queued upload to make it skip the queue.
+            createWebsocket()
+          }
         }
 
         const onFileRemove = (targetFile) => {

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -216,7 +216,7 @@ class Uploader {
     })
   }
 
-  #uploadState = 'idle'
+  #uploadState = states.idle
 
   #canceled = false
 


### PR DESCRIPTION
fixes #4815
also improve error logging when canceling

## also:
don't close socket when pausing:
because it prevented us from canceling an upload that is paused
note that we here sacrifice the ability to pause uploads and have other uploads take over the paused upload's rate limit queue spot.
this is sacrificed because we will soon remove the ability to pause/resume uploads anyways