### PR TITLE
@uppy/aws-s3: Fixed default shouldUseMultipart

### DIFF
--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -284,10 +284,8 @@ const defaultOptions = {
   allowedMetaFields: true,
   limit: 6,
   getTemporarySecurityCredentials: false as any,
-  // eslint-disable-next-line no-bitwise
   shouldUseMultipart: ((file: UppyFile<any, any>) =>
-    // eslint-disable-next-line no-bitwise
-    (file.size! >> 10) >> 10 > 100) as any as true,
+    (file.size || 0) > 100 * 1024 * 1024) as any as true,
   retryDelays: [0, 1000, 3000, 5000],
 } satisfies Partial<AwsS3MultipartOptions<any, any>>
 


### PR DESCRIPTION
Fixes https://github.com/transloadit/uppy/issues/5458

Fixed a bug in the `shouldUseMultipart` function where it failed to return the expected result for large file sizes.

For example, a file size of ~70GB incorrectly returned false.

```javascript
const shouldUseMultipart = (size) => (
  size >> 10 >> 10 > 100
)
shouldUseMultipart(75161927680) // Output: false
```

This issue was caused by improper use of the bitwise shift operator for size comparison.

Also, added some tests for the `defaultOptions` to ensure reliability and prevent similar issues in the future.