### PR TITLE
@uppy/vue: use markRaw() for uppy class in context provider

### DIFF
--- a/packages/@uppy/vue/src/headless/context-provider.ts
+++ b/packages/@uppy/vue/src/headless/context-provider.ts
@@ -2,10 +2,10 @@ import type { NonNullableUppyContext, UploadStatus } from '@uppy/components'
 import { createUppyEventAdapter } from '@uppy/components'
 import type Uppy from '@uppy/core'
 import type { PropType } from 'vue'
-import { markRaw } from 'vue'
 import {
   defineComponent,
   inject,
+  markRaw,
   onBeforeUnmount,
   onMounted,
   provide,

--- a/packages/@uppy/vue/src/headless/context-provider.ts
+++ b/packages/@uppy/vue/src/headless/context-provider.ts
@@ -2,6 +2,7 @@ import type { NonNullableUppyContext, UploadStatus } from '@uppy/components'
 import { createUppyEventAdapter } from '@uppy/components'
 import type Uppy from '@uppy/core'
 import type { PropType } from 'vue'
+import { markRaw } from 'vue'
 import {
   defineComponent,
   inject,
@@ -33,7 +34,7 @@ export const UppyContextProvider = defineComponent({
     const progress = ref(0)
 
     const uppyContext = reactive<UppyContext>({
-      uppy: props.uppy,
+      uppy: markRaw(props.uppy),
       status: 'init',
       progress: 0,
     })


### PR DESCRIPTION
**To Reproduce:** run `yarn workspace @uppy-example/vue3 run dev`

![image](https://github.com/user-attachments/assets/378bc21e-a22b-4a22-8dda-d2066f35a732)


**Cause :**  The Proxy object isn't an Uppy class instance, so it can't access private fields like #emitter that are only available within the actual class instance.

**Fix** : `markRaw()` prevents Vue from wrapping the Uppy instance in a Proxy 