### PR TITLE
@uppy/xhr-upload: fix regression for lowercase HTTP methods

### DIFF
--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -91,8 +91,9 @@ Configures which HTTP method to use for the upload (`string`, default:
 
 :::note
 
-Using non-uppercase string for `method` is deprecated and won’t be supported in
-future versions of Uppy.
+Uppy is not following the standard and will uppercase the method name. This
+behavior will be removed in a future version to align Uppy with the web APIs.
+This will affect only users who use custom HTTP method (e.g. `'PATCH'`).
 
 :::
 

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -93,7 +93,6 @@ Configures which HTTP method to use for the upload (`string`, default:
 
 Uppy is not following the standard and will uppercase the method name. This
 behavior will be removed in a future version to align Uppy with the web APIs.
-This will affect only users who use custom HTTP method (e.g. `'PATCH'`).
 
 :::
 

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -91,7 +91,7 @@ Configures which HTTP method to use for the upload (`string`, default:
 
 :::note
 
-Using non-uppercase string for `method` is deprecated and won't be supported in
+Using non-uppercase string for `method` is deprecated and won’t be supported in
 future versions of Uppy.
 
 :::

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -87,7 +87,14 @@ URL of the HTTP server (`string`, default: `null`).
 #### `method`
 
 Configures which HTTP method to use for the upload (`string`, default:
-`'post'`).
+`'POST'`).
+
+:::note
+
+Using non-uppercase string for `method` is deprecated and won't be supported in
+future versions of Uppy.
+
+:::
 
 #### `formData`
 

--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -214,6 +214,7 @@ export default class XHRUpload<
         try {
           const res = await fetcher(url, {
             ...options,
+            method: options?.method?.toUpperCase(),
             onTimeout: (timeout) => {
               const seconds = Math.ceil(timeout / 1000)
               const error = new Error(this.i18n('uploadStalled', { seconds }))


### PR DESCRIPTION
We might want to revert that in `4.x` branch.

Fixes: https://github.com/transloadit/uppy/issues/5165