### PR TITLE
support fingerprintExtra to include metadata in fingerprint

### DIFF
--- a/packages/@uppy/tus/src/getFingerprint.ts
+++ b/packages/@uppy/tus/src/getFingerprint.ts
@@ -31,13 +31,22 @@ function isReactNative() {
 // fingerprint handling take charge.
 export default function getFingerprint<M extends Meta, B extends Body>(
   uppyFile: UppyFile<M, B>,
+  extraKeys?: string[]
 ): tus.UploadOptions['fingerprint'] {
   return (file, options) => {
     if (isCordova() || isReactNative()) {
       return tus.defaultOptions.fingerprint(file, options)
     }
 
-    const uppyFingerprint = ['tus', uppyFile.id, options.endpoint].join('-')
+    let uppyFingerprintParts = ['tus', uppyFile.id, options.endpoint]
+
+    if (extraKeys && Array.isArray(extraKeys)) {
+      const extras = extraKeys.map((key) => String(uppyFile.meta?.[key] ?? '')).join(':')
+      uppyFingerprintParts.push(extras)
+    }
+
+    const uppyFingerprint = uppyFingerprintParts.join('-')
+
 
     return Promise.resolve(uppyFingerprint)
   }

--- a/packages/@uppy/tus/src/index.test.ts
+++ b/packages/@uppy/tus/src/index.test.ts
@@ -1,6 +1,7 @@
 import Core from '@uppy/core'
-import { describe, expect, expectTypeOf, it } from 'vitest'
-import Tus, { type TusBody } from './index.js'
+import {describe, expect, expectTypeOf, it} from 'vitest'
+import Tus, {type TusBody} from './index.js'
+import getFingerprint from './getFingerprint.js'
 
 describe('Tus', () => {
   it('Throws errors if autoRetry option is true', () => {
@@ -43,5 +44,104 @@ describe('Tus', () => {
     expectTypeOf(file.response?.body).toEqualTypeOf<
       { xhr: XMLHttpRequest } | undefined
     >()
+  })
+})
+
+describe('getFingerprint', () => {
+  it('includes extra metadata in the fingerprint', async () => {
+    const file = {
+      id: 'file1',
+      meta: {
+        customField: 'value1',
+      },
+    }
+    const extraKeys = ['customField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file1-http://example.com/upload-value1')
+  })
+
+  it('does not include extra metadata when extraKeys is not provided', async () => {
+    const file = {
+      id: 'file2',
+      meta: {
+        customField: 'value1',
+      },
+    }
+    const fingerprintFn = getFingerprint(file)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file2-http://example.com/upload')
+  })
+
+  it('handles multiple extra keys', async () => {
+    const file = {
+      id: 'file3',
+      meta: {
+        customField: 'value1',
+        anotherField: 'value2',
+      },
+    }
+    const extraKeys = ['customField', 'anotherField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file3-http://example.com/upload-value1:value2')
+  })
+
+  it('handles missing metadata keys', async () => {
+    const file = {
+      id: 'file4',
+      meta: {},
+    }
+    const extraKeys = ['customField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file4-http://example.com/upload-')
+  })
+
+  it('handles multiple extra keys with some missing', async () => {
+    const file = {
+      id: 'file5',
+      meta: {
+        customField: 'value1',
+      },
+    }
+    const extraKeys = ['customField', 'missingField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file5-http://example.com/upload-value1:')
+  })
+
+  it('converts metadata values to strings', async () => {
+    const file = {
+      id: 'file6',
+      meta: {
+        numberField: 123,
+        objectField: { key: 'value' },
+      },
+    }
+    const extraKeys = ['numberField', 'objectField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file6-http://example.com/upload-123:[object Object]')
+  })
+
+  it('handles special characters in metadata', async () => {
+    const file = {
+      id: 'file7',
+      meta: {
+        customField: 'value:with:colon',
+      },
+    }
+    const extraKeys = ['customField']
+    const fingerprintFn = getFingerprint(file, extraKeys)
+    const options = { endpoint: 'http://example.com/upload' }
+    const fingerprint = await fingerprintFn({}, options)
+    expect(fingerprint).toBe('tus-file7-http://example.com/upload-value:with:colon')
   })
 })

--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -55,6 +55,7 @@ export interface TusOpts<M extends Meta, B extends Body>
   withCredentials?: boolean
   allowedMetaFields?: boolean | string[]
   rateLimitedQueue?: RateLimitedQueue
+  fingerprintExtra?: string[]
 }
 export type { TusOpts as TusOptions }
 
@@ -237,7 +238,9 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
       // now also includes `relativePath` for files added from folders.
       // This means you can add 2 identical files, if one is in folder a,
       // the other in folder b.
-      uploadOptions.fingerprint = getFingerprint(file)
+
+      // Allow adding extra data to the fingerprint, for users to manually regenerate fingerprint
+      uploadOptions.fingerprint = getFingerprint(file, opts.fingerprintExtra)
 
       uploadOptions.onBeforeRequest = async (req) => {
         const xhr = req.getUnderlyingObject()


### PR DESCRIPTION
### Pull Request Description

#### Problem
The Uppy Tus plugin generates fingerprints for files based on their `id` and `endpoint`, which means identical files (same content and name) uploaded to different contexts, such as separate projects, are treated as the same file. This prevents scoping uploads to specific projects, as the plugin cannot differentiate between identical files uploaded to distinct projects. For example, uploading `file.jpg` to "project-123" and "project-456" results in the same fingerprint, causing conflicts in resumable uploads or incorrect file associations.

#### Solution
To address this, I introduced a new `fingerprintExtra` option to the Tus plugin. This option allows users to include additional metadata, such as a project ID, in the fingerprint calculation. By appending this extra data to the fingerprint, identical files uploaded to different projects generate unique fingerprints, ensuring proper scoping and preventing conflicts. For example, adding `fingerprintExtra: 'project-123'` ensures the fingerprint is unique to that project, even for identical files.

#### Changes
- **Modified `packages/@uppy/tus/src/index.ts`**:
  - Added `fingerprintExtra` as an optional configuration option in the `TusOpts` type.
  - Updated the `uploadOptions.fingerprint` assignment to use the `getFingerprint` function with `opts.fingerprintExtra`.
- **Modified `packages/@uppy/tus/src/getFingerprint.ts`**:
  - Enhanced the `getFingerprint` function to accept an `extraKeys` parameter and append the specified metadata values to the fingerprint, joined by colons.
  - Ensured compatibility with existing behavior by making `extraKeys` optional and handling missing metadata gracefully.
- **Added Unit Tests in `packages/@uppy/tus/index.test.ts`**:
  - Created a `describe` block for `getFingerprint` with tests covering:
    - Including extra metadata in the fingerprint.
    - Handling cases where `fingerprintExtra` is not provided.
    - Supporting multiple extra keys.
    - Handling missing metadata keys.
    - Converting metadata values to strings.
    - Supporting special characters in metadata.

## Example
```js
    uppy.use(Tus, {
      endpoint: 'https://tus.example.com',
      fingerprintExtra: 'project-123',
    });