### PR TITLE
PartialTree - change the `maxTotalFileSize` error

### DIFF
--- a/packages/@uppy/core/src/Restricter.ts
+++ b/packages/@uppy/core/src/Restricter.ts
@@ -98,25 +98,17 @@ class Restricter<M extends Meta, B extends Body> {
     }
 
     if (maxTotalFileSize) {
-      let totalFilesSize = existingFiles.reduce(
-        (total, f) => (total + (f.size ?? 0)) as number,
+      const totalFilesSize = [...existingFiles, ...addingFiles].reduce(
+        (total, f) => total + (f.size ?? 0),
         0,
       )
-
-      for (const addingFile of addingFiles) {
-        if (addingFile.size != null) {
-          // We can't check maxTotalFileSize if the size is unknown.
-          totalFilesSize += addingFile.size
-
-          if (totalFilesSize > maxTotalFileSize) {
-            throw new RestrictionError(
-              this.getI18n()('exceedsSize', {
-                size: prettierBytes(maxTotalFileSize),
-                file: addingFile.name,
-              }),
-            )
-          }
-        }
+      if (totalFilesSize > maxTotalFileSize) {
+        throw new RestrictionError(
+          this.getI18n()('aggregateExceedsSize', {
+            sizeAllowed: prettierBytes(maxTotalFileSize),
+            size: prettierBytes(totalFilesSize),
+          }),
+        )
       }
     }
   }

--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -2159,7 +2159,7 @@ describe('src/Core', () => {
     it('should enforce the maxTotalFileSize rule', () => {
       const core = new Core({
         restrictions: {
-          maxTotalFileSize: 34000,
+          maxTotalFileSize: 20000,
         },
       })
 
@@ -2178,7 +2178,9 @@ describe('src/Core', () => {
           data: testImage,
         })
       }).toThrowError(
-        new Error('foo1.jpg exceeds maximum allowed size of 33 KB'),
+        new Error(
+          'You selected 34 KB of files, but maximum allowed size is 20 KB',
+        ),
       )
     })
 

--- a/packages/@uppy/core/src/locale.ts
+++ b/packages/@uppy/core/src/locale.ts
@@ -12,6 +12,8 @@ export default {
       0: 'You have to select at least %{smart_count} file',
       1: 'You have to select at least %{smart_count} files',
     },
+    aggregateExceedsSize:
+      'You selected %{size} of files, but maximum allowed size is %{sizeAllowed}',
     exceedsSize: '%{file} exceeds maximum allowed size of %{size}',
     missingRequiredMetaField: 'Missing required meta fields',
     missingRequiredMetaFieldOnFile:


### PR DESCRIPTION
*This is a series of PRs that make the https://github.com/transloadit/uppy/pull/5050 PR smaller*

___

Currently, exceeding the aggregate size of files is reported as `"hi.png exceeds maximum allowed size of 20 MB"`, where `"hi.png"` is the first file that overflows the max allowed size (there might be many files after this first file!).

This PR changes this phrasing to `"You selected 25 MB of files, but maximum allowed size is 20 MB"`.

The former phrasing looks a bit better when we're hovering over greyed-out files, however in #5050 UI we won't have greyed-out files, so we shouldn't worry about that.

The new phrasing makes more sense as an error notification, both in current UI and in #5050 UI.

> [!NOTE] 
> I understand it seems like we should change `"You selected %{size} of files, but maximum allowed size is %{sizeAllowed}"` to  `"You want to select %{size} of files, but maximum allowed size is %{sizeAllowed}"`, however the former phrasing fits the #5050 UI better.

# Before

<img width="550" alt="image" src="https://github.com/transloadit/uppy/assets/7578559/4d478a25-0afa-400f-a0a3-1bb345d7c2bb">

<img width="550" alt="image" src="https://github.com/transloadit/uppy/assets/7578559/fdc0cb15-d7b4-45c6-ab7b-404757bb9390">



# After

<img width="550" alt="image" src="https://github.com/transloadit/uppy/assets/7578559/3e87a850-49ae-48f4-8e31-d80343ab0213">

<img width="550" alt="image" src="https://github.com/transloadit/uppy/assets/7578559/42dade8e-b542-40a2-91ef-07f7218b5118">



