### PR TITLE
@uppy/aws-s3: use default Body generic & export AwsBody

### DIFF
--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -175,7 +175,7 @@ Uppy always puts the response to an upload in `file.response.body`. If you want
 this to be type safe with `@uppy/aws-s3`, you can import the `AwsBody` type and
 pass it as the second genric to `Uppy`.
 
-```js {3,12} showLineNumbers
+```ts {3,12} showLineNumbers
 import Uppy from '@uppy/core';
 import Dashboard from '@uppy/dashboard';
 import AwsS3, { type AwsBody } from '@uppy/aws-s3';
@@ -185,7 +185,7 @@ import '@uppy/dashboard/dist/style.min.css';
 
 // Set this to `any` or `Record<string, unknown>`
 // if you do not set any metadata yourself
-type Meta = { license: string }
+type Meta = { license: string };
 
 const uppy = new Uppy<Meta, AwsBody>()
 	.use(Dashboard, { inline: true, target: 'body' })
@@ -196,7 +196,7 @@ const id = uppy.addFile(/* ... */);
 await uppy.upload();
 
 const body = uppy.getFile(id).response.body!;
-const { location } = body // This is now type safe
+const { location } = body; // This is now type safe
 ```
 
 ## API

--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -169,6 +169,36 @@ const uppy = new Uppy()
 	});
 ```
 
+### Use with TypeScript
+
+Uppy always puts the response to an upload in `file.response.body`. If you want
+this to be type safe with `@uppy/aws-s3`, you can import the `AwsBody` type and
+pass it as the second genric to `Uppy`.
+
+```js {3,12} showLineNumbers
+import Uppy from '@uppy/core';
+import Dashboard from '@uppy/dashboard';
+import AwsS3, { type AwsBody } from '@uppy/aws-s3';
+
+import '@uppy/core/dist/style.min.css';
+import '@uppy/dashboard/dist/style.min.css';
+
+// Set this to `any` or `Record<string, unknown>`
+// if you do not set any metadata yourself
+type Meta = { license: string }
+
+const uppy = new Uppy<Meta, AwsBody>()
+	.use(Dashboard, { inline: true, target: 'body' })
+	.use(AwsS3, { endpoint: '...' });
+
+const id = uppy.addFile(/* ... */);
+
+await uppy.upload();
+
+const body = uppy.getFile(id).response.body!;
+const { location } = body // This is now type safe
+```
+
 ## API
 
 ### Options

--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -1,4 +1,4 @@
-import type { Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
+import type { Meta, Body, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type {
   RateLimitedQueue,
   WrapPromiseFunctionType,
@@ -6,7 +6,7 @@ import type {
 import { pausingUploadReason, type Chunk } from './MultipartUploader.ts'
 import type AwsS3Multipart from './index.js'
 import { throwIfAborted } from './utils.ts'
-import type { Body, UploadPartBytesResult, UploadResult } from './utils.js'
+import type { UploadPartBytesResult, UploadResult } from './utils.js'
 import type { AwsS3MultipartOptions, uploadPartBytes } from './index.js'
 
 function removeMetadataFromURL(urlString: string) {

--- a/packages/@uppy/aws-s3/src/MultipartUploader.ts
+++ b/packages/@uppy/aws-s3/src/MultipartUploader.ts
@@ -1,8 +1,7 @@
 import type { Uppy } from '@uppy/core'
 import { AbortController } from '@uppy/utils/lib/AbortController'
-import type { Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
+import type { Meta, Body, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type { HTTPCommunicationQueue } from './HTTPCommunicationQueue.js'
-import type { Body } from './utils.js'
 
 const MB = 1024 * 1024
 

--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -4,7 +4,7 @@ import BasePlugin, {
 } from '@uppy/core/lib/BasePlugin.js'
 import { RequestClient } from '@uppy/companion-client'
 import type { RequestOptions } from '@uppy/utils/lib/CompanionClientProvider'
-import type { Body as _Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
+import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type { Uppy } from '@uppy/core'
 import EventManager from '@uppy/core/lib/EventManager.js'
 import { RateLimitedQueue } from '@uppy/utils/lib/RateLimitedQueue'
@@ -21,7 +21,6 @@ import type {
   UploadResultWithSignal,
   MultipartUploadResultWithSignal,
   UploadPartBytesResult,
-  Body,
 } from './utils.js'
 import createSignedURL from './createSignedURL.ts'
 import { HTTPCommunicationQueue } from './HTTPCommunicationQueue.ts'
@@ -33,13 +32,13 @@ interface MultipartFile<M extends Meta, B extends Body> extends UppyFile<M, B> {
   s3Multipart: UploadResult
 }
 
-type PartUploadedCallback<M extends Meta, B extends _Body> = (
+type PartUploadedCallback<M extends Meta, B extends Body> = (
   file: UppyFile<M, B>,
   part: { PartNumber: number; ETag: string },
 ) => void
 
 declare module '@uppy/core' {
-  export interface UppyEventMap<M extends Meta, B extends _Body> {
+  export interface UppyEventMap<M extends Meta, B extends Body> {
     's3-multipart:part-uploaded': PartUploadedCallback<M, B>
   }
 }
@@ -288,6 +287,8 @@ const defaultOptions = {
     (file.size! >> 10) >> 10 > 100) as any as true,
   retryDelays: [0, 1000, 3000, 5000],
 } satisfies Partial<AwsS3MultipartOptions<any, any>>
+
+export type { AwsBody } from './utils.ts'
 
 export default class AwsS3Multipart<
   M extends Meta,
@@ -839,7 +840,7 @@ export default class AwsS3Multipart<
             ...result,
           },
           status: 200,
-          uploadURL: result.location,
+          uploadURL: result.location as string,
         }
 
         this.resetUploaderReferences(file.id)

--- a/packages/@uppy/aws-s3/src/utils.ts
+++ b/packages/@uppy/aws-s3/src/utils.ts
@@ -1,5 +1,5 @@
 import { createAbortError } from '@uppy/utils/lib/AbortController'
-import type { Body as _Body } from '@uppy/utils/lib/UppyFile'
+import type { Body } from '@uppy/utils/lib/UppyFile'
 
 import type { AwsS3Part } from './index.js'
 
@@ -23,6 +23,6 @@ export type UploadPartBytesResult = {
   location?: string
 }
 
-export interface AwsBody extends _Body {
+export interface AwsBody extends Body {
   location: string
 }

--- a/packages/@uppy/aws-s3/src/utils.ts
+++ b/packages/@uppy/aws-s3/src/utils.ts
@@ -23,6 +23,6 @@ export type UploadPartBytesResult = {
   location?: string
 }
 
-export interface Body extends _Body {
+export interface AwsBody extends _Body {
   location: string
 }


### PR DESCRIPTION
Fixes #5347 

As seen in the issue, `new Uppy().use(AwsS3, {})` is causing generic type issues. The problem is the incompatibility between the `Body` generic on `Uppy` and `AwsS3`. It's probably safer to work with the default Body generic in plugins and export a enhanced type for users to implement if they care.