### PR TITLE
@uppy/tus: fix event upload-success response.body.xhr

### DIFF
--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -323,10 +323,10 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
           } as unknown as B,
         }
 
+        this.uppy.emit('upload-success', this.uppy.getFile(file.id), uploadResp)
+
         this.resetUploaderReferences(file.id)
         queuedRequest.done()
-
-        this.uppy.emit('upload-success', this.uppy.getFile(file.id), uploadResp)
 
         if (upload.url) {
           // @ts-expect-error not typed in tus-js-client


### PR DESCRIPTION
`this.resetUploaderReferences(file.id)` causes the xhr object to be reset to empty XMLHttpRequest

This patch fires the `upload-success` event before calling `this.resetUploaderReferences(file.id)`


to test this patch try:
```
uppy.on('upload-success', (file, response) => {
    const xhr = response.body.xhr;
    console.log('upload-success', xhr.readyState);

    // readyState should be `4` which is the DONE state, before this patch it was always `0`
    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState 
});
```

Related: #5444, #5456