### PR TITLE
@uppy/svelte: fix generated module to not bundle Svelte

### DIFF
--- a/packages/@uppy/svelte/rollup.config.js
+++ b/packages/@uppy/svelte/rollup.config.js
@@ -3,20 +3,17 @@ import resolve from '@rollup/plugin-node-resolve'
 import preprocess from 'svelte-preprocess'
 import svelteDts from 'rollup-plugin-svelte-types';
 
-const globals = {
-  '@uppy/dashboard': 'Dashboard',
-  '@uppy/drag-drop': 'DragDrop',
-  '@uppy/progress-bar': 'ProgressBar',
-  '@uppy/status-bar': 'StatusBar',
-}
-
 export default {
+  external: [
+    /^@uppy\//,
+    /node_modules/,
+  ],
   input: 'src/index.ts',
   output: [
     {
       file: 'lib/index.js',
       format: 'es',
-      globals,
+      sourcemap: 'inline',
     },
   ],
   plugins: [
@@ -25,7 +22,9 @@ export default {
       preprocess: preprocess(),
     }),
     resolve({
-      resolveOnly: ['svelte'],
+      browser: true,
+      exportConditions: ['svelte'],
+      extensions: ['.svelte']
     }),
     svelteDts.default({
       declarationDir: './lib/'


### PR DESCRIPTION
Fixes #5442 

We were bundling Svelte internal code, when we also list `svelte` as a peer dependencies. There was also an assumption that Uppy classes would be global, when we should instead import them.