### PR TITLE
fix(type): add missing requiredMetaFields key in restrictions

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -154,6 +154,7 @@ export interface Restrictions {
   maxNumberOfFiles?: number | null
   minNumberOfFiles?: number | null
   allowedFileTypes?: string[] | null
+  requiredMetaFields?: string[]
 }
 
 export interface UppyOptions<


### PR DESCRIPTION
as documented in https://uppy.io/docs/uppy/#restrictions