### PR TITLE
always use `getAssemblyUrl`

### DIFF
--- a/packages/@uppy/transloadit/src/AssemblyWatcher.ts
+++ b/packages/@uppy/transloadit/src/AssemblyWatcher.ts
@@ -50,7 +50,7 @@ class TransloaditAssemblyWatcher<
 
   #onAssemblyComplete = (assembly: AssemblyResponse) => {
     const assemblyId = assembly.assembly_id
-    if (!assemblyId || !this.#watching(assemblyId)) {
+    if (assemblyId == null || !this.#watching(assemblyId)) {
       return
     }
 
@@ -65,7 +65,7 @@ class TransloaditAssemblyWatcher<
 
   #onAssemblyCancel = (assembly: AssemblyResponse) => {
     const assemblyId = assembly.assembly_id
-    if (!assemblyId || !this.#watching(assemblyId)) {
+    if (assemblyId == null || !this.#watching(assemblyId)) {
       return
     }
 
@@ -74,7 +74,7 @@ class TransloaditAssemblyWatcher<
 
   #onAssemblyError = (assembly: AssemblyResponse, error: Error) => {
     const assemblyId = assembly.assembly_id
-    if (!assemblyId || !this.#watching(assemblyId)) {
+    if (assemblyId == null || !this.#watching(assemblyId)) {
       return
     }
 
@@ -94,7 +94,7 @@ class TransloaditAssemblyWatcher<
     error: Error,
   ) => {
     const assemblyId = assembly.assembly_id
-    if (!assemblyId || !this.#watching(assemblyId)) {
+    if (assemblyId == null || !this.#watching(assemblyId)) {
       return
     }
 

--- a/packages/@uppy/transloadit/src/Client.ts
+++ b/packages/@uppy/transloadit/src/Client.ts
@@ -6,9 +6,10 @@ import type {
   WrapPromiseFunctionType,
 } from '@uppy/utils'
 import { fetchWithNetworkError } from '@uppy/utils'
-import type {
-  AssemblyResponse,
-  OptionsWithRestructuredFields,
+import {
+  type AssemblyResponse,
+  getAssemblyUrl,
+  type OptionsWithRestructuredFields,
 } from './index.js'
 
 const ASSEMBLIES_ENDPOINT = '/assemblies'
@@ -45,15 +46,6 @@ export default class Client<M extends Meta, B extends Body> {
   #fetchWithNetworkError: WrapPromiseFunctionType<typeof fetchWithNetworkError>
 
   opts: Opts
-
-  #getAssemblySslUrl(assembly: AssemblyResponse): string {
-    if (!assembly.assembly_ssl_url) {
-      throw new Error(
-        'Transloadit: Assembly status is missing `assembly_ssl_url`.',
-      )
-    }
-    return assembly.assembly_ssl_url
-  }
 
   constructor(opts: Opts) {
     this.opts = opts
@@ -148,7 +140,7 @@ export default class Client<M extends Meta, B extends Body> {
     file: UppyFile<M, B>,
   ): Promise<AssemblyResponse> {
     const size = encodeURIComponent(file.size!)
-    const assemblyUrl = this.#getAssemblySslUrl(assembly)
+    const assemblyUrl = getAssemblyUrl(assembly)
     const url = `${assemblyUrl}/reserve_file?size=${size}`
     return this.#fetchJSON(url, {
       method: 'POST',
@@ -174,7 +166,7 @@ export default class Client<M extends Meta, B extends Body> {
     const fieldname = 'file'
 
     const qs = `size=${size}&filename=${filename}&fieldname=${fieldname}&s3Url=${uploadUrl}`
-    const assemblyUrl = this.#getAssemblySslUrl(assembly)
+    const assemblyUrl = getAssemblyUrl(assembly)
     const url = `${assemblyUrl}/add_file?${qs}`
     return this.#fetchJSON(url, {
       method: 'POST',
@@ -188,7 +180,7 @@ export default class Client<M extends Meta, B extends Body> {
    * Cancel a running Assembly.
    */
   async cancelAssembly(assembly: AssemblyResponse): Promise<void> {
-    const url = this.#getAssemblySslUrl(assembly)
+    const url = getAssemblyUrl(assembly)
     await this.#fetchWithNetworkError(url, {
       method: 'DELETE',
       headers: this.#headers,


### PR DESCRIPTION
- remove unneeded type assertions
- revert change in js behavior: `const prevStatus = (prev.ok ?? '') as string`
- reuse duplicated `convertStepResult` logic
- use safer check `assemblyId == null` instead of `!assemblyId`