### PR TITLE
add --no-daemon to turbo run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "private/*"
   ],
   "scripts": {
-    "build": "turbo run build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "build:clean": "cp .gitignore .gitignore.bak && printf '!node_modules\n!**/node_modules/**/*\n' >> .gitignore; git clean -Xfd packages e2e .parcel-cache coverage .turbo; mv .gitignore.bak .gitignore",
+    "build": "turbo run --no-daemon build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "build:watch": "yarn build && turbo watch build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "migrate:components": "yarn workspace @uppy/components migrate",
     "check": "yarn exec biome check --write",


### PR DESCRIPTION
pulled out from #5887

else I would get incorrect `cache hit (outputs already on disk), suppressing logs 10cc3ea7d018c083` see turbo issue https://github.com/vercel/turborepo/issues/4137

to reproduce the error:

```
$ yarn build:clean

$ yarn build:watch
turbo 2.5.4

• Packages in scope: @uppy/audio, @uppy/aws-s3, @uppy/box, @uppy/companion, @uppy/companion-client, @uppy/components, @uppy/compressor, @uppy/core, @uppy/dashboard, @uppy/drop-target, @uppy/dropbox, @uppy/facebook, @uppy/form, @uppy/golden-retriever, @uppy/google-drive, @uppy/google-drive-picker, @uppy/google-photos-picker, @uppy/image-editor, @uppy/instagram, @uppy/locales, @uppy/onedrive, @uppy/provider-views, @uppy/react, @uppy/react-native, @uppy/remote-sources, @uppy/screen-capture, @uppy/store-default, @uppy/svelte, @uppy/thumbnail-generator, @uppy/transloadit, @uppy/tus, @uppy/unsplash, @uppy/url, @uppy/utils, @uppy/vue, @uppy/webcam, @uppy/webdav, @uppy/xhr-upload, @uppy/zoom, angular, uppy
• Running build, build:css in 41 packages
• Remote caching disabled
@uppy/webcam:build:css: cache miss, executing 5c0414e13537d0f4
@uppy/dashboard:build:css: cache hit (outputs already on disk), suppressing logs 28466837ecce6b4f
@uppy/audio:build:css: cache hit (outputs already on disk), suppressing logs b765997d190b376f
@uppy/provider-views:build:css: cache hit (outputs already on disk), suppressing logs d4fa7d7e9867d5e2
@uppy/companion:build: cache hit (outputs already on disk), suppressing logs f887940a372c7525
@uppy/url:build:css: cache hit (outputs already on disk), suppressing logs 7fca1a99b842a49b
@uppy/components:build:css: cache hit (outputs already on disk), suppressing logs de42ff569ae6ab86
@uppy/image-editor:build:css: cache miss, executing 683efb501efd6115
@uppy/screen-capture:build:css: cache hit (outputs already on disk), suppressing logs d2c5155589ded48a
@uppy/core:build:css: cache hit (outputs already on disk), suppressing logs 10cc3ea7d018c083
@uppy/webcam:build:css:
@uppy/image-editor:build:css:
@uppy/react:build:css: cache hit (outputs already on disk), suppressing logs 8981f039da70560c
@uppy/store-default:build: cache hit (outputs already on disk), suppressing logs a9c93576559c5133
uppy:build:css: cache miss, executing 80feaeb228289c8e
@uppy/utils:build: cache miss, executing e191089978ee63dd
@uppy/vue:build:css: cache miss, executing b8a74afc856111f3
@uppy/drop-target:build:css: cache miss, executing 45cefc4689030a7d
uppy:build:css:
@uppy/utils:build:
@uppy/vue:build:css:
@uppy/drop-target:build:css:
@uppy/vue:build:css: cp: ../components/dist/styles.css: No such file or directory
@uppy/vue:build:css: ERROR: command finished with error: command (uppy/packages/@uppy/vue) /private/var/folders/bw/28xbd8s12fb_sg_c809s0lf80000gn/T/xfs-00ce34db/yarn run build:css exited (1)
@uppy/webcam:build:css:
@uppy/utils:build:
uppy:build:css:
@uppy/drop-target:build:css:
@uppy/image-editor:build:css:
@uppy/vue#build:css: command (uppy/packages/@uppy/vue) /private/var/folders/bw/28xbd8s12fb_sg_c809s0lf80000gn/T/xfs-00ce34db/yarn run build:css exited (1)

 Tasks:    10 successful, 16 total
Cached:    10 cached, 16 total
  Time:    1.004s
Failed:    @uppy/vue#build:css

 ERROR  run failed: command  exited (1)
```

(cherry picked from commit 250806a63b527569bb0a761cc90bc3e5cf1acca5)