### PR TITLE
Remove redundant `plugins` prop from examples

### DIFF
--- a/docs/framework-integrations/react.mdx
+++ b/docs/framework-integrations/react.mdx
@@ -122,7 +122,7 @@ function Component() {
 	// IMPORTANT: passing an initializer function to prevent Uppy from being reinstantiated on every render.
 	const [uppy] = useState(() => new Uppy().use(Webcam));
 
-	return <Dashboard uppy={uppy} plugins={['Webcam']} />;
+	return <Dashboard uppy={uppy} />;
 }
 ```
 
@@ -180,7 +180,7 @@ function Component(props) {
 		uppy.getPlugin('Webcam').setOptions({ modes: props.webcamModes });
 	}, [props.webcamModes]);
 
-	return <Dashboard uppy={uppy} plugins={['Webcam']} />;
+	return <Dashboard uppy={uppy} />;
 }
 ```
 

--- a/docs/framework-integrations/svelte.mdx
+++ b/docs/framework-integrations/svelte.mdx
@@ -50,7 +50,7 @@ instance can be passed into components as an `uppy` prop. Due to the way Svelte
 handles reactivity, you can initialize Uppy the same way you would with vanilla
 JavaScript.
 
-```html
+```svelte
 <script>
 	import { Dashboard } from '@uppy/svelte';
 	import Uppy from '@uppy/core';
@@ -64,7 +64,7 @@ JavaScript.
 	const uppy = new Uppy().use(Webcam);
 </script>
 
-<main><Dashboard uppy="{uppy}" /></main>
+<main><Dashboard uppy={uppy} /></main>
 ```
 
 [svelte]: https://svelte.dev

--- a/docs/framework-integrations/svelte.mdx
+++ b/docs/framework-integrations/svelte.mdx
@@ -50,7 +50,7 @@ instance can be passed into components as an `uppy` prop. Due to the way Svelte
 handles reactivity, you can initialize Uppy the same way you would with vanilla
 JavaScript.
 
-```html
+```svelte
 <script>
 	import { Dashboard } from '@uppy/svelte';
 	import Uppy from '@uppy/core';

--- a/docs/framework-integrations/svelte.mdx
+++ b/docs/framework-integrations/svelte.mdx
@@ -64,7 +64,7 @@ JavaScript.
 	const uppy = new Uppy().use(Webcam);
 </script>
 
-<main><Dashboard uppy={uppy} plugins={["Webcam"]} /></main>
+<main><Dashboard uppy={uppy} /></main>
 ```
 
 [svelte]: https://svelte.dev

--- a/docs/framework-integrations/svelte.mdx
+++ b/docs/framework-integrations/svelte.mdx
@@ -50,7 +50,7 @@ instance can be passed into components as an `uppy` prop. Due to the way Svelte
 handles reactivity, you can initialize Uppy the same way you would with vanilla
 JavaScript.
 
-```svelte
+```html
 <script>
 	import { Dashboard } from '@uppy/svelte';
 	import Uppy from '@uppy/core';
@@ -64,7 +64,7 @@ JavaScript.
 	const uppy = new Uppy().use(Webcam);
 </script>
 
-<main><Dashboard uppy={uppy} /></main>
+<main><Dashboard uppy="{uppy}" /></main>
 ```
 
 [svelte]: https://svelte.dev

--- a/docs/framework-integrations/vue.mdx
+++ b/docs/framework-integrations/vue.mdx
@@ -66,7 +66,7 @@ JavaScript.
 </script>
 
 <template>
-	<Dashboard :uppy="uppy" :plugins="['Webcam']" />
+	<Dashboard :uppy="uppy" />
 </template>
 ```
 


### PR DESCRIPTION
Closes #5021

Should we also remove `plugins` prop altogether (see issue)? It's not even documented as an API option 🤔 