### PR TITLE
@uppy/dashboard: import Preact h in Slide.tsx

### DIFF
--- a/packages/@uppy/dashboard/src/components/Slide.tsx
+++ b/packages/@uppy/dashboard/src/components/Slide.tsx
@@ -1,4 +1,5 @@
 import {
+  h,
   cloneElement,
   toChildArray,
   type VNode,


### PR DESCRIPTION
[Codesandbox currently crashes](https://codesandbox.io/p/sandbox/uppy-dashboard-xpxuhd?file=%2Fsrc%2Findex.js%3A12%2C28) with `TypeError: Cannot read properties of undefined (reading '__H')`. Importing `h` from `preact` in mandatory even if you don't directly reference it. Since this can't be reproduced locally, this is my "merge and pray" fix. _Hopefully_ it fixes the problem.