### PR TITLE
CONTRIBUTING.md - remove the Zoom section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -201,18 +201,6 @@ To generate the boilerplate for a new test run:
 
     yarn e2e:generate
 
-## Zoom
-
-See above Instagram instructions for setting up a tunnel, but replace
-`instagram` with `zoom` in the URL. Note that **you also have to add the OAuth
-redirect URL to `OAuth allow list`** in the Zoom Oauth app settings or it will
-not work.
-
-Add the following scopes: `recording:read`, `user:read`, `user_info:read`
-
-To test recording a meeting, you need to sign up for a Zoom Pro trial (can be
-cancelled later), for example using their iOS app.
-
 ## Releases
 
 Releases are managed by GitHub Actions, here’s an overview of the process to


### PR DESCRIPTION
# Explanation

1. Removes
    > See above Instagram instructions for setting up a tunnel, but replace instagram with zoom in the URL. Note that you also have to add the OAuth redirect URL to OAuth allow list in the Zoom Oauth app settings or it will not work.
  
    We don't need https for the Zoom integration.
    In fact, Zoom is the only provider that actively disallows `https`, at least `https` introduced using `http://redirectmeto.com` (ngrok alternative).

2. Removes 
    > Add the following scopes: recording:read, user:read, user_info:read

    The scopes are named differently now, and I'm describing the necessary scopes here https://uppy.io/docs/zoom.

3. Removes
    > To test recording a meeting, you need to sign up for a Zoom Pro trial (can be cancelled later), for example using their iOS app.
    
    I think that's not possible anymore. I do not own iOS devices, but I couldn't find any such option on the web & in their osx app. The fact that you need to be a licensed user is also described here https://uppy.io/docs/zoom now.