### PR TITLE
fix: multiply authStateExpiry by 1000 when adding tokens to cookies

### DIFF
--- a/packages/@uppy/companion/src/server/controllers/callback.js
+++ b/packages/@uppy/companion/src/server/controllers/callback.js
@@ -56,7 +56,7 @@ module.exports = function callback (req, res, next) { // eslint-disable-line no-
     req.companion.options.secret, req.companion.providerClass.authStateExpiry,
   )
 
-  tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry)
+  tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry * 1000)
 
   return res.redirect(req.companion.buildURL(`/${providerName}/send-token?uppyAuthToken=${uppyAuthToken}`, true))
 }

--- a/packages/@uppy/companion/src/server/controllers/refresh-token.js
+++ b/packages/@uppy/companion/src/server/controllers/refresh-token.js
@@ -36,7 +36,7 @@ async function refreshToken (req, res, next) {
       req.companion.options.secret, req.companion.providerClass.authStateExpiry,
     )
 
-    tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry)
+    tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry * 1000)
 
     res.send({ uppyAuthToken })
   } catch (err) {

--- a/packages/@uppy/companion/src/server/controllers/simple-auth.js
+++ b/packages/@uppy/companion/src/server/controllers/simple-auth.js
@@ -19,7 +19,7 @@ async function simpleAuth (req, res, next) {
       req.companion.options.secret, req.companion.providerClass.authStateExpiry,
     )
 
-    tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry)
+    tokenService.addToCookiesIfNeeded(req, res, uppyAuthToken, req.companion.providerClass.authStateExpiry * 1000)
 
     res.send({ uppyAuthToken })
   } catch (err) {


### PR DESCRIPTION
Fixes [Cookie maxAge is set in seconds instead of milliseconds for Companion providers' cookies](https://github.com/transloadit/uppy/issues/5745)