### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/companion-deploy.yml
+++ b/.github/workflows/companion-deploy.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -72,7 +72,7 @@ jobs:
     needs: docker
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           version: corepack yarn run version
           publish: corepack yarn run release
@@ -102,7 +102,7 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable=true
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/companion-deploy.yml`
- `.github/workflows/release.yml`

Resolved refs:

- `docker/setup-buildx-action@v3` -> `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f`
- `changesets/action@v1` -> `changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
