### PR TITLE
@uppy/companion: fix TypeError

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/connect.js
+++ b/packages/@uppy/companion/src/server/controllers/connect.js
@@ -25,7 +25,7 @@ module.exports = function connect(req, res) {
   } else if (oauthOrigin && oauthOrigin.length < 2) {
     // eslint-disable-next-line prefer-destructuring
     stateObj.origin = oauthOrigin[0]
-  } else {
+  } else if (req.query.state) {
     // If we have multiple allowed origins, we need to check the client-supplied origin from query.
     // If the client provides an untrusted origin,
     // we want to send `undefined`. `undefined` means `/`, which is the same origin when passed to `postMessage`.


### PR DESCRIPTION
The previous version was creating the opportunity for a TypeError when assumptions on the client request were not met.