### PR TITLE
@uppy/dashboard: add missing x-zip-compress archive type

### DIFF
--- a/packages/@uppy/dashboard/src/utils/getFileTypeIcon.tsx
+++ b/packages/@uppy/dashboard/src/utils/getFileTypeIcon.tsx
@@ -193,6 +193,7 @@ export default function getIconByMime(fileType: $TSFixMe): $TSFixMe {
   const archiveTypes = [
     'zip',
     'x-7z-compressed',
+    'x-zip-compressed',
     'x-rar-compressed',
     'x-tar',
     'x-gzip',


### PR DESCRIPTION
Adds missing application/x-zip-compress mime type in the array of archive type in `getFileTypeIcon.tsx` file.