### PR TITLE
@uppy/vue: fix passing of `props`

### DIFF
--- a/packages/@uppy/vue/src/dashboard-modal.ts
+++ b/packages/@uppy/vue/src/dashboard-modal.ts
@@ -27,13 +27,13 @@ export default defineComponent({
   setup(props) {
     const containerRef = ref<string>()
     const pluginRef = ref<DashboardPlugin<any, any>>()
-    const propsRef = ref(props)
+    const propsRef = ref(props.props)
     const onMount = () => {
       const { uppy } = props
       const options = {
         id: 'DashboardModal',
         inline: false,
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(DashboardPlugin, options)

--- a/packages/@uppy/vue/src/dashboard.ts
+++ b/packages/@uppy/vue/src/dashboard.ts
@@ -29,7 +29,7 @@ export default defineComponent({
       const options = {
         id: 'Dashboard',
         inline: true,
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(DashboardPlugin, options)

--- a/packages/@uppy/vue/src/drag-drop.ts
+++ b/packages/@uppy/vue/src/drag-drop.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       const { uppy } = props
       const options = {
         id: 'DragDrop',
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(DragDropPlugin, options)

--- a/packages/@uppy/vue/src/file-input.ts
+++ b/packages/@uppy/vue/src/file-input.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       const { uppy } = props
       const options = {
         id: 'FileInput',
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(FileInputPlugin, options)

--- a/packages/@uppy/vue/src/progress-bar.ts
+++ b/packages/@uppy/vue/src/progress-bar.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       const { uppy } = props
       const options = {
         id: 'ProgressBar',
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(ProgressBarPlugin, options)

--- a/packages/@uppy/vue/src/status-bar.ts
+++ b/packages/@uppy/vue/src/status-bar.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       const { uppy } = props
       const options = {
         id: 'StatusBar',
-        ...props,
+        ...props.props,
         target: containerRef.value,
       }
       uppy.use(StatusBarPlugin, options)


### PR DESCRIPTION
We were not passing the right props (the Vue ones instead of the Uppy ones).