### PR TITLE
upgrade `@transloadit/prettier-bytes`

### DIFF
--- a/packages/@uppy/compressor/package.json
+++ b/packages/@uppy/compressor/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@transloadit/prettier-bytes": "^0.0.9",
+    "@transloadit/prettier-bytes": "^0.2.0",
     "@uppy/utils": "workspace:^",
     "compressorjs": "^1.1.1",
     "preact": "^10.5.13",

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@transloadit/prettier-bytes": "0.0.9",
+    "@transloadit/prettier-bytes": "^0.2.0",
     "@uppy/store-default": "workspace:^",
     "@uppy/utils": "workspace:^",
     "lodash": "^4.17.21",

--- a/packages/@uppy/core/src/Restricter.ts
+++ b/packages/@uppy/core/src/Restricter.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable max-classes-per-file, class-methods-use-this */
-// @ts-ignore untyped
 import prettierBytes from '@transloadit/prettier-bytes'
 // @ts-ignore untyped
 import match from 'mime-match'

--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import assert from 'node:assert'
 import fs from 'node:fs'
 import path from 'node:path'
-// @ts-expect-error untyped
 import prettierBytes from '@transloadit/prettier-bytes'
 import Core from './index.ts'
 import UIPlugin from './UIPlugin.ts'

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@transloadit/prettier-bytes": "0.0.7",
+    "@transloadit/prettier-bytes": "^0.2.0",
     "@uppy/informer": "workspace:^",
     "@uppy/provider-views": "workspace:^",
     "@uppy/status-bar": "workspace:^",

--- a/packages/@uppy/golden-retriever/package.json
+++ b/packages/@uppy/golden-retriever/package.json
@@ -24,7 +24,6 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@transloadit/prettier-bytes": "0.0.9",
     "@uppy/utils": "workspace:^",
     "lodash": "^4.17.21"
   },

--- a/packages/@uppy/status-bar/package.json
+++ b/packages/@uppy/status-bar/package.json
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "dependencies": {
-    "@transloadit/prettier-bytes": "0.0.9",
+    "@transloadit/prettier-bytes": "^0.2.0",
     "@uppy/utils": "workspace:^",
     "classnames": "^2.2.6",
     "preact": "^10.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7743,17 +7743,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@transloadit/prettier-bytes@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@transloadit/prettier-bytes@npm:0.0.7"
-  checksum: af075e1b2b045cac55d5ab854b5c94273ef7f4bd825f05fe578559465f206d2a1535343b50170252a9efb31ffdc2d6420e64eb32d2faeabeeb8b7d81d5d46ef0
-  languageName: node
-  linkType: hard
-
-"@transloadit/prettier-bytes@npm:0.0.9, @transloadit/prettier-bytes@npm:^0.0.9":
-  version: 0.0.9
-  resolution: "@transloadit/prettier-bytes@npm:0.0.9"
-  checksum: efa5a723c41e7bce7ad17d1affe6a43209df857e17dc2b12a7c7bd6d3c921df8298086dbfb62ed740ca3e617d8c7f47485bb311adb637b20f2f75a28b08bac4f
+"@transloadit/prettier-bytes@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@transloadit/prettier-bytes@npm:0.2.0"
+  checksum: 0faaeffc879754e18103bd576510d4349ec5253c2ebe846f7f8e52f2e9bc4c6877a9197adf4d2f196fa9b442a64cd43c5a742b5b51268e7f56bb3451299af1ce
   languageName: node
   linkType: hard
 
@@ -9372,7 +9365,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/compressor@workspace:packages/@uppy/compressor"
   dependencies:
-    "@transloadit/prettier-bytes": ^0.0.9
+    "@transloadit/prettier-bytes": ^0.2.0
     "@uppy/utils": "workspace:^"
     compressorjs: ^1.1.1
     preact: ^10.5.13
@@ -9387,7 +9380,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/core@workspace:packages/@uppy/core"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.9
+    "@transloadit/prettier-bytes": ^0.2.0
     "@uppy/store-default": "workspace:^"
     "@uppy/utils": "workspace:^"
     lodash: ^4.17.21
@@ -9403,7 +9396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/dashboard@workspace:packages/@uppy/dashboard"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.7
+    "@transloadit/prettier-bytes": ^0.2.0
     "@uppy/google-drive": "workspace:^"
     "@uppy/informer": "workspace:^"
     "@uppy/provider-views": "workspace:^"
@@ -9498,7 +9491,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/golden-retriever@workspace:packages/@uppy/golden-retriever"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.9
     "@uppy/utils": "workspace:^"
     lodash: ^4.17.21
   peerDependencies:
@@ -9692,7 +9684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uppy/status-bar@workspace:packages/@uppy/status-bar"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.9
+    "@transloadit/prettier-bytes": ^0.2.0
     "@uppy/utils": "workspace:^"
     classnames: ^2.2.6
     preact: ^10.5.13


### PR DESCRIPTION
More recent versions are written in TS, so we can rely on upstream types.

Refs: https://github.com/transloadit/monolib/comapare/1d649aa77fbabed471420f73f9433954452743bd...HEAD
Refs: https://github.com/transloadit/monolib/commits/main/packages/prettier-bytes