### PR TITLE
@uppy/core: add `debugLogger` as export in manual types

### DIFF
--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -147,6 +147,8 @@ export interface Logger {
   error: (...args: any[]) => void
 }
 
+export const debugLogger: Logger
+
 export interface Restrictions {
   maxFileSize?: number | null
   minFileSize?: number | null


### PR DESCRIPTION
We export it here:
https://github.com/transloadit/uppy/blob/c48aa82a8a68392f5c5f09d866deebd8806fe8a6/packages/@uppy/core/src/index.ts#L5

But until then, it was missing from the types, see https://community.transloadit.com/t/module-uppy-core-has-no-exported-member-debuglogger/16930/2.