### PR TITLE
@uppy/transloadit: do not cancel assembly when removing all files

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -524,19 +524,12 @@ export default class Transloadit<
           } else if (fileRemoved.id in updatedFiles) {
             delete updatedFiles[fileRemoved.id]
             const nbOfRemainingFiles = Object.keys(updatedFiles).length
-            if (nbOfRemainingFiles === 0) {
-              assembly.close()
-              this.#cancelAssembly(newAssembly).catch(() => {
+
+            this.client
+              .updateNumberOfFilesInAssembly(newAssembly, nbOfRemainingFiles)
+              .catch(() => {
                 /* ignore potential errors */
               })
-              this.uppy.off('file-removed', fileRemovedHandler)
-            } else {
-              this.client
-                .updateNumberOfFilesInAssembly(newAssembly, nbOfRemainingFiles)
-                .catch(() => {
-                  /* ignore potential errors */
-                })
-            }
           }
         }
         this.uppy.on('file-removed', fileRemovedHandler)


### PR DESCRIPTION
A common use case is clear the state of Uppy (with setTimeout) after success. But the @uppy/transloadit plugin cancels all assemblies, even if in progress, when that happens. This is causing issues for two customers.