### PR TITLE
@uppy/core: check capabilities in clearUploadedFiles

### DIFF
--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -491,7 +491,7 @@ describe('src/Core', () => {
 
     assert.throws(
       () => core.removeFile(fileIDs[0]),
-      /individualCancellation is disabled/,
+      /The installed uploader plugin does not allow removing files during an upload/,
     )
 
     expect(core.getState().currentUploads[id]).toBeDefined()

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -608,6 +608,14 @@ export class Uppy<M extends Meta, B extends Body> {
   // @todo next major: rename to `clear()`, make it also cancel ongoing uploads
   // or throw and say you need to cancel manually
   clearUploadedFiles(): void {
+    const { capabilities, currentUploads } = this.getState()
+    if (
+      Object.keys(currentUploads).length > 0 &&
+      !capabilities.individualCancellation
+    ) {
+      throw new Error('individualCancellation is disabled')
+    }
+
     this.setState({ ...defaultUploadState, files: {} })
   }
 

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -613,7 +613,9 @@ export class Uppy<M extends Meta, B extends Body> {
       Object.keys(currentUploads).length > 0 &&
       !capabilities.individualCancellation
     ) {
-      throw new Error('individualCancellation is disabled')
+      throw new Error(
+        'The installed uploader plugin does not allow removing files during an upload.',
+      )
     }
 
     this.setState({ ...defaultUploadState, files: {} })
@@ -1190,7 +1192,9 @@ export class Uppy<M extends Meta, B extends Body> {
         newFileIDs.length !== currentUploads[uploadID].fileIDs.length &&
         !capabilities.individualCancellation
       ) {
-        throw new Error('individualCancellation is disabled')
+        throw new Error(
+          'The installed uploader plugin does not allow removing files during an upload.',
+        )
       }
 
       updatedUploads[uploadID] = {


### PR DESCRIPTION
Found out while working on #5158 that we block `removeFiles` during on upload if `capabilities.individualCancellation` is `false` but we blindly allow it in `clearUploadedFiles`.