### PR TITLE
@uppy/core: add generic to `getPlugin`

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -1724,7 +1724,9 @@ export class Uppy<M extends Meta, B extends Body = Record<string, never>> {
   /**
    * Find one Plugin by name.
    */
-  getPlugin<T extends UnknownPlugin<M, B>>(id: string): T | undefined {
+  getPlugin<T extends UnknownPlugin<M, B> = UnknownPlugin<M, B>>(
+    id: string,
+  ): T | undefined {
     for (const plugins of Object.values(this.#plugins)) {
       const foundPlugin = plugins.find((plugin) => plugin.id === id)
       if (foundPlugin != null) return foundPlugin as T

--- a/packages/@uppy/core/src/types.test.ts
+++ b/packages/@uppy/core/src/types.test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf, test } from 'vitest'
 
 import type { Body, InternalMetadata, Meta } from '@uppy/utils/lib/UppyFile'
-import Uppy from './Uppy'
+import Uppy, { type UnknownPlugin } from './Uppy'
 import UIPlugin, { type UIPluginOptions } from './UIPlugin'
 
 interface Opts extends UIPluginOptions {
@@ -28,7 +28,13 @@ test('can .use() a plugin', async () => {
 test('can .getPlugin() with a generic', async () => {
   const core = new Uppy().use(TestPlugin)
   const plugin = core.getPlugin<TestPlugin<any, any>>('TestPlugin')
+  const plugin2 = core.getPlugin('TestPlugin')
   expectTypeOf(plugin).toEqualTypeOf<TestPlugin<any, any> | undefined>()
+  expectTypeOf(plugin2).toEqualTypeOf<
+    // The default type
+    | UnknownPlugin<Meta, Record<string, never>, Record<string, unknown>>
+    | undefined
+  >()
 })
 
 test('Meta and Body generic move through the Uppy class', async () => {


### PR DESCRIPTION
It's a common use case to `getPlugin` and access something on it. Currently it's a bit awkward:

```ts
const state = (uppy.getPlugin('Transloadit') as Transloadit<any,any>).getPluginState()
```

This PR reintroduces the generic on `getPlugin`, so it's an improvement but also backwards compatibility with 3.x:

```ts
const state = uppy.getPlugin<Transloadit<any,any>>('Transloadit').getPluginState()
```

Unfortunately you must pass the generics, which should be optional but I don't know how to achieve that.