### PR TITLE
add css import for url plugin

### DIFF
--- a/docs/sources/companion-plugins/url.mdx
+++ b/docs/sources/companion-plugins/url.mdx
@@ -82,6 +82,7 @@ import Url from '@uppy/url';
 
 import '@uppy/core/dist/style.min.css';
 import '@uppy/dashboard/dist/style.min.css';
+import "@uppy/url/dist/style.min.css";
 
 new Uppy()
 	.use(Dashboard, { inline: true, target: '#dashboard' })


### PR DESCRIPTION
noticed the css import wasn't noted in the docs — and without it, the url plugin looks a bit weird.