### PR TITLE
@uppy/xhr-upload: bring back getResponseData

### DIFF
--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -245,6 +245,16 @@ export default {
 };
 ```
 
+#### `getResponseData`
+
+An optional function to turn your non-JSON response into JSON with a `url`
+property pointing to the uploaded file
+(`(xhr: XMLHttpRequest) => { url: string }`).
+
+You can also return properties other than `url` and they will end up in
+`file.response.body`. If you do, make sure to set the `Body` generic on `Uppy`
+to make it typesafe when using TS.
+
 ## Frequently Asked Questions
 
 ### How can I refresh auth tokens after they expire?

--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -222,9 +222,10 @@ export default class XHRUpload<
           let body = await this.opts.getResponseData?.(res)
           try {
             body ??= JSON.parse(res.responseText) as B
-          } catch {
+          } catch (cause) {
             throw new Error(
               '@uppy/xhr-upload expects a JSON response (with a `url` property). To parse non-JSON responses, use `getResponseData` to turn your response into JSON.',
+              { cause },
             )
           }
 


### PR DESCRIPTION
Closes #5349

`getResponseData` was deleted for 4.0 as I thought `onAfterResponse` covers the use case as well but you can't modify the response from inside it. I tried altering `onAfterResponse` to allow you to return a body and deprecate the `void` signature with backwards compatibility, but it didn't feel right and `onAfterResponse` is also called after every request, even it it fails. `getResponseData` is only called once after success(full retries).


