### PR TITLE
@uppy/core: fix plugin detection

### DIFF
--- a/packages/@uppy/core/src/UIPlugin.ts
+++ b/packages/@uppy/core/src/UIPlugin.ts
@@ -63,9 +63,18 @@ class UIPlugin<
     target: PluginTarget<Me, Bo>, // eslint-disable-line no-use-before-define
   ): UIPlugin<any, Me, Bo> | undefined {
     let targetPlugin
-    if (typeof target === 'object' && target instanceof UIPlugin) {
+    if (typeof (target as UIPlugin<any, any, any>)?.addTarget === 'function') {
       // Targeting a plugin *instance*
-      targetPlugin = target
+      targetPlugin = target as UIPlugin<any, any, any>
+      if (!(targetPlugin instanceof UIPlugin)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          new Error(
+            'The provided plugin is not an instance of UIPlugin. This is an indication of a bug with the way Uppy is bundled.',
+            { cause: { targetPlugin, UIPlugin } },
+          ),
+        )
+      }
     } else if (typeof target === 'function') {
       // Targeting a plugin type
       const Target = target


### PR DESCRIPTION
Using `instanceof` is problematic as it won't detect plugins from different Uppy distributions. Whether we should support that use-case is certainly debatable – having more than one Uppy distribution is good indication that there's a bug in the build chain – but it seems useful to only produce a warning rather than failing hard.