### PR TITLE
Add Yarn npm package age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,5 +9,6 @@ initScope: uppy
 
 nodeLinker: node-modules
 
-npmPublishAccess: public
+npmMinimalAgeGate: 2880
 
+npmPublishAccess: public


### PR DESCRIPTION
## Summary
- add Yarn's native `npmMinimalAgeGate` with a 2 day / 2880 minute cooldown to help protect against supply chain attacks
- rely on the existing Yarn 4.12.0 install path instead of a custom package-age script

Closes #5974.

## Verification
- `corepack yarn config get npmMinimalAgeGate` -> `2880`
- `corepack yarn install --immutable`
- `corepack yarn check`