### PR TITLE
feat: enable UppyFile.addFile to specify one or more plugins to specifically run on a per-file basis

### DIFF
--- a/packages/@uppy/core/src/getFilePlugins.ts
+++ b/packages/@uppy/core/src/getFilePlugins.ts
@@ -1,0 +1,5 @@
+export default function getFilePlugins(fileDescriptor: {
+  plugins?: string[]
+}): string[] {
+  return fileDescriptor.plugins || []
+}

--- a/packages/@uppy/utils/src/UppyFile.ts
+++ b/packages/@uppy/utils/src/UppyFile.ts
@@ -17,6 +17,7 @@ export interface UppyFile<M extends Meta, B extends Body> {
   isGhost: boolean
   meta: InternalMetadata & M
   name?: string
+  plugins?: string[]
   preview?: string
   progress: FileProgress
   missingRequiredMetaFields?: string[]


### PR DESCRIPTION
ref #4604

This required changing some internals like `uploaders` to a `Map<Processor, string>`.

We also use a new `installingPlugin` property as a means of identifying the uploader functions owner, because since there is no API to pass that, we do it on plugin registration and unset it after.

I am not sure what unit tests would be required for this, though I have been testing manually in my own project successfully.