### PR TITLE
@uppy/aws-s3 response undefined while listening for "upload-error" event

### DIFF
--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -831,7 +831,16 @@ export default class AwsS3Multipart<
 
       const onError = (err: unknown) => {
         this.uppy.log(err as Error)
-        this.uppy.emit('upload-error', file, err as Error)
+
+        const errorResponse: UppyFile<M, B>['response'] = {
+          status: (err as any)?.status || 500,
+          body: {
+            message: err instanceof Error ? err.message : 'Unknown error',
+          } as unknown as B,
+          bytesUploaded: file?.progress?.bytesUploaded || 0,
+        }
+
+        this.uppy.emit('upload-error', file, err as Error, errorResponse)
 
         this.resetUploaderReferences(file.id)
         reject(err)


### PR DESCRIPTION
Hi @Murderlon , this looked like an easy fix , but there are a few instances in the codebase where we're emitting "upload-error" without passing the response e.g. 

https://github.com/transloadit/uppy/blob/f877dac7e19d1513695cddc1544bfd590b59a974/packages/%40uppy/transloadit/src/index.ts#L833-L837

I can see that response is an optional param in the interface , so then it seems like it's by design that response was not passed correct ? aren't we expecting users to see the response in case of upload-error event in these cases ?

not sure about this hence will keep it as a Draft PR for now :) 

let me know if this works I'll add tests.
