### PR TITLE
@uppy/webcam: add missing types for `recordedVideo`

### DIFF
--- a/packages/@uppy/webcam/src/CameraScreen.tsx
+++ b/packages/@uppy/webcam/src/CameraScreen.tsx
@@ -21,6 +21,7 @@ interface CameraScreenProps extends VideoSourceSelectProps {
 
   src: MediaStream | null
   recording: boolean
+  recordedVideo: string | null
   modes: string[]
   supportsRecording: boolean
   showVideoSourceDropdown: boolean
@@ -53,7 +54,6 @@ class CameraScreen extends Component<CameraScreenProps> {
   render(): ComponentChild {
     const {
       src,
-      // @ts-expect-error TODO: remove unused
       recordedVideo,
       recording,
       modes,

--- a/packages/@uppy/webcam/src/Webcam.tsx
+++ b/packages/@uppy/webcam/src/Webcam.tsx
@@ -84,6 +84,7 @@ interface WebcamState {
   recordingLengthSeconds: number
   videoSources: MediaDeviceInfo[]
   currentDeviceId: null | string
+  recordedVideo: null | string
   isRecording: boolean
   [key: string]: unknown
 }


### PR DESCRIPTION
Contrarily to what the TODO says, it's not unused.