### PR TITLE
@uppy/transloadit: remove `updateNumberOfFilesInAssembly`

### DIFF
--- a/e2e/cypress/integration/dashboard-transloadit.spec.ts
+++ b/e2e/cypress/integration/dashboard-transloadit.spec.ts
@@ -209,58 +209,6 @@ describe('Dashboard with Transloadit', () => {
     })
   })
 
-  // Not working, the upstream changes have not landed yet.
-  it.skip('should create assembly if there is still one file to upload', () => {
-    cy.get('@file-input').selectFile(
-      [
-        'cypress/fixtures/images/cat.jpg',
-        'cypress/fixtures/images/traffic.jpg',
-      ],
-      { force: true },
-    )
-    cy.get('.uppy-StatusBar-actionBtn--upload').click()
-
-    cy.window().then(({ uppy }) => {
-      // eslint-disable-next-line
-      // @ts-ignore fix me
-      expect(
-        Object.values(uppy.getPlugin('Transloadit').activeAssemblies).length,
-      ).to.equal(0)
-
-      const { files } = uppy.getState()
-      const [fileID] = Object.keys(files)
-      uppy.removeFile(fileID)
-
-      cy.wait('@createAssemblies').then(() => {
-        cy.wait('@resumable')
-        cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
-      })
-    })
-  })
-
-  // Not working, the upstream changes have not landed yet.
-  it.skip('should complete upload if one gets cancelled mid-flight', () => {
-    cy.get('@file-input').selectFile(
-      [
-        'cypress/fixtures/images/cat.jpg',
-        'cypress/fixtures/images/traffic.jpg',
-      ],
-      { force: true },
-    )
-    cy.get('.uppy-StatusBar-actionBtn--upload').click()
-
-    cy.wait('@createAssemblies')
-    cy.wait('@resumable')
-
-    cy.window().then(({ uppy }) => {
-      const { files } = uppy.getState()
-      const [fileID] = Object.keys(files)
-      uppy.removeFile(fileID)
-
-      cy.get('.uppy-StatusBar-statusPrimary').should('contain', 'Complete')
-    })
-  })
-
   it('should not emit error if upload is cancelled right away', () => {
     cy.get('@file-input').selectFile('cypress/fixtures/images/cat.jpg', {
       force: true,

--- a/packages/@uppy/transloadit/src/Client.ts
+++ b/packages/@uppy/transloadit/src/Client.ts
@@ -171,30 +171,6 @@ export default class Client<M extends Meta, B extends Body> {
   }
 
   /**
-   * Update the number of expected files in an already created assembly.
-   */
-  async updateNumberOfFilesInAssembly(
-    assembly: AssemblyResponse,
-    num_expected_upload_files: number,
-  ): Promise<AssemblyResponse> {
-    const url = new URL(assembly.assembly_ssl_url)
-    url.pathname = '/update_assemblies'
-    const body = JSON.stringify({
-      assembly_updates: [
-        {
-          assembly_id: assembly.assembly_id,
-          num_expected_upload_files,
-        },
-      ],
-    })
-    return this.#fetchJSON(url, {
-      method: 'POST',
-      headers: this.#headers,
-      body,
-    }).catch((err) => this.#reportError(err, { url, type: 'API_ERROR' }))
-  }
-
-  /**
    * Cancel a running Assembly.
    */
   async cancelAssembly(assembly: AssemblyResponse): Promise<AssemblyResponse> {

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -462,17 +462,10 @@ export default class Transloadit<
         const files = this.uppy
           .getFiles()
           .filter(({ id }) => fileIDs.includes(id))
-        if (files.length !== fileIDs.length) {
-          if (files.length === 0) {
-            // All files have been removed, cancelling.
-            await this.client.cancelAssembly(newAssembly)
-            return null
-          }
-          // At least one file has been removed.
-          await this.client.updateNumberOfFilesInAssembly(
-            newAssembly,
-            files.length,
-          )
+        if (files.length === 0) {
+          // All files have been removed, cancelling.
+          await this.client.cancelAssembly(newAssembly)
+          return null
         }
 
         const assembly = new Assembly(newAssembly, this.#rateLimitedQueue)
@@ -521,15 +514,6 @@ export default class Transloadit<
           if (reason === 'cancel-all') {
             assembly.close()
             this.uppy.off('file-removed', fileRemovedHandler)
-          } else if (fileRemoved.id in updatedFiles) {
-            delete updatedFiles[fileRemoved.id]
-            const nbOfRemainingFiles = Object.keys(updatedFiles).length
-
-            this.client
-              .updateNumberOfFilesInAssembly(newAssembly, nbOfRemainingFiles)
-              .catch(() => {
-                /* ignore potential errors */
-              })
           }
         }
         this.uppy.on('file-removed', fileRemovedHandler)


### PR DESCRIPTION
- If you haven't started the upload yet, this is unneeded.
- If you did start the upload and you try to `removeFile`(s), Uppy throws an error that `individualCancellation` is not supported
- If you remove files after the upload is complete, the API returns a `404` for `/update_assemblies` (which was a bug in itself, trying to call this after the assembly is done).

Internally it was also brought up that `/update_assemblies` is not something we want to publicly expose.