### PR TITLE
implement facebook app secret proof

### DIFF
--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -29,6 +29,7 @@ These cover all the major Uppy versions and how to migrate to them.
   - `getProtectedHttpAgent` parameter `blockLocalIPs` changed to `allowLocalIPs`
     (inverted boolean).
   - `downloadURL` 2nd (boolean) argument inverted.
+  - `StreamHttpJsonError` renamed to `HttpError`.
 
 ### `@uppy/companion-client`
 

--- a/packages/@uppy/companion/src/server/helpers/utils.js
+++ b/packages/@uppy/companion/src/server/helpers/utils.js
@@ -148,7 +148,7 @@ module.exports.decrypt = (encrypted, secret) => {
 
 module.exports.defaultGetKey = (req, filename) => `${crypto.randomUUID()}-${filename}`
 
-class StreamHttpJsonError extends Error {
+class HttpError extends Error {
   statusCode
 
   responseJson
@@ -157,11 +157,11 @@ class StreamHttpJsonError extends Error {
     super(`Request failed with status ${statusCode}`)
     this.statusCode = statusCode
     this.responseJson = responseJson
-    this.name = 'StreamHttpJsonError'
+    this.name = 'HttpError'
   }
 }
 
-module.exports.StreamHttpJsonError = StreamHttpJsonError
+module.exports.HttpError = HttpError
 
 module.exports.prepareStream = async (stream) => new Promise((resolve, reject) => {
   stream
@@ -173,7 +173,7 @@ module.exports.prepareStream = async (stream) => new Promise((resolve, reject) =
     })
     .on('error', (err) => {
       // In this case the error object is not a normal GOT HTTPError where json is already parsed,
-      // we create our own StreamHttpJsonError error for this case
+      // we create our own HttpError error for this case
       if (typeof err.response?.body === 'string' && typeof err.response?.statusCode === 'number') {
         let responseJson
         try {
@@ -183,7 +183,7 @@ module.exports.prepareStream = async (stream) => new Promise((resolve, reject) =
           return
         }
 
-        reject(new StreamHttpJsonError({ statusCode: err.response.statusCode, responseJson }))
+        reject(new HttpError({ statusCode: err.response.statusCode, responseJson }))
         return
       }
 

--- a/packages/@uppy/companion/src/server/provider/Provider.js
+++ b/packages/@uppy/companion/src/server/provider/Provider.js
@@ -6,13 +6,14 @@ const { MAX_AGE_24H } = require('../helpers/jwt')
 class Provider {
   /**
    *
-   * @param {{providerName: string, allowLocalUrls: boolean, providerGrantConfig?: object}} options
+   * @param {{providerName: string, allowLocalUrls: boolean, providerGrantConfig?: object, secret: string}} options
    */
-  constructor ({ allowLocalUrls, providerGrantConfig }) {
+  constructor ({ allowLocalUrls, providerGrantConfig, secret }) {
     // Some providers might need cookie auth for the thumbnails fetched via companion
     this.needsCookieAuth = false
     this.allowLocalUrls = allowLocalUrls
     this.providerGrantConfig = providerGrantConfig
+    this.secret = secret
     return this
   }
 

--- a/packages/@uppy/companion/src/server/provider/facebook/index.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/index.js
@@ -6,7 +6,7 @@ const logger = require('../../logger')
 const { adaptData, sortImages } = require('./adapter')
 const { withProviderErrorHandling } = require('../providerErrors')
 const { prepareStream } = require('../../helpers/utils')
-const { StreamHttpJsonError } = require('../../helpers/utils')
+const { HttpError } = require('../../helpers/utils')
 
 const got = require('../../got')
 
@@ -41,7 +41,7 @@ class Facebook extends Provider {
 
     responses.forEach((response) => {
       if (response.code !== 200) {
-        throw new StreamHttpJsonError({ statusCode: response.code, responseJson: response.body })
+        throw new HttpError({ statusCode: response.code, responseJson: response.body })
       }
     })
 

--- a/packages/@uppy/companion/src/server/provider/facebook/index.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/index.js
@@ -28,16 +28,14 @@ class Facebook extends Provider {
       .update(token)
       .digest('hex');
   
-    const form = new FormData()
-    form.append('access_token', token)
-    form.append('appsecret_proof', appSecretProof)
-    // form.append('appsecret_time', String(time))
-    form.append('batch', JSON.stringify(requests))
+    const form = {
+      access_token: token,
+      appsecret_proof: appSecretProof,
+      // appsecret_time: String(time),
+      batch: JSON.stringify(requests),
+    }
   
-    const responsesRaw = await (await got).post('https://graph.facebook.com', {
-      // @ts-expect-error todo types
-      body: form,
-    }).json()
+    const responsesRaw = await (await got).post('https://graph.facebook.com', { form }).json()
 
     const responses = responsesRaw.map((response) => ({ ...response, body: JSON.parse(response.body) }))
 

--- a/packages/@uppy/companion/src/server/provider/facebook/index.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/index.js
@@ -1,24 +1,15 @@
+const crypto = require('node:crypto');
+
 const Provider = require('../Provider')
 const { getURLMeta } = require('../../helpers/request')
 const logger = require('../../logger')
 const { adaptData, sortImages } = require('./adapter')
 const { withProviderErrorHandling } = require('../providerErrors')
 const { prepareStream } = require('../../helpers/utils')
+const { StreamHttpJsonError } = require('../../helpers/utils')
 
 const got = require('../../got')
 
-const getClient = async ({ token }) => (await got).extend({
-  prefixUrl: 'https://graph.facebook.com',
-  headers: {
-    authorization: `Bearer ${token}`,
-  },
-})
-
-async function getMediaUrl ({ token, id }) {
-  const body = await (await getClient({ token })).get(String(id), { searchParams: { fields: 'images' }, responseType: 'json' }).json()
-  const sortedImages = sortImages(body.images)
-  return sortedImages[sortedImages.length - 1].source
-}
 
 /**
  * Adapter for API https://developers.facebook.com/docs/graph-api/using-graph-api/
@@ -27,6 +18,49 @@ class Facebook extends Provider {
   static get oauthProvider () {
     return 'facebook'
   }
+
+  async runRequestBatch({ token, requests }) {
+    // https://developers.facebook.com/docs/facebook-login/security/#appsecret
+    // couldn't get `appsecret_time` working, but it seems to be working without it
+    // const time = Math.floor(Date.now() / 1000)
+    const appSecretProof = crypto.createHmac('sha256', this.secret)
+      // .update(`${token}|${time}`)
+      .update(token)
+      .digest('hex');
+  
+    const form = new FormData()
+    form.append('access_token', token)
+    form.append('appsecret_proof', appSecretProof)
+    // form.append('appsecret_time', String(time))
+    form.append('batch', JSON.stringify(requests))
+  
+    const responsesRaw = await (await got).post('https://graph.facebook.com', {
+      // @ts-expect-error todo types
+      body: form,
+    }).json()
+
+    const responses = responsesRaw.map((response) => ({ ...response, body: JSON.parse(response.body) }))
+
+    responses.forEach((response) => {
+      if (response.code !== 200) {
+        throw new StreamHttpJsonError({ statusCode: response.code, responseJson: response.body })
+      }
+    })
+
+    return responses
+  }
+  
+  async getMediaUrl ({ token, id }) {
+    const [{ body }] = await this.runRequestBatch({
+      token,
+      requests: [
+        { method: 'GET', relative_url: `${id}?${new URLSearchParams({ fields: 'images' }).toString()}` },
+      ],
+    });
+  
+    const sortedImages = sortImages(body.images)
+    return sortedImages[sortedImages.length - 1].source
+  }  
 
   async list ({ directory, token, query = { cursor: null } }) {
     return this.#withErrorHandling('provider.facebook.list.error', async () => {
@@ -40,19 +74,23 @@ class Facebook extends Provider {
         qs.fields = 'icon,images,name,width,height,created_time'
       }
 
-      const client = await getClient({ token })
+      const [response1, response2] = await this.runRequestBatch({
+        token,
+        requests: [
+          { method: 'GET', relative_url: `me?${new URLSearchParams({ fields: 'email' }).toString()}` },
+          { method: 'GET', relative_url: `${path}?${new URLSearchParams(qs)}` },
+        ],
+      });
 
-      const [{ email }, list] = await Promise.all([
-        client.get('me', { searchParams: { fields: 'email' }, responseType: 'json' }).json(),
-        client.get(path, { searchParams: qs, responseType: 'json' }).json(),
-      ])
+      const { email } = response1.body
+      const list = response2.body
       return adaptData(list, email, directory, query)
     })
   }
 
   async download ({ id, token }) {
     return this.#withErrorHandling('provider.facebook.download.error', async () => {
-      const url = await getMediaUrl({ token, id })
+      const url = await this.getMediaUrl({ token, id })
       const stream = (await got).stream.get(url, { responseType: 'json' })
       await prepareStream(stream)
       return { stream }
@@ -68,7 +106,7 @@ class Facebook extends Provider {
 
   async size ({ id, token }) {
     return this.#withErrorHandling('provider.facebook.size.error', async () => {
-      const url = await getMediaUrl({ token, id })
+      const url = await this.getMediaUrl({ token, id })
       const { size } = await getURLMeta(url)
       return size
     })
@@ -76,7 +114,13 @@ class Facebook extends Provider {
 
   async logout ({ token }) {
     return this.#withErrorHandling('provider.facebook.logout.error', async () => {
-      await (await getClient({ token })).delete('me/permissions', { responseType: 'json' }).json()
+      await this.runRequestBatch({
+        token,
+        requests: [
+          { method: 'DELETE', relative_url: 'me/permissions' },
+        ],
+      });
+  
       return { revoked: true }
     })
   }

--- a/packages/@uppy/companion/src/server/provider/facebook/index.js
+++ b/packages/@uppy/companion/src/server/provider/facebook/index.js
@@ -11,6 +11,48 @@ const { HttpError } = require('../../helpers/utils')
 const got = require('../../got')
 
 
+async function runRequestBatch({ secret, token, requests }) {
+  // https://developers.facebook.com/docs/facebook-login/security/#appsecret
+  // couldn't get `appsecret_time` working, but it seems to be working without it
+  // const time = Math.floor(Date.now() / 1000)
+  const appSecretProof = crypto.createHmac('sha256', secret)
+    // .update(`${token}|${time}`)
+    .update(token)
+    .digest('hex');
+
+  const form = {
+    access_token: token,
+    appsecret_proof: appSecretProof,
+    // appsecret_time: String(time),
+    batch: JSON.stringify(requests),
+  }
+
+  const responsesRaw = await (await got).post('https://graph.facebook.com', { form }).json()
+
+  const responses = responsesRaw.map((response) => ({ ...response, body: JSON.parse(response.body) }))
+
+  const errorResponse = responses.find((response) => response.code !== 200)
+  if (errorResponse) {
+    throw new HttpError({ statusCode: errorResponse.code, responseJson: errorResponse.body })
+  }
+
+  return responses
+}
+
+async function getMediaUrl ({ secret, token, id }) {
+  const [{ body }] = await runRequestBatch({
+    secret,
+    token,
+    requests: [
+      { method: 'GET', relative_url: `${id}?${new URLSearchParams({ fields: 'images' }).toString()}` },
+    ],
+  });
+
+  const sortedImages = sortImages(body.images)
+  return sortedImages[sortedImages.length - 1].source
+}  
+
+
 /**
  * Adapter for API https://developers.facebook.com/docs/graph-api/using-graph-api/
  */
@@ -18,47 +60,6 @@ class Facebook extends Provider {
   static get oauthProvider () {
     return 'facebook'
   }
-
-  async runRequestBatch({ token, requests }) {
-    // https://developers.facebook.com/docs/facebook-login/security/#appsecret
-    // couldn't get `appsecret_time` working, but it seems to be working without it
-    // const time = Math.floor(Date.now() / 1000)
-    const appSecretProof = crypto.createHmac('sha256', this.secret)
-      // .update(`${token}|${time}`)
-      .update(token)
-      .digest('hex');
-  
-    const form = {
-      access_token: token,
-      appsecret_proof: appSecretProof,
-      // appsecret_time: String(time),
-      batch: JSON.stringify(requests),
-    }
-  
-    const responsesRaw = await (await got).post('https://graph.facebook.com', { form }).json()
-
-    const responses = responsesRaw.map((response) => ({ ...response, body: JSON.parse(response.body) }))
-
-    responses.forEach((response) => {
-      if (response.code !== 200) {
-        throw new HttpError({ statusCode: response.code, responseJson: response.body })
-      }
-    })
-
-    return responses
-  }
-  
-  async getMediaUrl ({ token, id }) {
-    const [{ body }] = await this.runRequestBatch({
-      token,
-      requests: [
-        { method: 'GET', relative_url: `${id}?${new URLSearchParams({ fields: 'images' }).toString()}` },
-      ],
-    });
-  
-    const sortedImages = sortImages(body.images)
-    return sortedImages[sortedImages.length - 1].source
-  }  
 
   async list ({ directory, token, query = { cursor: null } }) {
     return this.#withErrorHandling('provider.facebook.list.error', async () => {
@@ -72,7 +73,8 @@ class Facebook extends Provider {
         qs.fields = 'icon,images,name,width,height,created_time'
       }
 
-      const [response1, response2] = await this.runRequestBatch({
+      const [response1, response2] = await runRequestBatch({
+        secret: this.secret,
         token,
         requests: [
           { method: 'GET', relative_url: `me?${new URLSearchParams({ fields: 'email' }).toString()}` },
@@ -88,7 +90,7 @@ class Facebook extends Provider {
 
   async download ({ id, token }) {
     return this.#withErrorHandling('provider.facebook.download.error', async () => {
-      const url = await this.getMediaUrl({ token, id })
+      const url = await getMediaUrl({ secret: this.secret, token, id })
       const stream = (await got).stream.get(url, { responseType: 'json' })
       await prepareStream(stream)
       return { stream }
@@ -104,7 +106,7 @@ class Facebook extends Provider {
 
   async size ({ id, token }) {
     return this.#withErrorHandling('provider.facebook.size.error', async () => {
-      const url = await this.getMediaUrl({ token, id })
+      const url = await getMediaUrl({ secret: this.secret, token, id })
       const { size } = await getURLMeta(url)
       return size
     })
@@ -112,7 +114,8 @@ class Facebook extends Provider {
 
   async logout ({ token }) {
     return this.#withErrorHandling('provider.facebook.logout.error', async () => {
-      await this.runRequestBatch({
+      await runRequestBatch({
+        secret: this.secret,
         token,
         requests: [
           { method: 'DELETE', relative_url: 'me/permissions' },

--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -41,7 +41,7 @@ module.exports.getProviderMiddleware = (providers, grantConfig) => {
   const middleware = (req, res, next, providerName) => {
     const ProviderClass = providers[providerName]
     if (ProviderClass && validOptions(req.companion.options)) {
-      const { allowLocalUrls } = req.companion.options
+      const { allowLocalUrls, providerOptions } = req.companion.options
       const { oauthProvider } = ProviderClass
 
       let providerGrantConfig
@@ -51,7 +51,8 @@ module.exports.getProviderMiddleware = (providers, grantConfig) => {
         req.companion.providerGrantConfig = providerGrantConfig
       }
 
-      req.companion.provider = new ProviderClass({ providerName, providerGrantConfig, allowLocalUrls })
+      const { secret } = providerOptions[providerName]
+      req.companion.provider = new ProviderClass({ secret, providerName, providerGrantConfig, allowLocalUrls })
       req.companion.providerClass = ProviderClass
     } else {
       logger.warn('invalid provider options detected. Provider will not be loaded', 'provider.middleware.invalid', req.id)

--- a/packages/@uppy/companion/src/server/provider/providerErrors.js
+++ b/packages/@uppy/companion/src/server/provider/providerErrors.js
@@ -43,7 +43,7 @@ async function withProviderErrorHandling({
     if (err?.name === 'HTTPError') {
       statusCode = err.response?.statusCode
       body = err.response?.body
-    } else if (err?.name === 'StreamHttpJsonError') {
+    } else if (err?.name === 'HttpError') {
       statusCode = err.statusCode
       body = err.responseJson
     }

--- a/packages/@uppy/companion/test/__tests__/providers.js
+++ b/packages/@uppy/companion/test/__tests__/providers.js
@@ -19,8 +19,9 @@ const defaults = require('../fixtures/constants')
 const tokenService = require('../../src/server/helpers/jwt')
 const { getServer } = require('../mockserver')
 
+const secret = process.env.COMPANION_SECRET
 // todo don't share server between tests. rewrite to not use env variables
-const authServer = getServer({ COMPANION_CLIENT_SOCKET_CONNECT_TIMEOUT: '0' })
+const authServer = getServer({ COMPANION_CLIENT_SOCKET_CONNECT_TIMEOUT: '0', COMPANION_SECRET: secret })
 const OAUTH_STATE = 'some-cool-nice-encrytpion'
 const providers = require('../../src/server/provider').getDefaultProviders()
 
@@ -34,7 +35,7 @@ const authData = {}
 providerNames.forEach((provider) => {
   authData[provider] = { accessToken: 'token value' }
 })
-const token = tokenService.generateEncryptedAuthToken(authData, process.env.COMPANION_SECRET)
+const token = tokenService.generateEncryptedAuthToken(authData, secret)
 
 const thisOrThat = (value1, value2) => {
   if (value1 !== undefined) {

--- a/packages/@uppy/companion/test/mockserver.js
+++ b/packages/@uppy/companion/test/mockserver.js
@@ -31,6 +31,9 @@ const defaultEnv = {
   COMPANION_INSTAGRAM_KEY: 'instagram_key',
   COMPANION_INSTAGRAM_SECRET: 'instagram_secret',
 
+  COMPANION_FACEBOOK_KEY: 'facebook_key',
+  COMPANION_FACEBOOK_SECRET: 'facebook_secret',
+
   COMPANION_ZOOM_KEY: localZoomKey,
   COMPANION_ZOOM_SECRET: localZoomSecret,
   COMPANION_ZOOM_VERIFICATION_TOKEN: localZoomVerificationToken,


### PR DESCRIPTION
closes #5245

note that I couldn't get `appsecret_time` working, but it seems to be working without


___

[From Evgenia] In this PR:
- switching from singular requests to [Facebook's batch requests](https://developers.facebook.com/docs/graph-api/batch-requests/#errors)
- implementation of `appsecret_proof` support for Facebook
- decorative: renaming from `StreamHttpJsonError` to `HttpError`