### PR TITLE
meta: use `explicit-module-boundary-types` instead of `explicit-funct…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -471,7 +471,7 @@ module.exports = {
       files: ['packages/@uppy/*/src/**/*.ts', 'packages/@uppy/*/src/**/*.tsx'],
       excludedFiles: ['packages/@uppy/**/*.test.ts', 'packages/@uppy/core/src/mocks/*.ts'],
       rules: {
-        '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/explicit-module-boundary-types': 'error',
       },
     },
     {

--- a/packages/@uppy/core/src/BasePlugin.ts
+++ b/packages/@uppy/core/src/BasePlugin.ts
@@ -13,7 +13,7 @@
 import Translator from '@uppy/utils/lib/Translator'
 import type { I18n, Locale } from '@uppy/utils/lib/Translator'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type { Uppy } from '.'
+import type { State, Uppy } from './Uppy'
 
 export type PluginOpts = {
   locale?: Locale
@@ -103,7 +103,7 @@ export default class BasePlugin<
   uninstall(): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  update(state: any): void {}
+  update(state: State<M, B>): void {}
 
   // Called after every state update, after everything's mounted. Debounced.
   afterUpdate(): void {}

--- a/packages/@uppy/core/src/BasePlugin.ts
+++ b/packages/@uppy/core/src/BasePlugin.ts
@@ -103,7 +103,7 @@ export default class BasePlugin<
   uninstall(): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  update(state: State<M, B>): void {}
+  update(state: Partial<State<M, B>>): void {}
 
   // Called after every state update, after everything's mounted. Debounced.
   afterUpdate(): void {}

--- a/packages/@uppy/core/src/UIPlugin.ts
+++ b/packages/@uppy/core/src/UIPlugin.ts
@@ -7,6 +7,7 @@ import getTextDirection from '@uppy/utils/lib/getTextDirection'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import BasePlugin from './BasePlugin.ts'
 import type { PluginOpts } from './BasePlugin.ts'
+import type { State } from './Uppy.ts'
 
 /**
  * Defer a frequent call to the microtask queue.
@@ -48,7 +49,7 @@ class UIPlugin<
   M extends Meta,
   B extends Body,
 > extends BasePlugin<Opts, M, B> {
-  #updateUI: (state: any) => void
+  #updateUI: (state: State<M, B>) => void
 
   isTargetDOMEl: boolean
 
@@ -175,7 +176,7 @@ class UIPlugin<
     )
   }
 
-  update(state: any): void {
+  update(state: State<M, B>): void {
     if (this.el != null) {
       this.#updateUI?.(state)
     }

--- a/packages/@uppy/core/src/UIPlugin.ts
+++ b/packages/@uppy/core/src/UIPlugin.ts
@@ -49,7 +49,7 @@ class UIPlugin<
   M extends Meta,
   B extends Body,
 > extends BasePlugin<Opts, M, B> {
-  #updateUI: (state: State<M, B>) => void
+  #updateUI: (state: Partial<State<M, B>>) => void
 
   isTargetDOMEl: boolean
 
@@ -176,7 +176,7 @@ class UIPlugin<
     )
   }
 
-  update(state: State<M, B>): void {
+  update(state: Partial<State<M, B>>): void {
     if (this.el != null) {
       this.#updateUI?.(state)
     }


### PR DESCRIPTION
…ion-return-type`

It seems to better align with what we are after: stability of public API types. We likely don't need explicit types for all functions, and it's a bit tedious to have when converting an existing plugin.

Refs: https://typescript-eslint.io/rules/explicit-module-boundary-types/