### PR TITLE
Harden dependency installs

### DIFF
--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run:
-          corepack yarn install
+          corepack yarn install --immutable
         env:
           # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
           CYPRESS_INSTALL_BINARY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
         run:
-          corepack yarn install
+          corepack yarn install --immutable
       - name: Install Playwright Browsers
         run: corepack yarn workspace @uppy/dashboard playwright install --with-deps
       - name: Build
@@ -84,7 +84,7 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run:
-          corepack yarn install
+          corepack yarn install --immutable
       - run: corepack yarn run typecheck
 
   lint_js:

--- a/.github/workflows/manual-cdn.yml
+++ b/.github/workflows/manual-cdn.yml
@@ -30,18 +30,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run:
-          echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v5
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Why
Recent npm supply-chain compromises showed that dependency installs and shared CI caches can execute or preserve newly published malicious packages before advisories catch up. This PR reduces that exposure for this repo.

## What changed
- Made eligible Yarn installs immutable and removed shared dependency caching from the manual CDN upload path; existing minimal age gate remains unchanged.

## Validation
- Ran `git diff --check` across the prepared worktree.
- Audited this PR set for `pull_request_target` and release/deploy/CDN cache reuse; patched actionable hits.
- Did not run the full test suite; this is a workflow/config-only change.