### PR TITLE
PR: UppyContextProvider.svelte generates https://svelte.dev/e/state_referenced_locally warning

### DIFF
--- a/.changeset/nice-jeans-sniff.md
+++ b/.changeset/nice-jeans-sniff.md
@@ -2,4 +2,4 @@
 "@uppy/svelte": patch
 ---
 
-PR: UppyContextProvider.svelte generates https://svelte.dev/e/state_referenced_locally warning
+Fix only capturing the initial value of `uppy`in `UppyContextProvider`

--- a/.changeset/nice-jeans-sniff.md
+++ b/.changeset/nice-jeans-sniff.md
@@ -1,0 +1,5 @@
+---
+"@uppy/svelte": patch
+---
+
+PR: UppyContextProvider.svelte generates https://svelte.dev/e/state_referenced_locally warning

--- a/.changeset/nice-jeans-sniff.md
+++ b/.changeset/nice-jeans-sniff.md
@@ -2,4 +2,4 @@
 "@uppy/svelte": patch
 ---
 
-Fix only capturing the initial value of `uppy`in `UppyContextProvider`
+Fix only capturing the initial value of `uppy` in `UppyContextProvider`

--- a/.changeset/nice-jeans-sniff.md
+++ b/.changeset/nice-jeans-sniff.md
@@ -2,4 +2,4 @@
 "@uppy/svelte": patch
 ---
 
-Fix only capturing the initial value of `uppy` in `UppyContextProvider`
+Fix the `state_referenced_locally` warning emitted for `UppyContextProvider`, and make the provided context follow the `uppy` prop instead of capturing its initial value

--- a/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
+++ b/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
@@ -15,7 +15,7 @@ export type { UppyContext } from "@uppy/components";
   let { uppy, children } = $props()
 
   // Create a single reactive context object
-  const contextValue: UppyContext = $state({
+  const contextValue: UppyContext = $derived({
     uppy,
     status: 'init' as UploadStatus,
     progress: 0,

--- a/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
+++ b/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
@@ -14,12 +14,18 @@ export type { UppyContext } from "@uppy/components";
 
   let { uppy, children } = $props()
 
-  // Create a single reactive context object
-  const contextValue: UppyContext = $state({
-    uppy: (() => uppy)(),
-    status: 'init' as UploadStatus,
-    progress: 0,
-  })
+  // Create reactive state for properties of the context
+  let status = $state('init' as UploadStatus)
+  let progress = $state(0)
+
+  // Create a single context object, with some reactive properties
+  const contextValue: UppyContext = {
+    get uppy() { return uppy },
+    get status() { return status },
+    set status(value) { status = value },
+    get progress() { return progress },
+    set progress(value) { progress = value },
+  }
 
   onMount(() => {
     if (!uppy) {
@@ -29,10 +35,10 @@ export type { UppyContext } from "@uppy/components";
     const uppyEventAdapter = createUppyEventAdapter({
       uppy,
       onStatusChange: (newStatus: UploadStatus) => {
-        contextValue.status = newStatus
+        status = newStatus
       },
       onProgressChange: (newProgress: number) => {
-        contextValue.progress = newProgress
+        progress = newProgress
       },
     })
 

--- a/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
+++ b/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
@@ -15,8 +15,8 @@ export type { UppyContext } from "@uppy/components";
   let { uppy, children } = $props()
 
   // Create a single reactive context object
-  const contextValue: UppyContext = $derived({
-    uppy,
+  const contextValue: UppyContext = $state({
+    uppy: (() => uppy)(),
     status: 'init' as UploadStatus,
     progress: 0,
   })

--- a/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
+++ b/packages/@uppy/svelte/src/lib/components/headless/UppyContextProvider.svelte
@@ -10,7 +10,7 @@ export type { UppyContext } from "@uppy/components";
 </script>
 
 <script lang="ts">
-  import { setContext, onMount } from 'svelte'
+  import { setContext } from 'svelte'
 
   let { uppy, children } = $props()
 
@@ -27,7 +27,8 @@ export type { UppyContext } from "@uppy/components";
     set progress(value) { progress = value },
   }
 
-  onMount(() => {
+  // Re-subscribe whenever the `uppy` prop changes
+  $effect(() => {
     if (!uppy) {
       throw new Error('ContextProvider: passing `uppy` as a prop is required')
     }


### PR DESCRIPTION
Update UppyContextProvider.svelte: use callback functions, getters and setters together with $state() when dealing with $props() value since it's reactive, to avoid https://svelte.dev/e/state_referenced_locally warning.
Read more of an example where this concept is explored more: https://svelte.dev/docs/svelte/$state#Passing-state-into-functions

Issue: transloadit/uppy#6140

## To reproduce

It took a bit of time, but I managed to figure out that it in order to reproduce this warning you need a separate project that has uppy as a dependency, and that builds assets using webpack + svelte-loader.
I created a simple test project, and will just simply leave the essential files needed below:

`package.json`:

```json
{
  "name": "test-warnings-project",
  "version": "1.0.0",
  "type": "module",
  "private": true,
  "scripts": {
    "build": "webpack --mode=development"
  },
  "devDependencies": {
    "svelte-loader": "^3.2.4",
    "svelte-preprocess": "^6.0.3",
    "webpack": "^5.0.0",
    "webpack-cli": "^5.0.0"
  },
  "dependencies": {
    "@uppy/core": "^5.2.0",
    "@uppy/svelte": "^5.0.2",
    "svelte": "^5.46.4"
  }
}
```

`webpack.config.js`:

```js
import { sveltePreprocess } from 'svelte-preprocess';
import path from 'path';
import { fileURLToPath } from 'url';

const __dirname = path.dirname(fileURLToPath(import.meta.url));

export default {
  mode: 'development',
  entry: './src/main.js',
  output: {
    path: path.resolve(__dirname, 'dist'),
    filename: 'bundle.js',
  },
  resolve: {
    mainFields: ['svelte', 'browser', 'module', 'main'],
    extensions: ['.svelte', '.ts', '.js', '.mjs'],
    conditionNames: ['svelte', 'import', 'module', 'browser', 'development'],
  },
  module: {
    rules: [
      {
        test: /\.svelte$/,
        use: {
          loader: 'svelte-loader',
          options: {
            compilerOptions: {
              dev: true,
            },
            preprocess: sveltePreprocess({
              typescript: true,
            }),
          },
        },
      },
    ],
  },
};
```

`index.html`:

```html
<!DOCTYPE html>
<html>
<head>
  <title>Test Warnings</title>
</head>
<body>
  <script src="./dist/bundle.js"></script>
</body>
</html>
```

`src/main.js`:

```js
import App from './App.svelte';
import { mount } from 'svelte';

const app = mount(App, {
  target: document.body
});

export default app;
```

`src/App.svelte`:

```svelte
<script lang="ts">
  import { UppyContextProvider } from '@uppy/svelte';
  import Uppy from '@uppy/core';
  
  const uppy = new Uppy({
    debug: true,
    restrictions: {
      maxFileSize: 1000000,
      maxNumberOfFiles: 3,
      minNumberOfFiles: 1,
    }
  });
</script>

<main>
  <h1>Testing Warnings</h1>
  
  <UppyContextProvider {uppy}>
    <div>Uppy context provider test</div>
  </UppyContextProvider>
</main>
```