### PR TITLE
meta: add tsconfig.json to .npmignore, it confuses build tools, we should ignore it

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+tsconfig.json


### PR DESCRIPTION
See https://community.transloadit.com/t/esbuild-loader-complains-about-tsconfig-shared-not-found/16988