### PR TITLE
@uppy/xhr-upload: do not throw when res is missing url

### DIFF
--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -239,12 +239,9 @@ export default class XHRUpload<
           }
 
           const body = this.opts.getResponseData(res.responseText, res)
-          const uploadURL = body[this.opts.responseUrlFieldName]
-          if (typeof uploadURL !== 'string') {
-            throw new Error(
-              `The received response did not include a valid URL for key ${this.opts.responseUrlFieldName}`,
-            )
-          }
+          const uploadURL = body?.[this.opts.responseUrlFieldName] as
+            | string
+            | undefined
 
           for (const file of files) {
             this.uppy.emit('upload-success', file, {


### PR DESCRIPTION
Closes https://github.com/transloadit/uppy/issues/5131

Accidentally introduced a breaking change. I thought sending back a `url` is mandatory and that's why we have things like `getResponseData` and `responseUrlFieldName` so you can get it in a flexible way.  But it seems it wasn't needed and people didn't do it and now their uploads stopped working.