### PR TITLE
@uppy/transloadit: Add option for client name

### DIFF
--- a/packages/@uppy/transloadit/src/index.js
+++ b/packages/@uppy/transloadit/src/index.js
@@ -62,6 +62,7 @@ export default class Transloadit extends BasePlugin {
       getAssemblyOptions: null,
       limit: 20,
       retryDelays: [7_000, 10_000, 15_000, 20_000],
+      clientName: null,
     }
 
     this.opts = { ...defaultOptions, ...opts }
@@ -125,6 +126,10 @@ export default class Transloadit extends BasePlugin {
     addPluginVersion('OneDrive', 'uppy-onedrive')
     addPluginVersion('Zoom', 'uppy-zoom')
     addPluginVersion('Url', 'uppy-url')
+
+    if (this.opts.clientName != null) {
+      list.push(this.opts.clientName)
+    }
 
     return list.join(',')
   }

--- a/packages/@uppy/transloadit/types/index.d.ts
+++ b/packages/@uppy/transloadit/types/index.d.ts
@@ -111,6 +111,7 @@ interface Options extends PluginOptions {
   alwaysRunAssembly?: boolean
   locale?: TransloaditLocale
   limit?: number
+  clientName?: string
 }
 
 export type TransloaditOptions = Options &

--- a/packages/@uppy/transloadit/types/index.test-d.ts
+++ b/packages/@uppy/transloadit/types/index.test-d.ts
@@ -22,6 +22,7 @@ const validParams = {
     waitForEncoding: false,
     waitForMetadata: true,
     importFromUploadURLs: false,
+    clientName: 'my-application',
   })
   // Access to both transloadit events and core events
   uppy.on('transloadit:assembly-created', (assembly) => {


### PR DESCRIPTION
This adds an option `clientName` which, if present, will be appended to the `Transloadit-Client` header. The idea is that this can be used to add information about which client application created an Assembly. For example, it is helpful to know whether an Assembly was created by the Uppy dashboard on page A or page B.