### PR TITLE
@uppy/transloadit: add execution_progress to AssemblyResponse type

### DIFF
--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -73,6 +73,7 @@ export interface AssemblyResponse {
   has_dupe_jobs: boolean
   execution_start: string
   execution_duration: number
+  execution_progress: number
   queue_duration: number
   jobs_queue_duration: number
   notify_start?: any

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -73,7 +73,7 @@ export interface AssemblyResponse {
   has_dupe_jobs: boolean
   execution_start: string
   execution_duration: number
-  execution_progress: number
+  execution_progress?: number
   queue_duration: number
   jobs_queue_duration: number
   notify_start?: any


### PR DESCRIPTION
Used often in the Transloadit testing area but the type is missing in Uppy. 