### PR TITLE
meta: add `dependabot.yml` to keep GHA up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Basic set up for three package managers
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
We have a warning about using Node.js 16 on our GHA, it seems like something we could easily use automation to keep up-to-date with that.