### PR TITLE
Do not trigger Companion edge deploy on yarn.lock

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ['main']
     paths:
-      - yarn.lock
       - 'packages/@uppy/companion/**'
       - '.github/workflows/companion-deploy.yml'
 


### PR DESCRIPTION
This triggers way too often, which is not needed. Especially pushing to DockerHub is very unnecessary whenever `yarn.lock` changes.