### PR TITLE
@uppy/transloadit: do not mark `opts` as mandatory

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -283,7 +283,7 @@ export default class Transloadit<
 
   restored: Promise<void> | null = null
 
-  constructor(uppy: Uppy<M, B>, opts: TransloaditOptions<M, B>) {
+  constructor(uppy: Uppy<M, B>, opts?: TransloaditOptions<M, B>) {
     super(uppy, { ...defaultOptions, ...opts })
     this.type = 'uploader'
     this.id = this.opts.id || 'Transloadit'


### PR DESCRIPTION
There are no mandatory options, it's kinda silly to force TS users to provide an empty option bag if they're happy with the defaults – or rather want to define the assembly options later.