### PR TITLE
Enable `exactOptionalPropertyTypes` in TypeScript configuration

### DIFF
--- a/packages/@uppy/audio/src/Audio.tsx
+++ b/packages/@uppy/audio/src/Audio.tsx
@@ -111,7 +111,9 @@ export default class Audio<M extends Meta, B extends Body> extends UIPlugin<
     })
   }
 
-  #start = (options?: { deviceId?: string }): Promise<never> | undefined => {
+  #start = (options?: {
+    deviceId?: string | undefined
+  }): Promise<never> | undefined => {
     if (!this.#supportsUserMedia) {
       return Promise.reject(new Error('Microphone access not supported'))
     }

--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -248,7 +248,7 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
   async #nonMultipartUpload(
     file: UppyFile<M, B>,
     chunk: Chunk,
-    signal?: AbortSignal,
+    signal: AbortSignal | null = null,
   ) {
     const {
       method = 'POST',

--- a/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
+++ b/packages/@uppy/aws-s3/src/HTTPCommunicationQueue.ts
@@ -315,7 +315,7 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
       throwIfAborted(signal)
       return await this.#sendCompletionRequest(
         this.#getFile(file),
-        { key, uploadId, parts, signal },
+        { key, ...(uploadId !== undefined && { uploadId }), parts, signal },
         signal,
       ).abortOn(signal)
     } catch (err) {
@@ -351,7 +351,7 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
     throwIfAborted(signal)
     const alreadyUploadedParts = await this.#listParts(
       this.#getFile(file),
-      { uploadId, key, signal },
+      { ...(uploadId !== undefined && { uploadId }), key, signal },
       signal,
     ).abortOn(signal)
     throwIfAborted(signal)
@@ -372,7 +372,7 @@ export class HTTPCommunicationQueue<M extends Meta, B extends Body> {
     throwIfAborted(signal)
     return this.#sendCompletionRequest(
       this.#getFile(file),
-      { key, uploadId, parts, signal },
+      { key, ...(uploadId !== undefined && { uploadId }), parts, signal },
       signal,
     ).abortOn(signal)
   }

--- a/packages/@uppy/aws-s3/src/MultipartUploader.ts
+++ b/packages/@uppy/aws-s3/src/MultipartUploader.ts
@@ -236,7 +236,9 @@ class MultipartUploader<M extends Meta, B extends Body> {
       this.#resumeUpload()
     } else if (this.#isRestoring) {
       this.options.companionComm.restoreUploadFile(this.#file, {
-        uploadId: this.options.uploadId,
+        ...(this.options.uploadId !== undefined && {
+          uploadId: this.options.uploadId,
+        }),
         key: this.options.key,
       })
       this.#resumeUpload()

--- a/packages/@uppy/aws-s3/src/index.test.ts
+++ b/packages/@uppy/aws-s3/src/index.test.ts
@@ -221,7 +221,7 @@ describe('AwsS3Multipart', () => {
         signPart: vi.fn(async (file, { number }) => {
           return {
             url: `https://bucket.s3.us-east-2.amazonaws.com/test/upload/multitest.dat?partNumber=${number}&uploadId=6aeb1980f3fc7ce0b5454d25b71992&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATEST%2F20210729%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20210729T014044Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=test`,
-            headers: number === 1 ? { 'Content-MD5': 'foo' } : undefined,
+            ...(number === 1 && { headers: { 'Content-MD5': 'foo' } }),
           }
         }),
         listParts: undefined as any,

--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -120,7 +120,7 @@ type SignPartOptions = {
   key: string
   partNumber: number
   body: Blob
-  signal?: AbortSignal
+  signal?: AbortSignal | null
 }
 
 export type AwsS3UploadParameters =
@@ -159,7 +159,7 @@ type AWSS3WithCompanion = {
 }
 type AWSS3WithoutCompanion = {
   getTemporarySecurityCredentials?: (options?: {
-    signal?: AbortSignal
+    signal?: AbortSignal | null
   }) => MaybePromise<AwsS3STSResponse>
   uploadPartBytes?: (options: {
     signature: AwsS3UploadParameters
@@ -473,7 +473,7 @@ export default class AwsS3Multipart<
 
   createMultipartUpload(
     file: UppyFile<M, B>,
-    signal?: AbortSignal,
+    signal: AbortSignal | null = null,
   ): Promise<UploadResult> {
     this.#assertHost('createMultipartUpload')
     throwIfAborted(signal)
@@ -500,7 +500,7 @@ export default class AwsS3Multipart<
   listParts(
     file: UppyFile<M, B>,
     { key, uploadId, signal }: UploadResultWithSignal,
-    oldSignal?: AbortSignal,
+    oldSignal: AbortSignal | null = null,
   ): Promise<AwsS3Part[]> {
     signal ??= oldSignal
     this.#assertHost('listParts')
@@ -518,7 +518,7 @@ export default class AwsS3Multipart<
   completeMultipartUpload(
     file: UppyFile<M, B>,
     { key, uploadId, parts, signal }: MultipartUploadResultWithSignal,
-    oldSignal?: AbortSignal,
+    oldSignal: AbortSignal | null = null,
   ): Promise<B> {
     signal ??= oldSignal
     this.#assertHost('completeMultipartUpload')
@@ -607,7 +607,7 @@ export default class AwsS3Multipart<
 
   signPart(
     file: UppyFile<M, B>,
-    { uploadId, key, partNumber, signal }: SignPartOptions,
+    { uploadId, key, partNumber, signal = null }: SignPartOptions,
   ): Promise<AwsS3UploadParameters> {
     this.#assertHost('signPart')
     throwIfAborted(signal)
@@ -629,7 +629,7 @@ export default class AwsS3Multipart<
 
   abortMultipartUpload(
     file: UppyFile<M, B>,
-    { key, uploadId, signal }: UploadResultWithSignal,
+    { key, uploadId, signal = null }: UploadResultWithSignal,
   ): Promise<void> {
     this.#assertHost('abortMultipartUpload')
 
@@ -680,7 +680,7 @@ export default class AwsS3Multipart<
     size?: number
     onProgress: any
     onComplete: any
-    signal?: AbortSignal
+    signal?: AbortSignal | null
   }): Promise<UploadPartBytesResult> {
     throwIfAborted(signal)
 

--- a/packages/@uppy/aws-s3/src/index.ts
+++ b/packages/@uppy/aws-s3/src/index.ts
@@ -142,7 +142,7 @@ export type AwsS3UploadParameters =
 export interface AwsS3Part {
   PartNumber?: number
   Size?: number
-  ETag?: string
+  ETag?: string | undefined
 }
 
 type AWSS3WithCompanion = {
@@ -865,9 +865,9 @@ export default class AwsS3Multipart<
         companionComm: this.#companionCommunicationQueue,
 
         log: (...args: Parameters<Uppy<M, B>['log']>) => this.uppy.log(...args),
-        getChunkSize: this.opts.getChunkSize
-          ? this.opts.getChunkSize.bind(this)
-          : undefined,
+        ...(this.opts.getChunkSize !== undefined && {
+          getChunkSize: this.opts.getChunkSize.bind(this),
+        }),
 
         onProgress,
         onError,

--- a/packages/@uppy/aws-s3/src/utils.ts
+++ b/packages/@uppy/aws-s3/src/utils.ts
@@ -12,10 +12,12 @@ export function throwIfAborted(signal?: AbortSignal | null): void {
 }
 
 export type UploadResult = { key: string; uploadId?: string; bucket?: string }
-export type UploadResultWithSignal = UploadResult & { signal?: AbortSignal }
+export type UploadResultWithSignal = UploadResult & {
+  signal?: AbortSignal | null
+}
 export type MultipartUploadResult = UploadResult & { parts: AwsS3Part[] }
 export type MultipartUploadResultWithSignal = MultipartUploadResult & {
-  signal?: AbortSignal
+  signal?: AbortSignal | null
 }
 
 export type UploadPartBytesResult = {

--- a/packages/@uppy/box/src/Box.tsx
+++ b/packages/@uppy/box/src/Box.tsx
@@ -71,9 +71,15 @@ export default class Box<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'box',
       pluginId: this.id,
       supportsRefreshToken: false,

--- a/packages/@uppy/companion-client/src/Provider.ts
+++ b/packages/@uppy/companion-client/src/Provider.ts
@@ -44,7 +44,7 @@ export default class Provider<M extends Meta, B extends Body>
 
   tokenKey: string
 
-  companionKeysParams?: Record<string, string>
+  companionKeysParams?: Record<string, string> | undefined
 
   preAuthToken: string | null
 

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -175,13 +175,13 @@ export default class RequestClient<M extends Meta, B extends Body> {
     method = 'GET',
     data,
     skipPostResponse,
-    signal,
+    signal = null,
   }: {
     path: string
     method?: string
     data?: Record<string, unknown>
     skipPostResponse?: boolean
-    signal?: AbortSignal
+    signal?: AbortSignal | null
   }): Promise<ResBody> {
     try {
       const headers = await this.headers(!data)

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -23,7 +23,7 @@ export type Opts = {
   provider: string
   pluginId: string
   companionUrl: string
-  companionCookiesRule?: 'same-origin' | 'include' | 'omit'
+  companionCookiesRule?: 'same-origin' | 'include' | 'omit' | undefined
   companionHeaders?: CompanionHeaders
   companionKeysParams?: Record<string, string>
 }
@@ -179,7 +179,7 @@ export default class RequestClient<M extends Meta, B extends Body> {
   }: {
     path: string
     method?: string
-    data?: Record<string, unknown>
+    data?: Record<string, unknown> | undefined
     skipPostResponse?: boolean
     signal?: AbortSignal | null
   }): Promise<ResBody> {

--- a/packages/@uppy/components/src/FilesList.tsx
+++ b/packages/@uppy/components/src/FilesList.tsx
@@ -13,7 +13,7 @@ export type FilesListProps = {
 
 export default function FilesList(props: FilesListProps) {
   const [files, setFiles] = useState<UppyFile<any, any>[]>(() => [])
-  const { ctx, editFile, imageThumbnail } = props
+  const { ctx, editFile, imageThumbnail = false } = props
 
   useEffect(() => {
     const onStateUpdate: UppyEventMap<any, any>['state-update'] = (

--- a/packages/@uppy/components/src/hooks/dropzone.ts
+++ b/packages/@uppy/components/src/hooks/dropzone.ts
@@ -1,7 +1,7 @@
 import type { NonNullableUppyContext } from '../types.js'
 
 export type DropzoneOptions = {
-  noClick?: boolean
+  noClick?: boolean | undefined
   onDragOver?: (event: Event) => void
   onDragEnter?: (event: Event) => void
   onDragLeave?: (event: Event) => void
@@ -21,7 +21,7 @@ export type DropzoneReturn<DragEventType, ChangeEventType> = {
     id: string
     type: 'file'
     multiple: boolean
-    accept?: string
+    accept?: string | undefined
     onChange: (event: ChangeEventType) => void
   }
 }

--- a/packages/@uppy/components/src/hooks/file-input.ts
+++ b/packages/@uppy/components/src/hooks/file-input.ts
@@ -10,7 +10,7 @@ export type FileInputFunctions<EventType> = {
     id: string
     type: 'file'
     multiple: boolean
-    accept?: string
+    accept?: string | undefined
     onChange: (event: EventType) => void
   }
   getButtonProps: () => {

--- a/packages/@uppy/components/src/hooks/screencapture.ts
+++ b/packages/@uppy/components/src/hooks/screencapture.ts
@@ -14,7 +14,7 @@ export type ScreenCaptureSnapshot = {
   start: () => void
   getVideoProps: () => {
     playsInline: boolean
-    autoPlay?: boolean
+    autoPlay?: boolean | undefined
     muted: boolean
     controls?: boolean | undefined
     src?: string

--- a/packages/@uppy/components/src/hooks/webcam.ts
+++ b/packages/@uppy/components/src/hooks/webcam.ts
@@ -17,7 +17,7 @@ export type WebcamSnapshot = {
   start: () => void
   getVideoProps: () => {
     playsInline: boolean
-    autoPlay?: boolean
+    autoPlay?: boolean | undefined
     muted: boolean
     controls?: boolean | undefined
     src?: string

--- a/packages/@uppy/core/src/Restricter.ts
+++ b/packages/@uppy/core/src/Restricter.ts
@@ -42,7 +42,7 @@ class RestrictionError<M extends Meta, B extends Body> extends Error {
 
   constructor(
     message: string,
-    opts?: { isUserFacing?: boolean; file?: UppyFile<M, B> },
+    opts?: { isUserFacing?: boolean; file?: UppyFile<M, B> | undefined },
   ) {
     super(message)
     this.isUserFacing = opts?.isUserFacing ?? true

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -249,7 +249,7 @@ export interface State<M extends Meta, B extends Body>
     isHidden?: boolean
     type: LogLevel
     message: string
-    details?: string | Record<string, string> | null
+    details?: string | Record<string, string> | null | undefined
   }>
   plugins: Plugins
   totalProgress: number

--- a/packages/@uppy/dashboard/src/Dashboard.tsx
+++ b/packages/@uppy/dashboard/src/Dashboard.tsx
@@ -1305,7 +1305,7 @@ export default class Dashboard<M extends Meta, B extends Body> extends UIPlugin<
     } = this.opts
     return {
       thumbnailWidth,
-      thumbnailHeight,
+      ...(thumbnailHeight !== undefined && { thumbnailHeight }),
       thumbnailType,
       waitForThumbnailsBeforeUpload,
       // If we don't block on thumbnails, we can lazily generate them

--- a/packages/@uppy/dashboard/src/components/Dashboard.tsx
+++ b/packages/@uppy/dashboard/src/components/Dashboard.tsx
@@ -85,7 +85,7 @@ type DashboardUIProps<M extends Meta, B extends Body> = {
   metaFields: DashboardState<M, B>['metaFields']
   resumableUploads: boolean
   individualCancellation: boolean
-  isMobileDevice?: boolean
+  isMobileDevice?: boolean | undefined
   fileCardFor: string | null
   toggleFileCard: (show: boolean, fileID: string) => void
   toggleAddFilesPanel: (show: boolean) => void

--- a/packages/@uppy/dropbox/src/Dropbox.tsx
+++ b/packages/@uppy/dropbox/src/Dropbox.tsx
@@ -72,9 +72,15 @@ export default class Dropbox<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'dropbox',
       pluginId: this.id,
       supportsRefreshToken: true,

--- a/packages/@uppy/facebook/src/Facebook.tsx
+++ b/packages/@uppy/facebook/src/Facebook.tsx
@@ -76,9 +76,15 @@ export default class Facebook<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'facebook',
       pluginId: this.id,
       supportsRefreshToken: false,

--- a/packages/@uppy/google-drive/src/GoogleDrive.tsx
+++ b/packages/@uppy/google-drive/src/GoogleDrive.tsx
@@ -93,9 +93,15 @@ export default class GoogleDrive<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'drive',
       pluginId: this.id,
       supportsRefreshToken: true,

--- a/packages/@uppy/instagram/src/Instagram.tsx
+++ b/packages/@uppy/instagram/src/Instagram.tsx
@@ -90,9 +90,15 @@ export default class Instagram<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'instagram',
       pluginId: this.id,
       supportsRefreshToken: false,

--- a/packages/@uppy/onedrive/src/OneDrive.tsx
+++ b/packages/@uppy/onedrive/src/OneDrive.tsx
@@ -84,9 +84,15 @@ export default class OneDrive<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'onedrive',
       pluginId: this.id,
       supportsRefreshToken: true,

--- a/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
@@ -84,7 +84,7 @@ export interface PickedDriveItem extends PickedItemBase {
 export interface PickedPhotosItem extends PickedItemBase {
   platform: 'photos'
   url: string
-  metadata?: Record<string, string | number> // I think string and number is OK in Companion
+  metadata?: Record<string, string | number | undefined> // I think string and number is OK in Companion
 }
 
 export type PickedItem = PickedPhotosItem | PickedDriveItem

--- a/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
@@ -135,7 +135,7 @@ export async function ensureScriptsInjected(
 
 async function isTokenValid(
   accessToken: string,
-  signal: AbortSignal | undefined,
+  signal: AbortSignal | null = null,
 ) {
   const response = await fetch(
     `https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${encodeURIComponent(accessToken)}`,
@@ -265,12 +265,12 @@ export async function showPhotosPicker({
   token,
   pickingSession,
   onPickingSessionChange,
-  signal,
+  signal = null,
 }: {
   token: string
   pickingSession: PickingSession | undefined
   onPickingSessionChange: (ps: PickingSession) => void
-  signal: AbortSignal | undefined
+  signal?: AbortSignal | null | undefined
 }): Promise<void> {
   // https://developers.google.com/photos/picker/guides/get-started-picker
   const headers = getAuthHeader(token)

--- a/packages/@uppy/react/src/DashboardModal.ts
+++ b/packages/@uppy/react/src/DashboardModal.ts
@@ -48,7 +48,9 @@ class DashboardModal<M extends Meta, B extends Body> extends Component<
       const { uppy, ...options } = {
         ...this.props,
         inline: false,
-        onRequestCloseModal: onRequestClose,
+        ...(onRequestClose !== undefined && {
+          onRequestCloseModal: onRequestClose,
+        }),
       }
       this.plugin.setOptions(options)
     }
@@ -77,7 +79,9 @@ class DashboardModal<M extends Meta, B extends Body> extends Component<
       inline: false,
       target,
       open,
-      onRequestCloseModal: onRequestClose,
+      ...(onRequestClose !== undefined && {
+        onRequestCloseModal: onRequestClose,
+      }),
     }
 
     uppy.use(DashboardPlugin<M, B>, options)

--- a/packages/@uppy/react/src/StatusBar.ts
+++ b/packages/@uppy/react/src/StatusBar.ts
@@ -53,13 +53,13 @@ class StatusBar<M extends Meta, B extends Body> extends Component<
     } = this.props
     const options = {
       id: id || 'StatusBar',
-      hideUploadButton,
-      hideRetryButton,
-      hidePauseResumeButton,
-      hideCancelButton,
-      showProgressDetails,
-      hideAfterFinish,
-      doneButtonHandler,
+      ...(hideUploadButton !== undefined && { hideUploadButton }),
+      ...(hideRetryButton !== undefined && { hideRetryButton }),
+      ...(hidePauseResumeButton !== undefined && { hidePauseResumeButton }),
+      ...(hideCancelButton !== undefined && { hideCancelButton }),
+      ...(showProgressDetails !== undefined && { showProgressDetails }),
+      ...(hideAfterFinish !== undefined && { hideAfterFinish }),
+      ...(doneButtonHandler !== undefined && { doneButtonHandler }),
       target: this.container,
     }
 

--- a/packages/@uppy/remote-sources/src/index.ts
+++ b/packages/@uppy/remote-sources/src/index.ts
@@ -90,10 +90,12 @@ export default class RemoteSources<
 
   install(): void {
     this.opts.sources.forEach((pluginId) => {
-      const { sources, ...rest } = this.opts
+      const { sources, companionKeysParams, ...rest } = this.opts
       const optsForRemoteSourcePlugin: CompanionPluginOptions = {
         ...rest,
-        companionKeysParams: this.opts.companionKeysParams?.[pluginId],
+        ...(this.opts.companionKeysParams?.[pluginId] !== undefined && {
+          companionKeysParams: this.opts.companionKeysParams?.[pluginId],
+        }),
       }
       const plugin = availablePlugins[pluginId]
       if (plugin == null) {

--- a/packages/@uppy/transloadit/src/Client.ts
+++ b/packages/@uppy/transloadit/src/Client.ts
@@ -197,15 +197,15 @@ export default class Client<M extends Meta, B extends Body> {
   }
 
   async submitError(
-    err: { message?: string; details?: string },
+    err: { message?: string; details?: string | undefined },
     {
       endpoint,
       instance,
       assembly,
     }: {
       endpoint?: string | URL
-      instance?: string
-      assembly?: string
+      instance?: string | undefined
+      assembly?: string | undefined
     } = {},
   ): Promise<AssemblyResponse> {
     const message = err.details
@@ -240,8 +240,8 @@ export default class Client<M extends Meta, B extends Body> {
 
     const opts: {
       type: string
-      assembly?: string
-      instance?: string
+      assembly?: string | undefined
+      instance?: string | undefined
       endpoint?: URL | string
     } = {
       type: params.type,

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -239,7 +239,7 @@ export default class Transloadit<
 
   client: Client<M, B>
 
-  #assembly?: Assembly
+  #assembly?: Assembly | undefined
 
   #watcher!: AssemblyWatcher<M, B>
 

--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -241,7 +241,8 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
       // now also includes `relativePath` for files added from folders.
       // This means you can add 2 identical files, if one is in folder a,
       // the other in folder b.
-      uploadOptions.fingerprint = getFingerprint(file)
+      const fingerprint = getFingerprint(file)
+      if (fingerprint !== undefined) uploadOptions.fingerprint = fingerprint
 
       uploadOptions.onBeforeRequest = async (req) => {
         const xhr = req.getUnderlyingObject()

--- a/packages/@uppy/unsplash/src/Unsplash.tsx
+++ b/packages/@uppy/unsplash/src/Unsplash.tsx
@@ -95,7 +95,9 @@ export default class Unsplash<M extends Meta, B extends Body>
       provider: this.provider,
       viewType: 'unsplash',
       showFilter: true,
-      utmSource: this.opts.utmSource,
+      ...(this.opts.utmSource !== undefined && {
+        utmSource: this.opts.utmSource,
+      }),
     })
 
     const { target } = this.opts

--- a/packages/@uppy/utils/src/CompanionClientProvider.ts
+++ b/packages/@uppy/utils/src/CompanionClientProvider.ts
@@ -4,7 +4,7 @@ export type RequestOptions = {
   method?: string
   data?: Record<string, unknown>
   skipPostResponse?: boolean
-  signal?: AbortSignal
+  signal?: AbortSignal | null
   authFormData?: unknown
   qs?: Record<string, string>
 }

--- a/packages/@uppy/utils/src/CompanionFile.ts
+++ b/packages/@uppy/utils/src/CompanionFile.ts
@@ -16,7 +16,7 @@ export type CompanionFile = {
   modifiedDate: string
   thumbnail?: string
   requestPath: string
-  relDirPath?: string
+  relDirPath?: string | undefined
   absDirPath?: string
   author?: {
     name?: string

--- a/packages/@uppy/utils/src/FileProgress.ts
+++ b/packages/@uppy/utils/src/FileProgress.ts
@@ -26,7 +26,7 @@ interface FileProgressBase {
    */
   complete?: true
   /** `undefined` if we don't know the percentage (e.g. for files with `bytesTotal` null) */
-  percentage?: number
+  percentage?: number | undefined
   /**
    * note that Companion will send `bytesTotal` 0 if unknown size (not `null`).
    * this is not perfect because some files can actually have a size of 0,

--- a/packages/@uppy/utils/src/ProgressTimeout.ts
+++ b/packages/@uppy/utils/src/ProgressTimeout.ts
@@ -5,7 +5,7 @@
  * Call `timer.done()` when the upload has completed.
  */
 class ProgressTimeout {
-  #aliveTimer?: ReturnType<typeof setTimeout>
+  #aliveTimer?: ReturnType<typeof setTimeout> | undefined
 
   #isDone = false
 

--- a/packages/@uppy/utils/src/RateLimitedQueue.ts
+++ b/packages/@uppy/utils/src/RateLimitedQueue.ts
@@ -4,7 +4,7 @@ function createCancelError(cause?: string) {
 
 function abortOn(
   this: { abort: (cause: string) => void; then?: Promise<any>['then'] },
-  signal?: AbortSignal,
+  signal: AbortSignal | null = null,
 ) {
   if (signal != null) {
     const abortPromise = () => this.abort(signal.reason)

--- a/packages/@uppy/utils/src/UppyFile.ts
+++ b/packages/@uppy/utils/src/UppyFile.ts
@@ -18,20 +18,22 @@ interface UppyFileBase<M extends Meta, B extends Body> {
   isGhost: boolean
   meta: InternalMetadata & M
   name: string
-  preview?: string
+  preview?: string | undefined
   progress: FileProgress
   missingRequiredMetaFields?: string[]
   serverToken?: string | null
   size: number | null
   source?: string
   type: string
-  uploadURL?: string
-  response?: {
-    body?: B
-    status: number
-    bytesUploaded?: number
-    uploadURL?: string
-  }
+  uploadURL?: string | undefined
+  response?:
+    | {
+        body?: B | undefined
+        status: number
+        bytesUploaded?: number
+        uploadURL?: string | undefined
+      }
+    | undefined
 }
 
 export interface LocalUppyFile<M extends Meta, B extends Body>

--- a/packages/@uppy/utils/src/fetcher.ts
+++ b/packages/@uppy/utils/src/fetcher.ts
@@ -35,13 +35,12 @@ export type FetcherOptions = {
   onUploadProgress?: (event: ProgressEvent) => void
 
   /** A function to determine whether to retry the request. */
-  shouldRetry?: (xhr: XMLHttpRequest) => boolean
+  shouldRetry?: ((xhr: XMLHttpRequest) => boolean) | undefined
 
   /** Called after the response has succeeded or failed but before the promise is resolved. */
-  onAfterResponse?: (
-    xhr: XMLHttpRequest,
-    retryCount: number,
-  ) => void | Promise<void>
+  onAfterResponse?:
+    | ((xhr: XMLHttpRequest, retryCount: number) => void | Promise<void>)
+    | undefined
 
   /** Called when no XMLHttpRequest upload progress events have been received for `timeout` ms. */
   onTimeout?: (timeout: number) => void

--- a/packages/@uppy/utils/src/generateFileID.ts
+++ b/packages/@uppy/utils/src/generateFileID.ts
@@ -28,7 +28,7 @@ function encodeFilename(name: string): string {
 export default function generateFileID<M extends Meta, B extends Body>(
   file: Partial<Pick<UppyFile<M, B>, 'id' | 'type' | 'name'>> &
     Pick<UppyFile<M, B>, 'data'> & {
-      meta?: { relativePath?: unknown }
+      meta?: { relativePath?: unknown } | undefined
     },
   instanceId: string,
 ): string {

--- a/packages/@uppy/vue/src/dashboard-modal.ts
+++ b/packages/@uppy/vue/src/dashboard-modal.ts
@@ -33,7 +33,7 @@ export default defineComponent({
         id: 'DashboardModal',
         inline: false,
         ...props.props,
-        target: containerRef.value,
+        ...(containerRef.value !== undefined && { target: containerRef.value }),
       }
       uppy.use(DashboardPlugin, options)
       pluginRef.value = uppy.getPlugin(options.id) as DashboardPlugin<any, any>

--- a/packages/@uppy/vue/src/dashboard.ts
+++ b/packages/@uppy/vue/src/dashboard.ts
@@ -29,7 +29,7 @@ export default defineComponent({
         id: 'Dashboard',
         inline: true,
         ...props.props,
-        target: containerRef.value,
+        ...(containerRef.value !== undefined && { target: containerRef.value }),
       }
       uppy.use(DashboardPlugin, options)
       pluginRef.value = uppy.getPlugin(options.id) as DashboardPlugin<any, any>

--- a/packages/@uppy/vue/src/status-bar.ts
+++ b/packages/@uppy/vue/src/status-bar.ts
@@ -23,7 +23,7 @@ export default defineComponent({
       const options = {
         id: 'StatusBar',
         ...props.props,
-        target: containerRef.value,
+        ...(containerRef.value !== undefined && { target: containerRef.value }),
       }
       uppy.use(StatusBarPlugin, options)
       pluginRef.value = uppy.getPlugin(options.id) as StatusBarPlugin<any, any>

--- a/packages/@uppy/vue/src/useFileInput.ts
+++ b/packages/@uppy/vue/src/useFileInput.ts
@@ -6,7 +6,7 @@ export type VueFileInputFunctions = {
     id: string
     type: 'file'
     multiple: boolean
-    accept?: string
+    accept?: string | undefined
     onchange: (event: Event) => void
   }
   getButtonProps: () => {

--- a/packages/@uppy/webcam/src/Webcam.tsx
+++ b/packages/@uppy/webcam/src/Webcam.tsx
@@ -36,15 +36,15 @@ function toMimeType(fileType: string): string | undefined {
 /**
  * Is this MIME type a video?
  */
-function isVideoMimeType(mimeType?: string): boolean {
-  return /^video\/[^*]+$/.test(mimeType!)
+function isVideoMimeType(mimeType: string): boolean {
+  return /^video\/[^*]+$/.test(mimeType)
 }
 
 /**
  * Is this MIME type an image?
  */
-function isImageMimeType(mimeType?: string): boolean {
-  return /^image\/[^*]+$/.test(mimeType!)
+function isImageMimeType(mimeType: string): boolean {
+  return /^image\/[^*]+$/.test(mimeType)
 }
 
 function getMediaDevices() {
@@ -341,12 +341,13 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
     // Safari doesn't have the `isTypeSupported` API.
     if (MediaRecorder.isTypeSupported) {
       const { restrictions } = this.uppy.opts
-      let preferredVideoMimeTypes: Array<string | undefined> = []
+      let preferredVideoMimeTypes: Array<string> = []
       if (this.opts.preferredVideoMimeType) {
         preferredVideoMimeTypes = [this.opts.preferredVideoMimeType]
       } else if (restrictions.allowedFileTypes) {
         preferredVideoMimeTypes = restrictions.allowedFileTypes
           .map(toMimeType)
+          .filter((type) => type !== undefined)
           .filter(isVideoMimeType)
       }
 
@@ -626,7 +627,8 @@ export default class Webcam<M extends Meta, B extends Body> extends UIPlugin<
     } else if (restrictions.allowedFileTypes) {
       preferredImageMimeTypes = restrictions.allowedFileTypes
         .map(toMimeType)
-        .filter(isImageMimeType) as string[]
+        .filter((type) => type !== undefined)
+        .filter(isImageMimeType)
     }
 
     const mimeType = preferredImageMimeTypes[0] || 'image/jpeg'

--- a/packages/@uppy/webdav/src/Webdav.tsx
+++ b/packages/@uppy/webdav/src/Webdav.tsx
@@ -124,9 +124,15 @@ export default class Webdav<M extends Meta, B extends Body>
 
     this.provider = new WebdavSimpleAuthProvider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'webdav',
       pluginId: this.id,
       supportsRefreshToken: false,

--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -385,7 +385,7 @@ export default class XHRUpload<
       const fetch = this.#getFetcher([file])
       const body = opts.formData
         ? this.createFormDataUpload(file, opts)
-        : file.data
+        : (file.data ?? null)
       const endpoint =
         typeof opts.endpoint === 'string'
           ? opts.endpoint

--- a/packages/@uppy/zoom/src/Zoom.tsx
+++ b/packages/@uppy/zoom/src/Zoom.tsx
@@ -22,7 +22,7 @@ import packageJson from '../package.json' with { type: 'json' }
 import locale from './locale.js'
 
 export type ZoomOptions = CompanionPluginOptions & {
-  locale?: LocaleStrings<typeof locale>
+  locale?: LocaleStrings<typeof locale> | undefined
 }
 
 export default class Zoom<M extends Meta, B extends Body>
@@ -71,9 +71,15 @@ export default class Zoom<M extends Meta, B extends Body>
     )
     this.provider = new Provider(uppy, {
       companionUrl: this.opts.companionUrl,
-      companionHeaders: this.opts.companionHeaders,
-      companionKeysParams: this.opts.companionKeysParams,
-      companionCookiesRule: this.opts.companionCookiesRule,
+      ...(this.opts.companionHeaders !== undefined && {
+        companionHeaders: this.opts.companionHeaders,
+      }),
+      ...(this.opts.companionKeysParams !== undefined && {
+        companionKeysParams: this.opts.companionKeysParams,
+      }),
+      ...(this.opts.companionCookiesRule !== undefined && {
+        companionCookiesRule: this.opts.companionCookiesRule,
+      }),
       provider: 'zoom',
       pluginId: this.id,
       supportsRefreshToken: false,

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -12,6 +12,7 @@
     "jsxImportSource": "preact",
     "types": ["preact"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   }


### PR DESCRIPTION
This will help prevent regressions similar to #6033 in the future.