### PR TITLE
@uppy/webcam: add image preview and discard

### DIFF
--- a/packages/@uppy/components/src/hooks/webcam.ts
+++ b/packages/@uppy/components/src/hooks/webcam.ts
@@ -151,7 +151,7 @@ export function createWebcamController(
   const getDiscardButtonProps = () => ({
     type: 'button' as const,
     onClick: () => {
-      plugin.discardRecordedVideo()
+      plugin.discardRecordedMedia()
     },
     disabled: plugin.getStatus() !== 'captured',
   })

--- a/packages/@uppy/webcam/src/CameraScreen.tsx
+++ b/packages/@uppy/webcam/src/CameraScreen.tsx
@@ -22,6 +22,7 @@ interface CameraScreenProps extends VideoSourceSelectProps {
   src: MediaStream | null
   recording: boolean
   recordedVideo: string | null
+  capturedSnapshot: string | null
   modes: string[]
   supportsRecording: boolean
   showVideoSourceDropdown: boolean
@@ -32,7 +33,7 @@ interface CameraScreenProps extends VideoSourceSelectProps {
   onSnapshot: () => void
   onStartRecording: () => void
   onStopRecording: () => void
-  onDiscardRecordedVideo: () => void
+  onDiscardRecordedMedia: () => void
   recordingLengthSeconds: number
 }
 
@@ -55,6 +56,7 @@ class CameraScreen extends Component<CameraScreenProps> {
     const {
       src,
       recordedVideo,
+      capturedSnapshot,
       recording,
       modes,
       supportsRecording,
@@ -67,19 +69,21 @@ class CameraScreen extends Component<CameraScreenProps> {
       onSnapshot,
       onStartRecording,
       onStopRecording,
-      onDiscardRecordedVideo,
+      onDiscardRecordedMedia,
       recordingLengthSeconds,
     } = this.props
 
     const hasRecordedVideo = !!recordedVideo
+    const hasCapturedSnapshot = !!capturedSnapshot
+    const hasRecordedMedia = hasRecordedVideo || hasCapturedSnapshot
     const shouldShowRecordButton =
-      !hasRecordedVideo &&
+      !hasRecordedMedia &&
       supportsRecording &&
       (isModeAvailable(modes, 'video-only') ||
         isModeAvailable(modes, 'audio-only') ||
         isModeAvailable(modes, 'video-audio'))
     const shouldShowSnapshotButton =
-      !hasRecordedVideo && isModeAvailable(modes, 'picture')
+      !hasRecordedMedia && isModeAvailable(modes, 'picture')
     const shouldShowRecordingLength =
       supportsRecording && showRecordingLength && !hasRecordedVideo
     const shouldShowVideoSourceDropdown =
@@ -104,19 +108,30 @@ class CameraScreen extends Component<CameraScreenProps> {
       // @ts-expect-error srcObject does not exist on <video> props
       videoProps.srcObject = src
     }
-
     return (
       <div className="uppy uppy-Webcam-container">
         <div className="uppy-Webcam-videoContainer">
-          <video
-            /* eslint-disable-next-line no-return-assign */
-            ref={(videoElement) => (this.videoElement = videoElement!)}
-            className={`uppy-Webcam-video  ${
-              mirror ? 'uppy-Webcam-video--mirrored' : ''
-            }`}
-            /* eslint-disable-next-line react/jsx-props-no-spreading */
-            {...videoProps}
-          />
+          {
+            capturedSnapshot && !recording && !recordedVideo ?
+              <div className="uppy-Webcam-imageContainer">
+                <img
+                  src={capturedSnapshot}
+                  className="uppy-Webcam-video"
+                  alt="capturedSnapshot"
+                />
+              </div>
+              // eslint-disable-next-line jsx-a11y/media-has-caption
+            : <video
+                /* eslint-disable-next-line no-return-assign */
+                ref={(videoElement) => (this.videoElement = videoElement!)}
+                className={`uppy-Webcam-video  ${
+                  mirror ? 'uppy-Webcam-video--mirrored' : ''
+                }`}
+                /* eslint-disable-next-line react/jsx-props-no-spreading */
+                {...videoProps}
+              />
+
+          }
         </div>
         <div className="uppy-Webcam-footer">
           <div className="uppy-Webcam-videoSourceContainer">
@@ -138,12 +153,12 @@ class CameraScreen extends Component<CameraScreenProps> {
               />
             )}
 
-            {hasRecordedVideo && (
+            {(hasRecordedVideo || hasCapturedSnapshot) && (
               <SubmitButton onSubmit={onSubmit} i18n={i18n} />
             )}
 
-            {hasRecordedVideo && (
-              <DiscardButton onDiscard={onDiscardRecordedVideo} i18n={i18n} />
+            {(hasRecordedVideo || hasCapturedSnapshot) && (
+              <DiscardButton onDiscard={onDiscardRecordedMedia} i18n={i18n} />
             )}
           </div>
 

--- a/packages/@uppy/webcam/src/Webcam.tsx
+++ b/packages/@uppy/webcam/src/Webcam.tsx
@@ -92,6 +92,7 @@ export interface WebcamState {
   videoSources: MediaDeviceInfo[]
   currentDeviceId: string | MediaStreamTrack | null | undefined
   recordedVideo: null | string
+  capturedSnapshot: null | string
   isRecording: boolean
   [key: string]: unknown
 }
@@ -188,7 +189,7 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
     this.takeSnapshot = this.takeSnapshot.bind(this)
     this.startRecording = this.startRecording.bind(this)
     this.stopRecording = this.stopRecording.bind(this)
-    this.discardRecordedVideo = this.discardRecordedVideo.bind(this)
+    this.discardRecordedMedia = this.discardRecordedMedia.bind(this)
     this.submit = this.submit.bind(this)
     this.oneTwoThreeSmile = this.oneTwoThreeSmile.bind(this)
     this.focus = this.focus.bind(this)
@@ -207,6 +208,7 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
       recordingLengthSeconds: 0,
       videoSources: [],
       currentDeviceId: null,
+      capturedSnapshot: null,
     })
   }
 
@@ -480,8 +482,20 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
       )
   }
 
-  discardRecordedVideo(): void {
-    this.setPluginState({ recordedVideo: null })
+  discardRecordedMedia(): void {
+    const { recordedVideo, capturedSnapshot } = this.getPluginState()
+
+    if (recordedVideo) {
+      URL.revokeObjectURL(recordedVideo)
+    }
+    if (capturedSnapshot) {
+      URL.revokeObjectURL(capturedSnapshot)
+    }
+
+    this.setPluginState({
+      recordedVideo: null,
+      capturedSnapshot: null,
+    })
 
     if (this.opts.mirror) {
       this.#enableMirror = true
@@ -529,6 +543,7 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
 
     this.setPluginState({
       recordedVideo: null,
+      capturedSnapshot: null,
       isRecording: false,
       recordingLengthSeconds: 0,
     })
@@ -577,8 +592,12 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
 
     try {
       const tagFile = await this.getImage()
+      this.capturedMediaFile = tagFile
+
+      // Create object URL for preview
+      const capturedSnapshotUrl = URL.createObjectURL(tagFile.data as Blob)
+      this.setPluginState({ capturedSnapshot: capturedSnapshotUrl })
       this.captureInProgress = false
-      this.uppy.addFile(tagFile)
     } catch (error) {
       // Logging the error, except restrictions, which is handled in Core
       this.captureInProgress = false
@@ -706,7 +725,7 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
         onSnapshot={this.takeSnapshot}
         onStartRecording={this.startRecording}
         onStopRecording={this.stopRecording}
-        onDiscardRecordedVideo={this.discardRecordedVideo}
+        onDiscardRecordedMedia={this.discardRecordedMedia}
         onSubmit={this.submit}
         onFocus={this.focus}
         onStop={this.stop}

--- a/packages/@uppy/webcam/src/style.scss
+++ b/packages/@uppy/webcam/src/style.scss
@@ -35,6 +35,27 @@
   transform: scaleX(-1);
 }
 
+.uppy-Webcam-imageContainer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.uppy-Webcam-image {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  max-width: 100%;
+  max-height: 100%;
+  margin: auto;
+}
+
+.uppy-Webcam-image--mirrored {
+  transform: scaleX(-1);
+}
+
 .uppy-Webcam-footer {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
This PR adds image preview and discard functionality to the @uppy/webcam plugin.
	•	similar feature was added to @uppy/screen-capture in #5737  
	•	Some small changes were required in the headless hooks.
        •	all features tested and working !
 
@Murderlon — should I include these changes to useWebcam in this PR, or raise a separate one?