### PR TITLE
MetaEditor + ImageEditor - new state machine logic

### DIFF
--- a/packages/@uppy/dashboard/src/components/EditorPanel.jsx
+++ b/packages/@uppy/dashboard/src/components/EditorPanel.jsx
@@ -6,7 +6,7 @@ function EditorPanel (props) {
 
   const handleCancel = () => {
     props.uppy.emit('file-editor:cancel', file)
-    props.hideAllPanels()
+    props.closeFileEditor()
   }
 
   return (


### PR DESCRIPTION
Fixes #4878, implicitly fixes #4442.

Implements "file list ⟷ metaEditor ⟷ imageEditor" state machine we discussed in Slack.

Tested with all combinations of:
- `.use(ImageEditor, { target: Dashboard })` present/absent
- `autoOpenFileEditor` true/false
- `metaFields` present/absent