### PR TITLE
fix for totalProgress when files kept in state

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -1412,7 +1412,7 @@ export class Uppy<M extends Meta, B extends Body> {
 
     const inProgress = files.filter((file) => {
       return (
-        file.progress.uploadStarted ||
+        !file.progress.uploadComplete ||
         file.progress.preprocess ||
         file.progress.postprocess
       )


### PR DESCRIPTION
Mentioned in my FR https://github.com/transloadit/uppy/issues/4992

This allows not being uploaded files kept in state to not affect the total progress!