### PR TITLE
don't reject on incorrect origin

### DIFF
--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -190,71 +190,83 @@ export default class Provider<M extends Meta, B extends Body>
 
     signal.throwIfAborted()
 
-    return new Promise((resolve, reject) => {
-      const link = this.authUrl({ query: { uppyVersions }, authFormData })
-      const authWindow = window.open(link, '_blank')
+    const link = this.authUrl({ query: { uppyVersions }, authFormData })
+    const authWindow = window.open(link, '_blank')
+    let interval: number | undefined
+    let handleMessage: ((e: MessageEvent<any>) => void) | undefined
 
-      let cleanup: () => void
-
-      const handleToken = (e: MessageEvent<any>) => {
-        if (e.source !== authWindow) {
-          let jsonData = ''
-          try {
-            // TODO improve our uppy logger so that it can take an arbitrary number of arguments,
-            // each either objects, errors or strings,
-            // then we don’t have to manually do these things like json stringify when logging.
-            // the logger should never throw an error.
-            jsonData = JSON.stringify(e.data)
-          } catch (err) {
-            // in case JSON.stringify fails (ignored)
+    try {
+      return await new Promise((resolve, reject) => {
+        handleMessage = (e: MessageEvent<any>) => {
+          if (e.source !== authWindow) {
+            let jsonData = ''
+            try {
+              // TODO improve our uppy logger so that it can take an arbitrary number of arguments,
+              // each either objects, errors or strings,
+              // then we don’t have to manually do these things like json stringify when logging.
+              // the logger should never throw an error.
+              jsonData = JSON.stringify(e.data)
+            } catch (err) {
+              // in case JSON.stringify fails (ignored)
+            }
+            this.uppy.log(
+              `ignoring event from unknown source ${jsonData}`,
+              'warning',
+            )
+            return
           }
-          this.uppy.log(
-            `ignoring event from unknown source ${jsonData}`,
-            'warning',
-          )
-          return
+
+          const { companionAllowedHosts } = this.#getPlugin().opts
+          if (!isOriginAllowed(e.origin, companionAllowedHosts)) {
+            this.uppy.log(
+              `ignoring event from ${e.origin} vs allowed pattern ${companionAllowedHosts}`,
+              'warning',
+            )
+            // We cannot reject here because the page might send events from other origins
+            // before sending the "real" auth completed event.
+            // for example Box has a "Pendo" tool that sends events to the opener
+            // https://github.com/transloadit/uppy/pull/5719
+            return
+          }
+
+          // Check if it's a string before doing the JSON.parse to maintain support
+          // for older Companion versions that used object references
+          const data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
+
+          if (data.error) {
+            const { uppy } = this
+            const message = uppy.i18n('authAborted')
+            uppy.info({ message }, 'warning', 5000)
+            reject(new Error('auth aborted'))
+            return
+          }
+
+          if (!data.token) {
+            reject(new Error('did not receive token from auth window'))
+            return
+          }
+
+          resolve(this.setAuthToken(data.token))
         }
 
-        const { companionAllowedHosts } = this.#getPlugin().opts
-        if (!isOriginAllowed(e.origin, companionAllowedHosts)) {
-          reject(
-            new Error(
-              `rejecting event from ${e.origin} vs allowed pattern ${companionAllowedHosts}`,
-            ),
-          )
-          return
+        // poll for user closure of the window, so we can reject when it happens
+        if (authWindow) {
+          interval = window.setInterval(() => {
+            if (authWindow.closed) {
+              reject(new Error('Auth window was closed by the user'))
+            }
+          }, 500)
         }
 
-        // Check if it's a string before doing the JSON.parse to maintain support
-        // for older Companion versions that used object references
-        const data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
-
-        if (data.error) {
-          const { uppy } = this
-          const message = uppy.i18n('authAborted')
-          uppy.info({ message }, 'warning', 5000)
-          reject(new Error('auth aborted'))
-          return
-        }
-
-        if (!data.token) {
-          reject(new Error('did not receive token from auth window'))
-          return
-        }
-
-        cleanup()
-        resolve(this.setAuthToken(data.token))
-      }
-
-      cleanup = () => {
-        authWindow?.close()
-        window.removeEventListener('message', handleToken)
-        signal.removeEventListener('abort', cleanup)
-      }
-
-      signal.addEventListener('abort', cleanup)
-      window.addEventListener('message', handleToken)
-    })
+        signal.addEventListener('abort', () => reject(new Error('Aborted')))
+        window.addEventListener('message', handleMessage)
+      })
+    } finally {
+      // cleanup:
+      authWindow?.close()
+      window.clearInterval(interval)
+      if (handleMessage) window.removeEventListener('message', handleMessage)
+    }
   }
 
   async login({


### PR DESCRIPTION
because Box will send "Pendo" event to opener from a different origin before the real event gets sent.

pulled out from #5719 and improved upon. (i've put the cleanup code inside `finally` so that we get a guaranteed clean up in all scenarios)

closes #5719