### PR TITLE
CONTRIBUTING.md - remove ngrok section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,46 +78,6 @@ The following steps describe the actions that take place when a user Authenticat
 * Companion reports progress to Uppy, as if it were a local upload.
 * Completed!
 
-### Instagram integration
-
-Even though facebook [allows using](https://developers.facebook.com/blog/post/2018/06/08/enforce-https-facebook-login/) http://localhost in dev mode, Instagram doesn’t seem to support that, and seems to need a publically available domain name with HTTPS. So we will tunnel requests to localhost using `ngrok`.
-
-Make sure that you are using a development facebook app at <https://developers.facebook.com/apps>
-
-Go to “Instagram Basic Display” and find `Instagram App ID` and `Instagram App Secret`. Put them in a file called `.env` in the repo root:
-
-    COMPANION_INSTAGRAM_KEY="Instagram App ID"
-    COMPANION_INSTAGRAM_SECRET="Instagram App Secret"
-
-**Note!** `ngrok` seems to be blocked by Instagram now, so you may have to find an alternative.
-
-Run
-
-```bash
-ngrok http 3020
-```
-
-Note the ngrok https base URL, for example `https://e0c7de09808d.ngrok.io` and
-append `/instagram/redirect` to it, such as:
-
-    https://e0c7de09808d.ngrok.io/instagram/redirect
-
-Add this full ngrok URL to `Valid OAuth Redirect URIs` under `Instagram Basic Display`.
-
-Edit `.env` and change to your ngrok URI:
-
-    COMPANION_DOMAIN="e0c7de09808d.ngrok.io"
-    COMPANION_PROTOCOL="https"
-    VITE_COMPANION_URL = 'https://e0c7de09808d.ngrok.io'
-
-Go to: Roles -> Roles -> Add Instagram testers -> Add your instagram account
-
-Go to your instagram account at <https://www.instagram.com/accounts/manage_access/>
-
-Tester invites -> Accept
-
-Now you should be able to test the Instagram integration.
-
 ### Requiring files
 
 * If we are `require()`ing a file from the same subpackage, we can freely use relative imports as long as the required file is under the `src` directory (for example to import `@uppy/dashboard/src/utils/hi.js` from `@uppy/dashboard/src/index.js`, use `require('./utils/hi.js')`).


### PR DESCRIPTION
Local Instagram integration works just fine with http://localhost:3020 now!
Whatever problems we previously had that were requiring us to set up ngrok - they are gone now, let's save the contributors additional effort.

___

Update: No, we do still need ngrok, thought otherwise from the combination of nonrefreshed env vars & lack of errors in the Instagram Basic Display.