### PR TITLE
@uppy/companion-client: fix stale websocket connection

### DIFF
--- a/.changeset/lazy-berries-brake.md
+++ b/.changeset/lazy-berries-brake.md
@@ -1,0 +1,5 @@
+---
+"@uppy/companion-client": patch
+---
+
+uploadRemoteFile() now queues token request and websocket request as a single job in the request queue.

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -234,12 +234,13 @@ export default class RequestClient<M extends Meta, B extends Body> {
   }
 
   /**
-   * Remote uploading consists of two steps:
-   * 1. #requestSocketToken which starts the download/upload in companion and returns a unique token for the upload.
-   * Then companion will halt the upload until:
-   * 2. #awaitRemoteFileUpload is called, which will open/ensure a websocket connection towards companion, with the
-   * previously generated token provided. It returns a promise that will resolve/reject once the file has finished
-   * uploading or is otherwise done (failed, canceled)
+   * Remote uploading uses a single queue admission per attempt:
+   * 1. Acquire one queue slot.
+   * 2. Reuse an existing serverToken or request a new one from Companion.
+   * 3. Open/maintain the websocket and wait for Companion to finish.
+   *
+   * This prevents socket tokens from being created long before their websocket
+   * session is admitted by the queue.
    */
   async uploadRemoteFile(
     file: RemoteUppyFile<M, B>,
@@ -248,72 +249,46 @@ export default class RequestClient<M extends Meta, B extends Body> {
   ): Promise<void> {
     try {
       const { signal, getQueue } = options || {}
+      const queue = getQueue()
 
       return await pRetry(
         async () => {
-          // if we already have a serverToken, assume that we are resuming the existing server upload id
-          const existingServerToken = this.uppy.getFile(file.id)?.serverToken
-          if (existingServerToken != null) {
-            this.uppy.log(
-              `Connecting to exiting websocket ${existingServerToken}`,
-            )
-            return this.#awaitRemoteFileUpload({
-              file,
-              queue: getQueue(),
-              signal,
-            })
-          }
+          const queueRemoteUploadAttempt = queue.wrapPromiseFunction(
+            async () => {
+              const currentFile = this.uppy.getFile(file.id) as
+                | RemoteUppyFile<M, B>
+                | undefined
+              if (currentFile == null) return undefined
 
-          const queueRequestSocketToken = getQueue().wrapPromiseFunction(
-            async (
-              ...args: [
-                {
-                  file: RemoteUppyFile<M, B>
-                  postBody: Record<string, unknown>
-                  signal: AbortSignal
-                },
-              ]
-            ) => {
-              try {
-                return await this.#requestSocketToken(...args)
-              } catch (outerErr) {
-                // throwing AbortError will cause p-retry to stop retrying
-                if (outerErr.isAuthError) throw new AbortError(outerErr)
+              let serverToken = currentFile.serverToken
 
-                if (outerErr.cause == null) throw outerErr
-                const err = outerErr.cause
+              if (serverToken != null) {
+                this.uppy.log(`Connecting to exiting websocket ${serverToken}`)
+              } else {
+                serverToken = await this.#requestSocketTokenWithRetryStrategy({
+                  file: currentFile,
+                  postBody: reqBody,
+                  signal,
+                })
 
-                const isRetryableHttpError = () =>
-                  [408, 409, 429, 418, 423].includes(err.statusCode) ||
-                  (err.statusCode >= 500 &&
-                    err.statusCode <= 599 &&
-                    ![501, 505].includes(err.statusCode))
-                if (err.name === 'HttpError' && !isRetryableHttpError())
-                  throw new AbortError(err)
+                if (!this.uppy.getFile(file.id)) return undefined
 
-                // p-retry will retry most other errors,
-                // but it will not retry TypeError (except network error TypeErrors)
-                throw err
+                this.uppy.setFileState(file.id, { serverToken })
               }
+
+              const latestFile = this.uppy.getFile(file.id) as
+                | RemoteUppyFile<M, B>
+                | undefined
+              if (latestFile == null) return undefined
+
+              return this.#awaitRemoteFileUpload({
+                file: latestFile,
+                signal,
+              })
             },
-            { priority: -1 },
           )
 
-          const serverToken = await queueRequestSocketToken({
-            file,
-            postBody: reqBody,
-            signal,
-          }).abortOn(signal)
-
-          if (!this.uppy.getFile(file.id)) return undefined // has file since been removed?
-
-          this.uppy.setFileState(file.id, { serverToken })
-
-          return this.#awaitRemoteFileUpload({
-            file: this.uppy.getFile(file.id) as RemoteUppyFile<M, B>, // re-fetching file because it might have changed in the meantime
-            queue: getQueue(),
-            signal,
-          })
+          return queueRemoteUploadAttempt().abortOn(signal)
         },
         {
           retries: retryCount,
@@ -360,6 +335,39 @@ export default class RequestClient<M extends Meta, B extends Body> {
     return res.token
   }
 
+  #requestSocketTokenWithRetryStrategy = async ({
+    file,
+    postBody,
+    signal,
+  }: {
+    file: RemoteUppyFile<M, B>
+    postBody: Record<string, unknown>
+    signal: AbortSignal
+  }): Promise<string> => {
+    try {
+      return await this.#requestSocketToken({ file, postBody, signal })
+    } catch (outerErr) {
+      // throwing AbortError will cause p-retry to stop retrying
+      if (outerErr.isAuthError) throw new AbortError(outerErr)
+
+      if (outerErr.cause == null) throw outerErr
+      const err = outerErr.cause
+
+      const isRetryableHttpError = () =>
+        [408, 409, 429, 418, 423].includes(err.statusCode) ||
+        (err.statusCode >= 500 &&
+          err.statusCode <= 599 &&
+          ![501, 505].includes(err.statusCode))
+      if (err.name === 'HttpError' && !isRetryableHttpError()) {
+        throw new AbortError(err)
+      }
+
+      // p-retry will retry most other errors,
+      // but it will not retry TypeError (except network error TypeErrors)
+      throw err
+    }
+  }
+
   /**
    * This method will ensure a websocket for the specified file and returns a promise that resolves
    * when the file has finished downloading, or rejects if it fails.
@@ -367,11 +375,9 @@ export default class RequestClient<M extends Meta, B extends Body> {
    */
   async #awaitRemoteFileUpload({
     file,
-    queue,
     signal,
   }: {
     file: RemoteUppyFile<M, B>
-    queue: any
     signal: AbortSignal
   }): Promise<void> {
     let removeEventHandlers: () => void
@@ -430,126 +436,115 @@ export default class RequestClient<M extends Meta, B extends Body> {
           function resetActivityTimeout() {
             clearTimeout(activityTimeout)
             if (isPaused) return
-            activityTimeout = setTimeout(
-              () =>
-                onFatalError(
-                  new Error(
-                    'Timeout waiting for message from Companion socket',
-                  ),
-                ),
-              socketActivityTimeoutMs,
-            )
+            activityTimeout = setTimeout(() => {
+              onFatalError(
+                new Error('Timeout waiting for message from Companion socket'),
+              )
+            }, socketActivityTimeoutMs)
           }
 
           try {
-            await queue
-              .wrapPromiseFunction(async () => {
-                const reconnectWebsocket = async () =>
-                  new Promise((_, rejectSocket) => {
-                    socket = new WebSocket(`${host}/api/${token}`)
+            const reconnectWebsocket = async () =>
+              new Promise((_, rejectSocket) => {
+                socket = new WebSocket(`${host}/api/${token}`)
 
-                    resetActivityTimeout()
+                resetActivityTimeout()
 
-                    socket.addEventListener('close', () => {
-                      socket = undefined
-                      rejectSocket(new Error('Socket closed unexpectedly'))
-                    })
-
-                    socket.addEventListener('error', (error) => {
-                      this.uppy.log(
-                        `Companion socket error ${JSON.stringify(
-                          error,
-                        )}, closing socket`,
-                        'warning',
-                      )
-                      socket?.close() // will 'close' event to be emitted
-                    })
-
-                    socket.addEventListener('open', () => {
-                      sendState()
-                    })
-
-                    socket.addEventListener('message', (e) => {
-                      resetActivityTimeout()
-
-                      try {
-                        const { action, payload } = JSON.parse(e.data)
-
-                        switch (action) {
-                          case 'progress': {
-                            emitSocketProgress(
-                              this,
-                              payload,
-                              this.uppy.getFile(file.id),
-                            )
-                            break
-                          }
-                          case 'success': {
-                            // payload.response is sent from companion for xhr-upload (aka uploadMultipart in companion) and
-                            // s3 multipart (aka uploadS3Multipart)
-                            // but not for tus/transloadit (aka uploadTus)
-                            // responseText is a string which may or may not be in JSON format
-                            // this means that an upload destination of xhr or s3 multipart MUST respond with valid JSON
-                            // to companion, or the JSON.parse will crash
-                            const text = payload.response?.responseText
-
-                            this.uppy.emit(
-                              'upload-success',
-                              this.uppy.getFile(file.id),
-                              {
-                                uploadURL: payload.url,
-                                status: payload.response?.status ?? 200,
-                                body: text
-                                  ? (JSON.parse(text) as B)
-                                  : undefined,
-                              },
-                            )
-                            socketAbortController?.abort?.()
-                            resolve()
-                            break
-                          }
-                          case 'error': {
-                            const { message } = payload.error
-                            throw Object.assign(new Error(message), {
-                              cause: payload.error,
-                            })
-                          }
-                          default:
-                            this.uppy.log(
-                              `Companion socket unknown action ${action}`,
-                              'warning',
-                            )
-                        }
-                      } catch (err) {
-                        onFatalError(err)
-                      }
-                    })
-
-                    const closeSocket = () => {
-                      this.uppy.log(`Closing socket ${file.id}`)
-                      clearTimeout(activityTimeout)
-                      if (socket) socket.close()
-                      socket = undefined
-                    }
-
-                    socketAbortController.signal.addEventListener(
-                      'abort',
-                      () => {
-                        closeSocket()
-                      },
-                    )
-                  })
-
-                await pRetry(reconnectWebsocket, {
-                  retries: retryCount,
-                  signal: socketAbortController.signal,
-                  onFailedAttempt: () => {
-                    if (socketAbortController.signal.aborted) return // don't log in this case
-                    this.uppy.log(`Retrying websocket ${file.id}`)
-                  },
+                socket.addEventListener('close', () => {
+                  socket = undefined
+                  rejectSocket(new Error('Socket closed unexpectedly'))
                 })
-              })()
-              .abortOn(socketAbortController.signal)
+
+                socket.addEventListener('error', (error) => {
+                  this.uppy.log(
+                    `Companion socket error ${JSON.stringify(
+                      error,
+                    )}, closing socket`,
+                    'warning',
+                  )
+                  socket?.close() // will 'close' event to be emitted
+                })
+
+                socket.addEventListener('open', () => {
+                  sendState()
+                })
+
+                socket.addEventListener('message', (e) => {
+                  resetActivityTimeout()
+
+                  try {
+                    const { action, payload } = JSON.parse(e.data)
+
+                    switch (action) {
+                      case 'progress': {
+                        emitSocketProgress(
+                          this,
+                          payload,
+                          this.uppy.getFile(file.id),
+                        )
+                        break
+                      }
+                      case 'success': {
+                        // payload.response is sent from companion for xhr-upload (aka uploadMultipart in companion) and
+                        // s3 multipart (aka uploadS3Multipart)
+                        // but not for tus/transloadit (aka uploadTus)
+                        // responseText is a string which may or may not be in JSON format
+                        // this means that an upload destination of xhr or s3 multipart MUST respond with valid JSON
+                        // to companion, or the JSON.parse will crash
+                        const text = payload.response?.responseText
+
+                        this.uppy.emit(
+                          'upload-success',
+                          this.uppy.getFile(file.id),
+                          {
+                            uploadURL: payload.url,
+                            status: payload.response?.status ?? 200,
+                            body: text
+                              ? (JSON.parse(text) as B)
+                              : undefined,
+                          },
+                        )
+                        socketAbortController?.abort?.()
+                        resolve()
+                        break
+                      }
+                      case 'error': {
+                        const { message } = payload.error
+                        throw Object.assign(new Error(message), {
+                          cause: payload.error,
+                        })
+                      }
+                      default:
+                        this.uppy.log(
+                          `Companion socket unknown action ${action}`,
+                          'warning',
+                        )
+                    }
+                  } catch (err) {
+                    onFatalError(err)
+                  }
+                })
+
+                const closeSocket = () => {
+                  this.uppy.log(`Closing socket ${file.id}`)
+                  clearTimeout(activityTimeout)
+                  if (socket) socket.close()
+                  socket = undefined
+                }
+
+                socketAbortController.signal.addEventListener('abort', () => {
+                  closeSocket()
+                })
+              })
+
+            await pRetry(reconnectWebsocket, {
+              retries: retryCount,
+              signal: socketAbortController.signal,
+              onFailedAttempt: () => {
+                if (socketAbortController.signal.aborted) return // don't log in this case
+                this.uppy.log(`Retrying websocket ${file.id}`)
+              },
+            })
           } catch (err) {
             if (socketAbortController.signal.aborted) return
             onFatalError(err)

--- a/packages/@uppy/companion-client/src/RequestClient.ts
+++ b/packages/@uppy/companion-client/src/RequestClient.ts
@@ -499,9 +499,7 @@ export default class RequestClient<M extends Meta, B extends Body> {
                           {
                             uploadURL: payload.url,
                             status: payload.response?.status ?? 200,
-                            body: text
-                              ? (JSON.parse(text) as B)
-                              : undefined,
+                            body: text ? (JSON.parse(text) as B) : undefined,
                           },
                         )
                         socketAbortController?.abort?.()


### PR DESCRIPTION
fixes #6181

`uploadRemoteFile()` now treats one remote upload attempt as a single queue-owned unit. Instead of queueing “request token” and “open websocket / wait for upload” as two separate jobs, it now:

  - acquires one queue slot
  - reuses serverToken if resuming, otherwise requests a new
    token
  - immediately proceeds to the websocket/upload phase within
    that same admitted attempt

That removes the stale-token race where Companion starts its 60s socket-wait timer before the client’s websocket phase has actually been admitted by the queue. Retries still reacquire the queue per attempt, and existing abort/cancel behavior is
preserved.

refer https://github.com/transloadit/uppy/issues/6181#issuecomment-4295036192 for more context about the bug 