### PR TITLE
meta: fix `resize-observer-polyfill` types

### DIFF
--- a/.yarn/patches/resize-observer-polyfill-npm-1.5.1-603120e8a0.patch
+++ b/.yarn/patches/resize-observer-polyfill-npm-1.5.1-603120e8a0.patch
@@ -1,0 +1,19 @@
+diff --git a/src/index.d.ts b/src/index.d.ts
+index 74aacc0526ff554e9248c3f6fb44c353b5465efc..1b236d215a9db4cbc1c83f4d8bce24add202483e 100644
+--- a/src/index.d.ts
++++ b/src/index.d.ts
+@@ -1,14 +1,3 @@
+-interface DOMRectReadOnly {
+-    readonly x: number;
+-    readonly y: number;
+-    readonly width: number;
+-    readonly height: number;
+-    readonly top: number;
+-    readonly right: number;
+-    readonly bottom: number;
+-    readonly left: number;
+-}
+-
+ declare global {
+     interface ResizeObserverCallback {
+         (entries: ResizeObserverEntry[], observer: ResizeObserver): void

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "start-server-and-test": "patch:start-server-and-test@npm:1.14.0#.yarn/patches/start-server-and-test-npm-1.14.0-841aa34fdf.patch",
     "stylelint-config-rational-order": "patch:stylelint-config-rational-order@npm%3A0.1.2#./.yarn/patches/stylelint-config-rational-order-npm-0.1.2-d8336e84ed.patch",
     "uuid@^8.3.2": "patch:uuid@npm:8.3.2#.yarn/patches/uuid-npm-8.3.2-eca0baba53.patch",
-    "tus-js-client": "patch:tus-js-client@npm%3A3.1.3#./.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch"
+    "tus-js-client": "patch:tus-js-client@npm%3A3.1.3#./.yarn/patches/tus-js-client-npm-3.1.3-dc57874d23.patch",
+    "resize-observer-polyfill": "patch:resize-observer-polyfill@npm%3A1.5.1#./.yarn/patches/resize-observer-polyfill-npm-1.5.1-603120e8a0.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27391,10 +27391,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resize-observer-polyfill@npm:^1.5.0, resize-observer-polyfill@npm:^1.5.1":
+"resize-observer-polyfill@npm:1.5.1":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
   checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
+  languageName: node
+  linkType: hard
+
+"resize-observer-polyfill@patch:resize-observer-polyfill@npm%3A1.5.1#./.yarn/patches/resize-observer-polyfill-npm-1.5.1-603120e8a0.patch::locator=%40uppy-dev%2Fbuild%40workspace%3A.":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@patch:resize-observer-polyfill@npm%3A1.5.1#./.yarn/patches/resize-observer-polyfill-npm-1.5.1-603120e8a0.patch::version=1.5.1&hash=9a18c0&locator=%40uppy-dev%2Fbuild%40workspace%3A."
+  checksum: 77fe421d8aeb31ec823494ed7c7f5011fcdf83a6abba9020834c2f5c2e1e79ddf5d95e8db16b85d17022b59816553cd1749f9b00ab5522e766ccb5641338f2fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The upstream package is defining its own types which are incompatible with TS built-in DOM types.

There's already an open PR to fix the problem upstream (https://github.com/que-etc/resize-observer-polyfill/pull/102), but it looks like it's not going to be merged.