### PR TITLE
fix(@uppy/image-editor): destroy cropper and clean up state on file re-open and removal

### DIFF
--- a/.changeset/fix-image-editor-cleanup.md
+++ b/.changeset/fix-image-editor-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@uppy/image-editor": patch
+---
+
+Fix cropper not reinitializing after save/cancel by destroying previous instance in `start()` and cleaning up on file removal

--- a/packages/@uppy/image-editor/src/ImageEditor.tsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.tsx
@@ -350,6 +350,7 @@ export default class ImageEditor<
    */
   start = (file: UppyFile<M, B>): void => {
     // Clean up any previous editing session
+    this.destroyCropper()
     if (this.objectUrl) {
       URL.revokeObjectURL(this.objectUrl)
       this.objectUrl = null
@@ -480,8 +481,16 @@ export default class ImageEditor<
     return this.objectUrl
   }
 
+  handleFileRemoved = (file: UppyFile<M, B>): void => {
+    const { currentImage } = this.getPluginState()
+    if (currentImage && currentImage.id === file.id) {
+      this.stop()
+    }
+  }
+
   install(): void {
     this.resetEditorState(null)
+    this.uppy.on('file-removed', this.handleFileRemoved)
 
     const { target } = this.opts
     if (target) {
@@ -496,6 +505,7 @@ export default class ImageEditor<
       const file = this.uppy.getFile(currentImage.id)
       this.uppy.emit('file-editor:cancel', file)
     }
+    this.uppy.off('file-removed', this.handleFileRemoved)
     this.stop()
     this.unmount()
   }


### PR DESCRIPTION
Closes https://github.com/transloadit/uppy/issues/6210

## Problem

When using the ImageEditor with the Dashboard, the following sequence causes the editor to break on the second file:

1. Upload any image
2. Open the image editor, save or cancel
3. Open the image editor again

**Expected:** The image editor works normally in subsequent edits.

**Actual:** The image preview and actions show, but the cropper doesn't initialize properly, so no edits can be made.

## Root Cause

Two cleanup gaps in `ImageEditor`:

1. **`start()` doesn't destroy the previous cropper.** It revokes the old `objectUrl` but leaves the `Cropper` instance alive. When the `Editor` component mounts for the new file and calls `initCropper(imgElement)`, it hits the early return `if (this.cropper) return` and never creates a new cropper — the stale instance retains the old file's crop dimensions and references a destroyed DOM element.

2. **No `file-removed` listener.** When a file is removed from the Dashboard, the ImageEditor has no handler to clean up its state (`currentImage`, cropper, objectUrl, event listeners), so everything persists into the next editing session.

## Fix

- Call `this.destroyCropper()` at the top of `start()` to fully tear down any previous cropper before starting a new editing session
- Add a `handleFileRemoved` listener (registered in `install()`, deregistered in `uninstall()`) that calls `stop()` when the currently-edited file is removed from Uppy

## Changes

`packages/@uppy/image-editor/src/ImageEditor.tsx` — 10 insertions, 1 deletion

## Test Plan

1. Open Dashboard with ImageEditor (`autoOpen="imageEditor"`)
2. Drag an image — editor opens, crop/save/cancel
3. Open the image editor again — verify it works normally with a fresh cropper
4. Remove the file from the Dashboard, drag a new image — verify the editor opens cleanly
5. Repeat multiple times to confirm no state leaks
6. Verify that closing the editor via cancel still works correctly
7. Verify that editing the same file multiple times (without removing) still works
