### PR TITLE
@uppy/companion: merge config before validating

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -68,9 +68,9 @@ module.exports.setLoggerProcessName = setLoggerProcessName
 module.exports.app = (optionsArg = {}) => {
   setLoggerProcessName(optionsArg)
 
-  validateConfig(optionsArg)
-
   const options = merge({}, defaultOptions, optionsArg)
+
+  validateConfig(options)
 
   const providers = providerManager.getDefaultProviders()
 


### PR DESCRIPTION
Running `validateConfig` can throw errors and stop the application from starting. If you're using environment variables to pass configuration then these need to be merged in before attempting to validate the configuration.

A concrete example of why this is needed is if you're setting `COMPANION_UPLOAD_URLS` when running `NODE_ENV=production` the application will fail to start because `validateConfig` requires that `uploadUrls` is specified.
