### PR TITLE
fix the server crashing due a malformed json in websocket message

### DIFF
--- a/.changeset/afraid-cobras-fix.md
+++ b/.changeset/afraid-cobras-fix.md
@@ -1,0 +1,5 @@
+---
+"@uppy/companion": patch
+---
+
+fix the server crashing due a malformed json in a websocket message

--- a/packages/@uppy/companion/src/server/socket.js
+++ b/packages/@uppy/companion/src/server/socket.js
@@ -73,10 +73,14 @@ export default function setupSocket(server) {
     })
 
     ws.on('message', (jsonData) => {
-      const data = JSON.parse(jsonData.toString())
-      // whitelist triggered actions
-      if (['pause', 'resume', 'cancel'].includes(data.action)) {
-        emitter().emit(`${data.action}:${token}`)
+      try {
+        const data = JSON.parse(jsonData.toString())
+        // whitelist triggered actions
+        if (['pause', 'resume', 'cancel'].includes(data.action)) {
+          emitter().emit(`${data.action}:${token}`)
+        }
+      } catch (err) {
+        logger.error(err, 'websocket.error', Uploader.shortenToken(token))
       }
     })
 


### PR DESCRIPTION
You can verify it using:

```
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Media API PoC</title>
</head>

<body>
  <h1>Media API Cross-Site WebSocket Hijacking PoC</h1>

  <script>
    let ws = new WebSocket("wss://<url + base path>/api/poc");
    ws.onopen = function () {
        console.log("WebSocket connection established.");
        ws.send("Malformed JSON");
    };
  </script>
</body>

</html>
```