### PR TITLE
Fix companion dns and allow redirects from http->https again

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/url.js
+++ b/packages/@uppy/companion/src/server/controllers/url.js
@@ -25,7 +25,7 @@ const downloadURL = async (url, blockLocalIPs, traceId) => {
   // TODO in next major, rename all blockLocalIPs to allowLocalUrls and invert the bool, to make it consistent
   // see discussion https://github.com/transloadit/uppy/pull/4554/files#r1268677162
   try {
-    const protectedGot = getProtectedGot({ url, blockLocalIPs })
+    const protectedGot = getProtectedGot({ blockLocalIPs })
     const stream = protectedGot.stream.get(url, { responseType: 'json' })
     await prepareStream(stream)
     return stream

--- a/packages/@uppy/companion/test/__tests__/http-agent.js
+++ b/packages/@uppy/companion/test/__tests__/http-agent.js
@@ -1,36 +1,6 @@
 const nock = require('nock')
-const { getRedirectEvaluator, FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
+const { FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
 const { getProtectedGot } = require('../../src/server/helpers/request')
-
-describe('test getRedirectEvaluator', () => {
-  const httpURL = 'http://uppy.io'
-  const httpsURL = 'https://uppy.io'
-  const httpRedirectResp = {
-    headers: {
-      location: 'http://transloadit.com',
-    },
-  }
-
-  const httpsRedirectResp = {
-    headers: {
-      location: 'https://transloadit.com',
-    },
-  }
-
-  test('when original URL has "https:" as protocol', (done) => {
-    const shouldRedirectHttps = getRedirectEvaluator(httpsURL, true)
-    expect(shouldRedirectHttps(httpsRedirectResp)).toEqual(true)
-    expect(shouldRedirectHttps(httpRedirectResp)).toEqual(false)
-    done()
-  })
-
-  test('when original URL has "http:" as protocol', (done) => {
-    const shouldRedirectHttp = getRedirectEvaluator(httpURL, true)
-    expect(shouldRedirectHttp(httpRedirectResp)).toEqual(true)
-    expect(shouldRedirectHttp(httpsRedirectResp)).toEqual(false)
-    done()
-  })
-})
 
 afterAll(() => {
   nock.cleanAll()
@@ -41,24 +11,24 @@ describe('test protected request Agent', () => {
   test('allows URLs without IP addresses', async () => {
     nock('https://transloadit.com').get('/').reply(200)
     const url = 'https://transloadit.com'
-    await getProtectedGot({ url, blockLocalIPs: true }).get(url)
+    await getProtectedGot({ blockLocalIPs: true }).get(url)
   })
 
   test('blocks url that resolves to forbidden IP', async () => {
     const url = 'https://localhost'
-    const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
+    const promise = getProtectedGot({ blockLocalIPs: true }).get(url)
     await expect(promise).rejects.toThrow(/^Forbidden resolved IP address/)
   })
 
   test('blocks private http IP address', async () => {
     const url = 'http://172.20.10.4:8090'
-    const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
+    const promise = getProtectedGot({ blockLocalIPs: true }).get(url)
     await expect(promise).rejects.toThrow(new Error(FORBIDDEN_IP_ADDRESS))
   })
 
   test('blocks private https IP address', async () => {
     const url = 'https://172.20.10.4:8090'
-    const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
+    const promise = getProtectedGot({ blockLocalIPs: true }).get(url)
     await expect(promise).rejects.toThrow(new Error(FORBIDDEN_IP_ADDRESS))
   })
 
@@ -87,12 +57,12 @@ describe('test protected request Agent', () => {
 
     for (const ip of ipv4s) {
       const url = `http://${ip}:8090`
-      const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
+      const promise = getProtectedGot({ blockLocalIPs: true }).get(url)
       await expect(promise).rejects.toThrow(new Error(FORBIDDEN_IP_ADDRESS))
     }
     for (const ip of ipv6s) {
       const url = `http://[${ip}]:8090`
-      const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
+      const promise = getProtectedGot({ blockLocalIPs: true }).get(url)
       await expect(promise).rejects.toThrow(new Error(FORBIDDEN_IP_ADDRESS))
     }
   })

--- a/packages/@uppy/companion/test/__tests__/http-agent.js
+++ b/packages/@uppy/companion/test/__tests__/http-agent.js
@@ -1,5 +1,5 @@
 const nock = require('nock')
-const { getRedirectEvaluator, FORBIDDEN_IP_ADDRESS, FORBIDDEN_RESOLVED_IP_ADDRESS } = require('../../src/server/helpers/request')
+const { getRedirectEvaluator, FORBIDDEN_IP_ADDRESS } = require('../../src/server/helpers/request')
 const { getProtectedGot } = require('../../src/server/helpers/request')
 
 describe('test getRedirectEvaluator', () => {
@@ -47,7 +47,7 @@ describe('test protected request Agent', () => {
   test('blocks url that resolves to forbidden IP', async () => {
     const url = 'https://localhost'
     const promise = getProtectedGot({ url, blockLocalIPs: true }).get(url)
-    await expect(promise).rejects.toThrow(new Error(FORBIDDEN_RESOLVED_IP_ADDRESS))
+    await expect(promise).rejects.toThrow(/^Forbidden resolved IP address/)
   })
 
   test('blocks private http IP address', async () => {


### PR DESCRIPTION
## [fix companion dns validation](https://github.com/transloadit/uppy/commit/c95f70f1b9f503f31e8ec622644091442fe65989)

example: on our server, the url `https://mifi-testing.s3.us-east-1.amazonaws.com/` resolves to:

```js
[
  { address: '52.216.113.54', family: 4 },
  { address: '54.231.199.162', family: 4 },
  { address: '52.216.29.232', family: 4 },
  { address: '54.231.196.10', family: 4 },
  { address: '54.231.168.26', family: 4 },
  { address: '54.231.172.98', family: 4 },
  { address: '54.231.139.34', family: 4 },
  { address: '52.217.226.234', family: 4 },
  { address: '64:ff9b::34d8:1de8', family: 6 },
  { address: '64:ff9b::36e7:c40a', family: 6 },
  { address: '64:ff9b::36e7:a81a', family: 6 },
  { address: '64:ff9b::36e7:ac62', family: 6 },
  { address: '64:ff9b::36e7:8b22', family: 6 },
  { address: '64:ff9b::34d9:e2ea', family: 6 },
  { address: '64:ff9b::34d8:7136', family: 6 },
  { address: '64:ff9b::36e7:c7a2', family: 6 }
]
```

which caused it to fail because addresses like `64:ff9b::34d8:1de8` are not alloved. now instead filter out these.

## allow redirects from http->https again

because we are no longer using `request`