### PR TITLE
@uppy/companion: remove dependency on `express-request-id`

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -45,7 +45,6 @@
     "express": "4.19.2",
     "express-interceptor": "1.2.0",
     "express-prom-bundle": "7.0.0",
-    "express-request-id": "1.4.1",
     "express-session": "1.17.3",
     "got": "^13.0.0",
     "grant": "5.4.22",

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -1,10 +1,10 @@
 const express = require('express')
 const qs = require('node:querystring')
+const { randomUUID } = require('node:crypto')
 const helmet = require('helmet')
 const morgan = require('morgan')
 const { URL } = require('node:url')
 const session = require('express-session')
-const addRequestId = require('express-request-id')()
 const RedisStore = require('connect-redis').default
 
 const logger = require('../server/logger')
@@ -71,7 +71,17 @@ module.exports = function server(inputCompanionOptions) {
     return { query, censored }
   }
 
-  router.use(addRequestId)
+  router.use((request, response, next) => {
+  const headerName = 'X-Request-Id'
+		const oldValue = request.get(headerName);
+    if (oldValue === undefined) {
+      response.set(headerName, request.id = randomUUID());
+    } else {
+      request.id = oldValue;
+    }
+
+		next();
+	})
   // log server requests.
   router.use(morgan('combined'))
   morgan.token('url', (req) => {

--- a/packages/@uppy/companion/src/standalone/index.js
+++ b/packages/@uppy/companion/src/standalone/index.js
@@ -72,13 +72,9 @@ module.exports = function server(inputCompanionOptions) {
   }
 
   router.use((request, response, next) => {
-  const headerName = 'X-Request-Id'
+    const headerName = 'X-Request-Id'
 		const oldValue = request.get(headerName);
-    if (oldValue === undefined) {
-      response.set(headerName, request.id = randomUUID());
-    } else {
-      request.id = oldValue;
-    }
+    response.set(headerName, oldValue ?? randomUUID());
 
 		next();
 	})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8902,7 +8902,6 @@ __metadata:
     express: "npm:4.19.2"
     express-interceptor: "npm:1.2.0"
     express-prom-bundle: "npm:7.0.0"
-    express-request-id: "npm:1.4.1"
     express-session: "npm:1.17.3"
     got: "npm:^13.0.0"
     grant: "npm:5.4.22"
@@ -15509,15 +15508,6 @@ __metadata:
   peerDependencies:
     prom-client: ">=15.0.0"
   checksum: 10/82c0d97d1ecfec9f56b22595aeb8840687543b02899989a2f4a36ee6bee738cc199c4acaede01cf2d5d7ee0e25a84953fd48522563ab411b2b6d85d6672fa011
-  languageName: node
-  linkType: hard
-
-"express-request-id@npm:1.4.1":
-  version: 1.4.1
-  resolution: "express-request-id@npm:1.4.1"
-  dependencies:
-    uuid: "npm:^3.3.2"
-  checksum: 10/32ca1fcaf5701f7348b6726720966c3a8c15228d52f79dbd4c4c54add0088f4debeedec3fd109024bb0577bdafe72d64a85bb28fb1e6c8e10473157e11652fae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
That module is not doing anything special, IMO using it puts more maintenance burden on us than implementing it ourselves.