### PR TITLE
Allow Transloadit-hosted Companion with other uploaders

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -231,6 +231,7 @@ export interface State<M extends Meta, B extends Body>
   currentUploads: Record<string, CurrentUpload<M, B>>
   allowNewUpload: boolean
   recoveredState: null | Required<Pick<State<M, B>, 'files' | 'currentUploads'>>
+  remoteUploader?: 'tus' | 's3-multipart' | 'multipart'
   error: string | null
   files: {
     [key: string]: UppyFile<M, B>

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -130,6 +130,12 @@ export interface TransloaditOptions<M extends Meta, B extends Body>
   waitForMetadata?: boolean
   importFromUploadURLs?: boolean
   alwaysRunAssembly?: boolean
+  /**
+   * Only use Transloadit for remote file uploads (such as from Google Drive).
+   * Enabling this means you have to install another plugin for local files,
+   * such as @uppy/aws-s3 or @uppy/xhr-upload.
+   */
+  companionOnly?: boolean
   limit?: number
   clientName?: string | null
   retryDelays?: number[]
@@ -145,6 +151,7 @@ const defaultOptions = {
   waitForMetadata: false,
   alwaysRunAssembly: false,
   importFromUploadURLs: false,
+  companionOnly: false,
   limit: 20,
   retryDelays: [7_000, 10_000, 15_000, 20_000],
   clientName: null,
@@ -294,6 +301,13 @@ export default class Transloadit<
     this.#rateLimitedQueue = new RateLimitedQueue(this.opts.limit)
 
     this.i18nInit()
+
+    if (this.opts.companionOnly) {
+      // Transloadit is only a pre and post processor.
+      // To let Transloadit hosted Companion download the file,
+      // we instruct any other upload plugin to use tus for remote uploads.
+      this.uppy.setState({ remoteUploader: 'tus' })
+    }
 
     this.client = new Client({
       service: this.opts.service,
@@ -802,26 +816,30 @@ export default class Transloadit<
 
     assemblyOptions.fields ??= {}
     validateParams(assemblyOptions.params)
+    const ids =
+      this.opts.companionOnly ?
+        fileIDs.filter((id) => this.uppy.getFile(id).isRemote)
+      : fileIDs
 
     try {
       const assembly =
         // this.assembly can already be defined if we recovered files with Golden Retriever (this.#onRestored)
-        this.assembly ?? (await this.#createAssembly(fileIDs, assemblyOptions))
+        this.assembly ?? (await this.#createAssembly(ids, assemblyOptions))
 
       if (assembly == null)
         throw new Error('All files were canceled after assembly was created')
 
       if (this.opts.importFromUploadURLs) {
-        await this.#reserveFiles(assembly, fileIDs)
+        await this.#reserveFiles(assembly, ids)
       }
-      fileIDs.forEach((fileID) => {
+      ids.forEach((fileID) => {
         const file = this.uppy.getFile(fileID)
         this.uppy.emit('preprocess-complete', file)
       })
       this.#createAssemblyWatcher(assembly.status.assembly_id)
-      this.#connectAssembly(assembly, fileIDs)
+      this.#connectAssembly(assembly, ids)
     } catch (err) {
-      fileIDs.forEach((fileID) => {
+      ids.forEach((fileID) => {
         const file = this.uppy.getFile(fileID)
         // Clear preprocessing state when the Assembly could not be created,
         // otherwise the UI gets confused about the lingering progress keys
@@ -937,9 +955,9 @@ export default class Transloadit<
     if (this.opts.importFromUploadURLs) {
       // No uploader needed when importing; instead we take the upload URL from an existing uploader.
       this.uppy.on('upload-success', this.#onFileUploadURLAvailable)
-    } else {
-      // we don't need it here.
-      // the regional endpoint from the Transloadit API before we can set it.
+      // If companionOnly is true, another uploader plugin is installed for local uploads
+      // and we only use Transloadit to create an assembly for the remote files.
+    } else if (!this.opts.companionOnly) {
       this.uppy.use(Tus, {
         // Disable tus-js-client fingerprinting, otherwise uploading the same file at different times
         // will upload to an outdated Assembly, and we won't get socket events for it.
@@ -954,7 +972,6 @@ export default class Transloadit<
         // Send all metadata to Transloadit. Metadata set by the user
         // ends up as in the template as `file.user_meta`
         allowedMetaFields: true,
-        // Pass the limit option to @uppy/tus
         limit: this.opts.limit,
         rateLimitedQueue: this.#rateLimitedQueue,
         retryDelays: this.opts.retryDelays,

--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -438,9 +438,19 @@ export default class XHRUpload<
       opts.allowedMetaFields,
       file.meta,
     )
+    // When you .use(AwsS3) with .use(Transloadit, { companionOnly: true }),
+    // local files are uploaded with this plugin and remote files with the Transloadit plugin.
+    // Since the Transloadit plugin uses the tus plugin underneath, it's possible to have file.tus
+    // even though we are in this plugin.
+    // @ts-expect-error typed in @uppy/tus
+    if (file.tus) {
+      // @ts-expect-error typed in @uppy/tus
+      Object.assign(opts, file.tus)
+    }
+
     return {
       ...file.remote?.body,
-      protocol: 'multipart',
+      protocol: this.uppy.getState().remoteUploader || 'multipart',
       endpoint: opts.endpoint,
       size: file.data.size,
       fieldname: opts.fieldName,

--- a/private/dev/Dashboard.js
+++ b/private/dev/Dashboard.js
@@ -168,7 +168,7 @@ export default () => {
     .use(Webdav, {
       target: Dashboard,
       companionUrl: COMPANION_URL,
-      companionAllowedHosts
+      companionAllowedHosts,
     })
     .use(Audio, {
       target: Dashboard,
@@ -195,6 +195,15 @@ export default () => {
         shouldUseMultipart: false,
       })
       break
+    case 's3-with-transloadit-companion':
+      uppyDashboard.use(AwsS3, { endpoint: COMPANION_URL })
+      uppyDashboard.use(Transloadit, {
+        service: TRANSLOADIT_SERVICE_URL,
+        waitForEncoding: true,
+        assemblyOptions,
+        companionOnly: true,
+      })
+      break
     case 's3-multipart':
       uppyDashboard.use(AwsS3, {
         endpoint: COMPANION_URL,
@@ -206,6 +215,12 @@ export default () => {
         endpoint: XHR_ENDPOINT,
         limit: 6,
         bundle: false,
+      })
+      uppyDashboard.use(Transloadit, {
+        service: TRANSLOADIT_SERVICE_URL,
+        waitForEncoding: true,
+        assemblyOptions,
+        companionOnly: true,
       })
       break
     case 'transloadit':
@@ -221,6 +236,7 @@ export default () => {
         waitForEncoding: true,
         importFromUploadURLs: true,
         assemblyOptions,
+        companionOnly: true,
       })
       break
     case 'transloadit-xhr':


### PR DESCRIPTION
We want to allow people to only use Transloadit for Companion, even if they use another uploader. This makes using Transloadit less all-or-nothing. 

Unfortunately there is no pretty way of doing this. Instead of separating Companion logic from uploaders, every uploader implements remote uploads themselves. It works like this:

1. Install a remote plugin (such as `@uppy/google-drive`)
2. The remote plugin creates a companion request client (`@uppy/companion-client`) and `@uppy/provider-views`
3. Inside `@uppy/provider-views` we call `uppy.registerRequestClient()` to put the request client on core so it can be shared.
   - We need to store request clients by a unique ID, so we can share RequestClient instances across files
this allows us to do rate limiting and synchronous operations like refreshing provider tokens
example: refreshing tokens: if each file has their own requestclient,
we don't have any way to synchronize all requests in order to block all requests, refresh the token, and unblock all requests and allow them to run with a the new access token.
4. When the upload starts, uploader plugins (such as `@uppy/aws-s3`) filters the remote files and gets the instructions to tell Companion what uploader to use:

https://github.com/transloadit/uppy/blob/d6156bb92f0f0ff400a7dbb46bbe375f10421ac1/packages/%40uppy/aws-s3/src/index.ts#L925-L972

---

With this PR you can do this:

```ts
uppy.use(AwsS3, { /* ... */ })
uppy.use(Transloadit, { companionOnly: true /* ... */ })
```

This is the least ugly way I could come up with.