### PR TITLE
@uppy/companion: pass fetched origins to window.postMessage()

### DIFF
--- a/packages/@uppy/companion/src/companion.js
+++ b/packages/@uppy/companion/src/companion.js
@@ -163,6 +163,7 @@ module.exports.app = (optionsArg = {}) => {
           key,
           secret,
           redirect_uri: getRedirectUri(),
+          origins: ['http://localhost:5173'],
         },
       })
     })

--- a/packages/@uppy/companion/src/server/controllers/connect.js
+++ b/packages/@uppy/companion/src/server/controllers/connect.js
@@ -3,8 +3,8 @@ const oAuthState = require('../helpers/oauth-state')
 /**
  * Derived from `cors` npm package.
  * @see https://github.com/expressjs/cors/blob/791983ebc0407115bc8ae8e64830d440da995938/lib/index.js#L19-L34
- * @param {string} origin 
- * @param {*} allowedOrigins 
+ * @param {string} origin
+ * @param {*} allowedOrigins
  * @returns {boolean}
  */
 function isOriginAllowed(origin, allowedOrigins) {
@@ -16,7 +16,6 @@ function isOriginAllowed(origin, allowedOrigins) {
   }
   return allowedOrigins.test?.(origin) ?? !!allowedOrigins;
 }
-
 
 const queryString = (params, prefix = '?') => {
   const str = new URLSearchParams(params).toString()
@@ -66,7 +65,7 @@ function getClientOrigin(base64EncodedState) {
  *
  * The client has open a new tab and is about to be redirected to the auth
  * provider. When the user will return to companion, we'll have to send the auth
- * token back to Uppy with `window.postMessage()`. 
+ * token back to Uppy with `window.postMessage()`.
  * To prevent other tabs and unauthorized origins from accessing that token, we
  * reuse origin(s) from `corsOrigins` to limit the scope of `postMessage()`, which
  * has `targetOrigin` parameter, required for cross-origin messages (i.e. if Uppy
@@ -113,3 +112,4 @@ module.exports = function connect(req, res, next) {
   }
   encodeStateAndRedirect(req, res, stateObj)
 }
+module.exports.isOriginAllowed = isOriginAllowed

--- a/packages/@uppy/companion/src/server/controllers/send-token.js
+++ b/packages/@uppy/companion/src/server/controllers/send-token.js
@@ -53,7 +53,7 @@ const htmlContent = (token, origin) => {
  */
 module.exports = function sendToken(req, res, next) {
   // @ts-expect-error untyped
-  const {companion} = req
+  const { companion } = req
   const uppyAuthToken = companion.authToken
 
   const { state } = oAuthState.getGrantDynamicFromRequest(req)
@@ -62,8 +62,8 @@ module.exports = function sendToken(req, res, next) {
     return next()
   }
 
-  const decoded = oAuthState.decodeState(state, companion.options.secret)
-  const { origin: clientOrigin, customerDefinedAllowedOrigins } = decoded
+  const clientOrigin = oAuthState.getFromState(state, 'origin', companion.options.secret)
+  const customerDefinedAllowedOrigins = oAuthState.getFromState(state, 'customerDefinedAllowedOrigins', companion.options.secret)
 
   if (
     customerDefinedAllowedOrigins &&

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -113,7 +113,7 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
       // token through window.postMessage (see comment in connect.js).
       // postMessage happens in send-token.js, which is a different request, so we need to put the allowed origins
       // on the encrypted session state to access it later there.
-      if (credentials.origins) {
+      if (Array.isArray(credentials.origins) && credentials.origins.length > 0) {
         const decodedState = oAuthState.decodeState(state, companionOptions.secret)
         decodedState.customerDefinedAllowedOrigins = credentials.origins
         const newState = oAuthState.encodeState(decodedState, companionOptions.secret)

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -108,10 +108,32 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
 
       const credentials = await fetchProviderKeys(providerName, companionOptions, payload)
 
+      // Besides the key and secret the fetched credentials can also contain `origins`,
+      // which is an array of strings of allowed origins to prevent any origin from getting the OAuth
+      // token through window.postMessage (see comment in connect.js).
+      // postMessage happens in send-token.js, which is a different request, so we need to put the allowed origins
+      // on the encrypted session state to access it later there.
+      if (credentials.origins) {
+        const decodedState = oAuthState.decodeState(state, companionOptions.secret)
+        decodedState.customerDefinedAllowedOrigins = credentials.origins
+        const newState = oAuthState.encodeState(decodedState, companionOptions.secret)
+        // @ts-expect-error untyped
+        req.session.grant = {
+          // @ts-expect-error untyped
+          ...(req.session.grant || {}),
+          dynamic: {
+            // @ts-expect-error untyped
+            ...(req.session.grant?.dynamic || {}),
+            state: newState,
+          },
+        }
+      }
+
       res.locals.grant = {
         dynamic: {
           key: credentials.key,
           secret: credentials.secret,
+          origins: credentials.origins,
         },
       }
 

--- a/packages/@uppy/companion/src/server/provider/credentials.js
+++ b/packages/@uppy/companion/src/server/provider/credentials.js
@@ -120,10 +120,10 @@ exports.getCredentialsOverrideMiddleware = (providers, companionOptions) => {
         // @ts-expect-error untyped
         req.session.grant = {
           // @ts-expect-error untyped
-          ...(req.session.grant || {}),
+          ...req.session.grant,
           dynamic: {
             // @ts-expect-error untyped
-            ...(req.session.grant?.dynamic || {}),
+            ...req.session.grant?.dynamic,
             state: newState,
           },
         }

--- a/packages/@uppy/companion/src/server/provider/index.js
+++ b/packages/@uppy/companion/src/server/provider/index.js
@@ -136,7 +136,7 @@ module.exports.addProviderOptions = (companionOptions, grantConfig, getOauthProv
       grantConfig[oauthProvider].secret = providerOptions[providerName].secret
       if (providerOptions[providerName].credentialsURL) {
         // eslint-disable-next-line no-param-reassign
-        grantConfig[oauthProvider].dynamic = ['key', 'secret', 'redirect_uri']
+        grantConfig[oauthProvider].dynamic = ['key', 'secret', 'redirect_uri', 'origins']
       }
 
       const provider = exports.getDefaultProviders()[providerName]


### PR DESCRIPTION
Closes #5310 

This fixes the Companion side of the issue. Another change is required on the api side.

When the origins don't match the screen ends up with a 404.