### PR TITLE
@uppy/aws-s3: improve error when `endpoint` is not provided

### DIFF
--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -642,6 +642,7 @@ export default class AwsS3Multipart<
     file: UppyFile<M, B>,
     options: RequestOptions,
   ): Promise<AwsS3UploadParameters> {
+    this.#assertHost('getUploadParameters')
     const { meta } = file
     const { type, name: filename } = meta
     const allowedMetaFields = getAllowedMetaFields(


### PR DESCRIPTION
Fixes: https://github.com/transloadit/uppy/issues/5358