### PR TITLE
@uppy/core: fix undefined reference when cancelling an upload

### DIFF
--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -2243,6 +2243,11 @@ export class Uppy<
       this.log(
         `Not setting result for an upload that has been removed: ${uploadID}`,
       )
+      result = {
+        successful: [],
+        failed: [],
+        uploadID,
+      }
     }
     return result
   }


### PR DESCRIPTION
This fixes #5729 

Before : 

when you upload a large file and cancel it midway 
you would see this error , and in some cases as encountered by @LukasHirt , emits a complete event with undefined payload , both the issues are related , and infact same

![image](https://github.com/user-attachments/assets/0e417335-bcb0-4560-b4f6-b1e50bc8d49e)

complete event is emitted with an undefined result value , which errors out in handleComplete event 

This is happening because upon clicking the cancel button uppy.cancelAll() removeFiles is called which resets the currentUploads


which leads to currentUpload being undefined and result returned from #runUpload as undefined
and that result is sent with non null assertion in the 'complete' event

https://github.com/transloadit/uppy/blob/d58cc203728befb0aa4adc9e5b53d92dc49e813c/packages/%40uppy/core/src/Uppy.ts#L2334-L2338

all leading to this error 

After : 

in case of result == null , we send a default result object with empty succesfull and failed , arrays

![image](https://github.com/user-attachments/assets/2231b985-8a4d-4691-86ae-c8c705aa7e79)
