### PR TITLE
@uppy/aws-s3: fix signing on client for bucket name with dots

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.ts
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.test.ts
@@ -8,7 +8,7 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import createSignedURL from './createSignedURL.ts'
 
-const bucketName = 'some-bucket'
+const bucketName = 'some-bucket.with.dots'
 const s3ClientOptions = {
   region: 'us-bar-1',
   credentials: {

--- a/packages/@uppy/aws-s3-multipart/src/createSignedURL.ts
+++ b/packages/@uppy/aws-s3-multipart/src/createSignedURL.ts
@@ -114,14 +114,14 @@ export default async function createSignedURL({
   partNumber?: string | number
 }): Promise<URL> {
   const Service = 's3'
-  const host = `${bucketName}.${Service}.${Region}.amazonaws.com`
+  const host = `${Service}.${Region}.amazonaws.com`
   /**
    * List of char out of `encodeURI()` is taken from ECMAScript spec.
    * Note that the `/` character is purposefully not included in list below.
    *
    * @see https://tc39.es/ecma262/#sec-encodeuri-uri
    */
-  const CanonicalUri = `/${encodeURI(Key).replace(/[;?:@&=+$,#!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)}`
+  const CanonicalUri = `/${bucketName}/${encodeURI(Key).replace(/[;?:@&=+$,#!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)}`
   const payload = 'UNSIGNED-PAYLOAD'
 
   const requestDateTime = new Date().toISOString().replace(/[-:]|\.\d+/g, '') // YYYYMMDDTHHMMSSZ


### PR DESCRIPTION
Using dots in bucket names is discouraged by AWS documentation, but it is still allowed. In order to support such buckets without getting a TLS error, we need to move the bucket name parameter from domain name to URL path.