### PR TITLE
@uppy/react: fix use-sync-external-store import

### DIFF
--- a/packages/@uppy/react/src/useUppyState.ts
+++ b/packages/@uppy/react/src/useUppyState.ts
@@ -1,7 +1,7 @@
 import type { Uppy, State } from '@uppy/core'
 import type { Body, Meta } from '@uppy/utils/lib/UppyFile'
 import { useMemo, useCallback } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 
 export default function useUppyState<
   M extends Meta = Meta,


### PR DESCRIPTION
Fixes #5396 

There's a PR for export map in this package, which would fix this, but it's open for more than a year so it's likely not happening.