### PR TITLE
meta: enforce `.ts` extension for relative import types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -447,8 +447,11 @@ module.exports = {
       rules: {
         'no-extra-semi': 'off',
         'no-restricted-syntax': ['error', {
-          selector: 'ImportDeclaration[importKind="type"][source.value=/^(\\.+|@uppy\\x2F[a-z-0-9]+)\\x2F/]:not([source.value=/^@uppy\\x2Futils\\x2F/]):not([source.value=/\\.js$/])',
-          message: 'Use ".js" file extension for import type declarations',
+          selector: 'ImportDeclaration[importKind="type"][source.value=/^@uppy\\x2F[a-z-0-9]+\\x2F/]:not([source.value=/^@uppy\\x2Futils\\x2F/]):not([source.value=/\\.js$/])',
+          message: 'Use ".js" file extension for import type declarations from a different package',
+        }, {
+          selector: 'ImportDeclaration[importKind="type"][source.value=/^\\.\\.?\\x2F.+\\.js$/]',
+          message: 'Do not use ".js" file extension for relative import type declarations',
         }, {
           selector: 'ImportDeclaration[source.value=/^@uppy\\x2Futils\\x2Flib\\x2F.+\\.[mc]?[jt]sx?$/]',
           message: 'Do not use file extension when importing from @uppy/utils',

--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -4,10 +4,10 @@ import type {
   WrapPromiseFunctionType,
 } from '@uppy/utils/lib/RateLimitedQueue'
 import { pausingUploadReason, type Chunk } from './MultipartUploader.ts'
-import type AwsS3Multipart from './index.js'
+import type AwsS3Multipart from './index.ts'
 import { throwIfAborted } from './utils.ts'
-import type { UploadPartBytesResult, UploadResult } from './utils.js'
-import type { AwsS3MultipartOptions, uploadPartBytes } from './index.js'
+import type { UploadPartBytesResult, UploadResult } from './utils.ts'
+import type { AwsS3MultipartOptions, uploadPartBytes } from './index.ts'
 
 function removeMetadataFromURL(urlString: string) {
   const urlObject = new URL(urlString)

--- a/packages/@uppy/aws-s3/src/MultipartUploader.ts
+++ b/packages/@uppy/aws-s3/src/MultipartUploader.ts
@@ -1,7 +1,7 @@
 import type { Uppy } from '@uppy/core'
 import { AbortController } from '@uppy/utils/lib/AbortController'
 import type { Meta, Body, UppyFile } from '@uppy/utils/lib/UppyFile'
-import type { HTTPCommunicationQueue } from './HTTPCommunicationQueue.js'
+import type { HTTPCommunicationQueue } from './HTTPCommunicationQueue.ts'
 
 const MB = 1024 * 1024
 

--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -21,7 +21,7 @@ import type {
   UploadResultWithSignal,
   MultipartUploadResultWithSignal,
   UploadPartBytesResult,
-} from './utils.js'
+} from './utils.ts'
 import createSignedURL from './createSignedURL.ts'
 import { HTTPCommunicationQueue } from './HTTPCommunicationQueue.ts'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/@uppy/aws-s3/src/utils.ts
+++ b/packages/@uppy/aws-s3/src/utils.ts
@@ -1,7 +1,7 @@
 import { createAbortError } from '@uppy/utils/lib/AbortController'
 import type { Body } from '@uppy/utils/lib/UppyFile'
 
-import type { AwsS3Part } from './index.js'
+import type { AwsS3Part } from './index.ts'
 
 export function throwIfAborted(signal?: AbortSignal | null): void {
   if (signal?.aborted) {

--- a/packages/@uppy/companion-client/src/CompanionPluginOptions.ts
+++ b/packages/@uppy/companion-client/src/CompanionPluginOptions.ts
@@ -1,5 +1,5 @@
 import type { UIPluginOptions } from '@uppy/core'
-import type { tokenStorage } from './index.js'
+import type { tokenStorage } from './index.ts'
 
 export interface CompanionPluginOptions extends UIPluginOptions {
   storage?: typeof tokenStorage

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -7,7 +7,7 @@ import type {
 } from '@uppy/utils/lib/CompanionClientProvider'
 import type { UnknownProviderPlugin } from '@uppy/core/lib/Uppy.js'
 import RequestClient, { authErrorStatusCode } from './RequestClient.ts'
-import type { CompanionPluginOptions } from './index.js'
+import type { CompanionPluginOptions } from './index.ts'
 
 export interface Opts extends PluginOpts, CompanionPluginOptions {
   pluginId: string

--- a/packages/@uppy/core/src/BasePlugin.ts
+++ b/packages/@uppy/core/src/BasePlugin.ts
@@ -16,7 +16,7 @@ import type {
   OptionalPluralizeLocale,
 } from '@uppy/utils/lib/Translator'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type { State, UnknownPlugin, Uppy } from './Uppy.js'
+import type { State, UnknownPlugin, Uppy } from './Uppy.ts'
 
 export type PluginOpts = {
   locale?: Locale

--- a/packages/@uppy/core/src/EventManager.ts
+++ b/packages/@uppy/core/src/EventManager.ts
@@ -1,5 +1,5 @@
 import type { Meta, Body, UppyFile } from '@uppy/utils/lib/UppyFile'
-import type { Uppy, UppyEventMap, _UppyEventMap } from './Uppy.js'
+import type { Uppy, UppyEventMap, _UppyEventMap } from './Uppy.ts'
 
 /**
  * Create a wrapper around an event emitter with a `remove` method to remove

--- a/packages/@uppy/core/src/Restricter.ts
+++ b/packages/@uppy/core/src/Restricter.ts
@@ -5,7 +5,7 @@ import prettierBytes from '@transloadit/prettier-bytes'
 import match from 'mime-match'
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type { I18n } from '@uppy/utils/lib/Translator'
-import type { State, NonNullableUppyOptions } from './Uppy.js'
+import type { State, NonNullableUppyOptions } from './Uppy.ts'
 
 export type Restrictions = {
   maxFileSize: number | null

--- a/packages/@uppy/core/src/UIPlugin.ts
+++ b/packages/@uppy/core/src/UIPlugin.ts
@@ -5,8 +5,8 @@ import getTextDirection from '@uppy/utils/lib/getTextDirection'
 
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import BasePlugin from './BasePlugin.ts'
-import type { PluginOpts } from './BasePlugin.js'
-import type { State } from './Uppy.js'
+import type { PluginOpts } from './BasePlugin.ts'
+import type { State } from './Uppy.ts'
 
 /**
  * Defer a frequent call to the microtask queue.

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -45,8 +45,8 @@ import {
 import packageJson from '../package.json'
 import locale from './locale.ts'
 
-import type BasePlugin from './BasePlugin.js'
-import type { Restrictions, ValidateableFile } from './Restricter.js'
+import type BasePlugin from './BasePlugin.ts'
+import type { Restrictions, ValidateableFile } from './Restricter.ts'
 
 type Processor = (
   fileIDs: string[],

--- a/packages/@uppy/core/src/mocks/acquirerPlugin1.ts
+++ b/packages/@uppy/core/src/mocks/acquirerPlugin1.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest' // eslint-disable-line import/no-extraneous-dependencies
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.js'
+import type Uppy from '../Uppy.ts'
 
 type mock = ReturnType<typeof vi.fn>
 

--- a/packages/@uppy/core/src/mocks/acquirerPlugin2.ts
+++ b/packages/@uppy/core/src/mocks/acquirerPlugin2.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest' // eslint-disable-line import/no-extraneous-dependencies
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.js'
+import type Uppy from '../Uppy.ts'
 
 type mock = ReturnType<typeof vi.fn>
 

--- a/packages/@uppy/core/src/mocks/invalidPluginWithoutId.ts
+++ b/packages/@uppy/core/src/mocks/invalidPluginWithoutId.ts
@@ -1,5 +1,5 @@
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.js'
+import type Uppy from '../Uppy.ts'
 
 export default class InvalidPluginWithoutName extends UIPlugin<any, any, any> {
   public type: string

--- a/packages/@uppy/core/src/mocks/invalidPluginWithoutType.ts
+++ b/packages/@uppy/core/src/mocks/invalidPluginWithoutType.ts
@@ -1,5 +1,5 @@
 import UIPlugin from '../UIPlugin.ts'
-import type Uppy from '../Uppy.js'
+import type Uppy from '../Uppy.ts'
 
 export default class InvalidPluginWithoutType extends UIPlugin<any, any, any> {
   public id: string

--- a/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.tsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/Buttons/index.tsx
@@ -3,7 +3,7 @@ import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile'
 import type Uppy from '@uppy/core'
 import type { I18n } from '@uppy/utils/lib/Translator'
 import copyToClipboard from '../../../utils/copyToClipboard.ts'
-import type { DashboardState } from '../../../Dashboard.js'
+import type { DashboardState } from '../../../Dashboard.ts'
 
 type $TSFixMe = any
 

--- a/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.tsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/FileInfo/index.tsx
@@ -5,7 +5,7 @@ import truncateString from '@uppy/utils/lib/truncateString'
 import type { I18n } from '@uppy/utils/lib/Translator'
 import type { UppyFile } from '@uppy/core'
 import MetaErrorMessage from '../MetaErrorMessage.tsx'
-import type { DashboardState } from '../../../Dashboard.js'
+import type { DashboardState } from '../../../Dashboard.ts'
 
 const renderFileName = (props: {
   file: UppyFile<any, any>

--- a/packages/@uppy/dashboard/src/components/FileItem/index.tsx
+++ b/packages/@uppy/dashboard/src/components/FileItem/index.tsx
@@ -10,7 +10,7 @@ import FilePreviewAndLink from './FilePreviewAndLink/index.tsx'
 import FileProgress from './FileProgress/index.tsx'
 import FileInfo from './FileInfo/index.tsx'
 import Buttons from './Buttons/index.tsx'
-import type { DashboardState } from '../../Dashboard.js'
+import type { DashboardState } from '../../Dashboard.ts'
 
 type Props<M extends Meta, B extends Body> = {
   file: UppyFile<M, B>

--- a/packages/@uppy/dashboard/src/components/FileList.tsx
+++ b/packages/@uppy/dashboard/src/components/FileList.tsx
@@ -7,7 +7,7 @@ import type { UppyFile, Uppy, State } from '@uppy/core'
 import type { I18n } from '@uppy/utils/lib/Translator'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import FileItem from './FileItem/index.tsx'
-import type { DashboardState } from '../Dashboard.js'
+import type { DashboardState } from '../Dashboard.ts'
 
 type FileListProps<M extends Meta, B extends Body> = {
   id: string

--- a/packages/@uppy/image-editor/src/Editor.tsx
+++ b/packages/@uppy/image-editor/src/Editor.tsx
@@ -7,7 +7,7 @@ import getCanvasDataThatFitsPerfectlyIntoContainer from './utils/getCanvasDataTh
 import getScaleFactorThatRemovesDarkCorners from './utils/getScaleFactorThatRemovesDarkCorners.ts'
 import limitCropboxMovementOnMove from './utils/limitCropboxMovementOnMove.ts'
 import limitCropboxMovementOnResize from './utils/limitCropboxMovementOnResize.ts'
-import type ImageEditor from './ImageEditor.js'
+import type ImageEditor from './ImageEditor.ts'
 
 type Props<M extends Meta, B extends Body> = {
   currentImage: UppyFile<M, B>

--- a/packages/@uppy/provider-views/src/Breadcrumbs.tsx
+++ b/packages/@uppy/provider-views/src/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { PartialTreeFolder } from '@uppy/core/lib/Uppy.js'
 import { h, Fragment } from 'preact'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
-import type ProviderView from './ProviderView/index.js'
+import type ProviderView from './ProviderView/index.ts'
 
 type BreadcrumbsProps<M extends Meta, B extends Body> = {
   openFolder: ProviderView<M, B>['openFolder']

--- a/packages/@uppy/provider-views/src/ProviderView/AuthView.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/AuthView.tsx
@@ -2,8 +2,8 @@ import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import type Translator from '@uppy/utils/lib/Translator'
-import type { Opts } from './ProviderView.js'
-import type ProviderViews from './ProviderView.js'
+import type { Opts } from './ProviderView.ts'
+import type ProviderViews from './ProviderView.ts'
 
 type AuthViewProps<M extends Meta, B extends Body> = {
   loading: boolean | string

--- a/packages/@uppy/provider-views/src/ProviderView/Header.tsx
+++ b/packages/@uppy/provider-views/src/ProviderView/Header.tsx
@@ -6,7 +6,7 @@ import type { PartialTreeFolder } from '@uppy/core/lib/Uppy.js'
 import classNames from 'classnames'
 import User from './User.tsx'
 import Breadcrumbs from '../Breadcrumbs.tsx'
-import type ProviderView from './ProviderView.js'
+import type ProviderView from './ProviderView.ts'
 
 type HeaderProps<M extends Meta, B extends Body> = {
   showBreadcrumbs: boolean

--- a/packages/@uppy/status-bar/src/StatusBar.tsx
+++ b/packages/@uppy/status-bar/src/StatusBar.tsx
@@ -11,7 +11,7 @@ import StatusBarUI, { type StatusBarUIProps } from './StatusBarUI.tsx'
 // @ts-ignore We don't want TS to generate types for the package.json
 import packageJson from '../package.json'
 import locale from './locale.ts'
-import type { StatusBarOptions } from './StatusBarOptions.js'
+import type { StatusBarOptions } from './StatusBarOptions.ts'
 
 const speedFilterHalfLife = 2000
 const ETAFilterHalfLife = 2000

--- a/packages/@uppy/status-bar/src/StatusBarOptions.ts
+++ b/packages/@uppy/status-bar/src/StatusBarOptions.ts
@@ -1,5 +1,5 @@
 import type { UIPluginOptions } from '@uppy/core/lib/UIPlugin.js'
-import type StatusBarLocale from './locale.js'
+import type StatusBarLocale from './locale.ts'
 
 export interface StatusBarOptions extends UIPluginOptions {
   showProgressDetails?: boolean

--- a/packages/@uppy/transloadit/src/Assembly.ts
+++ b/packages/@uppy/transloadit/src/Assembly.ts
@@ -8,7 +8,7 @@ import type {
   RateLimitedQueue,
   WrapPromiseFunctionType,
 } from '@uppy/utils/lib/RateLimitedQueue'
-import type { AssemblyResponse } from './index.js'
+import type { AssemblyResponse } from './index.ts'
 
 const ASSEMBLY_UPLOADING = 'ASSEMBLY_UPLOADING'
 const ASSEMBLY_EXECUTING = 'ASSEMBLY_EXECUTING'

--- a/packages/@uppy/transloadit/src/AssemblyWatcher.ts
+++ b/packages/@uppy/transloadit/src/AssemblyWatcher.ts
@@ -1,7 +1,7 @@
 import type { Uppy } from '@uppy/core'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import Emitter from 'component-emitter'
-import type { AssemblyResponse } from './index.js'
+import type { AssemblyResponse } from './index.ts'
 
 /**
  * Track completion of multiple assemblies.

--- a/packages/@uppy/transloadit/src/Client.ts
+++ b/packages/@uppy/transloadit/src/Client.ts
@@ -7,7 +7,7 @@ import fetchWithNetworkError from '@uppy/utils/lib/fetchWithNetworkError'
 import type {
   AssemblyResponse,
   OptionsWithRestructuredFields,
-} from './index.js'
+} from './index.ts'
 
 const ASSEMBLIES_ENDPOINT = '/assemblies'
 

--- a/packages/@uppy/utils/src/CompanionClientProvider.ts
+++ b/packages/@uppy/utils/src/CompanionClientProvider.ts
@@ -1,4 +1,4 @@
-import type { CompanionFile } from './CompanionFile.js'
+import type { CompanionFile } from './CompanionFile.ts'
 
 export type RequestOptions = {
   method?: string

--- a/packages/@uppy/utils/src/ErrorWithCause.ts
+++ b/packages/@uppy/utils/src/ErrorWithCause.ts
@@ -1,4 +1,4 @@
-import type NetworkError from './NetworkError.js'
+import type NetworkError from './NetworkError.ts'
 import hasProperty from './hasProperty.ts'
 
 class ErrorWithCause extends Error {

--- a/packages/@uppy/utils/src/UppyFile.ts
+++ b/packages/@uppy/utils/src/UppyFile.ts
@@ -1,4 +1,4 @@
-import type { FileProgress } from './FileProgress.js'
+import type { FileProgress } from './FileProgress.ts'
 
 export type Meta = Record<string, unknown>
 

--- a/packages/@uppy/utils/src/emitSocketProgress.ts
+++ b/packages/@uppy/utils/src/emitSocketProgress.ts
@@ -1,6 +1,6 @@
 import throttle from 'lodash/throttle.js'
-import type { UppyFile } from './UppyFile.js'
-import type { FileProgress } from './FileProgress.js'
+import type { UppyFile } from './UppyFile.ts'
+import type { FileProgress } from './FileProgress.ts'
 
 function emitSocketProgress(
   uploader: any,

--- a/packages/@uppy/utils/src/fileFilters.ts
+++ b/packages/@uppy/utils/src/fileFilters.ts
@@ -1,4 +1,4 @@
-import type { UppyFile } from './UppyFile.js'
+import type { UppyFile } from './UppyFile.ts'
 
 export function filterNonFailedFiles(
   files: UppyFile<any, any>[],

--- a/packages/@uppy/utils/src/generateFileID.ts
+++ b/packages/@uppy/utils/src/generateFileID.ts
@@ -1,4 +1,4 @@
-import type { MinimalRequiredUppyFile, UppyFile } from './UppyFile.js'
+import type { MinimalRequiredUppyFile, UppyFile } from './UppyFile.ts'
 import getFileType from './getFileType.ts'
 
 function encodeCharacter(character: string): string {

--- a/packages/@uppy/utils/src/getAllowedMetaFields.ts
+++ b/packages/@uppy/utils/src/getAllowedMetaFields.ts
@@ -1,4 +1,4 @@
-import type { Meta } from './UppyFile.js'
+import type { Meta } from './UppyFile.ts'
 
 export default function getAllowedMetaFields<M extends Meta>(
   fields: string[] | boolean,

--- a/packages/@uppy/utils/src/getBytesRemaining.ts
+++ b/packages/@uppy/utils/src/getBytesRemaining.ts
@@ -1,4 +1,4 @@
-import type { FileProgress } from './FileProgress.js'
+import type { FileProgress } from './FileProgress.ts'
 
 export default function getBytesRemaining(fileProgress: FileProgress): number {
   if (fileProgress.bytesTotal == null) return 0

--- a/packages/@uppy/utils/src/getETA.ts
+++ b/packages/@uppy/utils/src/getETA.ts
@@ -1,6 +1,6 @@
 import getSpeed from './getSpeed.ts'
 import getBytesRemaining from './getBytesRemaining.ts'
-import type { FileProgress } from './FileProgress.js'
+import type { FileProgress } from './FileProgress.ts'
 
 export default function getETA(fileProgress: FileProgress): number {
   if (!fileProgress.bytesUploaded) return 0

--- a/packages/@uppy/utils/src/getFileType.test.ts
+++ b/packages/@uppy/utils/src/getFileType.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import getFileType from './getFileType.ts'
-import type { UppyFile } from './UppyFile.js'
+import type { UppyFile } from './UppyFile.ts'
 
 describe('getFileType', () => {
   it('should trust the filetype if the file comes from a remote source', () => {

--- a/packages/@uppy/utils/src/getSpeed.ts
+++ b/packages/@uppy/utils/src/getSpeed.ts
@@ -1,4 +1,4 @@
-import type { FileProgress } from './FileProgress.js'
+import type { FileProgress } from './FileProgress.ts'
 
 export default function getSpeed(fileProgress: FileProgress): number {
   if (!fileProgress.bytesUploaded) return 0

--- a/packages/@uppy/vue/src/dashboard-modal.ts
+++ b/packages/@uppy/vue/src/dashboard-modal.ts
@@ -1,7 +1,7 @@
 import { defineComponent, ref, watch, h, type PropType } from 'vue'
 import DashboardPlugin, { type DashboardOptions } from '@uppy/dashboard'
 import { Uppy } from '@uppy/core'
-import type { Meta, Body } from '../../utils/src/UppyFile.js'
+import type { Meta, Body } from '@uppy/utils/lib/UppyFile'
 import useUppy from './useUppy.ts'
 
 type DashboardModalOptions<M extends Meta, B extends Body> = Omit<

--- a/packages/@uppy/vue/src/dashboard.ts
+++ b/packages/@uppy/vue/src/dashboard.ts
@@ -1,7 +1,7 @@
 import { defineComponent, ref, h, type PropType } from 'vue'
 import DashboardPlugin, { type DashboardOptions } from '@uppy/dashboard'
 import type { Uppy } from '@uppy/core'
-import type { Meta, Body } from '../../utils/src/UppyFile.js'
+import type { Meta, Body } from '@uppy/utils/lib/UppyFile'
 import useUppy from './useUppy.ts'
 
 type DashboardInlineOptions<M extends Meta, B extends Body> = Omit<


### PR DESCRIPTION
It makes more sense for `import` and `import type` to be consistent with those rules:

- relative imports should use the actual `.ts` or `.tsx` file extension.
- imports from separate package should use the `lib/*.js` files, not the `src/*.ts` or `src/*.tsx` files.

Using `.ts` in `import type` declarations means they are going to show up in `.d.ts` files (which is a bit awkward, because in the `lib/` folder there won't be a `.ts` file but a `.js` one), but we already have those (e.g. `packages/@uppy/google-drive/lib/index.d.ts` has `export { default } from './GoogleDrive.tsx'`), and TS 5.0+ handles it fine (it's going to resolve the import to `index.d.ts`).