### PR TITLE
Update uppy-ProviderBrowser-viewType--list.scss

### DIFF
--- a/packages/@uppy/provider-views/src/style/uppy-ProviderBrowser-viewType--list.scss
+++ b/packages/@uppy/provider-views/src/style/uppy-ProviderBrowser-viewType--list.scss
@@ -69,6 +69,7 @@
   .uppy-ProviderBrowserItem-inner {
     display: flex;
     align-items: center;
+    color: inherit;
 
     // For better outline
     padding: 2px;


### PR DESCRIPTION
Added `inherit` to color to make sure that item is displayed in light color in dark mode.

Before:
<img width="430" alt="Screenshot 2024-02-08 at 10 20 55 PM" src="https://github.com/transloadit/uppy/assets/1086617/a59d5ee5-7e4f-4611-916c-f9e60eeef7c8">

After:
<img width="433" alt="Screenshot 2024-02-08 at 10 20 25 PM" src="https://github.com/transloadit/uppy/assets/1086617/34874aa4-e12d-461a-99e7-9f44005719de">
