### PR TITLE
fix missing lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -443,7 +443,7 @@ module.exports = {
       rules: {
         'no-extra-semi': 'off',
         'no-restricted-syntax': ['error', {
-          selector: 'ImportDeclaration[importKind="type"][source.value=/^@uppy\\x2F[a-z-0-9]+\\x2F/]:not([source.value=/^@uppy\\x2Futils\\x2F/]):not([source.value=/\\.js$/])',
+          selector: 'ImportDeclaration[source.value=/^@uppy\\x2F[a-z-0-9]+\\x2F/]:not([source.value=/^@uppy\\x2Futils\\x2F/]):not([source.value=/\\.(js|css)$/])',
           message: 'Use ".js" file extension for import type declarations from a different package',
         }, {
           selector: 'ImportDeclaration[importKind="type"][source.value=/^\\.\\.?\\x2F.+\\.js$/]',


### PR DESCRIPTION
that caused a bundle error because i forgot a `.js` in an import, which was only caught by the webpack bundle job.

```
ERROR in ./node_modules/@uppy/provider-views/lib/GooglePicker/GooglePickerView.js 5:0-65
Module not found: Error: Can't resolve '@uppy/core/lib/useUppyState' in '/home/runner/work/uppy/uppy/node_modules/@uppy/provider-views/lib/GooglePicker'
Did you mean 'useUppyState.js'?
```
https://github.com/transloadit/uppy/actions/runs/11855591962/job/33040156550?pr=5443