### PR TITLE
Fix docs for `method` in XHRUpload

### DIFF
--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -89,7 +89,7 @@ URL of the HTTP server (`string`, default: `null`).
 Configures which HTTP method to use for the upload (`string`, default:
 `'POST'`).
 
-Note: Since version 3.6.5 this is passed directly to `XMLHTTPRequest` so it must
+Note: Since version 3.6.5 this is passed directly to `XMLHttpRequest` so it must
 be written in capital letters (e.g. `'POST'`, `'PUT'`).
 
 #### `formData`

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -89,7 +89,7 @@ URL of the HTTP server (`string`, default: `null`).
 Configures which HTTP method to use for the upload (`string`, default:
 `'POST'`).
 
-Note: Since version 3.6.5 this is passed directly to `XMLHttpRequest` so it must
+Note: As of `@uppy/xhr-upload` v3.6.5, this is passed directly to `XMLHttpRequest` so it must
 be written in capital letters (e.g. `'POST'`, `'PUT'`).
 
 #### `formData`

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -87,7 +87,10 @@ URL of the HTTP server (`string`, default: `null`).
 #### `method`
 
 Configures which HTTP method to use for the upload (`string`, default:
-`'post'`).
+`'POST'`).
+
+Note: Since version 3.6.5 this is passed directly to `XMLHTTPRequest` so it must
+be written in capital letters (e.g. `'POST'`, `'PUT'`).
 
 #### `formData`
 


### PR DESCRIPTION
Following conversation with @Murderlon in #5165, this is a patch to the documentation that makes it clear methods need to be specified in capitals from version 3.6.5 onwards.