### PR TITLE
fix "Save" button translation in hr_HR.ts

### DIFF
--- a/packages/@uppy/locales/src/hr_HR.ts
+++ b/packages/@uppy/locales/src/hr_HR.ts
@@ -92,6 +92,7 @@ hr_HR.strings = {
   resumeUpload: 'Nastavi prijenos',
   retry: 'Pokušaj ponovo',
   retryUpload: 'Ponovno pokušaj prenijeti datoteku',
+  save: 'Spremi',
   saveChanges: 'Spremi promjene',
   selectX: {
     '0': 'Izaberi datoteku',


### PR DESCRIPTION
The "Save" button when in ImageEditor mode is not properly translated because of the missing "save" property in locale.

Before: 

![image](https://github.com/transloadit/uppy/assets/44570474/12ecbcaf-4851-4072-8fcd-cb2295524534)

AFter: 

![image](https://github.com/transloadit/uppy/assets/44570474/3a77242b-89b8-4367-927e-26ca0c213b5f)
