### PR TITLE
meta: fix `yarn build:clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "start:companion": "bash bin/companion.sh",
     "start:companion:with-loadbalancer": "e2e/start-companion-with-load-balancer.mjs",
     "build:bundle": "yarn node ./bin/build-bundle.mjs",
-    "build:clean": "git clean -e node_modules -Xfd packages e2e .parcel-cache coverage",
+    "build:clean": "cp .gitignore .gitignore.bak && grep -v 'node_modules' .gitignore.bak > .gitignore && echo '!**/node_modules/**/*' >> .gitignore; git clean -Xfd packages e2e .parcel-cache coverage; mv .gitignore.bak .gitignore",
     "build:companion": "yarn workspace @uppy/companion build",
     "build:css": "yarn node ./bin/build-css.js",
     "build:svelte": "yarn workspace @uppy/svelte build",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "start:companion": "bash bin/companion.sh",
     "start:companion:with-loadbalancer": "e2e/start-companion-with-load-balancer.mjs",
     "build:bundle": "yarn node ./bin/build-bundle.mjs",
-    "build:clean": "cp .gitignore .gitignore.bak && grep -v 'node_modules' .gitignore.bak > .gitignore && echo '!**/node_modules/**/*' >> .gitignore; git clean -Xfd packages e2e .parcel-cache coverage; mv .gitignore.bak .gitignore",
+    "build:clean": "cp .gitignore .gitignore.bak && printf '!node_modules\n!**/node_modules/**/*\n' >> .gitignore; git clean -Xfd packages e2e .parcel-cache coverage; mv .gitignore.bak .gitignore",
     "build:companion": "yarn workspace @uppy/companion build",
     "build:css": "yarn node ./bin/build-css.js",
     "build:svelte": "yarn workspace @uppy/svelte build",

--- a/packages/@uppy/angular/.gitignore
+++ b/packages/@uppy/angular/.gitignore
@@ -7,7 +7,6 @@
 /bazel-out
 
 # Node
-/node_modules
 npm-debug.log
 yarn-error.log
 

--- a/packages/@uppy/companion/.gitignore
+++ b/packages/@uppy/companion/.gitignore
@@ -22,10 +22,6 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directory
-# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-node_modules
-
 # oAuth Configuration
 config/auth.js
 

--- a/packages/@uppy/svelte/.gitignore
+++ b/packages/@uppy/svelte/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
-node_modules
 /dist/
 /src/empty.*
-package-lock.json

--- a/packages/@uppy/vue/.gitignore
+++ b/packages/@uppy/vue/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-node_modules
 /dist
 
 


### PR DESCRIPTION
Turns out that `-e` is completely ignored when using `-X`, so we had to be a bit more clever to make the clean command delete all ignored files but `node_modules/` folder – the trick we're using is to mark all the content of `node_modules/` as trackable, run `git clean -X`, and restore the `.gitignore` file.