### PR TITLE
meta: fix `js2ts` script

### DIFF
--- a/private/js2ts/index.mjs
+++ b/private/js2ts/index.mjs
@@ -38,10 +38,13 @@ const paths = Object.fromEntries(
     for (const pkg of uppyDeps) {
       // eslint-disable-next-line import/no-dynamic-require
       const pkgJson = require(`../../${pkg}/package.json`)
-      if (pkgJson.main || pkgJson.exports?.['.']) {
-        // If the package does have a main export (e.g. `import '@uppy/utils'`
-        // should flag an error because @uppy/utils does not have a main export).
-        yield [pkg, [`../${pkg.slice('@uppy/'.length)}/lib/index.js`]]
+      if (pkgJson.main) {
+        yield [pkg, [`../${pkg.slice('@uppy/'.length)}/${pkgJson.main}`]]
+      } else if (pkgJson.exports?.['.']) {
+        yield [
+          pkg,
+          [`../${pkg.slice('@uppy/'.length)}/${pkgJson.exports['.']}`],
+        ]
       }
       yield [`${pkg}/*`, [`../${pkg.slice('@uppy/'.length)}/*`]]
     }

--- a/private/js2ts/index.mjs
+++ b/private/js2ts/index.mjs
@@ -36,17 +36,15 @@ const paths = Object.fromEntries(
   (function* generatePaths() {
     const require = createRequire(packageRoot)
     for (const pkg of uppyDeps) {
+      const nickname = pkg.slice('@uppy/'.length)
       // eslint-disable-next-line import/no-dynamic-require
-      const pkgJson = require(`../../${pkg}/package.json`)
-      if (pkgJson.main) {
-        yield [pkg, [`../${pkg.slice('@uppy/'.length)}/${pkgJson.main}`]]
-      } else if (pkgJson.exports?.['.']) {
-        yield [
-          pkg,
-          [`../${pkg.slice('@uppy/'.length)}/${pkgJson.exports['.']}`],
-        ]
+      const pkgJson = require(`../${nickname}/package.json`)
+      if (pkgJson.exports?.['.']) {
+        yield [pkg, [`../${nickname}/${pkgJson.exports['.']}`]]
+      } else if (pkgJson.main) {
+        yield [pkg, [`../${nickname}/${pkgJson.main}`]]
       }
-      yield [`${pkg}/*`, [`../${pkg.slice('@uppy/'.length)}/*`]]
+      yield [`${pkg}/*`, [`../${nickname}/*`]]
     }
   })(),
 )


### PR DESCRIPTION
We were missing the `paths` property in `compilerOptions`, resulting in TS being unable to resolve local dependencies.