### PR TITLE
@uppy/compressor: mark `quality` as optional

### DIFF
--- a/packages/@uppy/compressor/src/index.ts
+++ b/packages/@uppy/compressor/src/index.ts
@@ -7,7 +7,7 @@ import prettierBytes from '@transloadit/prettier-bytes'
 import CompressorJS from 'compressorjs'
 
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
-import type { PluginOpts } from '@uppy/core/lib/BasePlugin.js'
+import type { DefinePluginOpts, PluginOpts } from '@uppy/core/lib/BasePlugin.js'
 
 import locale from './locale.ts'
 
@@ -18,29 +18,30 @@ declare module '@uppy/core' {
 }
 
 export interface CompressorOpts extends PluginOpts, CompressorJS.Options {
-  quality: number
   limit?: number
 }
+
+const defaultOptions = {
+  quality: 0.6,
+  limit: 10,
+} satisfies Partial<CompressorOpts>
 
 export default class Compressor<
   M extends Meta,
   B extends Body,
-> extends BasePlugin<CompressorOpts, M, B> {
+> extends BasePlugin<
+  DefinePluginOpts<CompressorOpts, keyof typeof defaultOptions>,
+  M,
+  B
+> {
   #RateLimitedQueue
 
-  constructor(uppy: Uppy<M, B>, opts: CompressorOpts) {
-    super(uppy, opts)
+  constructor(uppy: Uppy<M, B>, opts?: CompressorOpts) {
+    super(uppy, { ...defaultOptions, ...opts })
     this.id = this.opts.id || 'Compressor'
     this.type = 'modifier'
 
     this.defaultLocale = locale
-
-    const defaultOptions = {
-      quality: 0.6,
-      limit: 10,
-    }
-
-    this.opts = { ...defaultOptions, ...opts }
 
     this.#RateLimitedQueue = new RateLimitedQueue(this.opts.limit)
 


### PR DESCRIPTION
There's a default `quality` of `0.6`, it doesn't make sense to mark it as mandatory.