### PR TITLE
@uppy/core: set default for Body generic

### DIFF
--- a/examples/angular-example/src/app/app.component.ts
+++ b/examples/angular-example/src/app/app.component.ts
@@ -65,8 +65,7 @@ export class AppComponent implements OnInit {
     },
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  uppy: Uppy<any, any> = new Uppy({ debug: true, autoProceed: true })
+  uppy = new Uppy({ debug: true, autoProceed: true })
 
   ngOnInit(): void {
     this.uppy

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -308,7 +308,7 @@ const defaultUploadState = {
  * Manages plugins, state updates, acts as an event bus,
  * adds/removes files and metadata.
  */
-export class Uppy<M extends Meta, B extends Body> {
+export class Uppy<M extends Meta, B extends Body = Record<string, never>> {
   static VERSION = packageJson.version
 
   #plugins: Record<string, UnknownPlugin<M, B>[]> = Object.create(null)

--- a/packages/@uppy/core/src/types.test.ts
+++ b/packages/@uppy/core/src/types.test.ts
@@ -17,12 +17,12 @@ class TestPlugin<M extends Meta, B extends Body> extends UIPlugin<Opts, M, B> {
 
 test('can use Uppy class without generics', async () => {
   const core = new Uppy()
-  expectTypeOf(core).toEqualTypeOf<Uppy<Meta, Body>>()
+  expectTypeOf(core).toEqualTypeOf<Uppy<Meta, Record<string, never>>>()
 })
 
 test('can .use() a plugin', async () => {
   const core = new Uppy().use(TestPlugin)
-  expectTypeOf(core).toEqualTypeOf<Uppy<Meta, Body>>()
+  expectTypeOf(core).toEqualTypeOf<Uppy<Meta, Record<string, never>>>()
 })
 
 test('Meta and Body generic move through the Uppy class', async () => {


### PR DESCRIPTION
`@uppy/tus` and `@uppy/transloadit` return `{}` for the `Body` so it's better to set the default to `Record<string, never>`. `@uppy/xhr-upload` users should define their own `Body` type.