### PR TITLE
Fix google photos picker

### DIFF
--- a/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
@@ -345,7 +345,7 @@ async function resolvePickedPhotos({
       platform: 'photos' as const,
       id,
       mimeType,
-      url: type === 'VIDEO' ? `${baseUrl}=dv` : baseUrl, // dv to download video
+      url: type === 'VIDEO' ? `${baseUrl}=dv` : `${baseUrl}=d`, // dv to download video, d to get original image (non cropped)
       name: filename,
     }),
   )


### PR DESCRIPTION
When I implemented the plugin initially I assumed that not appending any `w` or `h` parameter to the [URL would give the original resolution](https://developers.google.com/photos/library/guides/access-media-items#base-urls), but that's clearly not the case.

https://community.transloadit.com/t/google-photos-picker-downloads-resized-image/17538