### PR TITLE
meta: disable `@typescript-eslint/no-non-null-assertion` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -466,6 +466,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-extra-semi': 'off',
         '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
     {

--- a/.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch
+++ b/.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 7a4efead6df94263db77b12c72ddaeafaeaa406c..e47e63f1159f19dd780986f7e33ffdd70bfdc371 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -2,7 +2,12 @@
+ 
+ export const isSupported: boolean
+ export const canStoreURLs: boolean
+-export const defaultOptions: UploadOptions
++export const defaultOptions: UploadOptions & Required<Pick<UploadOptions, 
++| 'httpStack'
++| 'fileReader'
++| 'urlStorage'
++| 'fingerprint'
++>>
+ 
+ // TODO: Consider using { read: () => Promise<{ done: boolean; value?: any; }>; } as type
+ export class Upload {
+@@ -12,7 +17,7 @@ export class Upload {
+   options: UploadOptions
+   url: string | null
+ 
+-  static terminate(url: string, options?: UploadOptions): Promise<void>
++  static terminate(url: string, options: UploadOptions): Promise<void>
+   start(): void
+   abort(shouldTerminate?: boolean): Promise<void>
+   findPreviousUploads(): Promise<PreviousUpload[]>
+@@ -25,7 +30,7 @@ interface UploadOptions {
+ 
+   uploadUrl?: string | null
+   metadata?: { [key: string]: string }
+-  fingerprint?: (file: File, options?: UploadOptions) => Promise<string>
++  fingerprint?: (file: File, options: UploadOptions) => Promise<string>
+   uploadSize?: number | null
+ 
+   onProgress?: ((bytesSent: number, bytesTotal: number) => void) | null

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "preact": "patch:preact@npm:10.10.0#.yarn/patches/preact-npm-10.10.0-dd04de05e8.patch",
     "start-server-and-test": "patch:start-server-and-test@npm:1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch",
     "stylelint-config-rational-order": "patch:stylelint-config-rational-order@npm%3A0.1.2#./.yarn/patches/stylelint-config-rational-order-npm-0.1.2-d8336e84ed.patch",
-    "uuid@^8.3.2": "patch:uuid@npm:8.3.2#.yarn/patches/uuid-npm-8.3.2-eca0baba53.patch"
+    "uuid@^8.3.2": "patch:uuid@npm:8.3.2#.yarn/patches/uuid-npm-8.3.2-eca0baba53.patch",
+    "tus-js-client": "patch:tus-js-client@npm%3A3.1.3#./.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch"
   }
 }

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -374,7 +374,6 @@ export default class RequestClient<M extends Meta, B extends Body> {
     try {
       return await new Promise((resolve, reject) => {
         const token = file.serverToken
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const host = getSocketHost(file.remote!.companionUrl)
 
         let socket: WebSocket | undefined

--- a/packages/@uppy/companion-client/src/Socket.ts
+++ b/packages/@uppy/companion-client/src/Socket.ts
@@ -50,9 +50,8 @@ export default class UppySocket {
       this.#isOpen = true
 
       while (this.#queued.length > 0 && this.#isOpen) {
-        const first = this.#queued.shift()
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.send(first!.action, first!.payload)
+        const first = this.#queued.shift()!
+        this.send(first.action, first.payload)
       }
     }
 

--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint no-console: "off", no-restricted-syntax: "off" */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -166,7 +165,6 @@ describe('src/Core', () => {
 
       core.use(AcquirerPlugin1)
       const plugin = core.getPlugin('TestSelector1')
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(plugin!.id).toEqual('TestSelector1')
       expect(plugin instanceof UIPlugin)
     })

--- a/packages/@uppy/image-editor/src/Editor.tsx
+++ b/packages/@uppy/image-editor/src/Editor.tsx
@@ -77,7 +77,7 @@ export default class Editor<M extends Meta, B extends Body> extends Component<
       const newCropboxData = limitCropboxMovementOnMove(
         canvasData,
         cropboxData,
-        prevCropboxData,
+        prevCropboxData!,
       )
       if (newCropboxData) this.cropper.setCropBoxData(newCropboxData)
       // 2. When we stretch the cropbox by one of its sides
@@ -85,7 +85,7 @@ export default class Editor<M extends Meta, B extends Body> extends Component<
       const newCropboxData = limitCropboxMovementOnResize(
         canvasData,
         cropboxData,
-        prevCropboxData,
+        prevCropboxData!,
       )
       if (newCropboxData) this.cropper.setCropBoxData(newCropboxData)
     }

--- a/packages/@uppy/image-editor/src/ImageEditor.tsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.tsx
@@ -10,6 +10,11 @@ import Editor from './Editor.tsx'
 import packageJson from '../package.json'
 import locale from './locale.ts'
 
+// const assertNonNull: (<T>(value: T) => T extends null | undefined ? never:void) = Function.prototype as any
+function assertNonNull(val: unknown) {
+  if (val == null) throw new Error('ERR_ASSERTION')
+}
+
 declare global {
   namespace preact {
     interface Component {
@@ -185,7 +190,6 @@ export default class ImageEditor<
 
     this.cropper
       .getCroppedCanvas(this.opts.cropperOptions.croppedCanvasOptions)
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .toBlob(saveBlobCallback, currentImage!.type, this.opts.quality)
   }
 

--- a/packages/@uppy/image-editor/src/ImageEditor.tsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.tsx
@@ -10,11 +10,6 @@ import Editor from './Editor.tsx'
 import packageJson from '../package.json'
 import locale from './locale.ts'
 
-// const assertNonNull: (<T>(value: T) => T extends null | undefined ? never:void) = Function.prototype as any
-function assertNonNull(val: unknown) {
-  if (val == null) throw new Error('ERR_ASSERTION')
-}
-
 declare global {
   namespace preact {
     interface Component {

--- a/packages/@uppy/image-editor/src/utils/limitCropboxMovementOnMove.ts
+++ b/packages/@uppy/image-editor/src/utils/limitCropboxMovementOnMove.ts
@@ -3,13 +3,13 @@ import type Cropper from 'cropperjs'
 function limitCropboxMovementOnMove(
   canvas: Cropper.CanvasData,
   cropbox: Cropper.CropBoxData,
-  prevCropbox: Cropper.CropBoxData | null,
+  prevCropbox: Cropper.CropBoxData,
 ): { left?: number; top?: number; width?: number; height?: number } | null {
   // For the left boundary
   if (cropbox.left < canvas.left) {
     return {
       left: canvas.left,
-      width: prevCropbox!.width,
+      width: prevCropbox.width,
     }
   }
 
@@ -17,23 +17,23 @@ function limitCropboxMovementOnMove(
   if (cropbox.top < canvas.top) {
     return {
       top: canvas.top,
-      height: prevCropbox!.height,
+      height: prevCropbox.height,
     }
   }
 
   // For the right boundary
   if (cropbox.left + cropbox.width > canvas.left + canvas.width) {
     return {
-      left: canvas.left + canvas.width - prevCropbox!.width,
-      width: prevCropbox!.width,
+      left: canvas.left + canvas.width - prevCropbox.width,
+      width: prevCropbox.width,
     }
   }
 
   // For the bottom boundary
   if (cropbox.top + cropbox.height > canvas.top + canvas.height) {
     return {
-      top: canvas.top + canvas.height - prevCropbox!.height,
-      height: prevCropbox!.height,
+      top: canvas.top + canvas.height - prevCropbox.height,
+      height: prevCropbox.height,
     }
   }
 

--- a/packages/@uppy/image-editor/src/utils/limitCropboxMovementOnResize.ts
+++ b/packages/@uppy/image-editor/src/utils/limitCropboxMovementOnResize.ts
@@ -3,13 +3,13 @@ import type Cropper from 'cropperjs'
 function limitCropboxMovementOnResize(
   canvas: Cropper.CanvasData,
   cropboxData: Cropper.CropBoxData,
-  prevCropbox: Cropper.CropBoxData | null,
+  prevCropbox: Cropper.CropBoxData,
 ): { left?: number; top?: number; width?: number; height?: number } | null {
   // For the left boundary
   if (cropboxData.left < canvas.left) {
     return {
       left: canvas.left,
-      width: prevCropbox!.left + prevCropbox!.width - canvas.left,
+      width: prevCropbox.left + prevCropbox.width - canvas.left,
     }
   }
 
@@ -17,23 +17,23 @@ function limitCropboxMovementOnResize(
   if (cropboxData.top < canvas.top) {
     return {
       top: canvas.top,
-      height: prevCropbox!.top + prevCropbox!.height - canvas.top,
+      height: prevCropbox.top + prevCropbox.height - canvas.top,
     }
   }
 
   // For the right boundary
   if (cropboxData.left + cropboxData.width > canvas.left + canvas.width) {
     return {
-      left: prevCropbox!.left,
-      width: canvas.left + canvas.width - prevCropbox!.left,
+      left: prevCropbox.left,
+      width: canvas.left + canvas.width - prevCropbox.left,
     }
   }
 
   // For the bottom boundary
   if (cropboxData.top + cropboxData.height > canvas.top + canvas.height) {
     return {
-      top: prevCropbox!.top,
-      height: canvas.top + canvas.height - prevCropbox!.top,
+      top: prevCropbox.top,
+      height: canvas.top + canvas.height - prevCropbox.top,
     }
   }
 

--- a/packages/@uppy/status-bar/src/Components.tsx
+++ b/packages/@uppy/status-bar/src/Components.tsx
@@ -209,7 +209,7 @@ function PauseResumeButton<M extends Meta, B extends Body>(
 
 interface DoneBtnProps {
   i18n: I18n
-  doneButtonHandler: (() => void) | null
+  doneButtonHandler: (() => void) | undefined
 }
 
 function DoneBtn(props: DoneBtnProps): JSX.Element {
@@ -219,7 +219,7 @@ function DoneBtn(props: DoneBtnProps): JSX.Element {
     <button
       type="button"
       className="uppy-u-reset uppy-c-btn uppy-StatusBar-actionBtn uppy-StatusBar-actionBtn--done"
-      onClick={doneButtonHandler!}
+      onClick={doneButtonHandler}
       data-uppy-super-focusable
     >
       {i18n('done')}
@@ -251,13 +251,12 @@ interface ProgressBarProcessingProps {
 function ProgressBarProcessing(props: ProgressBarProcessingProps): JSX.Element {
   const { progress } = props
   const { value, mode, message } = progress
-  const roundedValue = Math.round(value! * 100)
   const dot = `\u00B7`
 
   return (
     <div className="uppy-StatusBar-content">
       <LoadingSpinner />
-      {mode === 'determinate' ? `${roundedValue}% ${dot} ` : ''}
+      {mode === 'determinate' ? `${Math.round(value * 100)}% ${dot} ` : ''}
       {message}
     </div>
   )

--- a/packages/@uppy/status-bar/src/StatusBar.tsx
+++ b/packages/@uppy/status-bar/src/StatusBar.tsx
@@ -238,10 +238,10 @@ export default class StatusBar<M extends Meta, B extends Body> extends UIPlugin<
 
   onMount(): void {
     // Set the text direction if the page has not defined one.
-    const element = this.el
-    const direction = getTextDirection(element!)
+    const element = this.el!
+    const direction = getTextDirection(element)
     if (!direction) {
-      element!.dir = 'ltr'
+      element.dir = 'ltr'
     }
   }
 

--- a/packages/@uppy/status-bar/src/calculateProcessingProgress.ts
+++ b/packages/@uppy/status-bar/src/calculateProcessingProgress.ts
@@ -13,7 +13,7 @@ export default function calculateProcessingProgress(
     // In the future we should probably do this differently. For now we'll take the
     // mode and message from the first file…
     if (message == null && (preprocess || postprocess)) {
-      ;({ mode, message } = preprocess || postprocess!) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      ;({ mode, message } = preprocess || postprocess!)
     }
     if (preprocess?.mode === 'determinate') values.push(preprocess.value)
     if (postprocess?.mode === 'determinate') values.push(postprocess.value)

--- a/packages/@uppy/tus/src/getFingerprint.ts
+++ b/packages/@uppy/tus/src/getFingerprint.ts
@@ -34,10 +34,10 @@ export default function getFingerprint<M extends Meta, B extends Body>(
 ): tus.UploadOptions['fingerprint'] {
   return (file, options) => {
     if (isCordova() || isReactNative()) {
-      return tus.defaultOptions.fingerprint!(file, options)
+      return tus.defaultOptions.fingerprint(file, options)
     }
 
-    const uppyFingerprint = ['tus', uppyFile.id, options!.endpoint].join('-')
+    const uppyFingerprint = ['tus', uppyFile.id, options.endpoint].join('-')
 
     return Promise.resolve(uppyFingerprint)
   }

--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -166,13 +166,12 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
    * any events related to the file, and the Companion WebSocket connection.
    */
   resetUploaderReferences(fileID: string, opts?: { abort: boolean }): void {
-    if (this.uploaders[fileID]) {
-      const uploader = this.uploaders[fileID]
-
-      uploader!.abort()
+    const uploader = this.uploaders[fileID]
+    if (uploader) {
+      uploader.abort()
 
       if (opts?.abort) {
-        uploader!.abort(true)
+        uploader.abort(true)
       }
 
       this.uploaders[fileID] = null

--- a/packages/@uppy/utils/src/getDroppedFiles/utils/webkitGetAsEntryApi/index.ts
+++ b/packages/@uppy/utils/src/getDroppedFiles/utils/webkitGetAsEntryApi/index.ts
@@ -42,7 +42,6 @@ function getAsFileSystemHandleFromEntry(
           onSuccess: (dirEntries) =>
             resolve(
               dirEntries.map(
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 (file) => getAsFileSystemHandleFromEntry(file, logDropError)!,
               ),
             ),

--- a/packages/@uppy/xhr-upload/src/index.test.ts
+++ b/packages/@uppy/xhr-upload/src/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { vi, describe, it, expect } from 'vitest'
 import nock from 'nock'
 import Core from '@uppy/core'

--- a/yarn.lock
+++ b/yarn.lock
@@ -30266,7 +30266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tus-js-client@npm:^3.1.3":
+"tus-js-client@npm:3.1.3":
   version: 3.1.3
   resolution: "tus-js-client@npm:3.1.3"
   dependencies:
@@ -30278,6 +30278,21 @@ __metadata:
     proper-lockfile: ^4.1.2
     url-parse: ^1.5.7
   checksum: 6f25dbbdbe1de51f44688dfb9ee78cae8deb987ac0a8e5d7d3e09a52ed0a7bfa5e2c3e39e82f0913beb241da78ddf42bdcb4c44369ea57f7cf15fad17e5b954f
+  languageName: node
+  linkType: hard
+
+"tus-js-client@patch:tus-js-client@npm%3A3.1.3#./.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
+  version: 3.1.3
+  resolution: "tus-js-client@patch:tus-js-client@npm%3A3.1.3#./.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch::version=3.1.3&hash=f79010&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  dependencies:
+    buffer-from: ^1.1.2
+    combine-errors: ^3.0.3
+    is-stream: ^2.0.0
+    js-base64: ^3.7.2
+    lodash.throttle: ^4.1.1
+    proper-lockfile: ^4.1.2
+    url-parse: ^1.5.7
+  checksum: ae7275f12e016271e67f8d465f914f4b8c8b6ecd75501ebba95374176247903bada06452f5b7a0e8e7d80342cd63dc395eda5a707bf216c770b95cf60e1b0d63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Type assertions are not inherently bad, we need them in some places. We should still avoid using them when we can, I try to remove all that looked like could be avoided in this PR, the one that stay are those that are due to either TS unable to infer the correct types, or cases where there's nothing better than throwing a `TypeError` on runtime.

The `tus-js-client` patch was also sent upstream: https://github.com/tus/tus-js-client/pull/670