### PR TITLE
meta: fix linting of `.tsx` files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -444,7 +444,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/*.ts', '**/*.md/*.ts', '**/*.md/*.typescript'],
+      files: ['**/*.ts', '**/*.md/*.ts', '**/*.md/*.typescript', '**/*.tsx', '**/*.md/*.tsx'],
       excludedFiles: ['examples/angular-example/**/*.ts', 'packages/@uppy/angular/**/*.ts'],
       parser: '@typescript-eslint/parser',
       settings: {


### PR DESCRIPTION
Those should be linted as `.ts` files, except with JSX support.