### PR TITLE
add missing exports

### DIFF
--- a/packages/@uppy/audio/src/Audio.tsx
+++ b/packages/@uppy/audio/src/Audio.tsx
@@ -17,7 +17,7 @@ import locale from './locale.ts'
 // @ts-ignore We don't want TS to generate types for the package.json
 import packageJson from '../package.json'
 
-interface AudioOptions extends UIPluginOptions {
+export interface AudioOptions extends UIPluginOptions {
   showAudioSourceDropdown?: boolean
 }
 interface AudioState {

--- a/packages/@uppy/audio/src/index.ts
+++ b/packages/@uppy/audio/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Audio.tsx'
+export type { AudioOptions } from './Audio.tsx'

--- a/packages/@uppy/dashboard/src/Dashboard.tsx
+++ b/packages/@uppy/dashboard/src/Dashboard.tsx
@@ -112,7 +112,7 @@ interface DashboardState<M extends Meta, B extends Body> {
   [key: string]: unknown
 }
 
-interface DashboardOptions<M extends Meta, B extends Body>
+export interface DashboardOptions<M extends Meta, B extends Body>
   extends UIPluginOptions {
   animateOpenClose?: boolean
   browserBackButtonClose?: boolean

--- a/packages/@uppy/dashboard/src/index.ts
+++ b/packages/@uppy/dashboard/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Dashboard.tsx'
+export type { DashboardOptions } from './Dashboard.tsx'

--- a/packages/@uppy/drop-target/src/index.ts
+++ b/packages/@uppy/drop-target/src/index.ts
@@ -8,7 +8,7 @@ import toArray from '@uppy/utils/lib/toArray'
 // @ts-ignore We don't want TS to generate types for the package.json
 import packageJson from '../package.json'
 
-interface DropTargetOptions extends PluginOpts {
+export interface DropTargetOptions extends PluginOpts {
   target?: HTMLElement | string | null
   onDrop?: (event: DragEvent) => void
   onDragOver?: (event: DragEvent) => void

--- a/packages/@uppy/webcam/src/Webcam.tsx
+++ b/packages/@uppy/webcam/src/Webcam.tsx
@@ -59,7 +59,7 @@ function isModeAvailable<T>(modes: T[], mode: unknown): mode is T {
   return modes.includes(mode as T)
 }
 
-interface WebcamOptions<M extends Meta, B extends Body>
+export interface WebcamOptions<M extends Meta, B extends Body>
   extends UIPluginOptions {
   target?: PluginTarget<M, B>
   onBeforeSnapshot?: () => Promise<void>

--- a/packages/@uppy/webcam/src/index.ts
+++ b/packages/@uppy/webcam/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Webcam.tsx'
+export type { WebcamOptions } from './Webcam.tsx'


### PR DESCRIPTION
We forgot to expose the user-facing options on some plugins. This PR fixes that.