### PR TITLE
Fix many lurking undefined errors

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -416,7 +416,6 @@ export default class Transloadit<
           .getFiles()
           .filter(({ id }) => fileIDs.includes(id))
 
-          console.log(files)
         if (files.length === 0) {
           // All files have been removed, cancelling.
           await this.client.cancelAssembly(newAssembly)

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -699,8 +699,7 @@ export default class Transloadit<
     // Set up the Assembly instances and AssemblyWatchers for existing Assemblies.
     const restoreAssemblies = () => {
       this.#createAssemblyWatcher(previousAssembly.assembly_id)
-      if (this.assembly == null) throw new Error('Assembly was nullish')
-      this.#connectAssembly(this.assembly)
+      this.#connectAssembly(this.assembly!)
     }
 
     // Force-update all Assemblies to check for missed events.

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -415,7 +415,6 @@ export default class Transloadit<
         const files = this.uppy
           .getFiles()
           .filter(({ id }) => fileIDs.includes(id))
-
         if (files.length === 0) {
           // All files have been removed, cancelling.
           await this.client.cancelAssembly(newAssembly)


### PR DESCRIPTION
there was an assumption that assembly is required and is never undefined even though it is typed as optional and assigned to undefined in onError