### PR TITLE
don't close socket when pausing

### DIFF
--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -53,6 +53,9 @@ case you don’t have to do anything.
 - `RequestClient` methods `get`, `post`, `delete` no longer accepts a boolean as
   the third argument. Instead, pass `{ skipPostResponse: true | false }`. This
   won’t affect you unless you’ve been using `RequestClient`.
+- When pausing uploads, the WebSocket towards companion will no longer be
+  closed. This allows paused uploads to be cancelled, but once a file has been
+  paused it will still occupy its place in the concurrency queue.
 
 ## Migrate from Uppy 3.x to 4.x
 

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -540,15 +540,6 @@ export default class RequestClient<M extends Meta, B extends Body> {
 
           isPaused = newPausedState
           if (socket) sendState()
-
-          if (newPausedState) {
-            // Remove this file from the queue so another file can start in its place.
-            socketAbortController?.abort?.() // close socket to free up the request for other uploads
-          } else {
-            // Resuming an upload should be queued, else you could pause and then
-            // resume a queued upload to make it skip the queue.
-            createWebsocket()
-          }
         }
 
         const onFileRemove = (targetFile: UppyFile<M, B>) => {


### PR DESCRIPTION
because it prevented us from canceling an upload that is paused. Note that we here sacrifice the ability to pause uploads and have other uploads take over the paused upload's rate limit queue spot. this is sacrificed because we will soon remove the ability to pause/resume uploads anyways

(cherry picked from commit e4dbe77d2fd8912beebd695d9d7cf80a3ca924d6)

this was cherrypicked from https://github.com/transloadit/uppy/pull/4816#issuecomment-1850147652