### PR TITLE
@uppy/status-bar: show upload button when files are recovered

### DIFF
--- a/packages/@uppy/status-bar/src/StatusBarUI.tsx
+++ b/packages/@uppy/status-bar/src/StatusBarUI.tsx
@@ -140,8 +140,7 @@ export default function StatusBarUI<M extends Meta, B extends Body>({
   const showUploadBtn =
     !error &&
     newFiles &&
-    !isUploadInProgress &&
-    !isAllPaused &&
+    ((!isUploadInProgress && !isAllPaused) || recoveredState) &&
     allowNewUpload &&
     !hideUploadButton
 


### PR DESCRIPTION
Closes #5412

Possibly related: https://github.com/transloadit/uppy/pull/5350

These conditions aren't pretty. But until Uppy becomes a finite state machine, it is what it is.