### PR TITLE
@uppy/tus: fix no headers passed to companion if argument is a function

### DIFF
--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -545,6 +545,10 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
       Object.assign(opts, file.tus)
     }
 
+    if (typeof opts.headers === 'function') {
+      opts.headers = opts.headers(file)
+    } 
+
     return {
       ...file.remote?.body,
       endpoint: opts.endpoint,


### PR DESCRIPTION
Conditionally calling the headers argument was missing from getCompanionClientArgs.