### PR TITLE
meta: generate locale pack from output file

### DIFF
--- a/private/locale-pack/index.mjs
+++ b/private/locale-pack/index.mjs
@@ -14,7 +14,7 @@ const templatePath = path.join(localesPath, 'template.js')
 const englishLocalePath = path.join(localesPath, 'src', 'en_US.js')
 
 async function getLocalesAndCombinedLocale () {
-  const locales = await getLocales(`${root}/packages/@uppy/**/src/locale.js`)
+  const locales = await getLocales(`${root}/packages/@uppy/**/lib/locale.js`)
 
   const combinedLocale = {}
   for (const [pluginName, locale] of Object.entries(locales)) {


### PR DESCRIPTION
As we are starting to refactor packages to TS, we can no longer load the locale from the source file, we need to import the output JS file.

Refs: https://github.com/transloadit/uppy/actions/runs/7545261719/job/20540469630