### PR TITLE
@uppy/core: fix store option type

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -8,7 +8,7 @@ import Translator from '@uppy/utils/lib/Translator'
 import ee from 'namespace-emitter'
 import { nanoid } from 'nanoid/non-secure'
 import throttle from 'lodash/throttle.js'
-import DefaultStore from '@uppy/store-default'
+import DefaultStore, { type Listener } from '@uppy/store-default'
 import getFileType from '@uppy/utils/lib/getFileType'
 import getFileNameAndExtension from '@uppy/utils/lib/getFileNameAndExtension'
 import { getSafeFileId } from '@uppy/utils/lib/generateFileID'
@@ -236,6 +236,14 @@ export interface State<M extends Meta, B extends Body>
   companion?: Record<string, string>
 }
 
+export interface Store<M extends Meta, B extends Body> {
+  getState: () => State<M, B>
+
+  setState(patch?: Partial<State<M, B>>): void
+
+  subscribe(listener: Listener<State<M, B>>): () => void
+}
+
 export interface UppyOptions<M extends Meta, B extends Body> {
   id?: string
   autoProceed?: boolean
@@ -256,7 +264,7 @@ export interface UppyOptions<M extends Meta, B extends Body> {
     [key: string]: UppyFile<M, B>
   }) => { [key: string]: UppyFile<M, B> } | boolean
   locale?: Locale
-  store?: DefaultStore<State<M, B>>
+  store?: Store<M, B>
   infoTimeout?: number
 }
 

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -8,7 +8,7 @@ import Translator from '@uppy/utils/lib/Translator'
 import ee from 'namespace-emitter'
 import { nanoid } from 'nanoid/non-secure'
 import throttle from 'lodash/throttle.js'
-import DefaultStore, { type Listener } from '@uppy/store-default'
+import DefaultStore, { type Store } from '@uppy/store-default'
 import getFileType from '@uppy/utils/lib/getFileType'
 import getFileNameAndExtension from '@uppy/utils/lib/getFileNameAndExtension'
 import { getSafeFileId } from '@uppy/utils/lib/generateFileID'
@@ -236,14 +236,6 @@ export interface State<M extends Meta, B extends Body>
   companion?: Record<string, string>
 }
 
-export interface Store<M extends Meta, B extends Body> {
-  getState: () => State<M, B>
-
-  setState(patch?: Partial<State<M, B>>): void
-
-  subscribe(listener: Listener<State<M, B>>): () => void
-}
-
 export interface UppyOptions<M extends Meta, B extends Body> {
   id?: string
   autoProceed?: boolean
@@ -264,7 +256,7 @@ export interface UppyOptions<M extends Meta, B extends Body> {
     [key: string]: UppyFile<M, B>
   }) => { [key: string]: UppyFile<M, B> } | boolean
   locale?: Locale
-  store?: Store<M, B>
+  store?: Store<State<M, B>>
   infoTimeout?: number
 }
 

--- a/packages/@uppy/core/src/index.ts
+++ b/packages/@uppy/core/src/index.ts
@@ -1,7 +1,6 @@
 export { default } from './Uppy.ts'
 export {
   default as Uppy,
-  type Store,
   type State,
   type UnknownPlugin,
   type UnknownProviderPlugin,
@@ -13,6 +12,8 @@ export {
 export { default as UIPlugin } from './UIPlugin.ts'
 export { default as BasePlugin } from './BasePlugin.ts'
 export { debugLogger } from './loggers.ts'
+
+export type { Store } from '@uppy/store-default'
 
 export type { UIPluginOptions } from './UIPlugin.ts'
 

--- a/packages/@uppy/core/src/index.ts
+++ b/packages/@uppy/core/src/index.ts
@@ -1,6 +1,7 @@
 export { default } from './Uppy.ts'
 export {
   default as Uppy,
+  type Store,
   type State,
   type UnknownPlugin,
   type UnknownProviderPlugin,

--- a/packages/@uppy/store-default/src/index.ts
+++ b/packages/@uppy/store-default/src/index.ts
@@ -10,10 +10,18 @@ export type Listener<T> = (
   patch?: Partial<T>,
 ) => void
 
+export interface Store<T extends GenericState> {
+  getState: () => T
+
+  setState(patch?: Partial<T>): void
+
+  subscribe(listener: Listener<T>): () => void
+}
+
 /**
  * Default store that keeps state in a simple object.
  */
-class DefaultStore<T extends GenericState = GenericState> {
+class DefaultStore<T extends GenericState = GenericState> implements Store<T> {
   static VERSION = packageJson.version
 
   public state: T = {} as T


### PR DESCRIPTION
The current type is too tightly coupled to our implementation of `store-default` while it only matters that you have these methods present. Without this change, we get errors we can't resolve in the Transloadit testing area because we use a custom store there.

Tested that this change works for Transloadit.