### PR TITLE
fix broken `build:clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "turbo run build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
-    "build:clean": "cp .gitignore .gitignore.bak && printf '!node_modules\n!**/node_modules/**/*\n' >> .gitignore; git clean -Xfd packages e2e .parcel-cache coverage .turbo; mv .gitignore.bak .gitignore",
+    "build:clean": "git clean -Xfd packages e2e .parcel-cache coverage .turbo -e '!node_modules' -e '!**/node_modules/**/*'",
     "build:watch": "yarn build && turbo watch build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "migrate:components": "yarn workspace @uppy/components migrate",
     "check": "yarn exec biome check --write",


### PR DESCRIPTION
pulled out from #5887

It kept mysteriously deleting `packages/@uppy/companion/node_modules/webdav/dist/node/compat/env.js` turns out it was because of the line `env.*` in `packages/@uppy/companion/.gitignore`

chery picked from 2508068551ef42c6b7492d18702d7bfaa3dbc4e5