### PR TITLE
@uppy/companion: do not list Node.js 20.12 as compatible

### DIFF
--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -4,7 +4,8 @@ These cover all the major Uppy versions and how to migrate to them.
 
 ## Migrate from Companion 4.x to 5.x
 
-- Node.js `>=18.20.0` is now required.
+- End-of-Life versions of Node.js are no longer supported (use latest 18.x LTS,
+  20.x LTS, or 22.x current).
 - Setting the `oauthOrigin` option is now required. To get back to the unsafe
   behavior of the previous version, set it to `'*'`.
 - `COMPANION_REDIS_EXPRESS_SESSION_PREFIX` now defaults to `companion-session:`

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -107,7 +107,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
   },
   "engines": {
-    "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
+    "node": "^18.20.0 || ^20.15.0 || >=22.0.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"


### PR DESCRIPTION
There's a bug with `styleText` util we're using.