### PR TITLE
Update versions in readme's after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,23 +78,6 @@ jobs:
           EDGLY_KEY: ${{secrets.EDGLY_KEY}}
           EDGLY_SECRET: ${{secrets.EDGLY_SECRET}}
 
-      - name: Update CDN version references
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          VERSION=$(yarn workspace uppy exec npm pkg get version | grep -o '"[0-9]*\.[0-9]*\.[0-9]*"' | tr -d '"')
-          sed -i "s|https://releases\.transloadit\.com/uppy/v[0-9]*\.[0-9]*\.[0-9]*/|https://releases.transloadit.com/uppy/v$VERSION/|g" README.md
-          sed -i "s|https://releases\.transloadit\.com/uppy/v[0-9]*\.[0-9]*\.[0-9]*/|https://releases.transloadit.com/uppy/v$VERSION/|g" BUNDLE-README.md
-
-      - name: Commit README updates
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add README.md BUNDLE-README.md
-          git commit -m "Update CDN version references to latest release" || exit 0
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # See also companion-deploy.yml
   docker:

--- a/BUNDLE-README.md
+++ b/BUNDLE-README.md
@@ -2,7 +2,7 @@
 
 Hi, thanks for trying out the bundled version of the Uppy File Uploader. You can
 use this from a CDN
-(`<script src="https://releases.transloadit.com/uppy/v/uppy.min.js"></script>`)
+(`<script src="https://releases.transloadit.com/uppy/v4.18.1/uppy.min.js"></script>`)
 or bundle it with your webapp.
 
 Note that the recommended way to use Uppy is to install it with yarn/npm and use

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm install @uppy/core @uppy/dashboard @uppy/tus
 ```
 
 Add CSS
-[uppy.min.css](https://releases.transloadit.com/uppy/v/uppy.min.css),
+[uppy.min.css](https://releases.transloadit.com/uppy/v4.18.1/uppy.min.css),
 either to your HTML page’s `<head>` or include in JS, if your bundler of choice
 supports it.
 
@@ -117,7 +117,7 @@ CDN. In that case `Uppy` will attach itself to the global `window.Uppy` object.
 ```html
 <!-- 1. Add CSS to `<head>` -->
 <link
-  href="https://releases.transloadit.com/uppy/v/uppy.min.css"
+  href="https://releases.transloadit.com/uppy/v4.18.1/uppy.min.css"
   rel="stylesheet"
 />
 
@@ -128,7 +128,7 @@ CDN. In that case `Uppy` will attach itself to the global `window.Uppy` object.
     Uppy,
     Dashboard,
     Tus,
-  } from 'https://releases.transloadit.com/uppy/v/uppy.min.mjs'
+  } from 'https://releases.transloadit.com/uppy/v4.18.1/uppy.min.mjs'
 
   const uppy = new Uppy()
   uppy.use(Dashboard, { target: '#files-drag-drop' })

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "turbo run test --filter='./packages/@uppy/*' --filter='./packages/uppy' --filter='./examples/{react,vue,sveltekit}'",
     "test:watch": "turbo watch test --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "typecheck": "turbo run typecheck --filter='./packages/@uppy/*' --filter='./packages/uppy'",
-    "version": "changeset version && corepack yarn install --mode=update-lockfile",
+    "version": "changeset version && corepack yarn install --mode=update-lockfile && node scripts/update-readme-versions.js",
     "release": "changeset publish"
   },
   "devDependencies": {

--- a/scripts/update-readme-versions.js
+++ b/scripts/update-readme-versions.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const { readFileSync, writeFileSync } = require('fs');
+
+try {
+  // Get the current uppy version
+  const packageJsonOutput = execSync('yarn workspace uppy exec npm pkg get version', { encoding: 'utf8' });
+  const versionMatch = packageJsonOutput.match(/"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  
+  if (!versionMatch) {
+    console.log('Could not extract version from package.json');
+    process.exit(1);
+  }
+  
+  const version = versionMatch[1];
+  console.log(`Updating README files to version: ${version}`);
+  
+  // Update README.md
+  const readme = readFileSync('README.md', 'utf8');
+  const updatedReadme = readme.replace(
+    /https:\/\/releases\.transloadit\.com\/uppy\/v[0-9]+\.[0-9]+\.[0-9]+\//g,
+    `https://releases.transloadit.com/uppy/v${version}/`
+  );
+  
+  if (readme !== updatedReadme) {
+    writeFileSync('README.md', updatedReadme);
+    console.log('Updated README.md');
+  } else {
+    console.log('README.md already up to date');
+  }
+  
+  // Update BUNDLE-README.md
+  const bundleReadme = readFileSync('BUNDLE-README.md', 'utf8');
+  const updatedBundleReadme = bundleReadme.replace(
+    /https:\/\/releases\.transloadit\.com\/uppy\/v[0-9]+\.[0-9]+\.[0-9]+\//g,
+    `https://releases.transloadit.com/uppy/v${version}/`
+  );
+  
+  if (bundleReadme !== updatedBundleReadme) {
+    writeFileSync('BUNDLE-README.md', updatedBundleReadme);
+    console.log('Updated BUNDLE-README.md');
+  } else {
+    console.log('BUNDLE-README.md already up to date');
+  }
+  
+} catch (error) {
+  console.error('Error updating README versions:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
It didn't work in CI: https://github.com/transloadit/uppy/actions/runs/16771298008/job/47486827416#step:16:1

Instead of trying to hack in an extra commit, now a script runs on the `version` command, which resolves the versions based on changesets, which is ran before `publish` so it should become part of the changeset commit (hopefully)