### PR TITLE
Revert "build(deps): bump actions/setup-node from 4 to 5"

### DIFF
--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -22,8 +22,6 @@ jobs:
   isolate_uppy:
     name: Isolate Uppy packages
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -39,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
   unit_tests:
     name: Tests
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     strategy:
       matrix:
         node-version: [lts/*]
@@ -44,7 +42,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
@@ -65,8 +63,6 @@ jobs:
   types:
     name: Types
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -83,7 +79,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -101,7 +97,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DIFF_BUILDER: true
-      SKIP_YARN_COREPACK_CHECK: true
     outputs:
       diff: ${{ steps.diff.outputs.OUTPUT_DIFF }}
     steps:
@@ -55,7 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - run: corepack yarn install

--- a/.github/workflows/lockfile_check.yml
+++ b/.github/workflows/lockfile_check.yml
@@ -18,8 +18,6 @@ jobs:
   lint_lockfile:
     name: Lint yarn.lock
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -36,7 +34,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -23,8 +23,6 @@ env:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -41,7 +39,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install upload-to-cdn dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      SKIP_YARN_COREPACK_CHECK: true
     outputs:
       companionWasReleased: ${{ steps.checkIfCompanionWasReleased.outputs.version }}
       published: ${{ steps.changesets.outputs.published }}
@@ -23,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
 
@@ -40,14 +38,9 @@ jobs:
       - name: '@uppy/angular prepublish'
         run: corepack yarn workspace @uppy/angular prepublishOnly
 
-      - name: Add npm token to yarnrc
-        run: |
+      - run: |
           echo '' >> .yarnrc.yml
           echo 'npmAuthToken: "${NPM_TOKEN}"' >> .yarnrc.yml
-
-      - name: Add npm token to npmrc
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -64,10 +57,6 @@ jobs:
       - name: Remove npmAuthToken from yarnrc
         run: |
           sed -i '/npmAuthToken:/d' .yarnrc.yml
-
-      - name: Remove npmrc
-        run: |
-          rm .npmrc
 
       - name: Check if Companion was released
         id: checkIfCompanionWasReleased


### PR DESCRIPTION
Reverts transloadit/uppy#5954

because it fails the release

```
/usr/local/bin/yarn cache dir
error Error: Failed to replace env in config: ${NPM_TOKEN}
    at /usr/local/lib/node_modules/yarn/lib/cli.js:95453:13
    at String.replace (<anonymous>)
    at envReplace (/usr/local/lib/node_modules/yarn/lib/cli.js:95448:16)
    at Function.normalizeConfig (/usr/local/lib/node_modules/yarn/lib/cli.js:31940:69)
    at NpmRegistry.<anonymous> (/usr/local/lib/node_modules/yarn/lib/cli.js:31970:34)
    at Generator.next (<anonymous>)
    at step (/usr/local/lib/node_modules/yarn/lib/cli.js:310:30)
    at /usr/local/lib/node_modules/yarn/lib/cli.js:321:13
info Visit https://yarnpkg.com/en/docs/cli/cache for documentation about this command.
Error: error Error: Failed to replace env in config: ${NPM_TOKEN}
    at /usr/local/lib/node_modules/yarn/lib/cli.js:95453:13
    at String.replace (<anonymous>)
    at envReplace (/usr/local/lib/node_modules/yarn/lib/cli.js:95448:16)
    at Function.normalizeConfig (/usr/local/lib/node_modules/yarn/lib/cli.js:31940:69)
    at NpmRegistry.<anonymous> (/usr/local/lib/node_modules/yarn/lib/cli.js:31970:34)
    at Generator.next (<anonymous>)
    at step (/usr/local/lib/node_modules/yarn/lib/cli.js:310:30)
    at /usr/local/lib/node_modules/yarn/lib/cli.js:321:13
```