### PR TITLE
Add "files" to all package.json's

### DIFF
--- a/.changeset/eleven-flies-swim.md
+++ b/.changeset/eleven-flies-swim.md
@@ -1,0 +1,50 @@
+---
+"@uppy/angular": patch
+"@uppy/google-photos-picker": patch
+"@uppy/google-drive-picker": patch
+"@uppy/thumbnail-generator": patch
+"@uppy/aws-s3-multipart": patch
+"@uppy/companion-client": patch
+"@uppy/golden-retriever": patch
+"@uppy/redux-dev-tools": patch
+"@uppy/provider-views": patch
+"@uppy/remote-sources": patch
+"@uppy/screen-capture": patch
+"@uppy/store-default": patch
+"@uppy/google-drive": patch
+"@uppy/image-editor": patch
+"@uppy/progress-bar": patch
+"@uppy/react-native": patch
+"@uppy/drop-target": patch
+"@uppy/store-redux": patch
+"@uppy/transloadit": patch
+"@uppy/components": patch
+"@uppy/compressor": patch
+"@uppy/file-input": patch
+"@uppy/status-bar": patch
+"@uppy/xhr-upload": patch
+"@uppy/dashboard": patch
+"@uppy/drag-drop": patch
+"@uppy/instagram": patch
+"@uppy/facebook": patch
+"@uppy/informer": patch
+"@uppy/onedrive": patch
+"@uppy/unsplash": patch
+"@uppy/dropbox": patch
+"@uppy/locales": patch
+"@uppy/aws-s3": patch
+"@uppy/webcam": patch
+"@uppy/webdav": patch
+"@uppy/audio": patch
+"@uppy/react": patch
+"@uppy/utils": patch
+"@uppy/core": patch
+"@uppy/form": patch
+"@uppy/zoom": patch
+"@uppy/box": patch
+"@uppy/tus": patch
+"@uppy/url": patch
+"@uppy/vue": patch
+---
+
+Define "files" in package.json

--- a/packages/@uppy/angular/projects/uppy/angular/package.json
+++ b/packages/@uppy/angular/projects/uppy/angular/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepublishOnly": "rm -fr * && cp -r ../../../dist/uppy/angular .."
   },

--- a/packages/@uppy/audio/package.json
+++ b/packages/@uppy/audio/package.json
@@ -24,6 +24,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/aws-s3-multipart/package.json
+++ b/packages/@uppy/aws-s3-multipart/package.json
@@ -22,6 +22,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/aws-s3": "workspace:^"
   },

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -27,6 +27,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^"

--- a/packages/@uppy/box/package.json
+++ b/packages/@uppy/box/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/companion-client/package.json
+++ b/packages/@uppy/companion-client/package.json
@@ -25,6 +25,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "namespace-emitter": "^2.0.1",

--- a/packages/@uppy/components/package.json
+++ b/packages/@uppy/components/package.json
@@ -20,6 +20,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "build:css": "tailwindcss -m -i ./src/input.css -o ./dist/styles.css",

--- a/packages/@uppy/compressor/package.json
+++ b/packages/@uppy/compressor/package.json
@@ -21,6 +21,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@transloadit/prettier-bytes": "^0.3.4",
     "@uppy/utils": "workspace:^",

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@transloadit/prettier-bytes": "^0.3.4",
     "@uppy/store-default": "workspace:^",

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@transloadit/prettier-bytes": "^0.3.4",
     "@uppy/informer": "workspace:^",

--- a/packages/@uppy/drag-drop/package.json
+++ b/packages/@uppy/drag-drop/package.json
@@ -29,6 +29,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/drop-target/package.json
+++ b/packages/@uppy/drop-target/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^"
   },

--- a/packages/@uppy/dropbox/package.json
+++ b/packages/@uppy/dropbox/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/facebook/package.json
+++ b/packages/@uppy/facebook/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/file-input/package.json
+++ b/packages/@uppy/file-input/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/form/package.json
+++ b/packages/@uppy/form/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "get-form-data": "^3.0.0"

--- a/packages/@uppy/golden-retriever/package.json
+++ b/packages/@uppy/golden-retriever/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "lodash": "^4.17.21"

--- a/packages/@uppy/google-drive-picker/package.json
+++ b/packages/@uppy/google-drive-picker/package.json
@@ -25,6 +25,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/google-drive/package.json
+++ b/packages/@uppy/google-drive/package.json
@@ -24,6 +24,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/google-photos-picker/package.json
+++ b/packages/@uppy/google-photos-picker/package.json
@@ -25,6 +25,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/image-editor/package.json
+++ b/packages/@uppy/image-editor/package.json
@@ -30,6 +30,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "cropperjs": "^1.6.2",

--- a/packages/@uppy/informer/package.json
+++ b/packages/@uppy/informer/package.json
@@ -27,6 +27,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/instagram/package.json
+++ b/packages/@uppy/instagram/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/locales/package.json
+++ b/packages/@uppy/locales/package.json
@@ -24,6 +24,10 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "lib",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "chalk": "^5.0.0",

--- a/packages/@uppy/onedrive/package.json
+++ b/packages/@uppy/onedrive/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/progress-bar/package.json
+++ b/packages/@uppy/progress-bar/package.json
@@ -27,6 +27,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/provider-views/package.json
+++ b/packages/@uppy/provider-views/package.json
@@ -24,6 +24,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "classnames": "^2.2.6",

--- a/packages/@uppy/react-native/package.json
+++ b/packages/@uppy/react-native/package.json
@@ -20,6 +20,10 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "file-picker",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/core": "workspace:*",
     "@uppy/instagram": "workspace:^",

--- a/packages/@uppy/react/package.json
+++ b/packages/@uppy/react/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/components": "workspace:^",
     "@uppy/utils": "workspace:^",

--- a/packages/@uppy/redux-dev-tools/package.json
+++ b/packages/@uppy/redux-dev-tools/package.json
@@ -20,6 +20,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "peerDependencies": {
     "@uppy/core": "workspace:^"
   },

--- a/packages/@uppy/remote-sources/package.json
+++ b/packages/@uppy/remote-sources/package.json
@@ -30,6 +30,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/box": "workspace:^",
     "@uppy/dashboard": "workspace:^",

--- a/packages/@uppy/screen-capture/package.json
+++ b/packages/@uppy/screen-capture/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "preact": "^10.5.13"

--- a/packages/@uppy/status-bar/package.json
+++ b/packages/@uppy/status-bar/package.json
@@ -30,6 +30,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@transloadit/prettier-bytes": "^0.3.4",
     "@uppy/utils": "workspace:^",

--- a/packages/@uppy/store-default/package.json
+++ b/packages/@uppy/store-default/package.json
@@ -27,5 +27,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
-  }
+  },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/@uppy/store-redux/package.json
+++ b/packages/@uppy/store-redux/package.json
@@ -19,6 +19,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "nanoid": "^5.0.9"
   },

--- a/packages/@uppy/thumbnail-generator/package.json
+++ b/packages/@uppy/thumbnail-generator/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "exifr": "^7.0.0"

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -31,6 +31,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/tus/package.json
+++ b/packages/@uppy/tus/package.json
@@ -26,6 +26,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^",

--- a/packages/@uppy/unsplash/package.json
+++ b/packages/@uppy/unsplash/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/url/package.json
+++ b/packages/@uppy/url/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^",

--- a/packages/@uppy/utils/package.json
+++ b/packages/@uppy/utils/package.json
@@ -21,6 +21,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "exports": {
     "./package.json": "./package.json",
     "./lib/Translator": "./lib/Translator.js",

--- a/packages/@uppy/vue/package.json
+++ b/packages/@uppy/vue/package.json
@@ -9,6 +9,12 @@
     "build:css": "mkdir -p dist && cp ../components/dist/styles.css dist/styles.css",
     "typecheck": "tsc --build"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/components": "workspace:^",
     "preact": "^10.5.13",

--- a/packages/@uppy/webcam/package.json
+++ b/packages/@uppy/webcam/package.json
@@ -31,6 +31,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/utils": "workspace:^",
     "is-mobile": "^4.0.0",

--- a/packages/@uppy/webdav/package.json
+++ b/packages/@uppy/webdav/package.json
@@ -27,6 +27,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -28,6 +28,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/utils": "workspace:^"

--- a/packages/@uppy/zoom/package.json
+++ b/packages/@uppy/zoom/package.json
@@ -23,6 +23,12 @@
     "type": "git",
     "url": "git+https://github.com/transloadit/uppy.git"
   },
+  "files": [
+    "src",
+    "lib",
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@uppy/companion-client": "workspace:^",
     "@uppy/provider-views": "workspace:^",


### PR DESCRIPTION
Closes #5865

I noticed we are publishing all files, we should filter them. npm automatically adds package.json, license, and readme so you can leave them out of the files array.

https://www.npmjs.com/package/@uppy/compressor?activeTab=code