### PR TITLE
@uppy/transloadit: fix check if all files have been removed

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -416,10 +416,12 @@ export default class Transloadit<
         .getFiles()
         .filter(({ id }) => fileIDs.includes(id))
 
-      if (files.length === 0) {
-        // All files have been removed, cancelling.
-        await this.client.cancelAssembly(newAssembly)
-        return null
+      if (files.length !== fileIDs.length) {
+        if (files.length === 0) {
+          // All files have been removed, cancelling.
+          await this.client.cancelAssembly(newAssembly)
+          return null
+        }
       }
 
       const assembly = new Assembly(newAssembly, this.#rateLimitedQueue)

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -416,12 +416,10 @@ export default class Transloadit<
         .getFiles()
         .filter(({ id }) => fileIDs.includes(id))
 
-      if (files.length !== fileIDs.length) {
-        if (files.length === 0) {
-          // All files have been removed, cancelling.
-          await this.client.cancelAssembly(newAssembly)
-          return null
-        }
+      if (files.length !== fileIDs.length && files.length === 0) {
+        // All files have been removed, cancelling.
+        await this.client.cancelAssembly(newAssembly)
+        return null
       }
 
       const assembly = new Assembly(newAssembly, this.#rateLimitedQueue)

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -416,7 +416,7 @@ export default class Transloadit<
         .getFiles()
         .filter(({ id }) => fileIDs.includes(id))
 
-      if (files.length !== fileIDs.length && files.length === 0) {
+      if (files.length === 0 && fileIDs.length !== 0) {
         // All files have been removed, cancelling.
         await this.client.cancelAssembly(newAssembly)
         return null


### PR DESCRIPTION
When you use Uppy and allow uploads to start without any files added, which means you want Transloadit to import files, `@uppy/transloadit` currently always sends a DELETE request immediately after starting the assembly.

This is a regression from #5202