### PR TITLE
@uppy/core: export UppyOptions, UppyFile, Meta, Body

### DIFF
--- a/packages/@uppy/core/src/index.ts
+++ b/packages/@uppy/core/src/index.ts
@@ -7,9 +7,12 @@ export {
   type UnknownSearchProviderPlugin,
   type UploadResult,
   type UppyEventMap,
+  type UppyOptions,
 } from './Uppy.ts'
 export { default as UIPlugin } from './UIPlugin.ts'
 export { default as BasePlugin } from './BasePlugin.ts'
 export { debugLogger } from './loggers.ts'
 
 export type { UIPluginOptions } from './UIPlugin.ts'
+
+export type { UppyFile, Meta, Body } from '@uppy/utils/lib/UppyFile'


### PR DESCRIPTION
Common types which should be exported for consumers. Transloadit testing area also needs all of these.