### PR TITLE
Fix #6111: Missing translation for NetworkError

### DIFF
--- a/packages/@uppy/utils/src/NetworkError.ts
+++ b/packages/@uppy/utils/src/NetworkError.ts
@@ -5,9 +5,14 @@ class NetworkError extends Error {
 
   public request: null | XMLHttpRequest
 
-  constructor(error: unknown, xhr: null | XMLHttpRequest = null) {
+  constructor(
+    error: unknown,
+    xhr: null | XMLHttpRequest = null,
+    message?: string,
+  ) {
     super(
-      `This looks like a network error, the endpoint might be blocked by an internet provider or a firewall.`,
+      message ??
+        `This looks like a network error, the endpoint might be blocked by an internet provider or a firewall.`,
     )
 
     this.cause = error

--- a/packages/@uppy/xhr-upload/src/index.ts
+++ b/packages/@uppy/xhr-upload/src/index.ts
@@ -94,6 +94,7 @@ declare module '@uppy/core' {
 function buildResponseError(
   xhr?: XMLHttpRequest,
   err?: string | Error | NetworkError,
+  networkErrorMessage?: string,
 ) {
   let error = err
   // No error message
@@ -106,7 +107,7 @@ function buildResponseError(
   }
 
   if (isNetworkError(xhr)) {
-    error = new NetworkError(error, xhr)
+    error = new NetworkError(error, xhr, networkErrorMessage)
     return error
   }
 
@@ -276,7 +277,7 @@ export default class XHRUpload<
             this.uppy.emit(
               'upload-error',
               this.uppy.getFile(file.id),
-              buildResponseError(request, error),
+              buildResponseError(request, error, this.i18n('networkError')),
               request,
             )
           }

--- a/packages/@uppy/xhr-upload/src/locale.ts
+++ b/packages/@uppy/xhr-upload/src/locale.ts
@@ -3,5 +3,8 @@ export default {
     // Shown in the Informer if an upload is being canceled because it stalled for too long.
     uploadStalled:
       'Upload has not made any progress for %{seconds} seconds. You may want to retry it.',
+    // Shown in the Dashboard when a network error occurs during upload.
+    networkError:
+      'This looks like a network error, the endpoint might be blocked by an internet provider or a firewall.',
   },
 }


### PR DESCRIPTION
Fixes #6111

## Summary
This PR addresses: Missing translation for NetworkError

## Changes
```
packages/@uppy/utils/src/NetworkError.ts | 9 +++++++--
 packages/@uppy/xhr-upload/src/index.ts   | 5 +++--
 packages/@uppy/xhr-upload/src/locale.ts  | 3 +++
 3 files changed, 13 insertions(+), 4 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*