### PR TITLE
@uppy/provider-views: rename `getFolder` to `navigateToFolder`

### DIFF
--- a/packages/@uppy/provider-views/src/Breadcrumbs.tsx
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.tsx
@@ -4,20 +4,20 @@ import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import type ProviderView from './ProviderView/index.js'
 
 type BreadcrumbProps = {
-  getFolder: () => void
+  navigateToFolder: () => void
   title: string
   isLast: boolean
 }
 
 const Breadcrumb = (props: BreadcrumbProps) => {
-  const { getFolder, title, isLast } = props
+  const { navigateToFolder, title, isLast } = props
 
   return (
     <Fragment>
       <button
         type="button"
         className="uppy-u-reset uppy-c-btn"
-        onClick={getFolder}
+        onClick={navigateToFolder}
       >
         {title}
       </button>
@@ -27,7 +27,7 @@ const Breadcrumb = (props: BreadcrumbProps) => {
 }
 
 type BreadcrumbsProps<M extends Meta, B extends Body> = {
-  getFolder: ProviderView<M, B>['getFolder']
+  navigateToFolder: ProviderView<M, B>['navigateToFolder']
   title: string
   breadcrumbsIcon: h.JSX.Element
   breadcrumbs: UnknownProviderPluginState['breadcrumbs']
@@ -36,7 +36,7 @@ type BreadcrumbsProps<M extends Meta, B extends Body> = {
 export default function Breadcrumbs<M extends Meta, B extends Body>(
   props: BreadcrumbsProps<M, B>,
 ) {
-  const { getFolder, title, breadcrumbsIcon, breadcrumbs } = props
+  const { navigateToFolder, title, breadcrumbsIcon, breadcrumbs } = props
 
   return (
     <div className="uppy-Provider-breadcrumbs">
@@ -44,7 +44,9 @@ export default function Breadcrumbs<M extends Meta, B extends Body>(
       {breadcrumbs.map((directory, i) => (
         <Breadcrumb
           key={directory.id}
-          getFolder={() => getFolder(directory.requestPath, directory.name)}
+          navigateToFolder={() =>
+            navigateToFolder(directory.requestPath, directory.name)
+          }
           title={i === 0 ? title : (directory.name as string)}
           isLast={i + 1 === breadcrumbs.length}
         />

--- a/packages/@uppy/provider-views/src/ProviderView/Header.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/Header.tsx
@@ -9,7 +9,7 @@ import type ProviderView from './ProviderView.js'
 
 type HeaderProps<M extends Meta, B extends Body> = {
   showBreadcrumbs: boolean
-  getFolder: ProviderView<M, B>['getFolder']
+  navigateToFolder: ProviderView<M, B>['navigateToFolder']
   breadcrumbs: UnknownProviderPluginState['breadcrumbs']
   pluginIcon: () => h.JSX.Element
   title: string
@@ -25,7 +25,7 @@ export default function Header<M extends Meta, B extends Body>(
     <Fragment>
       {props.showBreadcrumbs && (
         <Breadcrumbs
-          getFolder={props.getFolder}
+          navigateToFolder={props.navigateToFolder}
           breadcrumbs={props.breadcrumbs}
           breadcrumbsIcon={props.pluginIcon && props.pluginIcon()}
           title={props.title}

--- a/packages/@uppy/provider-views/src/ProviderView/ProviderView.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/ProviderView.tsx
@@ -99,7 +99,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
     // Logic
     this.filterQuery = this.filterQuery.bind(this)
     this.clearFilter = this.clearFilter.bind(this)
-    this.getFolder = this.getFolder.bind(this)
+    this.navigateToFolder = this.navigateToFolder.bind(this)
     this.getNextFolder = this.getNextFolder.bind(this)
     this.logout = this.logout.bind(this)
     this.handleAuth = this.handleAuth.bind(this)
@@ -213,12 +213,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
     return { files, folders }
   }
 
-  /**
-   * Select a folder based on its id: fetches the folder and then updates state with its contents
-   * TODO rename to something better like selectFolder or navigateToFolder (breaking change?)
-   *
-   */
-  async getFolder(requestPath?: string, name?: string): Promise<void> {
+  async navigateToFolder(requestPath?: string, name?: string): Promise<void> {
     this.setLoading(true)
     try {
       await this.#withAbort(async (signal) => {
@@ -287,7 +282,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
    * Fetches new folder
    */
   getNextFolder(folder: CompanionFile): void {
-    this.getFolder(folder.requestPath, folder.name)
+    this.navigateToFolder(folder.requestPath, folder.name)
     this.lastCheckbox = undefined
   }
 
@@ -343,7 +338,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
         this.setLoading(true)
         await this.provider.login({ authFormData, signal })
         this.plugin.setPluginState({ authenticated: true })
-        await this.getFolder(this.plugin.rootFolderId || undefined)
+        await this.navigateToFolder(this.plugin.rootFolderId || undefined)
       })
     } catch (err) {
       if (err.name === 'UserFacingApiError') {
@@ -554,7 +549,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
     if (!didFirstRender) {
       this.plugin.setPluginState({ didFirstRender: true })
       this.provider.fetchPreAuthToken()
-      this.getFolder(this.plugin.rootFolderId || undefined)
+      this.navigateToFolder(this.plugin.rootFolderId || undefined)
     }
 
     const targetViewOptions = { ...this.opts, ...viewOptions }
@@ -566,7 +561,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
 
     const headerProps = {
       showBreadcrumbs: targetViewOptions.showBreadcrumbs,
-      getFolder: this.getFolder,
+      navigateToFolder: this.navigateToFolder,
       breadcrumbs: this.plugin.getPluginState().breadcrumbs,
       pluginIcon,
       title: this.plugin.title,
@@ -583,7 +578,7 @@ export default class ProviderView<M extends Meta, B extends Body> extends View<
       files: hasInput ? filterItems(files) : files,
       folders: hasInput ? filterItems(folders) : folders,
       getNextFolder: this.getNextFolder,
-      getFolder: this.getFolder,
+      navigateToFolder: this.navigateToFolder,
       loadAllFiles: this.opts.loadAllFiles,
 
       // For SearchFilterInput component


### PR DESCRIPTION
In conflict with https://github.com/transloadit/uppy/pull/5050