### PR TITLE
Fix locale-pack for en_US

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "build:js": "npm-run-all build:js:typeless build:locale-pack build:angular build:bundle",
     "build:ts": "yarn workspaces list --no-private --json | yarn tsc -b && yarn workspace @uppy/svelte validate",
     "build:lib": "yarn node ./bin/build-lib.js",
-    "build:locale-pack": "yarn workspace @uppy-dev/locale-pack build && eslint packages/@uppy/locales/src/en_US.js --fix && yarn workspace @uppy-dev/locale-pack test unused",
+    "build:locale-pack": "yarn workspace @uppy-dev/locale-pack build && eslint packages/@uppy/locales/src/en_US.ts --fix && yarn workspace @uppy-dev/locale-pack test unused",
     "build": "npm-run-all --serial build:ts --parallel build:js build:css --serial size",
     "contributors:save": "yarn node ./bin/update-contributors.mjs",
     "dev:with-companion": "npm-run-all --parallel start:companion dev",

--- a/packages/@uppy/locales/src/en_US.ts
+++ b/packages/@uppy/locales/src/en_US.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Locale } from '@uppy/utils/lib/Translator'
 
 const en_US: Locale<0 | 1> = {
@@ -98,9 +99,6 @@ en_US.strings = {
     '1': 'Added %{smart_count} files from %{folder}',
   },
   folderAlreadyAdded: 'The folder "%{folder}" was already added',
-  generateImage: 'Generate image',
-  generateImagePlaceholder:
-    'A serene sunset over a mountain lake, with pine trees reflecting in the water and a small wooden cabin on the shore."',
   generatingThumbnails: 'Generating thumbnails...',
   import: 'Import',
   importFiles: 'Import files from:',
@@ -236,7 +234,9 @@ en_US.strings = {
   zoomOut: 'Zoom out',
 }
 
+// @ts-ignore untyped
 if (typeof Uppy !== 'undefined') {
+  // @ts-ignore untyped
   globalThis.Uppy.locales.en_US = en_US
 }
 

--- a/packages/@uppy/locales/src/en_US.ts
+++ b/packages/@uppy/locales/src/en_US.ts
@@ -2,8 +2,8 @@ import type { Locale } from '@uppy/utils/lib/Translator'
 
 const en_US: Locale<0 | 1> = {
   strings: {},
-  pluralize(count) {
-    if (count === 1) {
+  pluralize(n) {
+    if (n === 1) {
       return 0
     }
     return 1
@@ -21,6 +21,8 @@ en_US.strings = {
     '%{count} additional restrictions were not fulfilled',
   addMore: 'Add more',
   addMoreFiles: 'Add more files',
+  aggregateExceedsSize:
+    'You selected %{size} of files, but maximum allowed size is %{sizeAllowed}',
   allFilesFromFolderNamed: 'All files from folder %{name}',
   allowAccessDescription:
     'In order to take pictures or record video with your camera, please allow camera access for this site.',
@@ -70,8 +72,8 @@ en_US.strings = {
   dropPasteImportFiles: 'Drop files here, %{browseFiles} or import from:',
   dropPasteImportFolders: 'Drop files here, %{browseFolders} or import from:',
   editFile: 'Edit file',
-  editImage: 'Edit image',
   editFileWithFilename: 'Edit file %{file}',
+  editImage: 'Edit image',
   editing: 'Editing %{file}',
   emptyFolderAdded: 'No files were added from empty folder',
   encoding: 'Encoding...',
@@ -90,12 +92,15 @@ en_US.strings = {
   },
   filter: 'Filter',
   finishEditingFile: 'Finish editing file',
-  flipHorizontal: 'Flip horizontal',
+  flipHorizontal: 'Flip horizontally',
   folderAdded: {
     '0': 'Added %{smart_count} file from %{folder}',
     '1': 'Added %{smart_count} files from %{folder}',
   },
   folderAlreadyAdded: 'The folder "%{folder}" was already added',
+  generateImage: 'Generate image',
+  generateImagePlaceholder:
+    'A serene sunset over a mountain lake, with pine trees reflecting in the water and a small wooden cabin on the shore."',
   generatingThumbnails: 'Generating thumbnails...',
   import: 'Import',
   importFiles: 'Import files from:',
@@ -134,8 +139,12 @@ en_US.strings = {
   pluginNameDropbox: 'Dropbox',
   pluginNameFacebook: 'Facebook',
   pluginNameGoogleDrive: 'Google Drive',
+  pluginNameGooglePhotos: 'Google Photos',
   pluginNameInstagram: 'Instagram',
   pluginNameOneDrive: 'OneDrive',
+  pluginNameScreenCapture: 'Screencast',
+  pluginNameUnsplash: 'Unsplash',
+  pluginNameUrl: 'Link',
   pluginNameZoom: 'Zoom',
   poweredBy: 'Powered by %{uppy}',
   processingXFiles: {
@@ -160,8 +169,8 @@ en_US.strings = {
   resumeUpload: 'Resume upload',
   retry: 'Retry',
   retryUpload: 'Retry upload',
-  revert: 'Revert',
-  rotate: 'Rotate',
+  revert: 'Reset',
+  rotate: 'Rotate 90°',
   save: 'Save',
   saveChanges: 'Save changes',
   search: 'Search',
@@ -185,7 +194,7 @@ en_US.strings = {
   submitRecordedFile: 'Submit recorded file',
   takePicture: 'Take a picture',
   takePictureBtn: 'Take Picture',
-  timedOut: 'Upload stalled for %{seconds} seconds, aborting.',
+  unnamed: 'Unnamed',
   upload: 'Upload',
   uploadComplete: 'Upload complete',
   uploadFailed: 'Upload failed',
@@ -225,6 +234,10 @@ en_US.strings = {
   },
   zoomIn: 'Zoom in',
   zoomOut: 'Zoom out',
+}
+
+if (typeof Uppy !== 'undefined') {
+  globalThis.Uppy.locales.en_US = en_US
 }
 
 export default en_US

--- a/packages/@uppy/locales/template.ts
+++ b/packages/@uppy/locales/template.ts
@@ -1,6 +1,9 @@
-const en_US = {
-  pluralize (count) {
-    if (count === 1) {
+import type { Locale } from '@uppy/utils/lib/Translator'
+
+const en_US: Locale<0 | 1> = {
+  strings: {},
+  pluralize(n) {
+    if (n === 1) {
       return 0
     }
     return 1

--- a/packages/@uppy/locales/template.ts
+++ b/packages/@uppy/locales/template.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Locale } from '@uppy/utils/lib/Translator'
 
 const en_US: Locale<0 | 1> = {
@@ -12,7 +13,9 @@ const en_US: Locale<0 | 1> = {
 
 en_US.strings = {}
 
+// @ts-ignore untyped
 if (typeof Uppy !== 'undefined') {
+  // @ts-ignore untyped
   globalThis.Uppy.locales.en_US = en_US
 }
 

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -17,6 +17,7 @@ import DropTarget from '@uppy/drop-target'
 import Audio from '@uppy/audio'
 import Compressor from '@uppy/compressor'
 import GoogleDrive from '@uppy/google-drive'
+import english from '@uppy/locales/lib/en_US.js'
 /* eslint-enable import/no-extraneous-dependencies */
 
 import generateSignatureIfSecret from './generateSignatureIfSecret.js'
@@ -90,6 +91,7 @@ export default () => {
   // }
 
   const uppyDashboard = new Uppy({
+    locale: english,
     logger: debugLogger,
     meta: {
       username: 'John',

--- a/private/dev/package.json
+++ b/private/dev/package.json
@@ -7,7 +7,8 @@
     }
   },
   "dependencies": {
-    "@uppy/companion": "workspace:^"
+    "@uppy/companion": "workspace:^",
+    "@uppy/locales": "workspace:^"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.6",

--- a/private/dev/package.json
+++ b/private/dev/package.json
@@ -7,8 +7,7 @@
     }
   },
   "dependencies": {
-    "@uppy/companion": "workspace:^",
-    "@uppy/locales": "workspace:^"
+    "@uppy/companion": "workspace:^"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.6",

--- a/private/locale-pack/index.mjs
+++ b/private/locale-pack/index.mjs
@@ -8,10 +8,10 @@ import { getLocales, sortObjectAlphabetically } from './helpers.mjs'
 const root = fileURLToPath(new URL('../../', import.meta.url))
 
 const localesPath = path.join(root, 'packages', '@uppy', 'locales')
-const templatePath = path.join(localesPath, 'template.js')
-const englishLocalePath = path.join(localesPath, 'src', 'en_US.js')
+const templatePath = path.join(localesPath, 'template.ts')
+const englishLocalePath = path.join(localesPath, 'src', 'en_US.ts')
 
-async function getLocalesAndCombinedLocale () {
+async function getLocalesAndCombinedLocale() {
   const locales = await getLocales(`${root}/packages/@uppy/**/lib/locale.js`)
 
   const combinedLocale = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,6 +8081,7 @@ __metadata:
   resolution: "@uppy-dev/dev@workspace:private/dev"
   dependencies:
     "@uppy/companion": "workspace:^"
+    "@uppy/locales": "workspace:^"
     autoprefixer: "npm:^10.2.6"
     postcss-dir-pseudo-class: "npm:^6.0.0"
     postcss-logical: "npm:^5.0.0"
@@ -8855,7 +8856,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uppy/locales@workspace:packages/@uppy/locales":
+"@uppy/locales@workspace:^, @uppy/locales@workspace:packages/@uppy/locales":
   version: 0.0.0-use.local
   resolution: "@uppy/locales@workspace:packages/@uppy/locales"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,7 +8081,6 @@ __metadata:
   resolution: "@uppy-dev/dev@workspace:private/dev"
   dependencies:
     "@uppy/companion": "workspace:^"
-    "@uppy/locales": "workspace:^"
     autoprefixer: "npm:^10.2.6"
     postcss-dir-pseudo-class: "npm:^6.0.0"
     postcss-logical: "npm:^5.0.0"
@@ -8856,7 +8855,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uppy/locales@workspace:^, @uppy/locales@workspace:packages/@uppy/locales":
+"@uppy/locales@workspace:packages/@uppy/locales":
   version: 0.0.0-use.local
   resolution: "@uppy/locales@workspace:packages/@uppy/locales"
   dependencies:


### PR DESCRIPTION
I was wondering why my locale changes don't show up locally. Turns out we use the Uppy CDN bundle in our dev setup with does not have `@uppy/locales`. Then it still didn't work and it turns out the script was broken since the TS migration.