### PR TITLE
@uppy/core: make upload() idempotent

### DIFF
--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -821,27 +821,6 @@ describe('src/Core', () => {
         uploadStarted: null,
       })
     })
-
-    it('should report an error if post-processing a file fails', () => {
-      const core = new Core()
-
-      core.addFile({
-        source: 'vi',
-        name: 'foo.jpg',
-        type: 'image/jpeg',
-        data: testImage,
-      })
-
-      const fileId = Object.keys(core.getState().files)[0]
-      const file = core.getFile(fileId)
-      core.emit('error', new Error('foooooo'), file)
-
-      expect(core.getState().error).toEqual('foooooo')
-
-      expect(core.upload()).resolves.toMatchObject({
-        failed: [{ name: 'foo.jpg' }],
-      })
-    })
   })
 
   describe('uploaders', () => {

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -2241,7 +2241,7 @@ export class Uppy<
   /**
    * Start an upload for all the files that are not currently being uploaded.
    */
-  upload(): Promise<NonNullable<UploadResult<M, B>> | undefined> {
+  async upload(): Promise<NonNullable<UploadResult<M, B>> | undefined> {
     if (!this.#plugins['uploader']?.length) {
       this.log('No uploader type plugins are used', 'warning')
     }
@@ -2275,7 +2275,15 @@ export class Uppy<
       const uploadID = this.#createUpload(filesToRetry, {
         forceAllowNewUpload: true, // create new upload even if allowNewUpload: false
       })
-      return this.#runUpload(uploadID)
+      const result = await this.#runUpload(uploadID)
+      const hasNewFiles = this.getFiles().filter(
+        (file) => file.progress.uploadStarted == null,
+      )
+
+      if (!hasNewFiles) {
+        return result
+      }
+      files = this.getState().files
     }
 
     // If no files to retry, proceed with original upload() behavior for new files

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -2272,13 +2272,6 @@ export class Uppy<
 
       this.emit('retry-all', Object.values(updatedFiles))
 
-      if (filesToRetry.length === 0) {
-        return Promise.resolve({
-          successful: [],
-          failed: [],
-        })
-      }
-
       const uploadID = this.#createUpload(filesToRetry, {
         forceAllowNewUpload: true, // create new upload even if allowNewUpload: false
       })
@@ -2340,13 +2333,6 @@ export class Uppy<
             waitingFileIDs.push(file.id)
           }
         })
-
-        if (waitingFileIDs.length === 0) {
-          return Promise.resolve({
-            successful: [],
-            failed: [],
-          })
-        }
 
         const uploadID = this.#createUpload(waitingFileIDs)
         return this.#runUpload(uploadID)


### PR DESCRIPTION
Closes #5669 
Closes #5676 

**Before**
1. Add a file
2. Call `uppy.upload()` but make it fail (set throttling to offline in your browser)
3. Call `uppy.upload()` again but no throttling
4. Events are not fired, endless uploading state.

You must call `retryAll()` instead but it's better DX if you can simply call `upload()` again and let us figure it out.

**After**

`upload()` behaves like `retryAll()` when errors occurred in a backwards compatible way.

**What if an upload fails and you also add a new file?**

Backwards compatible behaviour similar to how it currently works when using the dashboard. In the dashboard you can only click the retry button and once that upload is done you can click upload again to upload the new files.

When a previous upload partially failed, you add a new file, and call `upload()` this PR makes sure two uploads are done in a row. That does mean you get the `'complete'` event twice.
