### PR TITLE
meta: enforce use of `.js` extension in `import type` declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -474,6 +474,10 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
       ],
       rules: {
+        'no-restricted-syntax': ['error', {
+          selector: 'ImportDeclaration[importKind="type"][source.value=/^\\./]:not([source.value=/\\.js$/])',
+          message: 'Use ".js" file extension for import type declarations',
+        }],
         'import/prefer-default-export': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-explicit-any': 'off',

--- a/packages/@uppy/audio/types/index.d.ts
+++ b/packages/@uppy/audio/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { PluginTarget, UIPlugin, UIPluginOptions } from '@uppy/core'
-import type AudioLocale from './generatedLocale'
+import type AudioLocale from './generatedLocale.js'
 
 export interface AudioOptions extends UIPluginOptions {
   target?: PluginTarget

--- a/packages/@uppy/aws-s3-multipart/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3-multipart/src/HTTPCommunicationQueue.ts
@@ -4,10 +4,10 @@ import type {
   WrapPromiseFunctionType,
 } from '@uppy/utils/lib/RateLimitedQueue'
 import { pausingUploadReason, type Chunk } from './MultipartUploader.ts'
-import type AwsS3Multipart from './index.ts'
+import type AwsS3Multipart from './index.js'
 import { throwIfAborted } from './utils.ts'
-import type { Body, UploadPartBytesResult, UploadResult } from './utils.ts'
-import type { AwsS3MultipartOptions, uploadPartBytes } from './index.ts'
+import type { Body, UploadPartBytesResult, UploadResult } from './utils.js'
+import type { AwsS3MultipartOptions, uploadPartBytes } from './index.js'
 
 function removeMetadataFromURL(urlString: string) {
   const urlObject = new URL(urlString)

--- a/packages/@uppy/aws-s3-multipart/src/MultipartUploader.ts
+++ b/packages/@uppy/aws-s3-multipart/src/MultipartUploader.ts
@@ -1,8 +1,8 @@
 import type { Uppy } from '@uppy/core'
 import { AbortController } from '@uppy/utils/lib/AbortController'
 import type { Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
-import type { HTTPCommunicationQueue } from './HTTPCommunicationQueue'
-import type { Body } from './utils'
+import type { HTTPCommunicationQueue } from './HTTPCommunicationQueue.js'
+import type { Body } from './utils.js'
 
 const MB = 1024 * 1024
 

--- a/packages/@uppy/aws-s3-multipart/src/index.test.ts
+++ b/packages/@uppy/aws-s3-multipart/src/index.test.ts
@@ -4,7 +4,7 @@ import 'whatwg-fetch'
 import nock from 'nock'
 import Core from '@uppy/core'
 import AwsS3Multipart from './index.ts'
-import type { Body } from './utils.ts'
+import type { Body } from './utils.js'
 
 const KB = 1024
 const MB = KB * KB

--- a/packages/@uppy/aws-s3-multipart/src/index.ts
+++ b/packages/@uppy/aws-s3-multipart/src/index.ts
@@ -22,7 +22,7 @@ import type {
   MultipartUploadResultWithSignal,
   UploadPartBytesResult,
   Body,
-} from './utils.ts'
+} from './utils.js'
 import createSignedURL from './createSignedURL.ts'
 import { HTTPCommunicationQueue } from './HTTPCommunicationQueue.ts'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/@uppy/aws-s3-multipart/src/utils.ts
+++ b/packages/@uppy/aws-s3-multipart/src/utils.ts
@@ -1,7 +1,7 @@
 import { createAbortError } from '@uppy/utils/lib/AbortController'
 import type { Body as _Body } from '@uppy/utils/lib/UppyFile'
 
-import type { AwsS3Part } from './index'
+import type { AwsS3Part } from './index.js'
 
 export function throwIfAborted(signal?: AbortSignal | null): void {
   if (signal?.aborted) {

--- a/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
+++ b/packages/@uppy/aws-s3-multipart/types/index.test-d.ts
@@ -2,6 +2,7 @@ import { expectError, expectType } from 'tsd'
 import Uppy from '@uppy/core'
 import type { UppyFile } from '@uppy/core'
 import AwsS3Multipart from '..'
+// eslint-disable-next-line no-restricted-syntax
 import type { AwsS3Part } from '..'
 
 {

--- a/packages/@uppy/companion-client/src/CompanionPluginOptions.ts
+++ b/packages/@uppy/companion-client/src/CompanionPluginOptions.ts
@@ -1,5 +1,5 @@
 import type { UIPluginOptions } from '@uppy/core'
-import type { tokenStorage } from '.'
+import type { tokenStorage } from './index.js'
 
 export interface CompanionPluginOptions extends UIPluginOptions {
   title?: string

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -7,7 +7,7 @@ import type {
 } from '@uppy/utils/lib/CompanionClientProvider'
 import type { UnknownProviderPlugin } from '@uppy/core/lib/Uppy'
 import RequestClient, { authErrorStatusCode } from './RequestClient.ts'
-import type { CompanionPluginOptions } from '.'
+import type { CompanionPluginOptions } from './index.js'
 
 // TODO: remove deprecated options in next major release
 export interface Opts extends PluginOpts, CompanionPluginOptions {

--- a/packages/@uppy/compressor/types/index.d.ts
+++ b/packages/@uppy/compressor/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { PluginOptions, BasePlugin } from '@uppy/core'
 import { UppyFile } from '@uppy/utils'
-import type CompressorLocale from './generatedLocale'
+import type CompressorLocale from './generatedLocale.js'
 
 export interface CompressorOptions extends PluginOptions {
   quality?: number

--- a/packages/@uppy/core/src/BasePlugin.ts
+++ b/packages/@uppy/core/src/BasePlugin.ts
@@ -16,7 +16,7 @@ import type {
   OptionalPluralizeLocale,
 } from '@uppy/utils/lib/Translator'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type { State, UnknownPlugin, Uppy } from './Uppy'
+import type { State, UnknownPlugin, Uppy } from './Uppy.js'
 
 export type PluginOpts = {
   locale?: Locale

--- a/packages/@uppy/core/src/EventManager.ts
+++ b/packages/@uppy/core/src/EventManager.ts
@@ -4,7 +4,7 @@ import type {
   Uppy,
   UppyEventMap,
   _UppyEventMap,
-} from './Uppy'
+} from './Uppy.js'
 
 /**
  * Create a wrapper around an event emitter with a `remove` method to remove

--- a/packages/@uppy/core/src/Restricter.ts
+++ b/packages/@uppy/core/src/Restricter.ts
@@ -6,7 +6,7 @@ import match from 'mime-match'
 import Translator from '@uppy/utils/lib/Translator'
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type { I18n } from '@uppy/utils/lib/Translator'
-import type { State, NonNullableUppyOptions } from './Uppy'
+import type { State, NonNullableUppyOptions } from './Uppy.js'
 
 export type Restrictions = {
   maxFileSize: number | null

--- a/packages/@uppy/core/src/UIPlugin.ts
+++ b/packages/@uppy/core/src/UIPlugin.ts
@@ -5,8 +5,8 @@ import getTextDirection from '@uppy/utils/lib/getTextDirection'
 
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import BasePlugin from './BasePlugin.ts'
-import type { PluginOpts } from './BasePlugin.ts'
-import type { State } from './Uppy.ts'
+import type { PluginOpts } from './BasePlugin.js'
+import type { State } from './Uppy.js'
 
 /**
  * Defer a frequent call to the microtask queue.

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -47,8 +47,8 @@ import {
 import packageJson from '../package.json'
 import locale from './locale.ts'
 
-import type BasePlugin from './BasePlugin.ts'
-import type { Restrictions, ValidateableFile } from './Restricter.ts'
+import type BasePlugin from './BasePlugin.js'
+import type { Restrictions, ValidateableFile } from './Restricter.js'
 
 type Processor = (
   fileIDs: string[],

--- a/packages/@uppy/core/src/mocks/acquirerPlugin1.ts
+++ b/packages/@uppy/core/src/mocks/acquirerPlugin1.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest' // eslint-disable-line import/no-extraneous-dependencies
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.ts'
+import type Uppy from '../Uppy.js'
 
 type mock = ReturnType<typeof vi.fn>
 

--- a/packages/@uppy/core/src/mocks/acquirerPlugin2.ts
+++ b/packages/@uppy/core/src/mocks/acquirerPlugin2.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest' // eslint-disable-line import/no-extraneous-dependencies
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.ts'
+import type Uppy from '../Uppy.js'
 
 type mock = ReturnType<typeof vi.fn>
 

--- a/packages/@uppy/core/src/mocks/invalidPluginWithoutId.ts
+++ b/packages/@uppy/core/src/mocks/invalidPluginWithoutId.ts
@@ -1,5 +1,5 @@
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.ts'
+import type Uppy from '../Uppy.js'
 
 export default class InvalidPluginWithoutName extends UIPlugin<any, any, any> {
   public type: string

--- a/packages/@uppy/core/src/mocks/invalidPluginWithoutType.ts
+++ b/packages/@uppy/core/src/mocks/invalidPluginWithoutType.ts
@@ -1,5 +1,5 @@
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.ts'
+import type Uppy from '../Uppy.js'
 
 export default class InvalidPluginWithoutType extends UIPlugin<any, any, any> {
   public id: string

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -9,7 +9,7 @@ import type {
   PluginOptions,
   UppyFile,
   SuccessResponse,
-} from '..'
+} from '../index.js'
 
 type anyObject = Record<string, unknown>
 

--- a/packages/@uppy/core/types/index.test-d.ts
+++ b/packages/@uppy/core/types/index.test-d.ts
@@ -3,13 +3,14 @@ import { expectError, expectType } from 'tsd'
 import DefaultStore from '@uppy/store-default'
 // eslint-disable-next-line import/no-named-as-default
 import Uppy, { UIPlugin } from '..'
+// eslint-disable-next-line no-restricted-syntax
 import type {
   UploadedUppyFile,
   FailedUppyFile,
   PluginOptions,
   UppyFile,
   SuccessResponse,
-} from '../index.js'
+} from '..'
 
 type anyObject = Record<string, unknown>
 

--- a/packages/@uppy/image-editor/src/Editor.tsx
+++ b/packages/@uppy/image-editor/src/Editor.tsx
@@ -7,7 +7,7 @@ import getCanvasDataThatFitsPerfectlyIntoContainer from './utils/getCanvasDataTh
 import getScaleFactorThatRemovesDarkCorners from './utils/getScaleFactorThatRemovesDarkCorners.ts'
 import limitCropboxMovementOnMove from './utils/limitCropboxMovementOnMove.ts'
 import limitCropboxMovementOnResize from './utils/limitCropboxMovementOnResize.ts'
-import type ImageEditor from './ImageEditor.tsx'
+import type ImageEditor from './ImageEditor.js'
 
 type Props<M extends Meta, B extends Body> = {
   currentImage: UppyFile<M, B>

--- a/packages/@uppy/provider-views/src/Breadcrumbs.tsx
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { UnknownProviderPluginState } from '@uppy/core/lib/Uppy'
 import { h, Fragment } from 'preact'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type ProviderView from './ProviderView'
+import type ProviderView from './ProviderView.js'
 
 type BreadcrumbProps = {
   getFolder: () => void

--- a/packages/@uppy/provider-views/src/Breadcrumbs.tsx
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { UnknownProviderPluginState } from '@uppy/core/lib/Uppy'
 import { h, Fragment } from 'preact'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type ProviderView from './ProviderView.js'
+import type ProviderView from './ProviderView/index.js'
 
 type BreadcrumbProps = {
   getFolder: () => void

--- a/packages/@uppy/provider-views/src/ProviderView/AuthView.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/AuthView.tsx
@@ -3,8 +3,8 @@ import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import type Translator from '@uppy/utils/lib/Translator'
-import type { ProviderViewOptions } from './ProviderView'
-import type ProviderViews from './ProviderView'
+import type { ProviderViewOptions } from './ProviderView.js'
+import type ProviderViews from './ProviderView.js'
 
 type AuthViewProps<M extends Meta, B extends Body> = {
   loading: boolean | string

--- a/packages/@uppy/provider-views/src/ProviderView/Header.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/Header.tsx
@@ -5,7 +5,7 @@ import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import type { UnknownProviderPluginState } from '@uppy/core/lib/Uppy'
 import User from './User.tsx'
 import Breadcrumbs from '../Breadcrumbs.tsx'
-import type ProviderView from './ProviderView.tsx'
+import type ProviderView from './ProviderView.js'
 
 type HeaderProps<M extends Meta, B extends Body> = {
   showBreadcrumbs: boolean

--- a/packages/@uppy/react/types/Dashboard.d.ts
+++ b/packages/@uppy/react/types/Dashboard.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import type { DashboardOptions } from '@uppy/dashboard'
-import type { Omit, WithBaseUppyProps } from './CommonTypes'
+import type { Omit, WithBaseUppyProps } from './CommonTypes.js'
 
 // This type is mapped into `DashboardProps` below so IntelliSense doesn't display this big mess of nested types
 type DashboardPropsInner = Omit<

--- a/packages/@uppy/react/types/DashboardModal.d.ts
+++ b/packages/@uppy/react/types/DashboardModal.d.ts
@@ -1,5 +1,5 @@
 import type { DashboardOptions } from '@uppy/dashboard'
-import type { Omit, ToUppyProps } from './CommonTypes'
+import type { Omit, ToUppyProps } from './CommonTypes.js'
 
 // This type is mapped into `DashboardModalProps` below so IntelliSense doesn't display this big mess of nested types
 type DashboardModalPropsInner = {

--- a/packages/@uppy/react/types/DragDrop.d.ts
+++ b/packages/@uppy/react/types/DragDrop.d.ts
@@ -1,5 +1,5 @@
 import type { DragDropOptions } from '@uppy/drag-drop'
-import type { ToUppyProps } from './CommonTypes'
+import type { ToUppyProps } from './CommonTypes.js'
 
 export type DragDropProps = ToUppyProps<DragDropOptions> &
   React.BaseHTMLAttributes<HTMLDivElement>

--- a/packages/@uppy/react/types/FileInput.d.ts
+++ b/packages/@uppy/react/types/FileInput.d.ts
@@ -1,5 +1,5 @@
 import type { FileInputOptions } from '@uppy/file-input'
-import type { ToUppyProps } from './CommonTypes'
+import type { ToUppyProps } from './CommonTypes.js'
 
 export type FileInputProps = ToUppyProps<FileInputOptions>
 

--- a/packages/@uppy/react/types/ProgressBar.d.ts
+++ b/packages/@uppy/react/types/ProgressBar.d.ts
@@ -1,5 +1,5 @@
 import type { ProgressBarOptions } from '@uppy/progress-bar'
-import type { ToUppyProps } from './CommonTypes'
+import type { ToUppyProps } from './CommonTypes.js'
 
 export type ProgressBarProps = ToUppyProps<ProgressBarOptions> &
   React.BaseHTMLAttributes<HTMLDivElement>

--- a/packages/@uppy/react/types/StatusBar.d.ts
+++ b/packages/@uppy/react/types/StatusBar.d.ts
@@ -1,5 +1,5 @@
 import type { StatusBarOptions } from '@uppy/status-bar'
-import type { ToUppyProps } from './CommonTypes'
+import type { ToUppyProps } from './CommonTypes.js'
 
 export type StatusBarProps = ToUppyProps<StatusBarOptions> &
   React.BaseHTMLAttributes<HTMLDivElement>

--- a/packages/@uppy/status-bar/src/StatusBar.tsx
+++ b/packages/@uppy/status-bar/src/StatusBar.tsx
@@ -11,7 +11,7 @@ import StatusBarUI, { type StatusBarUIProps } from './StatusBarUI.tsx'
 // @ts-ignore We don't want TS to generate types for the package.json
 import packageJson from '../package.json'
 import locale from './locale.ts'
-import type { StatusBarOptions } from './StatusBarOptions.ts'
+import type { StatusBarOptions } from './StatusBarOptions.js'
 
 const speedFilterHalfLife = 2000
 const ETAFilterHalfLife = 2000

--- a/packages/@uppy/status-bar/src/StatusBarOptions.ts
+++ b/packages/@uppy/status-bar/src/StatusBarOptions.ts
@@ -1,5 +1,5 @@
 import type { UIPluginOptions } from '@uppy/core/lib/UIPlugin'
-import type StatusBarLocale from './locale.ts'
+import type StatusBarLocale from './locale.js'
 
 export interface StatusBarOptions extends UIPluginOptions {
   showProgressDetails?: boolean

--- a/packages/@uppy/transloadit/src/Assembly.ts
+++ b/packages/@uppy/transloadit/src/Assembly.ts
@@ -8,7 +8,7 @@ import type {
   RateLimitedQueue,
   WrapPromiseFunctionType,
 } from '@uppy/utils/lib/RateLimitedQueue'
-import type { AssemblyResponse } from '.'
+import type { AssemblyResponse } from './index.js'
 
 const ASSEMBLY_UPLOADING = 'ASSEMBLY_UPLOADING'
 const ASSEMBLY_EXECUTING = 'ASSEMBLY_EXECUTING'

--- a/packages/@uppy/transloadit/src/AssemblyOptions.ts
+++ b/packages/@uppy/transloadit/src/AssemblyOptions.ts
@@ -1,6 +1,10 @@
 import ErrorWithCause from '@uppy/utils/lib/ErrorWithCause'
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
-import type { AssemblyParameters, Opts, AssemblyOptions as Options } from '.'
+import type {
+  AssemblyParameters,
+  Opts,
+  AssemblyOptions as Options,
+} from './index.js'
 
 /**
  * Check that Assembly parameters are present and include all required fields.

--- a/packages/@uppy/transloadit/src/AssemblyWatcher.ts
+++ b/packages/@uppy/transloadit/src/AssemblyWatcher.ts
@@ -1,7 +1,7 @@
 import type { Uppy } from '@uppy/core'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import Emitter from 'component-emitter'
-import type { AssemblyResponse } from '.'
+import type { AssemblyResponse } from './index.js'
 
 /**
  * Track completion of multiple assemblies.

--- a/packages/@uppy/transloadit/src/Client.ts
+++ b/packages/@uppy/transloadit/src/Client.ts
@@ -4,8 +4,8 @@ import type {
 } from '@uppy/utils/lib/RateLimitedQueue'
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
 import fetchWithNetworkError from '@uppy/utils/lib/fetchWithNetworkError'
-import type { AssemblyResponse } from '.'
-import type { OptionsWithRestructuredFields } from './AssemblyOptions'
+import type { AssemblyResponse } from './index.js'
+import type { OptionsWithRestructuredFields } from './AssemblyOptions.js'
 
 const ASSEMBLIES_ENDPOINT = '/assemblies'
 

--- a/packages/@uppy/utils/src/ErrorWithCause.ts
+++ b/packages/@uppy/utils/src/ErrorWithCause.ts
@@ -1,4 +1,4 @@
-import type NetworkError from './NetworkError.ts'
+import type NetworkError from './NetworkError.js'
 import hasProperty from './hasProperty.ts'
 
 class ErrorWithCause extends Error {

--- a/packages/@uppy/utils/src/UppyFile.ts
+++ b/packages/@uppy/utils/src/UppyFile.ts
@@ -1,4 +1,4 @@
-import type { FileProgress } from './FileProgress'
+import type { FileProgress } from './FileProgress.js'
 
 export type Meta = Record<string, unknown>
 

--- a/packages/@uppy/utils/src/emitSocketProgress.ts
+++ b/packages/@uppy/utils/src/emitSocketProgress.ts
@@ -1,6 +1,6 @@
 import throttle from 'lodash/throttle.js'
-import type { UppyFile } from './UppyFile'
-import type { FileProgress } from './FileProgress'
+import type { UppyFile } from './UppyFile.js'
+import type { FileProgress } from './FileProgress.js'
 
 function emitSocketProgress(
   uploader: any,

--- a/packages/@uppy/utils/src/fileFilters.ts
+++ b/packages/@uppy/utils/src/fileFilters.ts
@@ -1,4 +1,4 @@
-import type { UppyFile } from './UppyFile'
+import type { UppyFile } from './UppyFile.js'
 
 export function filterNonFailedFiles(
   files: UppyFile<any, any>[],

--- a/packages/@uppy/utils/src/generateFileID.ts
+++ b/packages/@uppy/utils/src/generateFileID.ts
@@ -1,4 +1,4 @@
-import type { MinimalRequiredUppyFile } from './UppyFile'
+import type { MinimalRequiredUppyFile } from './UppyFile.js'
 import getFileType from './getFileType.ts'
 
 function encodeCharacter(character: string): string {

--- a/packages/@uppy/utils/src/getBytesRemaining.ts
+++ b/packages/@uppy/utils/src/getBytesRemaining.ts
@@ -1,4 +1,4 @@
-import type { FileProgress } from './FileProgress'
+import type { FileProgress } from './FileProgress.js'
 
 export default function getBytesRemaining(fileProgress: FileProgress): number {
   if (fileProgress.bytesTotal == null) return 0

--- a/packages/@uppy/utils/src/getETA.ts
+++ b/packages/@uppy/utils/src/getETA.ts
@@ -1,6 +1,6 @@
 import getSpeed from './getSpeed.ts'
 import getBytesRemaining from './getBytesRemaining.ts'
-import type { FileProgress } from './FileProgress.ts'
+import type { FileProgress } from './FileProgress.js'
 
 export default function getETA(fileProgress: FileProgress): number {
   if (!fileProgress.bytesUploaded) return 0

--- a/packages/@uppy/utils/src/getFileType.test.ts
+++ b/packages/@uppy/utils/src/getFileType.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import getFileType from './getFileType.ts'
-import type { UppyFile } from './UppyFile.ts'
+import type { UppyFile } from './UppyFile.js'
 
 describe('getFileType', () => {
   it('should trust the filetype if the file comes from a remote source', () => {

--- a/packages/@uppy/utils/src/getSpeed.ts
+++ b/packages/@uppy/utils/src/getSpeed.ts
@@ -1,4 +1,4 @@
-import type { FileProgress, FileProgressStarted } from './FileProgress'
+import type { FileProgress, FileProgressStarted } from './FileProgress.js'
 
 export default function getSpeed(fileProgress: FileProgress): number {
   if (!fileProgress.bytesUploaded) return 0


### PR DESCRIPTION
Hopefully that should make https://arethetypeswrong.github.io/?p=@uppy/core@4.0.0-beta.3 happier.