### PR TITLE
Use assembly_ssl_url for final status fetch

### DIFF
--- a/.changeset/prefer-assembly-ssl-url.md
+++ b/.changeset/prefer-assembly-ssl-url.md
@@ -1,0 +1,5 @@
+---
+"@uppy/transloadit": patch
+---
+
+Ensure final assembly status fetch uses `assembly_ssl_url` so Transloadit requests stay on HTTPS.

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -581,7 +581,7 @@ export default class Transloadit<
    * and emit it.
    */
   #onAssemblyFinished(assembly: Assembly) {
-    const url = getAssemblyUrl(assembly.status)
+    const url = getAssemblyUrlSsl(assembly.status)
     this.client.getAssemblyStatus(url).then((finalStatus) => {
       assembly.status = finalStatus
       this.uppy.emit('transloadit:complete', finalStatus)


### PR DESCRIPTION
## Summary
- ensure the final Transloadit status fetch prefers `assembly_ssl_url`
- add a changeset preparing the patch release

## Testing
- yarn workspace @uppy/transloadit test
