### PR TITLE
@uppy/aws-s3: always set S3 meta to UppyFile & include key

### DIFF
--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -276,15 +276,20 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
       signal,
     }).abortOn(signal)) as unknown as B // todo this doesn't make sense
 
-    // location will be missing from result if CORS is not correctly set up on the bucket.
-    return 'location' in result ? result : (
-        {
-          // todo `url` is not really the final location URL of the resulting file, it's just the base URL of the bucket
-          // https://github.com/transloadit/uppy/issues/5388
-          location: removeMetadataFromURL(url),
-          ...result,
-        }
+    const key = fields?.key
+    if (!key) {
+      throw new Error(
+        'Expected `fields.key` to be returend but the backend/Companion',
       )
+    }
+    this.#setS3MultipartState(file, { key })
+
+    return {
+      ...result,
+      location: removeMetadataFromURL(url),
+      bucket: fields.bucket,
+      key,
+    }
   }
 
   async uploadFile(
@@ -393,7 +398,8 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
 
       try {
         signature = await this.#fetchSignature(this.#getFile(file), {
-          uploadId,
+          // Always defined for multipart uploads
+          uploadId: uploadId!,
           key,
           partNumber,
           body: chunkData,

--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -278,16 +278,17 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
 
     const key = fields?.key
     if (!key) {
-      throw new Error(
+      console.error(
         'Expected `fields.key` to be returend but the backend/Companion',
       )
     }
-    this.#setS3MultipartState(file, { key })
+    this.#setS3MultipartState(file, { key: key! })
 
     return {
       ...result,
-      location: removeMetadataFromURL(url),
-      bucket: fields.bucket,
+      location:
+        (result.location as string | undefined) ?? removeMetadataFromURL(url),
+      bucket: fields?.bucket,
       key,
     }
   }

--- a/packages/@uppy/aws-s3/src/MultipartUploader.ts
+++ b/packages/@uppy/aws-s3/src/MultipartUploader.ts
@@ -16,7 +16,7 @@ interface MultipartUploaderOptions<M extends Meta, B extends Body> {
   file: UppyFile<M, B>
   log: Uppy<M, B>['log']
 
-  uploadId: string
+  uploadId?: string
   key: string
 }
 

--- a/packages/@uppy/aws-s3/src/index.test.ts
+++ b/packages/@uppy/aws-s3/src/index.test.ts
@@ -50,7 +50,10 @@ describe('AwsS3Multipart', () => {
         getUploadParameters: () => ({
           method: 'POST',
           url: 'https://bucket.s3.us-east-2.amazonaws.com/',
-          fields: {},
+          fields: {
+            key: 'file',
+            bucket: 'https://bucket.s3.us-east-2.amazonaws.com/',
+          },
         }),
       })
       const scope = nock(
@@ -89,6 +92,8 @@ describe('AwsS3Multipart', () => {
           ETag: 'test',
           etag: 'test',
           location: 'http://example.com',
+          key: 'file',
+          bucket: 'https://bucket.s3.us-east-2.amazonaws.com/',
         },
         status: 200,
         uploadURL: 'http://example.com',

--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -510,7 +510,7 @@ export default class AwsS3Multipart<
     return this.#client
       .get<
         AwsS3Part[]
-      >(`s3/multipart/${encodeURIComponent(uploadId)}?key=${filename}`, { signal })
+      >(`s3/multipart/${encodeURIComponent(uploadId!)}?key=${filename}`, { signal })
       .then(assertServerError)
   }
 
@@ -524,7 +524,7 @@ export default class AwsS3Multipart<
     throwIfAborted(signal)
 
     const filename = encodeURIComponent(key)
-    const uploadIdEnc = encodeURIComponent(uploadId)
+    const uploadIdEnc = encodeURIComponent(uploadId!)
     return this.#client
       .post<B>(
         `s3/multipart/${uploadIdEnc}/complete?key=${filename}`,
@@ -633,7 +633,7 @@ export default class AwsS3Multipart<
     this.#assertHost('abortMultipartUpload')
 
     const filename = encodeURIComponent(key)
-    const uploadIdEnc = encodeURIComponent(uploadId)
+    const uploadIdEnc = encodeURIComponent(uploadId!)
     return this.#client
       .delete<void>(`s3/multipart/${uploadIdEnc}?key=${filename}`, undefined, {
         signal,

--- a/packages/@uppy/aws-s3/src/utils.ts
+++ b/packages/@uppy/aws-s3/src/utils.ts
@@ -11,7 +11,7 @@ export function throwIfAborted(signal?: AbortSignal | null): void {
   }
 }
 
-export type UploadResult = { key: string; uploadId: string }
+export type UploadResult = { key: string; uploadId?: string; bucket?: string }
 export type UploadResultWithSignal = UploadResult & { signal?: AbortSignal }
 export type MultipartUploadResult = UploadResult & { parts: AwsS3Part[] }
 export type MultipartUploadResultWithSignal = MultipartUploadResult & {
@@ -25,4 +25,6 @@ export type UploadPartBytesResult = {
 
 export interface AwsBody extends Body {
   location: string
+  key: string
+  bucket: string
 }

--- a/packages/@uppy/companion/src/server/controllers/s3.js
+++ b/packages/@uppy/companion/src/server/controllers/s3.js
@@ -135,6 +135,7 @@ module.exports = function s3 (config) {
       res.json({
         key: data.Key,
         uploadId: data.UploadId,
+        bucket: data.Bucket
       })
     }, next)
   }
@@ -360,6 +361,8 @@ module.exports = function s3 (config) {
     })).then(data => {
       res.json({
         location: data.Location,
+        key: data.Key,
+        bucket: data.Bucket
       })
     }, next)
   }


### PR DESCRIPTION
Closes #5513 
Closes #5586
Closes #5565 
Closes #5569 

- `uppy.on('upload-success', (file, response) => {})` now correctly has `response.body` populated.
- `uppy.getFile(someId).s3Multipart` is now always populated (previously only for multipart uploads).
- `uppy.getFile(someId).meta` does not contain S3 related data. Use `file.s3Multipart` for that.