### PR TITLE
@uppy/core: fix `setOptions` not re-rendereing plugin UI

### DIFF
--- a/packages/@uppy/core/src/BasePlugin.ts
+++ b/packages/@uppy/core/src/BasePlugin.ts
@@ -72,7 +72,6 @@ export default class BasePlugin<
   }
 
   setPluginState(update?: Partial<PluginState>): void {
-    if (!update) return
     const { plugins } = this.uppy.getState()
 
     this.uppy.setState({


### PR DESCRIPTION
c48aa82a8a68392f5c5f09d866deebd8806fe8a6 introduced that condition, but it looks like a bug, we don't want to skip the `setState` call otherwise the plugin UI will not get re-rendered.

Fixes: https://github.com/transloadit/uppy/issues/5071