### PR TITLE
@uppy/angular: fix TS build errors

### DIFF
--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/components/dashboard-modal/dashboard-modal.component.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/components/dashboard-modal/dashboard-modal.component.ts
@@ -11,20 +11,20 @@ import {
 import Dashboard from '@uppy/dashboard';
 // @ts-expect-error
 import type { DashboardOptions } from '@uppy/dashboard';
-// @ts-expect-error
 import { Uppy } from '@uppy/core';
 import { UppyAngularWrapper } from '../../utils/wrapper';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 @Component({
   selector: 'uppy-dashboard-modal',
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardModalComponent
-  extends UppyAngularWrapper<Dashboard>
+export class DashboardModalComponent<M extends Meta, B extends Body>
+  extends UppyAngularWrapper<M, B, Dashboard>
   implements OnDestroy, OnChanges
 {
-  @Input() uppy: Uppy = new Uppy();
+  @Input() uppy: Uppy<M, B> = new Uppy();
   @Input() props: DashboardOptions = {};
   @Input() open: boolean = false;
 

--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/components/dashboard/dashboard.component.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/components/dashboard/dashboard.component.ts
@@ -11,20 +11,20 @@ import {
 import Dashboard from '@uppy/dashboard';
 // @ts-expect-error
 import type { DashboardOptions } from '@uppy/dashboard';
-// @ts-expect-error
 import { Uppy } from '@uppy/core';
 import { UppyAngularWrapper } from '../../utils/wrapper';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 @Component({
   selector: 'uppy-dashboard',
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent
-  extends UppyAngularWrapper
+export class DashboardComponent<M extends Meta, B extends Body>
+  extends UppyAngularWrapper<M, B>
   implements OnDestroy, OnChanges
 {
-  @Input() uppy: Uppy = new Uppy();
+  @Input() uppy: Uppy<M, B> = new Uppy();
   @Input() props: DashboardOptions = {};
 
   constructor(public el: ElementRef) {

--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/components/drag-drop/drag-drop.component.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/components/drag-drop/drag-drop.component.ts
@@ -7,24 +7,24 @@ import {
   SimpleChanges,
   ElementRef,
 } from '@angular/core';
-// @ts-expect-error
 import { Uppy } from '@uppy/core';
 // @ts-expect-error
 import DragDrop from '@uppy/drag-drop';
 // @ts-expect-error
 import type { DragDropOptions } from '@uppy/drag-drop';
 import { UppyAngularWrapper } from '../../utils/wrapper';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 @Component({
   selector: 'uppy-drag-drop',
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DragDropComponent
-  extends UppyAngularWrapper
+export class DragDropComponent<M extends Meta, B extends Body>
+  extends UppyAngularWrapper<M, B>
   implements OnDestroy, OnChanges
 {
-  @Input() uppy: Uppy = new Uppy();
+  @Input() uppy: Uppy<M, B> = new Uppy();
   @Input() props: DragDropOptions = {};
 
   constructor(public el: ElementRef) {

--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/components/progress-bar/progress-bar.component.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/components/progress-bar/progress-bar.component.ts
@@ -7,24 +7,24 @@ import {
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
-// @ts-expect-error
 import { Uppy } from '@uppy/core';
 // @ts-expect-error
 import ProgressBar from '@uppy/progress-bar';
 // @ts-expect-error
 import type { ProgressBarOptions } from '@uppy/progress-bar';
 import { UppyAngularWrapper } from '../../utils/wrapper';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 @Component({
   selector: 'uppy-progress-bar',
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProgressBarComponent
-  extends UppyAngularWrapper
+export class ProgressBarComponent<M extends Meta, B extends Body>
+  extends UppyAngularWrapper<M, B>
   implements OnDestroy, OnChanges
 {
-  @Input() uppy: Uppy = new Uppy();
+  @Input() uppy: Uppy<M, B> = new Uppy();
   @Input() props: ProgressBarOptions = {};
 
   constructor(public el: ElementRef) {

--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/components/status-bar/status-bar.component.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/components/status-bar/status-bar.component.ts
@@ -3,29 +3,28 @@ import {
   ChangeDetectionStrategy,
   Input,
   ElementRef,
-  SimpleChange,
   OnDestroy,
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
-// @ts-expect-error
 import { Uppy } from '@uppy/core';
 // @ts-expect-error
 import StatusBar from '@uppy/status-bar';
 // @ts-expect-error
 import type { StatusBarOptions } from '@uppy/status-bar';
 import { UppyAngularWrapper } from '../../utils/wrapper';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 @Component({
   selector: 'uppy-status-bar',
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StatusBarComponent
-  extends UppyAngularWrapper
+export class StatusBarComponent<M extends Meta, B extends Body>
+  extends UppyAngularWrapper<M, B>
   implements OnDestroy, OnChanges
 {
-  @Input() uppy: Uppy = new Uppy();
+  @Input() uppy: Uppy<M, B> = new Uppy();
   @Input() props: StatusBarOptions = {};
 
   constructor(public el: ElementRef) {

--- a/packages/@uppy/angular/projects/uppy/angular/src/lib/utils/wrapper.ts
+++ b/packages/@uppy/angular/projects/uppy/angular/src/lib/utils/wrapper.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import type { Uppy, UIPlugin } from '@uppy/core';
 import type { ElementRef, SimpleChanges } from '@angular/core';
 // @ts-expect-error
@@ -7,19 +6,25 @@ import type { DragDropOptions } from '@uppy/drag-drop';
 import type { StatusBarOptions } from '@uppy/status-bar';
 // @ts-expect-error
 import type { ProgressBarOptions } from '@uppy/progress-bar';
+import { Body, Meta } from '@uppy/utils/lib/UppyFile';
 
 export abstract class UppyAngularWrapper<
-  PluginType extends UIPlugin = UIPlugin,
+  M extends Meta,
+  B extends Body,
+  PluginType extends UIPlugin<any, M, B> = UIPlugin<any, M, B>,
 > {
   abstract props: DragDropOptions | StatusBarOptions | ProgressBarOptions;
   abstract el: ElementRef;
-  abstract uppy: Uppy;
+  abstract uppy: Uppy<M, B>;
   private options: any;
   plugin: PluginType | undefined;
 
   onMount(
     defaultOptions: Record<string, unknown>,
-    plugin: new (uppy: Uppy, opts?: Record<string, unknown>) => UIPlugin,
+    plugin: new (
+      uppy: Uppy<M, B>,
+      opts?: Record<string, unknown>,
+    ) => UIPlugin<any, M, B>,
   ) {
     this.options = {
       ...defaultOptions,
@@ -47,7 +52,6 @@ export abstract class UppyAngularWrapper<
       this.props !== changes['props'].previousValue &&
       changes['props'].previousValue !== undefined
     ) {
-      // @ts-expect-error
       this.plugin.setOptions({ ...this.options });
     }
   }


### PR DESCRIPTION
Now that `@uppy/core` is typed, we have a few types to update in `@uppy/angular` (which is consuming it). Not sure if setting `Meta` and `Body` as mandatory is the best DX, but at least that makes the CI green.