### PR TITLE
fix(@uppy/locales): repair smart_count placeholder in ja_JP folderAdded

### DIFF
--- a/.changeset/quiet-jars-repair.md
+++ b/.changeset/quiet-jars-repair.md
@@ -1,0 +1,5 @@
+---
+"@uppy/locales": patch
+---
+
+Fix the smart_count placeholder in the ja_JP folderAdded string.

--- a/packages/@uppy/locales/src/ja_JP.ts
+++ b/packages/@uppy/locales/src/ja_JP.ts
@@ -74,8 +74,8 @@ ja_JP.strings = {
   filter: 'フィルタ',
   finishEditingFile: 'ファイルの編集を終了',
   folderAdded: {
-    '0': '%{folder} から% {smart_count} 個のファイルを追加しました',
-    '1': '%{folder} から% {smart_count} 個のファイルを追加しました',
+    '0': '%{folder} から%{smart_count} 個のファイルを追加しました',
+    '1': '%{folder} から%{smart_count} 個のファイルを追加しました',
   },
   import: 'インポート',
   importFrom: '%{name}からインポート',


### PR DESCRIPTION
`folderAdded` in the Japanese locale writes the count placeholder as `% {smart_count}` (with a space) instead of `%{smart_count}`. Uppy's `Translator` (in `@uppy/utils`) builds the interpolation regex from the exact `%{arg}` token, so the extra space stops the substitution and the message shows the literal text `% {smart_count}` rather than the file count.

Every other use of the placeholder in this file is `%{smart_count}` (20 of them), and the en_US source is `Added %{smart_count} file(s) from %{folder}`. This removes the stray space in both plural forms.
