### PR TITLE
@uppy/aws-s3-multipart: Fix escaping issue with client signed request

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
@@ -101,7 +101,6 @@ export default async function createSignedURL ({
    * @see https://tc39.es/ecma262/#sec-encodeuri-uri
    */
   const CanonicalUri = `/${encodeURI(Key).replace(/[;?:@&=+$,#!'()*]/g, percentEncode)}`
-  console.log(CanonicalUri)
   const payload = 'UNSIGNED-PAYLOAD'
 
   const requestDateTime = new Date().toISOString().replace(/[-:]|\.\d+/g, '') // YYYYMMDDTHHMMSSZ

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
@@ -154,5 +154,5 @@ export default async function createSignedURL ({
   // Step 5: Add the signature to the request
   url.searchParams.set('X-Amz-Signature', signature)
 
-  return url;
+  return url
 }

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
@@ -95,7 +95,8 @@ export default async function createSignedURL ({
   const Service = 's3'
   const host = `${bucketName}.${Service}.${Region}.amazonaws.com`
   /**
-   * List of char out of `encodeURI()` is taken from ECMAScript spec
+   * List of char out of `encodeURI()` is taken from ECMAScript spec.
+   * Note that the `/` character is purposefully not included in list below.
    *
    * @see https://tc39.es/ecma262/#sec-encodeuri-uri
    */

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.js
@@ -77,6 +77,30 @@ async function hash (key, data) {
 }
 
 /**
+ * @see
+ *   https://github.com/smithy-lang/smithy-typescript/blob/main/packages/smithy-client/src/extended-encode-uri-component.ts
+ */
+function extendedEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, (c) =>
+    `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+}
+
+class Query {
+  #params = []
+
+  append(key, value) {
+    this.#params.push([key, value])
+  }
+
+  toString() {
+    return this.#params
+      .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
+      .join('&')
+  }
+}
+
+/**
  * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
  * @param {Record<string,string>} param0
  * @returns {Promise<URL>} the signed URL
@@ -90,32 +114,32 @@ export default async function createSignedURL ({
 }) {
   const Service = 's3'
   const host = `${bucketName}.${Service}.${Region}.amazonaws.com`
-  const CanonicalUri = `/${encodeURI(Key)}`
+  const CanonicalUri = `/${Key.split('/').map(extendedEncodeURIComponent).join('/')}`
   const payload = 'UNSIGNED-PAYLOAD'
 
   const requestDateTime = new Date().toISOString().replace(/[-:]|\.\d+/g, '') // YYYYMMDDTHHMMSSZ
   const date = requestDateTime.slice(0, 8) // YYYYMMDD
   const scope = `${date}/${Region}/${Service}/aws4_request`
 
-  const url = new URL(`https://${host}${CanonicalUri}`)
+  const query = new Query();
   // N.B.: URL search params needs to be added in the ASCII order
-  url.searchParams.set('X-Amz-Algorithm', 'AWS4-HMAC-SHA256')
-  url.searchParams.set('X-Amz-Content-Sha256', payload)
-  url.searchParams.set('X-Amz-Credential', `${accountKey}/${scope}`)
-  url.searchParams.set('X-Amz-Date', requestDateTime)
-  url.searchParams.set('X-Amz-Expires', expires)
+  query.append('X-Amz-Algorithm', 'AWS4-HMAC-SHA256')
+  query.append('X-Amz-Content-Sha256', payload)
+  query.append('X-Amz-Credential', `${accountKey}/${scope}`)
+  query.append('X-Amz-Date', requestDateTime)
+  query.append('X-Amz-Expires', expires)
   // We are signing on the client, so we expect there's going to be a session token:
-  url.searchParams.set('X-Amz-Security-Token', sessionToken)
-  url.searchParams.set('X-Amz-SignedHeaders', 'host')
+  query.append('X-Amz-Security-Token', sessionToken)
+  query.append('X-Amz-SignedHeaders', 'host')
   // Those two are present only for Multipart Uploads:
-  if (partNumber) url.searchParams.set('partNumber', partNumber)
-  if (uploadId) url.searchParams.set('uploadId', uploadId)
-  url.searchParams.set('x-id', partNumber && uploadId ? 'UploadPart' : 'PutObject')
+  if (partNumber) query.append('partNumber', partNumber)
+  if (uploadId) query.append('uploadId', uploadId)
+  query.append('x-id', partNumber && uploadId ? 'UploadPart' : 'PutObject')
 
   // Step 1: Create a canonical request
   const canonical = createCanonicalRequest({
     CanonicalUri,
-    CanonicalQueryString: url.search.slice(1),
+    CanonicalQueryString: query.toString(),
     SignedHeaders: {
       host,
     },
@@ -141,7 +165,7 @@ export default async function createSignedURL ({
   const signature = arrayBufferToHexString(await hash(kSigning, stringToSign))
 
   // Step 5: Add the signature to the request
-  url.searchParams.set('X-Amz-Signature', signature)
+  query.append('X-Amz-Signature', signature)
 
-  return url
+  return new URL(`https://${host}${CanonicalUri}?${query.toString()}`)
 }

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
@@ -105,8 +105,9 @@ describe('createSignedURL', () => {
     )
     assert.strictEqual(implResult.pathname, sdkResult.pathname)
 
-    const extractUploadIdQueryValue = (result) =>
-      result.search.match(/uploadId=(.+?)(&|$)/)[1]
-    assert.strictEqual(extractUploadIdQueryValue(implResult), extractUploadIdQueryValue(sdkResult))
+    const extractUploadId = /([?&])uploadId=([^&]+?)(&|$)/
+    const extractSignature = /([?&])X-Amz-Signature=([^&]+?)(&|$)/
+    assert.strictEqual(implResult.search.match(extractUploadId)[2], sdkResult.search.match(extractUploadId)[2])
+    assert.strictEqual(implResult.search.match(extractSignature)[2], sdkResult.search.match(extractSignature)[2])
   })
 })

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
@@ -51,8 +51,6 @@ describe('createSignedURL', () => {
     )
   })
   it('should be able to sign multipart upload', async () => {
-    const url = new URL('https://example.com/?%21%27%28%29%2A')
-    console.log(url.search)
     const client = new S3Client(s3ClientOptions)
     const partNumber = 99
     const uploadId = 'dummyUploadId'

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
@@ -47,7 +47,7 @@ describe('createSignedURL', () => {
         Bucket: bucketName,
         Fields: {},
         Key: 'some/key',
-      }, { expiresIn: 900 }))).searchParams.get('X-Amz-Signature'),
+      }), { expiresIn: 900 })).searchParams.get('X-Amz-Signature'),
     )
   })
   it('should be able to sign multipart upload', async () => {

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.js
@@ -79,8 +79,10 @@ describe('createSignedURL', () => {
   it('should escape path and query as restricted to RFC 3986', async () => {
     const client = new S3Client(s3ClientOptions)
     const partNumber = 99
-    const uploadId = 'Upload!\'()*Id'
-    const Key = '!\'()*/!\'()*.ext'
+    const specialChars = ';?:@&=+$,#!\'()'
+    const uploadId = `Upload${specialChars}Id`
+    // '.*' chars of path should be encoded
+    const Key = `${specialChars}.*/${specialChars}.*.ext`
     const implResult =
       await createSignedURL({
         accountKey: s3ClientOptions.credentials.accessKeyId,


### PR DESCRIPTION
This fixes #5005 .

## AWS SDK implementation

AWS SDK will escape all characters including "!'()*" such as not escaped by `encodeURI/encodeURIComponent` .
This is aimed according to RFC 3986.
https://datatracker.ietf.org/doc/html/rfc3986

Those are escaped by AWS SDK's implementation, but it is complicated, so I investigated what code escapes that:

### Escaping path

S3 presigner using command (for example, UploadPartCommand)
=> Ser(Request serializer) Middleware of UploadPartCommand
=> se_UploadPartCommand
=> resolvedPath
=> extended-uri-component
https://github.com/smithy-lang/smithy-typescript/blob/main/packages/smithy-client/src/extended-encode-uri-component.ts

### Escaping query

@aws/signature-v4 (now deprecated, moved to @smithy/signature-v4)
SignatureV4
=> getCanonicalQuery
https://github.com/smithy-lang/smithy-typescript/blob/main/packages/signature-v4/src/getCanonicalQuery.ts
=> escapeUri
https://github.com/smithy-lang/smithy-typescript/blob/main/packages/util-uri-escape/src/escape-uri.ts

## Uppy's current implementation

### Escaping path

Using `encodeURI` to path directly
=> All of "!'()*" chars are not escaped.

### Escaping query

Using `URL#searchParams` to escape query
=> Almost of special chars are escaped, but not only "*" is NOT.
