### PR TITLE
@uppy/drop-target: change drop event type to DragEvent

### DIFF
--- a/packages/@uppy/drop-target/types/index.d.ts
+++ b/packages/@uppy/drop-target/types/index.d.ts
@@ -2,9 +2,9 @@ import type { PluginOptions, BasePlugin } from '@uppy/core'
 
 interface DropTargetOptions extends PluginOptions {
   target: string | Element
-  onDragOver?: (event: MouseEvent) => void
-  onDrop?: (event: MouseEvent) => void
-  onDragLeave?: (event: MouseEvent) => void
+  onDragOver?: (event: DragEvent) => void
+  onDrop?: (event: DragEvent) => void
+  onDragLeave?: (event: DragEvent) => void
 }
 
 declare class DropTarget extends BasePlugin<DropTargetOptions> {}


### PR DESCRIPTION
`@uppy/drop-target` is catching `DragEvent` and passing the event to `onDrop`, `onDrogOver` and `onDragLeave` while in the types it defines the event as `MouseEvent`.

As an example consider this implementation in `packages/@uppy/drop-target/src/index.ts`:

``` ts
handleDrop = async (event: DragEvent): Promise<void> => {
   ...
   ...
    this.opts.onDrop?.(event)
   ...
```

And the types is defined as `onDragOver?: (event: MouseEvent) => void` while it should be `onDragOver?: (event: DragEvent) => void`.