### PR TITLE
fix various type issues

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -942,7 +942,7 @@ export class Uppy<M extends Meta, B extends Body> {
         bytesTotal: size,
         uploadComplete: false,
         uploadStarted: null,
-      } as FileProgressNotStarted,
+      } satisfies FileProgressNotStarted,
       size,
       isGhost: false,
       isRemote: file.isRemote || false,
@@ -1377,6 +1377,8 @@ export class Uppy<M extends Meta, B extends Body> {
   //    and click 'ADD MORE FILES', - focus won't activate in Firefox.
   //    - We must throttle at around >500ms to avoid performance lags.
   //    [Practical Check] Firefox, try to upload a big file for a prolonged period of time. Laptop will start to heat up.
+  // todo when uploading multiple files, this will cause problems because they share the same throttle,
+  // meaning some files might never get their progress reported (eaten up by progress events from other files)
   calculateProgress = throttle(
     (file, data) => {
       const fileInState = this.getFile(file?.id)
@@ -1559,7 +1561,6 @@ export class Uppy<M extends Meta, B extends Body> {
           file.id,
           {
             progress: {
-              progress: 0,
               uploadStarted: Date.now(),
               uploadComplete: false,
               percentage: 0,

--- a/packages/@uppy/utils/src/FileProgress.ts
+++ b/packages/@uppy/utils/src/FileProgress.ts
@@ -13,10 +13,9 @@ export type FileProcessingInfo =
   | DeterminateFileProcessing
 
 interface FileProgressBase {
-  progress?: number
   uploadComplete?: boolean
   percentage?: number
-  bytesTotal: number
+  bytesTotal: number | null
   preprocess?: FileProcessingInfo
   postprocess?: FileProcessingInfo
 }
@@ -26,7 +25,6 @@ interface FileProgressBase {
 export type FileProgressStarted = FileProgressBase & {
   uploadStarted: number
   bytesUploaded: number
-  progress?: number
 }
 export type FileProgressNotStarted = FileProgressBase & {
   uploadStarted: null

--- a/packages/@uppy/utils/src/emitSocketProgress.ts
+++ b/packages/@uppy/utils/src/emitSocketProgress.ts
@@ -4,17 +4,22 @@ import type { FileProgress } from './FileProgress'
 
 function emitSocketProgress(
   uploader: any,
-  progressData: FileProgress,
+  progressData: {
+    progress: string // pre-formatted percentage
+    bytesTotal: number
+    bytesUploaded: number
+  },
   file: UppyFile<any, any>,
 ): void {
   const { progress, bytesUploaded, bytesTotal } = progressData
   if (progress) {
     uploader.uppy.log(`Upload progress: ${progress}`)
     uploader.uppy.emit('upload-progress', file, {
+      // @ts-expect-error todo remove in next major
       uploader,
       bytesUploaded,
       bytesTotal,
-    })
+    } satisfies FileProgress)
   }
 }
 

--- a/packages/@uppy/utils/src/getBytesRemaining.ts
+++ b/packages/@uppy/utils/src/getBytesRemaining.ts
@@ -1,5 +1,6 @@
 import type { FileProgress } from './FileProgress'
 
 export default function getBytesRemaining(fileProgress: FileProgress): number {
+  if (fileProgress.bytesTotal == null) return 0
   return fileProgress.bytesTotal - (fileProgress.bytesUploaded as number)
 }


### PR DESCRIPTION
neglected in #4911:

- bytesTotal can be null (also handle that bug in runtime)
- progress is not a property on the progress object
- use `satisfies` instead of `as`
- add todo about broken `throttle` implementation
- in emitSocketProgress, progressData should not have the FileProgress type, as it is a completely different type (it comes from companion)