### PR TITLE
@uppy/xhr-upload: show remove button

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/index.scss
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.scss
@@ -170,12 +170,6 @@
   }
 }
 
-.uppy-Dashboard-Item.is-inprogress:not(.is-resumable) {
-  .uppy-Dashboard-Item-action--remove {
-    display: none;
-  }
-}
-
 .uppy-Dashboard-Item-errorDetails {
   position: relative;
   top: 0;


### PR DESCRIPTION
Closes #4835

I'm not sure why this CSS was there. `xhr-upload` has a `bundle` option, which sends all the files in one request instead of multiple. For this option it makes sense to hide the individual file remove button, because you can't alter a concatenated upload. Removing this CSS however doesn't change that, when `bundle` is `true` the button is still hidden on files, but now it does show the button when the option is `false`.