### PR TITLE
docs: fix Golden Retriever service worker import

### DIFF
--- a/docs/golden-retriever.mdx
+++ b/docs/golden-retriever.mdx
@@ -106,7 +106,7 @@ store references to large files.
    :::
 
    ```js title="sw.js"
-   import('@uppy/golden-retriever/lib/ServiceWorker');
+   import '@uppy/golden-retriever/lib/ServiceWorker'
    ```
 
 2. Register it in your app’s entry point:

--- a/docs/golden-retriever.mdx
+++ b/docs/golden-retriever.mdx
@@ -106,7 +106,7 @@ store references to large files.
    :::
 
    ```js title="sw.js"
-   import '@uppy/golden-retriever/lib/ServiceWorker'
+   import '@uppy/golden-retriever/lib/ServiceWorker';
    ```
 
 2. Register it in your app’s entry point:


### PR DESCRIPTION
Updated Golden Retriever documentation so that sw.js import works properly. Otherwise service worker throws an error on registration:

```
TypeError: import() is disallowed on ServiceWorkerGlobalScope by the HTML specification.
```

Reported here: https://github.com/transloadit/uppy/issues/5424