### PR TITLE
@uppy/core: add clearUploadedFiles to type definition

### DIFF
--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -1971,6 +1971,57 @@ describe('src/Core', () => {
     })
   })
 
+  describe('clearUploadedFiles', () => {
+    it('should reset state to default', () => {
+      const core = new Core()
+      core.addFile({
+        source: 'vi',
+        name: 'foo.jpg',
+        type: 'image/jpeg',
+        data: testImage,
+      })
+      core.addFile({
+        source: 'vi',
+        name: 'foo2.jpg',
+        type: 'image/jpeg',
+        data: testImage,
+      })
+      core.clearUploadedFiles()
+      expect(core.getState()).toMatchObject({
+        totalProgress: 0,
+        allowNewUpload: true,
+        error: null,
+        recoveredState: null,
+        files: {},
+      })
+    })
+
+    it('should throw error if plugin does not allow removing files during an upload', () => {
+      const core = new Core()
+      const newState = {
+        capabilities: {
+          individualCancellation: false,
+          uploadProgress: true,
+          resumableUploads: false,
+        },
+        currentUploads: {
+          upload1: {
+            fileIDs: [
+              'uppy-file1/jpg-1e-image/jpeg',
+              'uppy-file2/jpg-1e-image/jpeg',
+              'uppy-file3/jpg-1e-image/jpeg',
+            ],
+          },
+        },
+      }
+      // @ts-ignore
+      core.setState(newState)
+      expect(() => {
+        core.clearUploadedFiles()
+      }).toThrowError()
+    })
+  })
+
   describe('checkRestrictions', () => {
     it('should enforce the maxNumberOfFiles rule', () => {
       const core = new Core({

--- a/packages/@uppy/core/types/index.d.ts
+++ b/packages/@uppy/core/types/index.d.ts
@@ -335,6 +335,8 @@ export class Uppy<
 
   resetProgress(): void
 
+  clearUploadedFiles(): void
+
   addPreProcessor(fn: UploadHandler): void
 
   removePreProcessor(fn: UploadHandler): void


### PR DESCRIPTION
Hello Team,

Even though the clearUploadedFiles in the `uppy/core` method is documented on the doc site, it is not accessible outside.
Upon investigation, I realized it is not present in `index.d.ts`.

This PR adds the method to the `index.d.ts` file along with some unit tests for said method.