### PR TITLE
@uppy/dashboard: do not allow drag&drop of file preview

### DIFF
--- a/packages/@uppy/dashboard/src/components/FilePreview.tsx
+++ b/packages/@uppy/dashboard/src/components/FilePreview.tsx
@@ -9,6 +9,7 @@ export default function FilePreview(props: $TSFixMe) {
   if (file.preview) {
     return (
       <img
+        draggable={false}
         className="uppy-Dashboard-Item-previewImg"
         alt={file.name}
         src={file.preview}


### PR DESCRIPTION
Closes #5639 

Browsers have subtle differences when which makes it hard to detect a duplicate between a generated file preview and the original file so we simply do not allow drag & drop of the generated file preview.