### PR TITLE
`toggleAddFilesPanel()` - make args consistent

### DIFF
--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.tsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.tsx
@@ -76,7 +76,7 @@ const renderFileSize = (props: { file: UppyFile<any, any> }) =>
 
 const ReSelectButton = (props: {
   file: UppyFile<any, any>
-  toggleAddFilesPanel: () => void
+  toggleAddFilesPanel: (show: boolean) => void
   i18n: I18n
 }) =>
   props.file.isGhost && (
@@ -85,7 +85,7 @@ const ReSelectButton = (props: {
       <button
         className="uppy-u-reset uppy-c-btn uppy-Dashboard-Item-reSelect"
         type="button"
-        onClick={props.toggleAddFilesPanel}
+        onClick={() => props.toggleAddFilesPanel(true)}
       >
         {props.i18n('reSelect')}
       </button>
@@ -121,7 +121,7 @@ type FileInfoProps = {
   containerWidth: number
   containerHeight: number
   i18n: I18n
-  toggleAddFilesPanel: () => void
+  toggleAddFilesPanel: (show: boolean) => void
   toggleFileCard: (show: boolean, fileId: string) => void
   metaFields: DashboardState<any, any>['metaFields']
   isSingleFile: boolean

--- a/packages/@uppy/dashboard/src/components/FileItem/index.tsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.tsx
@@ -28,7 +28,7 @@ type Props<M extends Meta, B extends Body> = {
   id: string
   containerWidth: number
   containerHeight: number
-  toggleAddFilesPanel: () => void
+  toggleAddFilesPanel: (show: boolean) => void
   isSingleFile: boolean
   hideRetryButton: boolean
   hideCancelButton: boolean

--- a/packages/@uppy/dashboard/src/components/FileList.tsx
+++ b/packages/@uppy/dashboard/src/components/FileList.tsx
@@ -30,7 +30,7 @@ type FileListProps<M extends Meta, B extends Body> = {
   itemsPerRow: number
   openFileEditor: (file: UppyFile<M, B>) => void
   canEditFile: (file: UppyFile<M, B>) => boolean
-  toggleAddFilesPanel: () => void
+  toggleAddFilesPanel: (show: boolean) => void
   containerWidth: number
   containerHeight: number
 }


### PR DESCRIPTION
Previously it worked because `props.toggleAddFilesPanel(event)` is also truthy 😞 
This was setting `state.showAddFilesPanel` to `event`.