### PR TITLE
@uppy/core: fix TypeScript errors

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -649,9 +649,6 @@ export class Uppy<
           ...files[fileID].progress,
           ...defaultProgress,
         },
-        // @ts-expect-error these typed are inserted
-        // into the namespace in their respective packages
-        // but core isn't ware of those
         tus: undefined,
         transloadit: undefined,
       }
@@ -899,7 +896,9 @@ export class Uppy<
     try {
       this.#restricter.validateSingleFile(file)
     } catch (err) {
-      return err.message
+      if (err instanceof Error) {
+        return err.message
+      }
     }
     return null
   }
@@ -911,7 +910,9 @@ export class Uppy<
     try {
       this.#restricter.validateAggregateRestrictions(existingFiles, files)
     } catch (err) {
-      return err.message
+      if (err instanceof Error) {
+        return err.message
+      }
     }
     return null
   }

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -649,6 +649,9 @@ export class Uppy<
           ...files[fileID].progress,
           ...defaultProgress,
         },
+        // these types are inserted into the namespace in their
+        // respective packages but core isn't aware of those
+        // @ts-expect-error 
         tus: undefined,
         transloadit: undefined,
       }


### PR DESCRIPTION
`@ts-expect-error` directive is not needed; nothing wrong with defining `tus` as `undefined`. 

Do some type narrowing of `err` in catch block to confirm it's an `Error` before returning message.

Closes #5592