### PR TITLE
@uppy/aws-s3-multipart: mark `opts` as optional

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.ts
+++ b/packages/@uppy/aws-s3-multipart/src/index.ts
@@ -346,7 +346,7 @@ export default class AwsS3Multipart<
 
   protected uploaderSockets: Record<string, never>
 
-  constructor(uppy: Uppy<M, B>, opts: AwsS3MultipartOptions<M, B>) {
+  constructor(uppy: Uppy<M, B>, opts?: AwsS3MultipartOptions<M, B>) {
     super(uppy, {
       ...defaultOptions,
       uploadPartBytes: AwsS3Multipart.uploadPartBytes,


### PR DESCRIPTION
It's not invalid to initialize that plugin with just the default values.