### PR TITLE
@uppy/tus: fix onBeforeRequest type

### DIFF
--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -42,7 +42,10 @@ export interface TusOpts<M extends Meta, B extends Body>
     | ((file: UppyFile<M, B>) => Record<string, string>)
   limit?: number
   chunkSize?: number
-  onBeforeRequest?: (req: tus.HttpRequest, file: UppyFile<M, B>) => void
+  onBeforeRequest?: (
+    req: tus.HttpRequest,
+    file: UppyFile<M, B>,
+  ) => void | Promise<void>
   onShouldRetry?: (
     err: tus.DetailedError,
     retryAttempt: number,


### PR DESCRIPTION
c.f. https://github.com/transloadit/uppy/blob/d6156bb92f0f0ff400a7dbb46bbe375f10421ac1/packages/%40uppy/tus/src/index.ts#L243-L271

Sonarcloud was complaining because we returned a Promise in our onBeforeRequest handler:
![image](https://github.com/user-attachments/assets/ec46904e-b6e5-41a7-b07e-96aff53818b9)
https://github.com/owncloud/web/pull/12052#issuecomment-2565281692