### PR TITLE
Don't reject on unknown data format

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -250,7 +250,7 @@ export default class Provider<M extends Meta, B extends Body>
       cleanup = () => {
         authWindow?.close()
         if (interval) {
-          clearInterval(interval)
+          window.clearInterval(interval)
           interval = null
         }
         window.removeEventListener('message', handleToken)
@@ -258,9 +258,9 @@ export default class Provider<M extends Meta, B extends Body>
       }
 
       if (authWindow) {
-        interval = setInterval(() => {
+        interval = window.setInterval(() => {
           if (authWindow.closed) {
-            this.uppy.log('Auth window closed', 'info')
+            this.uppy.log('Auth window closed')
             cleanup()
             reject(new Error('Auth window was closed by the user'))
           }

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -238,7 +238,10 @@ export default class Provider<M extends Meta, B extends Body>
         }
 
         if (!data.token) {
-          reject(new Error('did not receive token from auth window'))
+          this.uppy.log(
+            `Ignoring malformed data from auth window: ${data}`,
+            'warning',
+          )
           return
         }
 

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -245,7 +245,7 @@ export default class Provider<M extends Meta, B extends Body>
         resolve(this.setAuthToken(data.token))
       }
 
-      let interval: NodeJS.Timeout | null = null
+      let interval: number | null = null
 
       cleanup = () => {
         authWindow?.close()

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -217,10 +217,9 @@ export default class Provider<M extends Meta, B extends Body>
 
         const { companionAllowedHosts } = this.#getPlugin().opts
         if (!isOriginAllowed(e.origin, companionAllowedHosts)) {
-          reject(
-            new Error(
-              `rejecting event from ${e.origin} vs allowed pattern ${companionAllowedHosts}`,
-            ),
+          this.uppy.log(
+            `rejecting event from ${e.origin} vs allowed pattern ${companionAllowedHosts}`,
+            'warning',
           )
           return
         }
@@ -238,10 +237,7 @@ export default class Provider<M extends Meta, B extends Body>
         }
 
         if (!data.token) {
-          this.uppy.log(
-            `Ignoring malformed data from auth window: ${data}`,
-            'warning',
-          )
+          reject(new Error('did not receive token from auth window'))
           return
         }
 

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -188,6 +188,12 @@ const getConfigFromEnv = () => {
     corsOrigins: getCorsOrigins(),
     testDynamicOauthCredentials: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS === 'true',
     testDynamicOauthCredentialsSecret: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS_SECRET,
+    endpointOptions: {
+      endpoint: process.env.COMPANION_UPLOADER_ENDPOINT,
+      proxyAuth: process.env.COMPANION_UPLOADER_PROXY_AUTH,
+      proxyAuthCookieName: process.env.COMPANION_UPLOADER_PROXY_AUTH_COOKIE_NAME || "__s__",
+      proxyAuthHeaderName: process.env.COMPANION_UPLOADER_PROXY_AUTH_HEADER_NAME || "Authorization",
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This pull request includes a change to the `Provider` class in the `packages/@uppy/companion-client/src/Provider.ts` file to improve error handling for misaligned origins. Rather than rejecting the `handleToken` Promise on misaligned origin, simply log and return, which will allow subsequent events through.

## Why

It appears as if `Box` has recently[?] added `pendo` to their site, which seems to be attempting to send events to its opener (Uppy Dashboard). These events are dispatched JUST before the rendered `send-token` HTML is able to send its payload off, which currently will cause the Promise to reject, which ends up leaving the "Please authenticate with Box to select files" panel active, even though Box has been auth'd successfully.

### Screenshot of bug in action:

<img width="1457" alt="Screenshot 2025-04-11 at 2 35 28 PM" src="https://github.com/user-attachments/assets/8cdeb61b-55c9-43c1-902c-aba066e1d930" />
