### PR TITLE
Add PATCH to valid XHR types

### DIFF
--- a/packages/@uppy/xhr-upload/types/index.d.ts
+++ b/packages/@uppy/xhr-upload/types/index.d.ts
@@ -15,7 +15,7 @@ export interface XHRUploadOptions extends PluginOptions {
   timeout?: number
   responseUrlFieldName?: string
   endpoint: string
-  method?: 'GET' | 'POST' | 'PUT' | 'HEAD' | 'get' | 'post' | 'put' | 'head'
+  method?: 'GET' | 'POST' | 'PUT' | 'HEAD' | 'PATCH' | 'get' | 'post' | 'put' | 'head' | 'patch'
   locale?: XHRUploadLocale
   responseType?: string
   withCredentials?: boolean


### PR DESCRIPTION
Thanks for fixing #5165 a couple of months back! I'm in the process of migrating my codebase to TS and this has hit me again because PATCH isn't in the list of valid methods.

PATCH is commonly used in Rails backends for issuing updates to existing records, so I think this would benefit more than just me. I know it works well because I've been using it for a long time in untyped JS.

Let me know if you need any more info!