### PR TITLE
Improve provider docs: Box & Zoom

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # Uppy documentation
 
-To lint/build the documentation, see <https://github.com/transloadit/uppy.io>.
+See instructions for linting this documentation and seeing this documentation in
+the browser in <https://github.com/transloadit/uppy.io>.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Uppy documentation
 
-To build the documentation, see <https://github.com/transloadit/uppy.io>.
+To lint/build the documentation, see <https://github.com/transloadit/uppy.io>.

--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -88,8 +88,7 @@ You can create a Box App on the
 
 Things to note:
 
-- Choose `Custom App` and select the `User Authentication (OAuth 2.0)`
-  app type.
+- Choose `Custom App` and select the `User Authentication (OAuth 2.0)` app type.
 - You must enable full write access, or you will get
   [403 when downloading files](https://support.box.com/hc/en-us/community/posts/360049195613-403-error-while-file-download-API-Call)
 

--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -88,7 +88,7 @@ You can create a Box App on the
 
 Things to note:
 
-- Choose `Custom App` and select the `Standard OAuth 2.0 (User Authentication)`
+- Choose `Custom App` and select the `User Authentication (OAuth 2.0)`
   app type.
 - You must enable full write access, or you will get
   [403 when downloading files](https://support.box.com/hc/en-us/community/posts/360049195613-403-error-while-file-download-API-Call)

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -9,8 +9,8 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Zoom
 
-The `@uppy/zoom` plugin lets users import files from their
-[Zoom](https://zoom.com) account.
+The `@uppy/zoom` plugin lets users import cloud video recordings from their
+[Zoom](https://zoom.com) account. Note that [only licensed](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0063923) Zoom accounts can store their recordings in the cloud, so this functionality will only be available to users with a paid Zoom account.
 
 :::tip
 
@@ -21,7 +21,7 @@ The `@uppy/zoom` plugin lets users import files from their
 
 ## When should I use this?
 
-When you want to let users import files from their [Zoom](https://zoom.com)
+When you want to let users import cloud video recordings from their [Zoom](https://zoom.com)
 account.
 
 A [Companion](/docs/companion) instance is required for the Zoom plugin to work.
@@ -83,26 +83,48 @@ new Uppy()
 
 ### Use in Companion
 
-Configure the Zoom key and secret. With the standalone Companion server, specify
-environment variables:
+To sign up for API keys, go through the following steps:
 
-```shell
-export COMPANION_ZOOM_KEY="Zoom API key"
-export COMPANION_ZOOM_SECRET="Zoom API secret"
-```
+1. Sign up on [Zoom Marketplace](https://marketplace.zoom.us)  
 
-When using the Companion Node.js API, configure these options:
+2. Go to [https://marketplace.zoom.us](https://marketplace.zoom.us). There will be a dropdown in the header called "Develop". From that dropdown, select "Build app".  
 
-```js
-companion.app({
-	providerOptions: {
-		zoom: {
-			key: 'Zoom API key',
-			secret: 'Zoom API secret',
-		},
-	},
-});
-```
+3. In the "Basic Information" tab, Zoom shows your new "Client ID" and "Client Secret" - copy them.
+
+    With the standalone Companion server, specify
+    environment variables:
+
+    ```shell
+    export COMPANION_ZOOM_KEY="Zoom API key"
+    export COMPANION_ZOOM_SECRET="Zoom API secret"
+    ```
+
+    When using the Companion Node.js API, configure these options:
+
+    ```js
+    companion.app({
+      providerOptions: {
+        zoom: {
+          key: 'Zoom API key',
+          secret: 'Zoom API secret',
+        },
+      },
+    });
+    ```
+
+3. In the "Basic Information" tab, set "OAuth Redirect URL" input field to:
+
+    ```
+    https://$YOUR_COMPANION_HOST_NAME/zoom/redirect
+    ```
+
+    If you are using Transloadit hosted Companion:
+
+    ```
+    https://api2.transloadit.com/companion/zoom/redirect
+    ```
+
+4. In the "Scopes" tab, add "cloud_recording:read:list_user_recordings" and "user:read:user" scopes. If Zoom asks for further permissions when you interact with your Zoom integration - add those too.
 
 ## API
 

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -91,11 +91,11 @@ To sign up for API keys, go through the following steps:
 1. Sign up on [Zoom Marketplace](https://marketplace.zoom.us)
 
 2. Go to [https://marketplace.zoom.us](https://marketplace.zoom.us). There will
-   be a dropdown in the header called "Develop". From that dropdown, select
-   "Build app".
+   be a dropdown in the header called “Develop”. From that dropdown, select
+   “Build app”.
 
-3. In the "Basic Information" tab, Zoom shows your new "Client ID" and "Client
-   Secret" - copy them.
+3. In the “Basic Information” tab, Zoom shows your new “Client ID” and “Client
+   Secret” - copy them.
 
    With the standalone Companion server, specify environment variables:
 
@@ -117,7 +117,7 @@ To sign up for API keys, go through the following steps:
    });
    ```
 
-4. In the "Basic Information" tab, set "OAuth Redirect URL" input field to:
+4. In the “Basic Information” tab, set “OAuth Redirect URL” input field to:
 
    ```
    https://$YOUR_COMPANION_HOST_NAME/zoom/redirect
@@ -129,8 +129,8 @@ To sign up for API keys, go through the following steps:
    https://api2.transloadit.com/companion/zoom/redirect
    ```
 
-5. In the "Scopes" tab, add "cloud_recording:read:list_user_recordings" and
-   "user:read:user" scopes. If Zoom asks for further permissions when you
+5. In the “Scopes” tab, add “cloud_recording:read:list_user_recordings” and
+   “user:read:user” scopes. If Zoom asks for further permissions when you
    interact with your Zoom integration - add those too.
 
 ## API

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -10,7 +10,10 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 # Zoom
 
 The `@uppy/zoom` plugin lets users import cloud video recordings from their
-[Zoom](https://zoom.com) account. Note that [only licensed](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0063923) Zoom accounts can store their recordings in the cloud, so this functionality will only be available to users with a paid Zoom account.
+[Zoom](https://zoom.com) account. Note that
+[only licensed](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0063923)
+Zoom accounts can store their recordings in the cloud, so this functionality
+will only be available to users with a paid Zoom account.
 
 :::tip
 
@@ -21,8 +24,8 @@ The `@uppy/zoom` plugin lets users import cloud video recordings from their
 
 ## When should I use this?
 
-When you want to let users import cloud video recordings from their [Zoom](https://zoom.com)
-account.
+When you want to let users import cloud video recordings from their
+[Zoom](https://zoom.com) account.
 
 A [Companion](/docs/companion) instance is required for the Zoom plugin to work.
 Companion handles authentication with Zoom, downloads the files, and uploads
@@ -85,46 +88,50 @@ new Uppy()
 
 To sign up for API keys, go through the following steps:
 
-1. Sign up on [Zoom Marketplace](https://marketplace.zoom.us)  
+1. Sign up on [Zoom Marketplace](https://marketplace.zoom.us)
 
-2. Go to [https://marketplace.zoom.us](https://marketplace.zoom.us). There will be a dropdown in the header called "Develop". From that dropdown, select "Build app".  
+2. Go to [https://marketplace.zoom.us](https://marketplace.zoom.us). There will
+   be a dropdown in the header called "Develop". From that dropdown, select
+   "Build app".
 
-3. In the "Basic Information" tab, Zoom shows your new "Client ID" and "Client Secret" - copy them.
+3. In the "Basic Information" tab, Zoom shows your new "Client ID" and "Client
+   Secret" - copy them.
 
-    With the standalone Companion server, specify
-    environment variables:
+   With the standalone Companion server, specify environment variables:
 
-    ```shell
-    export COMPANION_ZOOM_KEY="Zoom API key"
-    export COMPANION_ZOOM_SECRET="Zoom API secret"
-    ```
+   ```shell
+   export COMPANION_ZOOM_KEY="Zoom API key"
+   export COMPANION_ZOOM_SECRET="Zoom API secret"
+   ```
 
-    When using the Companion Node.js API, configure these options:
+   When using the Companion Node.js API, configure these options:
 
-    ```js
-    companion.app({
-      providerOptions: {
-        zoom: {
-          key: 'Zoom API key',
-          secret: 'Zoom API secret',
-        },
-      },
-    });
-    ```
+   ```js
+   companion.app({
+   	providerOptions: {
+   		zoom: {
+   			key: 'Zoom API key',
+   			secret: 'Zoom API secret',
+   		},
+   	},
+   });
+   ```
 
-3. In the "Basic Information" tab, set "OAuth Redirect URL" input field to:
+4. In the "Basic Information" tab, set "OAuth Redirect URL" input field to:
 
-    ```
-    https://$YOUR_COMPANION_HOST_NAME/zoom/redirect
-    ```
+   ```
+   https://$YOUR_COMPANION_HOST_NAME/zoom/redirect
+   ```
 
-    If you are using Transloadit hosted Companion:
+   If you are using Transloadit hosted Companion:
 
-    ```
-    https://api2.transloadit.com/companion/zoom/redirect
-    ```
+   ```
+   https://api2.transloadit.com/companion/zoom/redirect
+   ```
 
-4. In the "Scopes" tab, add "cloud_recording:read:list_user_recordings" and "user:read:user" scopes. If Zoom asks for further permissions when you interact with your Zoom integration - add those too.
+5. In the "Scopes" tab, add "cloud_recording:read:list_user_recordings" and
+   "user:read:user" scopes. If Zoom asks for further permissions when you
+   interact with your Zoom integration - add those too.
 
 ## API
 


### PR DESCRIPTION
fixes #2453

This PR:

- adds documentation for Zoom
- updates wording for Box to match what's written on their site at the moment
- in the Readme.md, adds a more clear direction towards docs in uppy.io (https://github.com/transloadit/uppy.io/pull/243)