### PR TITLE
packages/@uppy/* : remove "main" from package.json 

### DIFF
--- a/packages/@uppy/angular/projects/uppy/angular/tsconfig.lib.json
+++ b/packages/@uppy/angular/projects/uppy/angular/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../out-tsc/lib",
+    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,

--- a/packages/@uppy/audio/package.json
+++ b/packages/@uppy/audio/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that records audio using the device’s microphone.",
   "version": "3.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "keywords": [
     "file uploader",

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -3,7 +3,6 @@
   "description": "Upload to Amazon S3 with Uppy",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/box/package.json
+++ b/packages/@uppy/box/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from Box, into Uppy.",
   "version": "4.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/companion-client/package.json
+++ b/packages/@uppy/companion-client/package.json
@@ -3,7 +3,6 @@
   "description": "Client library for communication with Companion. Intended for use in Uppy plugins.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -2,7 +2,6 @@
   "name": "@uppy/companion",
   "version": "6.0.1",
   "description": "OAuth helper and remote fetcher for Uppy's (https://uppy.io) extensible file upload widget with support for drag&drop, resumable uploads, previews, restrictions, file processing/encoding, remote providers like Dropbox and Google Drive, S3 and more :dog:",
-  "main": "lib/companion.js",
   "types": "lib/companion.d.ts",
   "author": "Transloadit.com",
   "license": "MIT",

--- a/packages/@uppy/components/package.json
+++ b/packages/@uppy/components/package.json
@@ -3,7 +3,6 @@
   "description": "Headless Uppy components, made in Preact",
   "version": "1.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": [
     "*.css"

--- a/packages/@uppy/compressor/package.json
+++ b/packages/@uppy/compressor/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that compresses images before upload, saving up to 60% in size",
   "version": "3.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "keywords": [
     "file uploader",
     "uppy",

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -3,7 +3,6 @@
   "description": "Core module for the extensible JavaScript file upload widget with support for drag&drop, resumable uploads, previews, restrictions, file processing/encoding, remote providers like Instagram, Dropbox, Google Drive, S3 and more :dog:",
   "version": "5.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -3,7 +3,6 @@
   "description": "Universal UI plugin for Uppy.",
   "version": "5.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/drag-drop/package.json
+++ b/packages/@uppy/drag-drop/package.json
@@ -3,7 +3,6 @@
   "description": "Droppable zone UI for Uppy. Drag and drop files into it to upload.",
   "version": "5.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/drop-target/package.json
+++ b/packages/@uppy/drop-target/package.json
@@ -3,7 +3,6 @@
   "description": "Lets your users drag and drop files on a DOM element",
   "version": "4.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": [
     "*.css"

--- a/packages/@uppy/dropbox/package.json
+++ b/packages/@uppy/dropbox/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from Dropbox, into Uppy.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/facebook/package.json
+++ b/packages/@uppy/facebook/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from Facebook, into Uppy.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/form/package.json
+++ b/packages/@uppy/form/package.json
@@ -3,7 +3,6 @@
   "description": "Connect Uppy to an existing HTML <form>.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/golden-retriever/package.json
+++ b/packages/@uppy/golden-retriever/package.json
@@ -3,7 +3,6 @@
   "description": "The GoldenRetriever Uppy plugin saves selected files in browser cache to seamlessly resume uploding after browser crash or accidentally closed tab",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/google-drive-picker/package.json
+++ b/packages/@uppy/google-drive-picker/package.json
@@ -3,7 +3,6 @@
   "description": "The Google Drive Picker plugin for Uppy lets users import files from their Google Drive account",
   "version": "1.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/google-drive/package.json
+++ b/packages/@uppy/google-drive/package.json
@@ -3,7 +3,6 @@
   "description": "The Google Drive plugin for Uppy lets users import files from their Google Drive account",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/google-photos-picker/package.json
+++ b/packages/@uppy/google-photos-picker/package.json
@@ -3,7 +3,6 @@
   "description": "The Google Photos Picker plugin for Uppy lets users import files from their Google Photos account",
   "version": "1.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/image-editor/package.json
+++ b/packages/@uppy/image-editor/package.json
@@ -3,7 +3,6 @@
   "description": "Image editor and cropping UI",
   "version": "4.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/instagram/package.json
+++ b/packages/@uppy/instagram/package.json
@@ -3,7 +3,6 @@
   "description": "Import photos and videos from Instagram, into Uppy.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/onedrive/package.json
+++ b/packages/@uppy/onedrive/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from OneDrive, into Uppy.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/provider-views/package.json
+++ b/packages/@uppy/provider-views/package.json
@@ -3,7 +3,6 @@
   "description": "View library for Uppy remote provider plugins.",
   "version": "5.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/react/package.json
+++ b/packages/@uppy/react/package.json
@@ -3,7 +3,6 @@
   "description": "React component wrappers around Uppy's official UI plugins.",
   "version": "5.0.2",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": [
     "*.css"

--- a/packages/@uppy/remote-sources/package.json
+++ b/packages/@uppy/remote-sources/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that includes all remote sources that Uppy+Companion offer, like Instagram, Google Drive, Dropox, Box, Unsplash, Url etc",
   "version": "3.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/screen-capture/package.json
+++ b/packages/@uppy/screen-capture/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that captures video from display or application.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/status-bar/package.json
+++ b/packages/@uppy/status-bar/package.json
@@ -3,7 +3,6 @@
   "description": "A progress bar for Uppy, with many bells and whistles.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/thumbnail-generator/package.json
+++ b/packages/@uppy/thumbnail-generator/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that generates small previews of images to show on your upload UI.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -3,7 +3,6 @@
   "description": "The Transloadit plugin can be used to upload files to Transloadit for all kinds of processing, such as transcoding video, resizing images, zipping/unzipping, and more",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/tus/package.json
+++ b/packages/@uppy/tus/package.json
@@ -3,7 +3,6 @@
   "description": "Resumable uploads for Uppy using Tus.io",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/unsplash/package.json
+++ b/packages/@uppy/unsplash/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from Unsplash, the free stock photography resource, into Uppy",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/url/package.json
+++ b/packages/@uppy/url/package.json
@@ -3,7 +3,6 @@
   "description": "The Url plugin lets users import files from the Internet. Paste any URL and it’ll be added!",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/utils/package.json
+++ b/packages/@uppy/utils/package.json
@@ -4,7 +4,6 @@
   "version": "7.0.1",
   "license": "MIT",
   "type": "module",
-  "main": "./lib/index.js",
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build tsconfig.build.json",

--- a/packages/@uppy/vue/package.json
+++ b/packages/@uppy/vue/package.json
@@ -6,7 +6,6 @@
   "sideEffects": [
     "*.css"
   ],
-  "main": "lib/index.js",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "build:css": "mkdir -p dist && cp ../components/dist/styles.css dist/styles.css",

--- a/packages/@uppy/webcam/package.json
+++ b/packages/@uppy/webcam/package.json
@@ -3,7 +3,6 @@
   "description": "Uppy plugin that takes photos or records videos using the device's camera.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "style": "dist/style.min.css",
   "type": "module",
   "sideEffects": [

--- a/packages/@uppy/webdav/package.json
+++ b/packages/@uppy/webdav/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from WebDAV into Uppy.",
   "version": "1.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "types": "types/index.d.ts",
   "type": "module",
   "sideEffects": false,

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -3,7 +3,6 @@
   "description": "Plain and simple classic HTML multipart form uploads with Uppy, as well as uploads using the HTTP PUT method.",
   "version": "5.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/@uppy/zoom/package.json
+++ b/packages/@uppy/zoom/package.json
@@ -3,7 +3,6 @@
   "description": "Import files from zoom, into Uppy.",
   "version": "4.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {

--- a/packages/uppy/package.json
+++ b/packages/uppy/package.json
@@ -3,7 +3,6 @@
   "description": "Extensible JavaScript file upload widget with support for drag&drop, resumable uploads, previews, restrictions, file processing/encoding, remote providers like Instagram, Dropbox, Google Drive, S3 and more :dog:",
   "version": "5.1.1",
   "license": "MIT",
-  "main": "lib/index.js",
   "module": "lib/index.js",
   "type": "module",
   "unpkg": "dist/uppy.min.js",


### PR DESCRIPTION
- The blocker was `@uppy/angular` — its build was failing because it could not resolve modules and types for its dependencies (`@uppy/dashboard`, `@uppy/utils`, `@uppy/provider-views`, `@uppy/core`).

```typescript
------------------------------------------------------------------------------
Building entry point '@uppy/angular'
------------------------------------------------------------------------------
✖ Compiling with Angular sources in Ivy partial compilation mode.
../dashboard/lib/Dashboard.d.ts:1:106 - error TS2307: Cannot find module '@uppy/core' or its corresponding type declarations.

1 import type { Body, DefinePluginOpts, Meta, State, UIPluginOptions, UnknownPlugin, Uppy, UppyFile } from '@uppy/core';
                                                                                                           ~~~~~~~~~~~~
../dashboard/lib/Dashboard.d.ts:2:26 - error TS2307: Cannot find module '@uppy/core' or its corresponding type declarations.

2 import { UIPlugin } from '@uppy/core';
                           ~~~~~~~~~~~~
../dashboard/lib/Dashboard.d.ts:3:35 - error TS2307: Cannot find module '@uppy/provider-views' or its corresponding type declarations.


```

Angular (TypeScript with moduleResolution: node) required a "main" or "types" field in each dependency’s package.json, and ignored their "exports" map.
