### PR TITLE
@uppy-example/aws-nodejs: fix fileType not present in S3 objects

### DIFF
--- a/examples/aws-nodejs/index.js
+++ b/examples/aws-nodejs/index.js
@@ -74,8 +74,10 @@ function getSTSClient() {
   return stsClient
 }
 
+// Generate a unique S3 key for the file
 const generateS3Key = (filename) => `${crypto.randomUUID()}-${filename}`
 
+// Extract the file parameters from the request
 const extractFileParameters = (req) => {
   const isPostRequest = req.method === 'POST'
   const params = isPostRequest ? req.body : req.query
@@ -86,6 +88,7 @@ const extractFileParameters = (req) => {
   }
 }
 
+// Validate the file parameters
 const validateFileParameters = (filename, contentType) => {
   if (!filename || !contentType) {
     throw new Error('Missing required parameters: filename and content type are required')

--- a/examples/aws-nodejs/index.js
+++ b/examples/aws-nodejs/index.js
@@ -74,6 +74,24 @@ function getSTSClient() {
   return stsClient
 }
 
+const generateS3Key = (filename) => `${crypto.randomUUID()}-${filename}`
+
+const extractFileParameters = (req) => {
+  const isPostRequest = req.method === 'POST'
+  const params = isPostRequest ? req.body : req.query
+
+  return {
+    filename: params.filename,
+    contentType: params.type
+  }
+}
+
+const validateFileParameters = (filename, contentType) => {
+  if (!filename || !contentType) {
+    throw new Error('Missing required parameters: filename and content type are required')
+  }
+}
+
 app.use(bodyParser.urlencoded({ extended: true }), bodyParser.json())
 
 app.get('/s3/sts', (req, res, next) => {
@@ -109,8 +127,11 @@ const signOnServer = (req, res, next) => {
   // are authorized to perform that operation, and if the request is legit.
   // For the sake of simplification, we skip that check in this example.
 
-  const Key = `${crypto.randomUUID()}-${req.body.filename}`
-  const { contentType } = req.body
+  const { filename, contentType } = extractFileParameters(req)
+  validateFileParameters(filename, contentType)
+
+  // Generate S3 key and prepare command
+  const Key = generateS3Key(filename)
 
   getSignedUrl(
     getS3Client(),


### PR DESCRIPTION
Fixes #5666

@Murderlon while trying to reproduce and I came across this bug , where uploading a file from the example code provided at `examples/aws-nodejs/public/index.html`
resulted in uploaded files with **undefined_name** in instead of **fileName** in the S3 key as well as no **fileType** present

reference - 

![image](https://github.com/user-attachments/assets/b1b21fb4-fd92-48cd-aaeb-399331f896a3)


this was because while making the request to /s3/params  to get the signed URL , it parses the fileName and contentType from the request body to append it to the Key 

https://github.com/transloadit/uppy/blob/f877dac7e19d1513695cddc1544bfd590b59a974/examples/aws-nodejs/index.js#L107-L121

but in default case (without the customEndpoint) it's a **GET request** which causes this error as we're trying to parse the fileName and contentType from req body ,

https://github.com/transloadit/uppy/blob/f877dac7e19d1513695cddc1544bfd590b59a974/packages/%40uppy/aws-s3/src/index.ts#L659-L665

**After**  : 

![image](https://github.com/user-attachments/assets/a9827a2b-6833-4711-9095-1eb85fea118c)

File uploaded with correct **fileName** and correct **fileType**
