### PR TITLE
@uppy/companion: do not use unsafe call to `JSON.stringify`

### DIFF
--- a/packages/@uppy/companion/src/server/emitter/redis-emitter.js
+++ b/packages/@uppy/companion/src/server/emitter/redis-emitter.js
@@ -1,4 +1,5 @@
 const { EventEmitter } = require('node:events')
+const util = require('node:util')
 
 const logger = require('../logger')
 
@@ -141,7 +142,7 @@ module.exports = (redisClient, redisPubSubScope) => {
    * @param {string} eventName name of the event
    */
   function emit (eventName, ...args) {
-    runWhenConnected(() => publisher.publish(getPrefixedEventName(eventName), JSON.stringify(args)))
+    runWhenConnected(() => publisher.publish(getPrefixedEventName(eventName), util.inspect(args)))
   }
 
   /**


### PR DESCRIPTION
Calling `JSON.stringify` on some objects (e.g. self-referencing objects) can lead to a `TypeError`; instead we can use `util.inspect` that is able to deal with those, and is basically guaranteed to never throw. It also means the output will be more readable by humans – but no as readable for machines.