### PR TITLE
@uppy/core: fix events when retrying with upload()

### DIFF
--- a/packages/@uppy/core/src/Uppy.test.ts
+++ b/packages/@uppy/core/src/Uppy.test.ts
@@ -1351,6 +1351,13 @@ describe('src/Core', () => {
             // @ts-ignore
             core.emit('upload-error', file, new Error('foo'))
             hasError = true
+          } else {
+            // Second time, emit success
+            core.emit('upload-success', file, {
+              status: 200,
+              body: { success: true },
+              uploadURL: 'http://dummy.com/upload/success',
+            })
           }
         })
         return Promise.resolve()
@@ -1376,13 +1383,6 @@ describe('src/Core', () => {
       onUpload.mockReset()
       onUploadError.mockReset()
 
-      // One failed file in memory but we add a new one before uploading
-      core.addFile({
-        source: 'vi',
-        name: 'bar.jpg',
-        type: 'image/jpeg',
-        data: testImage,
-      })
       const onComplete = vi.fn()
       core.on('complete', onComplete)
       // Second time two uploads should happen back-to-back.

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -2280,7 +2280,7 @@ export class Uppy<
         (file) => file.progress.uploadStarted == null,
       )
 
-      if (!hasNewFiles) {
+      if (!hasNewFiles.length) {
         return result
       }
       files = this.getState().files


### PR DESCRIPTION
This fixes #5694 

**Before** -- 

Add a file
Call uppy.upload() but make it fail (set throttling to offline in your browser)
Call uppy.upload() again but no throttling

Current behavior -- The return value of uppy.upload() has zero 'successful' uploads. Instead we get something like {"successful":[],"failed":[],"uploadID":"b3TigKGvK_EoPjsJz9LU_"}

**After** -- 

onComplete get's called once and correct state returned in upload result.


![bug_image](https://github.com/user-attachments/assets/0b86d21d-8410-47ac-9e3f-8415cc072d7b)


