### PR TITLE
Transform the `accept` prop into a string everywhere

### DIFF
--- a/packages/@uppy/dashboard/src/components/AddFiles.tsx
+++ b/packages/@uppy/dashboard/src/components/AddFiles.tsx
@@ -55,7 +55,7 @@ class AddFiles extends Component {
         name="files[]"
         multiple={this.props.maxNumberOfFiles !== 1}
         onChange={this.onFileInputChange}
-        accept={this.props.allowedFileTypes}
+        accept={this.props.allowedFileTypes?.join(', ')}
         ref={refCallback}
       />
     )

--- a/packages/@uppy/drag-drop/src/DragDrop.tsx
+++ b/packages/@uppy/drag-drop/src/DragDrop.tsx
@@ -165,8 +165,7 @@ export default class DragDrop<M extends Meta, B extends Body> extends UIPlugin<
         }}
         name={this.opts.inputName}
         multiple={restrictions.maxNumberOfFiles !== 1}
-        // @ts-expect-error We actually want to coerce the array to a string (or keep it as null/undefined)
-        accept={restrictions.allowedFileTypes}
+        accept={restrictions.allowedFileTypes?.join(', ')}
         onChange={this.onInputChange}
       />
     )

--- a/packages/@uppy/file-input/src/FileInput.tsx
+++ b/packages/@uppy/file-input/src/FileInput.tsx
@@ -96,10 +96,6 @@ export default class FileInput<M extends Meta, B extends Body> extends UIPlugin<
     } satisfies h.JSX.IntrinsicElements['input']['style']
 
     const { restrictions } = this.uppy.opts
-    const accept =
-      restrictions.allowedFileTypes ?
-        restrictions.allowedFileTypes.join(',')
-      : undefined
 
     return (
       <div className="uppy-FileInput-container">
@@ -110,7 +106,7 @@ export default class FileInput<M extends Meta, B extends Body> extends UIPlugin<
           name={this.opts.inputName}
           onChange={this.handleInputChange}
           multiple={restrictions.maxNumberOfFiles !== 1}
-          accept={accept}
+          accept={restrictions.allowedFileTypes?.join(', ')}
           ref={(input) => {
             this.input = input as HTMLFileInputElement
           }}

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -79,7 +79,15 @@ function getCompanionKeysParams (name) {
 
 export default () => {
   const restrictions = undefined
-  // const restrictions = { requiredMetaFields: ['caption'], maxNumberOfFiles: 3 }
+  // const restrictions = {
+  //   maxFileSize:      1 * 1000000, // 1mb
+  //   minFileSize:      1 * 1000000, // 1mb
+  //   maxTotalFileSize: 1 * 1000000, // 1mb
+  //   maxNumberOfFiles: 3,
+  //   minNumberOfFiles: 1,
+  //   allowedFileTypes: ['image/*', '.jpg', '.jpeg', '.png', '.gif'],
+  //   requiredMetaFields: ['caption'],
+  // }
 
   const uppyDashboard = new Uppy({
     logger: debugLogger,


### PR DESCRIPTION
This PR passes a string to `accept`, just like its type wants`(property) JSXInternal.HTMLAttributes<HTMLInputElement>.accept?: string | undefined`.

Technically, `accept` was already transforming the array into a string - but that was undocumented behaviour.

# Before

<img width="550" alt="image" src="https://github.com/user-attachments/assets/9fd52d6d-7dfe-4337-9a0a-f71d3c3ee0e3">

# After
<img width="550" alt="image" src="https://github.com/user-attachments/assets/a47a6f58-6581-4c40-b2aa-e6ae2c1fa0b6">
