### PR TITLE
@uppy/transloadit: also fix outdated assembly transloadit:result

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -682,12 +682,8 @@ export default class Transloadit<
     this.setPluginState({
       results: [...state.results, entry],
     })
-    this.uppy.emit(
-      'transloadit:result',
-      stepName,
-      result,
-      this.getAssembly(assemblyId),
-    )
+    const assembly = this.activeAssemblies[assemblyId].status
+    this.uppy.emit('transloadit:result', stepName, result, assembly)
   }
 
   /**


### PR DESCRIPTION
Ref: #5231 

Current state of Transloadit plugin is a bit hacky, keeping track of the same things in multiple places but some more outdated than others. This has all been fixed and simplified in #5158, but let's backport one more fix into 3.x.