### PR TITLE
@uppy/form: bring back submit() instead of requestSubmit()

### DIFF
--- a/packages/@uppy/form/src/index.ts
+++ b/packages/@uppy/form/src/index.ts
@@ -76,10 +76,12 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
     }
 
     if (this.opts.submitOnSuccess) {
-      // When false is returned, cancelable invalid events are fired
-      // for each invalid child and validation problems are reported to the user.
-      this.form.reportValidity()
-      this.form.submit()
+      // Returns true if the element's child controls satisfy their validation constraints.
+      // When false is returned, cancelable invalid events are fired for each invalid child
+      // and validation problems are reported to the user.
+      if (this.form.reportValidity()) {
+        this.form.submit()
+      }
     }
   }
 

--- a/packages/@uppy/form/src/index.ts
+++ b/packages/@uppy/form/src/index.ts
@@ -76,6 +76,9 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
     }
 
     if (this.opts.submitOnSuccess) {
+      // When false is returned, cancelable invalid events are fired
+      // for each invalid child and validation problems are reported to the user.
+      this.form.reportValidity()
       this.form.submit()
     }
   }

--- a/packages/@uppy/form/src/index.ts
+++ b/packages/@uppy/form/src/index.ts
@@ -52,12 +52,6 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
 
   form: HTMLFormElement // TODO: make this private (or at least, mark it as readonly)
 
-  /**
-   * Unfortunately Uppy isn't a state machine in which we can guarantee it's
-   * currently in one state and one state only so we use this completed property which is set on `upload-success'.
-   */
-  #completed = false
-
   constructor(uppy: Uppy<M, B>, opts?: FormOptions) {
     super(uppy, { ...defaultOptions, ...opts })
     this.type = 'acquirer'
@@ -71,25 +65,23 @@ export default class Form<M extends Meta, B extends Body> extends BasePlugin<
   }
 
   handleUploadStart(): void {
-    this.#completed = false
     if (this.opts.getMetaFromForm) {
       this.getMetaFromForm()
     }
   }
 
   handleSuccess(result: Result<M, B>): void {
-    this.#completed = true
     if (this.opts.addResultToForm) {
       this.addResultToForm(result)
     }
 
     if (this.opts.submitOnSuccess) {
-      this.form.requestSubmit()
+      this.form.submit()
     }
   }
 
   handleFormSubmit(ev: Event): void {
-    if (this.opts.triggerUploadOnSubmit && !this.#completed) {
+    if (this.opts.triggerUploadOnSubmit) {
       ev.preventDefault()
       const elements = toArray((ev.target as HTMLFormElement).elements)
       const disabledByUppy: HTMLButtonElement[] = []


### PR DESCRIPTION
Closes #5278

Sometime ago I switched our `form.submit()` to `form.requestSubmit()` (https://github.com/transloadit/uppy/pull/4852) so that we first trigger form validation and only submit when there are no errors, while `submit()` always submits.

Unfortunately I didn't realize that unlike `submit()` `requestSubmit()` triggers the `'submit'` event again, which caused a loop. This was fixed in https://github.com/transloadit/uppy/pull/5058. 

Unfortunately I didn't realize again that `requestSubmit()` no longer works after `event.preventDefault()`, which we need for the `triggerUploadOnSubmit` in order to hold off the submit to upload with Uppy. If you also enable `submitOnSuccess`, then once we reach `requestSubmit()` it no longer works because of `preventDefault()`.

AFAIK for these specific set of conditions we support in Uppy, we can't reliably use `requestSubmit` so I'm putting `submit` back.