### PR TITLE
added useMemo instead of useState

### DIFF
--- a/docs/framework-integrations/react.mdx
+++ b/docs/framework-integrations/react.mdx
@@ -72,9 +72,7 @@ Use this hook when you need to access Uppy’s state reactively. Most of the
 times, this is needed if you are building a custom UI for Uppy in React.
 
 ```js
-// IMPORTANT: passing an initializer function to prevent Uppy from being reinstantiated on every render.
-const [uppy] = useState(() => new Uppy());
-
+const uppy = useMemo(() => new Uppy(), []);
 const files = useUppyState(uppy, (state) => state.files);
 const totalProgress = useUppyState(uppy, (state) => state.totalProgress);
 // We can also get specific plugin state.
@@ -119,13 +117,7 @@ import '@uppy/dashboard/dist/style.min.css';
 import '@uppy/webcam/dist/style.min.css';
 
 function Component() {
-	// IMPORTANT: passing an initializer function to prevent Uppy from being reinstantiated on every render.
-	const uppy = useMemo(() => {
-		const instance = new Uppy().use(Webcam)
-
-		return instance;
-	}, []);
-
+	const uppy = useMemo(() => new Uppy().use(Webcam), []);
 	return <Dashboard uppy={uppy} />;
 }
 ```
@@ -155,7 +147,6 @@ function Page2({ uppy }) {
 }
 
 export default function App() {
-	// keeping the uppy instance alive above the pages the user can switch during uploading
 	const uppy = useMemo(() => new Uppy(), []);
 
 	return (
@@ -173,12 +164,7 @@ export default function App() {
 ```js
 // ...
 function Component(props) {
-	// IMPORTANT: passing an initializer function to prevent the state from recreating.
-	const uppy = useMemo(() => {
-		const instance = new Uppy().use(Webcam)
-
-		return instance;
-	}, []);
+	const uppy = useMemo(() => new Uppy().use(Webcam), []);
 
 	useEffect(() => {
 		uppy.setOptions({ restrictions: props.restrictions });
@@ -220,8 +206,7 @@ function createUppy(userId) {
 }
 
 function Component({ userId }) {
-	// IMPORTANT: passing an initializer function to prevent Uppy from being reinstantiated on every render.
-	const [uppy] = useState(() => createUppy(userId));
+	const uppy = useMemo(() => createUppy(userId), []);
 
 	useEffect(() => {
 		if (userId) {

--- a/docs/framework-integrations/react.mdx
+++ b/docs/framework-integrations/react.mdx
@@ -109,7 +109,7 @@ unique `id`.
 :::
 
 ```js
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import Uppy from '@uppy/core';
 import Webcam from '@uppy/webcam';
 import { Dashboard } from '@uppy/react';
@@ -120,7 +120,11 @@ import '@uppy/webcam/dist/style.min.css';
 
 function Component() {
 	// IMPORTANT: passing an initializer function to prevent Uppy from being reinstantiated on every render.
-	const [uppy] = useState(() => new Uppy().use(Webcam));
+	const uppy = useMemo(() => {
+		const instance = new Uppy().use(Webcam)
+
+		return instance;
+	}, []);
 
 	return <Dashboard uppy={uppy} />;
 }
@@ -133,7 +137,7 @@ you can
 [lift the state up](https://react.dev/learn/sharing-state-between-components#lifting-state-up-by-example).
 
 ```js
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import Uppy from '@uppy/core';
 import { Dashboard } from '@uppy/react';
 
@@ -152,7 +156,7 @@ function Page2({ uppy }) {
 
 export default function App() {
 	// keeping the uppy instance alive above the pages the user can switch during uploading
-	const [uppy] = useState(() => new Uppy());
+	const uppy = useMemo(() => new Uppy(), []);
 
 	return (
 		// Add your router here
@@ -170,7 +174,11 @@ export default function App() {
 // ...
 function Component(props) {
 	// IMPORTANT: passing an initializer function to prevent the state from recreating.
-	const [uppy] = useState(() => new Uppy().use(Webcam));
+	const uppy = useMemo(() => {
+		const instance = new Uppy().use(Webcam)
+
+		return instance;
+	}, []);
 
 	useEffect(() => {
 		uppy.setOptions({ restrictions: props.restrictions });


### PR DESCRIPTION
In most cases, you don't need to update Uppy via state. It's better to use useMemo to ensure that Uppy is initialized only once.