### PR TITLE
@uppy/aws-s3: only send `PartNumber` and `ETag` in completion request

### DIFF
--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -524,7 +524,7 @@ export default class AwsS3Multipart<
     return this.#client
       .post<B>(
         `s3/multipart/${uploadIdEnc}/complete?key=${filename}`,
-        { parts },
+        { parts: parts.map(({ ETag, PartNumber }) => ({ ETag, PartNumber })) },
         { signal },
       )
       .then(assertServerError)


### PR DESCRIPTION
Fixes: https://github.com/transloadit/uppy/issues/5352