### PR TITLE
Export Processor type to fix TypeScript errors

### DIFF
--- a/.changeset/export-processor-type.md
+++ b/.changeset/export-processor-type.md
@@ -1,0 +1,5 @@
+---
+"@uppy/core": patch
+---
+
+Export the `Processor` type so consumers can type functions passed to `addPreProcessor`, `addPostProcessor`, and `addUploader`

--- a/packages/@uppy/core/src/Uppy.ts
+++ b/packages/@uppy/core/src/Uppy.ts
@@ -42,7 +42,7 @@ import {
   Translator,
 } from './utils/index.js'
 
-type Processor = (
+export type Processor = (
   fileIDs: string[],
   uploadID: string,
   // biome-ignore lint/suspicious/noConfusingVoidType: ...

--- a/packages/@uppy/core/src/index.ts
+++ b/packages/@uppy/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   PartialTreeFolderRoot,
   PartialTreeId,
   PluginTypeRegistry,
+  Processor,
   State,
   UnknownPlugin,
   UnknownProviderPlugin,


### PR DESCRIPTION
Add export to the Processor type definition. This enables TypeScript support for `addPostProcessor`, `addPreProcessor` and `addUploader` which use the same type.

```
import Uppy from "@uppy/core";

const uppy = new Uppy();

// TS2339: Property 'addPostProcessor' does not exist on type 'Uppy'
uppy.addPostProcessor(async (fileIds) => {});
```