### PR TITLE
@uppy/transloadit: fix transloadit:result event

### DIFF
--- a/packages/@uppy/transloadit/src/Assembly.ts
+++ b/packages/@uppy/transloadit/src/Assembly.ts
@@ -104,14 +104,14 @@ class TransloaditAssembly extends Emitter {
 
     this.#sse.addEventListener('assembly_upload_finished', (e) => {
       const file = JSON.parse(e.data)
-      this.emit('upload', file)
       this.status.uploads.push(file)
+      this.emit('upload', file)
     })
 
     this.#sse.addEventListener('assembly_result_finished', (e) => {
       const [stepName, result] = JSON.parse(e.data)
-      this.emit('result', stepName, result)
       ;(this.status.results[stepName] ??= []).push(result)
+      this.emit('result', stepName, result)
     })
 
     this.#sse.addEventListener('assembly_execution_progress', (e) => {


### PR DESCRIPTION
We have to update the state before we emit otherwise `transloadit:result` doesn't emit the results.