### PR TITLE
fix e2e flake

### DIFF
--- a/e2e/cypress/integration/dashboard-transloadit.spec.ts
+++ b/e2e/cypress/integration/dashboard-transloadit.spec.ts
@@ -183,7 +183,6 @@ describe('Dashboard with Transloadit', () => {
       ],
       { force: true },
     )
-    cy.get('.uppy-StatusBar-actionBtn--upload').click()
 
     cy.window().then(({ uppy }) => {
       // eslint-disable-next-line
@@ -191,6 +190,8 @@ describe('Dashboard with Transloadit', () => {
       expect(
         Object.values(uppy.getPlugin('Transloadit').activeAssemblies).length,
       ).to.equal(0)
+
+      cy.get('.uppy-StatusBar-actionBtn--upload').click()
 
       const { files } = uppy.getState()
       // eslint-disable-next-line


### PR DESCRIPTION
has been failing 3 times in an hour:
https://github.com/transloadit/uppy/actions/runs/8029895005/job/21936709051 https://github.com/transloadit/uppy/actions/runs/8029682841/job/21936256011 https://github.com/transloadit/uppy/actions/runs/8029645114/job/21936175459

      cy:command ✔  get	.uppy-StatusBar-actionBtn--upload
      cy:command ✔  click
        cy:fetch ➟  (createAssemblies) POST ***/assemblies
                    Status: 200
          cy:xhr ➟  POST https://api2-baarn.transloadit.com/resumable/files/
                    Status: 201
          cy:xhr ➟  POST https://api2-baarn.transloadit.com/resumable/files/
      cy:command ✔  window
      cy:command ✘  assert	expected **1** to equal **0**