### PR TITLE
Use StackBlitz for all examples/issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -26,7 +26,9 @@ body:
 
         Starters:
 
-        - [Uppy Dashboard](https://codesandbox.io/s/uppy-dashboard-xpxuhd?file=/src/index.js)
+        - [Uppy Dashboard](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js)
+        - [Uppy React](https://stackblitz.com/edit/vitejs-vite-vehvbq?file=src%2FApp.tsx)
+        - [Uppy Vue](https://stackblitz.com/edit/vitejs-vite-ubjwys?file=src%2FApp.vue)
     validations:
       required: false
   - type: textarea

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -15,10 +15,10 @@ about more important problems than building a file uploader.
 
 :::tip
 
-You can take Uppy for a walk inside CodeSandbox with a
-[minimal drag & drop](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js)
+You can take Uppy for a walk inside StackBlitz with a
+[minimal drag & drop](https://stackblitz.com/edit/vitejs-vite-yzbujq?file=main.js/g)
 experience or a
-[full featured dashboard](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[full featured dashboard](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/audio.mdx
+++ b/docs/sources/audio.mdx
@@ -17,7 +17,7 @@ time sound wavelength when recording.
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -15,7 +15,7 @@ The `@uppy/box` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/dropbox.mdx
+++ b/docs/sources/companion-plugins/dropbox.mdx
@@ -15,7 +15,7 @@ The `@uppy/dropbox` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/facebook.mdx
+++ b/docs/sources/companion-plugins/facebook.mdx
@@ -15,7 +15,7 @@ The `@uppy/facebook` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -15,7 +15,7 @@ The `@uppy/google-drive` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/instagram.mdx
+++ b/docs/sources/companion-plugins/instagram.mdx
@@ -15,7 +15,7 @@ The `@uppy/instagram` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/onedrive.mdx
+++ b/docs/sources/companion-plugins/onedrive.mdx
@@ -15,7 +15,7 @@ The `@uppy/onedrive` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/unsplash.mdx
+++ b/docs/sources/companion-plugins/unsplash.mdx
@@ -15,7 +15,7 @@ The `@uppy/unsplash` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/url.mdx
+++ b/docs/sources/companion-plugins/url.mdx
@@ -15,7 +15,7 @@ URL and it will be added!
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -15,7 +15,7 @@ The `@uppy/zoom` plugin lets users import files from their
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/screen-capture.mdx
+++ b/docs/sources/screen-capture.mdx
@@ -16,7 +16,7 @@ save it as a video.
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/sources/webcam.mdx
+++ b/docs/sources/webcam.mdx
@@ -16,7 +16,7 @@ camera on desktop and mobile devices.
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/user-interfaces/dashboard.mdx
+++ b/docs/user-interfaces/dashboard.mdx
@@ -21,7 +21,7 @@ integrate.
 :::tip
 
 [Try out the live example with all plugins](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-zaqyaf?file=main.js).
 
 :::
 

--- a/docs/user-interfaces/drag-drop.mdx
+++ b/docs/user-interfaces/drag-drop.mdx
@@ -15,7 +15,7 @@ The `@uppy/drag-drop` plugin renders a drag and drop area for file selection.
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-yzbujq?file=main.js/g).
 
 :::
 

--- a/docs/user-interfaces/elements/drop-target.mdx
+++ b/docs/user-interfaces/elements/drop-target.mdx
@@ -19,7 +19,7 @@ solution targeting any DOM element.
 :::tip
 
 [Try out the live example](/examples) or take it for a spin in
-[CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js).
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-yzbujq?file=main.js/g).
 
 :::
 

--- a/docs/user-interfaces/elements/status-bar.mdx
+++ b/docs/user-interfaces/elements/status-bar.mdx
@@ -17,7 +17,7 @@ pre- and post-processing information, and allows users to control
 :::tip
 
 Try it out together with [`@uppy/drag-drop`](/docs/drag-drop) in
-[CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js)
+[StackBlitz](https://stackblitz.com/edit/vitejs-vite-yzbujq?file=main.js/g)
 
 :::
 


### PR DESCRIPTION
CodeSandbox often resolves dependencies wrong and has an awkward distinction between "sandboxes" and "devboxes" (paid). The latter is more powerful but you already get for free in StackBlitz.