### PR TITLE
@uppy/utils: add fetcher

### DIFF
--- a/packages/@uppy/utils/package.json
+++ b/packages/@uppy/utils/package.json
@@ -70,7 +70,8 @@
     "./lib/CompanionClientProvider": "./lib/CompanionClientProvider.js",
     "./lib/FileProgress": "./lib/FileProgress.js",
     "./src/microtip.scss": "./src/microtip.scss",
-    "./lib/UserFacingApiError": "./lib/UserFacingApiError.js"
+    "./lib/UserFacingApiError": "./lib/UserFacingApiError.js",
+    "./lib/fetcher": "./lib/fetcher.js"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/packages/@uppy/utils/src/fetcher.ts
+++ b/packages/@uppy/utils/src/fetcher.ts
@@ -92,10 +92,10 @@ export function fetcher(
       }
 
       signal?.addEventListener('abort', () => {
-          xhr.abort()
-          // Using DOMException for abort errors aligns with
-          // the convention established by the Fetch API.
-          reject(new DOMException('Aborted', 'AbortError'))
+        xhr.abort()
+        // Using DOMException for abort errors aligns with
+        // the convention established by the Fetch API.
+        reject(new DOMException('Aborted', 'AbortError'))
       })
 
       xhr.onload = async () => {

--- a/packages/@uppy/utils/src/fetcher.ts
+++ b/packages/@uppy/utils/src/fetcher.ts
@@ -72,7 +72,7 @@ export function fetcher(
     responseType,
     retries = 3,
     signal = null,
-    timeout = 30 * 1000,
+    timeout = 30_000,
     withCredentials = false,
   } = options
 
@@ -91,14 +91,12 @@ export function fetcher(
         xhr.responseType = responseType
       }
 
-      if (signal) {
-        signal.addEventListener('abort', () => {
+      signal?.addEventListener('abort', () => {
           xhr.abort()
           // Using DOMException for abort errors aligns with
           // the convention established by the Fetch API.
           reject(new DOMException('Aborted', 'AbortError'))
-        })
-      }
+      })
 
       xhr.onload = async () => {
         await onAfterRequest(xhr, retryCount)

--- a/packages/@uppy/utils/src/fetcher.ts
+++ b/packages/@uppy/utils/src/fetcher.ts
@@ -1,0 +1,138 @@
+import NetworkError from './NetworkError.ts'
+import ProgressTimeout from './ProgressTimeout.ts'
+
+const noop = (): void => {}
+
+/**
+ * Optional settings for the fetch operation.
+ */
+export type FetcherOptions = {
+  /** The HTTP method to use for the request. Default is 'GET'. */
+  method?: string
+
+  /** The request payload, if any. Default is null. */
+  body?: string | null
+
+  /** Milliseconds between XMLHttpRequest upload progress events before the request is aborted. Default is 30000 ms. */
+  timeout?: number
+
+  /** Sets the withCredentials property of the XMLHttpRequest object. Default is false. */
+  withCredentials?: boolean
+
+  /** Sets the responseType property of the XMLHttpRequest object. Default is an empty string. */
+  responseType?: XMLHttpRequestResponseType
+
+  /** An object representing any headers to send with the request. */
+  headers?: Record<string, string>
+
+  /** The number of retry attempts to make if the request fails. Default is 3. */
+  retries?: number
+
+  /** A callback function for tracking upload progress. */
+  onBeforeRequest?: (xhr: XMLHttpRequest) => void | Promise<void>
+
+  /** A callback function for tracking upload progress. */
+  onUploadProgress?: (event: ProgressEvent) => void
+
+  /** A function to determine whether to retry the request. */
+  shouldRetry?: (xhr: XMLHttpRequest) => boolean
+
+  /** Called when no XMLHttpRequest upload progress events have been received for `timeout` ms. */
+  onTimeout?: () => void
+
+  /** Signal to abort the upload. */
+  signal?: AbortSignal
+}
+
+/**
+ * Fetches data from a specified URL using XMLHttpRequest, with optional retry functionality and progress tracking.
+ *
+ * @param url The URL to send the request to.
+ * @param options Optional settings for the fetch operation.
+ */
+export function fetcher(
+  url: string,
+  options: FetcherOptions = {},
+): Promise<XMLHttpRequest> {
+  const {
+    body = null,
+    headers = {},
+    method = 'GET',
+    onBeforeRequest = noop,
+    onUploadProgress = noop,
+    shouldRetry = () => true,
+    onTimeout = noop,
+    responseType,
+    retries = 3,
+    signal = null,
+    timeout = 30 * 1000,
+    withCredentials = false,
+  } = options
+
+  // 300 ms, 600 ms, 1200 ms, 2400 ms, 4800 ms
+  const delay = (attempt: number): number => 0.3 * 2 ** (attempt - 1) * 1000
+  const timer = new ProgressTimeout(timeout, onTimeout)
+
+  function requestWithRetry(retryCount = 0): Promise<XMLHttpRequest> {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+
+      xhr.open(method, url, true)
+      xhr.withCredentials = withCredentials
+      if (responseType) {
+        xhr.responseType = responseType
+      }
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          xhr.abort()
+          // Using DOMException for abort errors aligns with
+          // the convention established by the Fetch API.
+          reject(new DOMException('Aborted', 'AbortError'))
+        })
+      }
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          timer.done()
+          resolve(xhr)
+        } else if (shouldRetry(xhr) && retryCount < retries) {
+          setTimeout(() => {
+            requestWithRetry(retryCount + 1).then(resolve, reject)
+          }, delay(retryCount))
+        } else {
+          timer.done()
+          reject(new NetworkError(xhr.statusText, xhr))
+        }
+      }
+
+      xhr.onerror = () => {
+        if (shouldRetry(xhr) && retryCount < retries) {
+          setTimeout(() => {
+            requestWithRetry(retryCount + 1).then(resolve, reject)
+          }, delay(retryCount))
+        } else {
+          timer.done()
+          reject(new NetworkError(xhr.statusText, xhr))
+        }
+      }
+
+      xhr.upload.onprogress = (event: ProgressEvent) => {
+        timer.progress()
+        onUploadProgress(event)
+      }
+
+      if (headers) {
+        Object.keys(headers).forEach((key) => {
+          xhr.setRequestHeader(key, headers[key])
+        })
+      }
+
+      await onBeforeRequest(xhr)
+      xhr.send(body)
+    })
+  }
+
+  return requestWithRetry()
+}

--- a/packages/@uppy/utils/src/fetcher.ts
+++ b/packages/@uppy/utils/src/fetcher.ts
@@ -8,7 +8,7 @@ export type FetcherOptions = {
   method?: string
 
   /** The request payload, if any. Default is null. */
-  body?: string | null
+  body?: Document | XMLHttpRequestBodyInit | null
 
   /** Milliseconds between XMLHttpRequest upload progress events before the request is aborted. Default is 30000 ms. */
   timeout?: number


### PR DESCRIPTION
Taken out of #4745.

Tried to write tests but unsuccessful:
- `XMLHttpRequest` does not work in Node.js so testing without mocking not possible
- Tried [`xhr-mock`](https://www.npmjs.com/package/xhr-mock) but it didn't work at all for me
- Tried [`mock-xmlhttprequest`](https://www.npmjs.com/package/mock-xmlhttprequest) but only `newServer` worked, which wasn't flexible enough, and the more flexible `newMockXhr` didn't work for me.

However once I add this to `xhr-upload`, we can indirectly test it in e2e because all requests will be made with `fetcher` then.