### PR TITLE
meta: fix `js2ts` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
           corepack yarn run build:lib
           corepack yarn run build:companion
           corepack yarn run build:locale-pack
+          find packages/@uppy -name 'tsconfig.json' -delete
       - name: Run type tests
         run: corepack yarn run test:type
       - name: Drop manual tyoes
@@ -108,6 +109,7 @@ jobs:
         # We don't want to remove that file to not break users.
         # However, we want to validate the types based on the types inferred from source.
         run: |
+          git checkout -- packages/@uppy
           node --input-type=module <<'EOF'
             import { existsSync } from 'node:fs';
             import { opendir, readFile, writeFile } from 'node:fs/promises';

--- a/packages/@uppy/core/tsconfig.build.json
+++ b/packages/@uppy/core/tsconfig.build.json
@@ -5,6 +5,11 @@
     "rootDir": "./src",
     "resolveJsonModule": false,
     "noImplicitAny": false,
+    "paths": {
+      "@uppy/store-default": ["../store-default/src/index.js"],
+      "@uppy/store-default/lib/*": ["../store-default/src/*"],
+      "@uppy/utils/lib/*": ["../utils/src/*"]
+    },
     "skipLibCheck": true
   },
   "include": ["./src/**/*.*"],

--- a/packages/@uppy/core/tsconfig.json
+++ b/packages/@uppy/core/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../../tsconfig.shared",
   "compilerOptions": {
     "emitDeclarationOnly": false,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@uppy/store-default": ["../store-default/src/index.js"],
+      "@uppy/store-default/lib/*": ["../store-default/src/*"],
+      "@uppy/utils/lib/*": ["../utils/src/*"]
+    }
   },
   "include": ["./package.json", "./src/**/*.*"],
   "references": [

--- a/packages/@uppy/locales/tsconfig.build.json
+++ b/packages/@uppy/locales/tsconfig.build.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
+    "paths": {
+      "@uppy/utils/lib/*": ["../utils/src/*"]
+    },
     "skipLibCheck": true
   },
   "include": ["./src/**/*.*"],

--- a/packages/@uppy/locales/tsconfig.json
+++ b/packages/@uppy/locales/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../../tsconfig.shared",
   "compilerOptions": {
     "emitDeclarationOnly": false,
+    "paths": {
+      "@uppy/utils/lib/*": ["../utils/src/*"]
+    },
     "noEmit": true
   },
   "include": ["./package.json", "./src/**/*.*"],

--- a/private/js2ts/index.mjs
+++ b/private/js2ts/index.mjs
@@ -32,6 +32,7 @@ const uppyDeps = Object.keys(packageJSON.dependencies || {})
   .concat(Object.keys(packageJSON.devDependencies || {}))
   .filter((pkg) => pkg.startsWith('@uppy/'))
 
+// We want TS to check the source files so it doesn't use outdated (or missing) types:
 const paths = Object.fromEntries(
   (function* generatePaths() {
     const require = createRequire(packageRoot)
@@ -39,12 +40,13 @@ const paths = Object.fromEntries(
       const nickname = pkg.slice('@uppy/'.length)
       // eslint-disable-next-line import/no-dynamic-require
       const pkgJson = require(`../${nickname}/package.json`)
-      if (pkgJson.exports?.['.']) {
-        yield [pkg, [`../${nickname}/${pkgJson.exports['.']}`]]
-      } else if (pkgJson.main) {
-        yield [pkg, [`../${nickname}/${pkgJson.main}`]]
+      if (pkgJson.main) {
+        yield [
+          pkg,
+          [`../${nickname}/${pkgJson.main.replace(/^(\.\/)?lib\//, 'src/')}`],
+        ]
       }
-      yield [`${pkg}/*`, [`../${nickname}/*`]]
+      yield [`${pkg}/lib/*`, [`../${nickname}/src/*`]]
     }
   })(),
 )

--- a/private/js2ts/index.mjs
+++ b/private/js2ts/index.mjs
@@ -27,10 +27,12 @@ if (packageJSON.type !== 'module') {
   throw new Error('Cannot convert non-ESM package to TS')
 }
 
-const uppyDeps = Object.keys(packageJSON.dependencies || {})
-  .concat(Object.keys(packageJSON.peerDependencies || {}))
-  .concat(Object.keys(packageJSON.devDependencies || {}))
-  .filter((pkg) => pkg.startsWith('@uppy/'))
+const uppyDeps = new Set(
+  Object.keys(packageJSON.dependencies || {})
+    .concat(Object.keys(packageJSON.peerDependencies || {}))
+    .concat(Object.keys(packageJSON.devDependencies || {}))
+    .filter((pkg) => pkg.startsWith('@uppy/')),
+)
 
 // We want TS to check the source files so it doesn't use outdated (or missing) types:
 const paths = Object.fromEntries(
@@ -50,7 +52,7 @@ const paths = Object.fromEntries(
     }
   })(),
 )
-const references = uppyDeps.map((pkg) => ({
+const references = Array.from(uppyDeps, (pkg) => ({
   path: `../${pkg.slice('@uppy/'.length)}/tsconfig.build.json`,
 }))
 


### PR DESCRIPTION
We should not rely on the default resolve for `@uppy/**` deps, as the local build may be outdated, or missing. I'm also removing support for exports map because we are currently not using those in Uppy.