### PR TITLE
@uppy/utils: improve return type of `dataURItoFile`

### DIFF
--- a/packages/@uppy/utils/src/dataURItoBlob.ts
+++ b/packages/@uppy/utils/src/dataURItoBlob.ts
@@ -1,8 +1,17 @@
 const DATA_URL_PATTERN = /^data:([^/]+\/[^,;]+(?:[^,]*?))(;base64)?,([\s\S]*)$/
 
-export default function dataURItoBlob(
+type dataURItoBlobOptions = { mimeType?: string; name?: string }
+
+function dataURItoBlob(dataURI: string, opts: dataURItoBlobOptions): Blob
+function dataURItoBlob(
   dataURI: string,
-  opts: { mimeType?: string; name?: string },
+  opts: dataURItoBlobOptions,
+  toFile: true,
+): File
+
+function dataURItoBlob(
+  dataURI: string,
+  opts: dataURItoBlobOptions,
   toFile?: boolean,
 ): Blob | File {
   // get the base64 data
@@ -30,3 +39,5 @@ export default function dataURItoBlob(
 
   return new Blob(data, { type: mimeType })
 }
+
+export default dataURItoBlob

--- a/packages/@uppy/utils/src/dataURItoFile.ts
+++ b/packages/@uppy/utils/src/dataURItoFile.ts
@@ -3,6 +3,6 @@ import dataURItoBlob from './dataURItoBlob.ts'
 export default function dataURItoFile(
   dataURI: string,
   opts: { mimeType?: string; name?: string },
-): File | Blob {
+): File {
   return dataURItoBlob(dataURI, opts, true)
 }


### PR DESCRIPTION
As its name implies, it returns a `File`.