### PR TITLE
@uppy/form: fix `submitOnSuccess` and `triggerUploadOnSubmit` combination

### DIFF
--- a/packages/@uppy/form/src/index.ts
+++ b/packages/@uppy/form/src/index.ts
@@ -57,12 +57,6 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
     this.type = 'acquirer'
     this.id = this.opts.id || 'Form'
 
-    if (this.opts.submitOnSuccess && this.opts.triggerUploadOnSubmit) {
-      throw new Error(
-        'Can not have both `submitOnSuccess` and `triggerUploadOnSubmit` options enabled at the same time',
-      )
-    }
-
     this.handleFormSubmit = this.handleFormSubmit.bind(this)
     this.handleUploadStart = this.handleUploadStart.bind(this)
     this.handleSuccess = this.handleSuccess.bind(this)
@@ -87,7 +81,11 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
   }
 
   handleFormSubmit(ev: Event): void {
-    if (this.opts.triggerUploadOnSubmit) {
+    // If `submitOnSuccess` is enabled, Uppy already uploaded the files
+    // and then calls `form.requestSubmit()`. In that case we don’t want to upload the files again.
+    const allowUpload = this.uppy.getState().allowNewUpload
+
+    if (this.opts.triggerUploadOnSubmit && allowUpload) {
       ev.preventDefault()
       const elements = toArray((ev.target as HTMLFormElement).elements)
       const disabledByUppy: HTMLButtonElement[] = []

--- a/packages/@uppy/form/src/index.ts
+++ b/packages/@uppy/form/src/index.ts
@@ -57,6 +57,12 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
     this.type = 'acquirer'
     this.id = this.opts.id || 'Form'
 
+    if (this.opts.submitOnSuccess && this.opts.triggerUploadOnSubmit) {
+      throw new Error(
+        'Can not have both `submitOnSuccess` and `triggerUploadOnSubmit` options enabled at the same time',
+      )
+    }
+
     this.handleFormSubmit = this.handleFormSubmit.bind(this)
     this.handleUploadStart = this.handleUploadStart.bind(this)
     this.handleSuccess = this.handleSuccess.bind(this)


### PR DESCRIPTION
Closes #5057 

`submitOnSuccess` and `triggerUploadOnSubmit` is a valid combination for a use case where you want Uppy to start uploading if the user manually clicks submit inside the form but also submit the form after Uppy has successfully uploaded files (clicking upload instead of submit). Because we use `form.requestSubmit()` the submit only happens if form validations pass.

The problem however is that `submitOnSuccess` triggers the `submit` event listener which we use to `triggerUploadOnSubmit`, which makes Uppy start uploading after it just finished uploading, causing an infinite loop.


**Solution**

Manually setting a `completed` boolean based on `upload` (start) and `upload-success`.

It doesn't feel right but I don't think we can do much better without redesigning uppy internals.

**Alternatives that don't work**

If Uppy was a finite state machine, we could easily check in which state we are and prevent a double upload. Unfortunately that's not the case  and there is no easy/cheap way to know all uploads have been done.

- Iterate over all files or uploads (expensive) to check if they're done
- Use `uppy.getState().allowUpload`, a property that's set based on some condition like allow multiple uploads, retrying, etc. Should theoretically be ideal for this scenario but it can be still be `true` in some cases so it doesn't work.