### PR TITLE
Add screenshot

### DIFF
--- a/packages/@uppy/screen-capture/src/RecordButton.tsx
+++ b/packages/@uppy/screen-capture/src/RecordButton.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { h } from 'preact'
+import type { I18n } from '@uppy/utils/lib/Translator'
 
-type $TSFixMe = any
+interface RecordButtonProps {
+  recording: boolean | undefined
+  onStartRecording: () => void
+  onStopRecording: () => Promise<void>
+  i18n: I18n
+}
 
 /**
  * Control screen capture recording. Will show record or stop button.
@@ -11,7 +17,7 @@ export default function RecordButton({
   onStartRecording,
   onStopRecording,
   i18n,
-}: $TSFixMe) {
+}: RecordButtonProps): h.JSX.Element {
   if (recording) {
     return (
       <button

--- a/packages/@uppy/screen-capture/src/RecorderScreen.tsx
+++ b/packages/@uppy/screen-capture/src/RecorderScreen.tsx
@@ -15,6 +15,8 @@ type RecorderScreenProps<M extends Meta, B extends Body> = {
   onSubmit: ScreenCapture<M, B>['submit']
   i18n: ScreenCapture<M, B>['i18n']
   stream: ScreenCapture<M, B>['videoStream']
+  onScreenshot: ScreenCapture<M, B>['captureScreenshot']
+  enableScreenshots: boolean
 } & ScreenCaptureState
 
 class RecorderScreen<M extends Meta, B extends Body> extends Component<

--- a/packages/@uppy/screen-capture/src/RecorderScreen.tsx
+++ b/packages/@uppy/screen-capture/src/RecorderScreen.tsx
@@ -7,6 +7,7 @@ import StopWatch from './StopWatch.jsx'
 import StreamStatus from './StreamStatus.jsx'
 
 import ScreenCapture, { type ScreenCaptureState } from './ScreenCapture.jsx'
+import ScreenshotButton from './ScreenshotButton.js'
 
 type RecorderScreenProps<M extends Meta, B extends Body> = {
   onStartRecording: ScreenCapture<M, B>['startRecording']
@@ -30,7 +31,12 @@ class RecorderScreen<M extends Meta, B extends Body> extends Component<
   }
 
   render(): ComponentChild {
-    const { recording, stream: videoStream, recordedVideo } = this.props
+    const {
+      recording,
+      stream: videoStream,
+      recordedVideo,
+      enableScreenshots,
+    } = this.props
 
     const videoProps: {
       muted?: boolean
@@ -78,6 +84,7 @@ class RecorderScreen<M extends Meta, B extends Body> extends Component<
         </div>
 
         <div className="uppy-ScreenCapture-buttonContainer">
+          {enableScreenshots && <ScreenshotButton {...this.props} />}
           <RecordButton {...this.props} />
           <SubmitButton {...this.props} />
         </div>

--- a/packages/@uppy/screen-capture/src/ScreenCapture.tsx
+++ b/packages/@uppy/screen-capture/src/ScreenCapture.tsx
@@ -57,6 +57,9 @@ const defaultOptions = {
     audio: true,
   },
   preferredVideoMimeType: 'video/webm',
+  preferredImageMimeType: 'image/png',
+  screenshotQuality: 0.92,
+  enableScreenshots: false,
 }
 
 type Opts = DefinePluginOpts<ScreenCaptureOptions, keyof typeof defaultOptions>
@@ -131,6 +134,7 @@ export default class ScreenCapture<
     this.stopRecording = this.stopRecording.bind(this)
     this.submit = this.submit.bind(this)
     this.streamInterrupted = this.streamInactivated.bind(this)
+    this.captureScreenshot = this.captureScreenshot.bind(this)
 
     // initialize
     this.captureActive = false
@@ -576,6 +580,8 @@ export default class ScreenCapture<
         {...recorderState} // eslint-disable-line react/jsx-props-no-spreading
         onStartRecording={this.startRecording}
         onStopRecording={this.stopRecording}
+        enableScreenshots={this.opts.enableScreenshots}
+        onScreenshot={this.captureScreenshot}
         onStop={this.stop}
         onSubmit={this.submit}
         i18n={this.i18n}

--- a/packages/@uppy/screen-capture/src/ScreenshotButton.tsx
+++ b/packages/@uppy/screen-capture/src/ScreenshotButton.tsx
@@ -1,0 +1,36 @@
+import { h } from 'preact'
+
+interface ScreenshotButtonProps {
+  onScreenshot: () => void
+  i18n: (key: string) => string
+}
+
+export default function ScreenshotButton({
+  onScreenshot,
+  i18n,
+}: ScreenshotButtonProps) {
+  return (
+    <button
+      className="uppy-u-reset uppy-c-btn uppy-ScreenCapture-button uppy-ScreenCapture-button--screenshot"
+      type="button"
+      title={i18n('takeScreenshot')}
+      aria-label={i18n('takeScreenshot')}
+      onClick={onScreenshot}
+      data-uppy-super-focusable
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="uppy-c-icon"
+        width="32"
+        height="32"
+        viewBox="0 0 32 32"
+      >
+        <path
+          d="M27 9h-3.33l-2-2H13.33l-2 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h19c1.1 0 2-.9 2-2V11c0-1.1-.9-2-2-2zM17.5 19c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  )
+}

--- a/packages/@uppy/screen-capture/src/SubmitButton.tsx
+++ b/packages/@uppy/screen-capture/src/SubmitButton.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { h } from 'preact'
+import type { I18n } from '@uppy/utils/lib/Translator'
 
-type $TSFixMe = any
+interface SubmitButtonProps {
+  recording: boolean
+  recordedVideo: string | null
+  onSubmit: () => void
+  i18n: I18n
+}
 
 /**
  * Submit recorded video to uppy. Enabled when file is available
@@ -11,7 +17,7 @@ export default function SubmitButton({
   recordedVideo,
   onSubmit,
   i18n,
-}: $TSFixMe) {
+}: SubmitButtonProps): h.JSX.Element | null {
   if (recordedVideo && !recording) {
     return (
       <button

--- a/packages/@uppy/screen-capture/src/locale.ts
+++ b/packages/@uppy/screen-capture/src/locale.ts
@@ -8,6 +8,6 @@ export default {
     streamPassive: 'Stream passive',
     micDisabled: 'Microphone access denied by user',
     recording: 'Recording',
-    takeScreenshot: 'Take screenshot',
+    takeScreenshot: 'Take Screenshot',
   },
 }

--- a/packages/@uppy/screen-capture/src/locale.ts
+++ b/packages/@uppy/screen-capture/src/locale.ts
@@ -8,5 +8,6 @@ export default {
     streamPassive: 'Stream passive',
     micDisabled: 'Microphone access denied by user',
     recording: 'Recording',
+    takeScreenshot: 'Take screenshot',
   },
 }

--- a/packages/@uppy/screen-capture/src/style.scss
+++ b/packages/@uppy/screen-capture/src/style.scss
@@ -154,3 +154,34 @@
     background-color: darken($red, 10%);
   }
 }
+
+.uppy-ScreenCapture-button--screenshot {
+  margin-right: 8px;
+  background-color: $gray-500;
+  color: $white;
+  outline: none;
+
+  [data-uppy-theme='dark'] & {
+    background-color: $gray-700;
+  }
+
+  svg {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
+    vertical-align: text-top;
+    fill: currentColor;
+  }
+
+  &:hover {
+    background-color: darken($gray-500, 10%);
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
# Screenshot Support for Screen Capture Plugin

Closes #3310

## Overview

Added screenshot capture functionality to `@uppy/screen-capture` plugin, allowing users to take screenshots alongside screen recordings.

### API Changes
Added new configuration options:
- `enableScreenshots`: Toggle screenshot functionality (default: false)
- `screenshotQuality`: Control image compression (0.0-1.0, default: 0.9)
- `preferredImageMimeType`: Set output format ('image/jpeg'|'image/png', default: 'image/jpeg')

### Implementation Details
- Reused existing screen capture stream for drawing screenshot and converting them to Blob and storing the image
- proper state cleanup , in case of error and component unmount
- added missing component prop types and return types in RecordButton and SubmitButton Components 

Hi @Murderlon let me know what do you think about this, also how do I update the docs for this plugin ? and the stackblitz live example.

## Screenshots
![image](https://github.com/user-attachments/assets/c68c4746-fdf8-447d-87c3-ff6c1b517637)
