### PR TITLE
feat(google-drive-picker): add `selectFolders` option to control folder selection

### DIFF
--- a/.changeset/google-drive-picker-select-folders.md
+++ b/.changeset/google-drive-picker-select-folders.md
@@ -1,0 +1,6 @@
+---
+"@uppy/core": patch
+"@uppy/google-drive-picker": minor
+---
+
+`@uppy/google-drive-picker`: add a `selectFolders` option (default `false`) to control whether folders can be _selected_ in the picker. Folders remain visible for navigation. Folder selection now defaults to **off**: under the `drive.file` scope the picker could offer folder selection that returned few or no files. Set `selectFolders: true` to restore folder selection. When enabled and a picked folder yields no accessible files, the user is shown a warning.

--- a/packages/@uppy/core/src/locale.ts
+++ b/packages/@uppy/core/src/locale.ts
@@ -44,6 +44,8 @@ export default {
     logIn: 'Log in',
     pickFiles: 'Pick files',
     pickPhotos: 'Pick photos',
+    emptyOrInaccessibleFolder:
+      "This folder is empty, or it contains files this app doesn't have permission to access.",
     filter: 'Filter',
     resetFilter: 'Reset filter',
     loading: 'Loading...',

--- a/packages/@uppy/core/src/provider-views/GooglePicker/GooglePickerView.tsx
+++ b/packages/@uppy/core/src/provider-views/GooglePicker/GooglePickerView.tsx
@@ -51,11 +51,13 @@ export type GooglePickerViewProps = {
       pickerType: 'drive'
       apiKey: string
       appId: string
+      selectFolders?: boolean
     }
   | {
       pickerType: 'photos'
       apiKey?: undefined
       appId?: undefined
+      selectFolders?: undefined
     }
 )
 
@@ -67,6 +69,7 @@ export default function GooglePickerView({
   pickerType,
   apiKey,
   appId,
+  selectFolders,
   storage,
 }: GooglePickerViewProps) {
   const [loading, setLoading] = useState(false)
@@ -103,7 +106,11 @@ export default function GooglePickerView({
             token,
             apiKey,
             appId,
+            selectFolders: selectFolders ?? false,
             onFilesPicked,
+            onEmptyFolder: () => {
+              uppy.info(i18n('emptyOrInaccessibleFolder'), 'warning', 4000)
+            },
             signal,
             onLoadingChange: (isLoading: boolean) => setLoading(isLoading),
             onError: (err: unknown) => {
@@ -178,6 +185,7 @@ export default function GooglePickerView({
       clientId,
       onFilesPicked,
       pickerType,
+      selectFolders,
       setAccessToken,
       uppy,
       i18n,

--- a/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.test.ts
+++ b/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { showDrivePicker } from './googlePicker.js'
+
+let capturedCallback: ((resp: any) => void) | undefined
+let docsViewCalls: Record<string, unknown>
+
+function installGoogleMock() {
+  capturedCallback = undefined
+  docsViewCalls = {}
+
+  class DocsView {
+    setIncludeFolders(v: boolean) {
+      docsViewCalls.includeFolders = v
+      return this
+    }
+    setSelectFolderEnabled(v: boolean) {
+      docsViewCalls.selectFolderEnabled = v
+      return this
+    }
+    setMode() {
+      return this
+    }
+  }
+
+  class PickerBuilder {
+    enableFeature() {
+      return this
+    }
+    setDeveloperKey() {
+      return this
+    }
+    setAppId() {
+      return this
+    }
+    setOAuthToken() {
+      return this
+    }
+    addView() {
+      return this
+    }
+    setCallback(cb: (resp: any) => void) {
+      capturedCallback = cb
+      return this
+    }
+    build() {
+      return { setVisible() {}, dispose() {} }
+    }
+  }
+
+  ;(globalThis as any).google = {
+    picker: {
+      Action: { PICKED: 'picked' },
+      Feature: { NAV_HIDDEN: 'nav', MULTISELECT_ENABLED: 'multi' },
+      ViewId: { DOCS: 'docs' },
+      DocsViewMode: { LIST: 'list' },
+      DocsView,
+      PickerBuilder,
+    },
+  }
+}
+
+function installFetchMock(folderFiles: unknown[] = []) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      if (url.includes('oauth2/v1/tokeninfo')) {
+        return { ok: true } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ files: folderFiles }),
+      } as unknown as Response
+    }),
+  )
+}
+
+const baseArgs = {
+  token: 'tok',
+  apiKey: 'key',
+  appId: 'app',
+  signal: undefined,
+  onLoadingChange: () => {},
+  onError: () => {},
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  ;(globalThis as any).google = undefined
+})
+
+describe('showDrivePicker selectFolders', () => {
+  it('always shows folders (setIncludeFolders true) regardless of selectFolders', async () => {
+    installGoogleMock()
+    installFetchMock()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: false,
+      onFilesPicked: () => {},
+      onEmptyFolder: () => {},
+    })
+    expect(docsViewCalls.includeFolders).toBe(true)
+  })
+
+  it('disables folder selection when selectFolders is false', async () => {
+    installGoogleMock()
+    installFetchMock()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: false,
+      onFilesPicked: () => {},
+      onEmptyFolder: () => {},
+    })
+    expect(docsViewCalls.selectFolderEnabled).toBe(false)
+  })
+
+  it('enables folder selection when selectFolders is true', async () => {
+    installGoogleMock()
+    installFetchMock()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: true,
+      onFilesPicked: () => {},
+      onEmptyFolder: () => {},
+    })
+    expect(docsViewCalls.includeFolders).toBe(true)
+    expect(docsViewCalls.selectFolderEnabled).toBe(true)
+  })
+
+  it('calls onEmptyFolder when a picked folder resolves to zero files', async () => {
+    installGoogleMock()
+    installFetchMock([])
+    const onEmptyFolder = vi.fn()
+    const onFilesPicked = vi.fn()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: true,
+      onFilesPicked,
+      onEmptyFolder,
+    })
+    await capturedCallback!({
+      action: 'picked',
+      docs: [
+        {
+          id: 'folder1',
+          name: 'My Folder',
+          mimeType: 'application/vnd.google-apps.folder',
+        },
+      ],
+    })
+    expect(onEmptyFolder).toHaveBeenCalledTimes(1)
+    expect(onFilesPicked).toHaveBeenCalledWith([], 'tok')
+  })
+
+  it('does NOT call onEmptyFolder when a picked folder has files', async () => {
+    installGoogleMock()
+    installFetchMock([{ id: 'f1', name: 'a.pdf', mimeType: 'application/pdf' }])
+    const onEmptyFolder = vi.fn()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: true,
+      onFilesPicked: () => {},
+      onEmptyFolder,
+    })
+    await capturedCallback!({
+      action: 'picked',
+      docs: [
+        {
+          id: 'folder1',
+          name: 'My Folder',
+          mimeType: 'application/vnd.google-apps.folder',
+        },
+      ],
+    })
+    expect(onEmptyFolder).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call onEmptyFolder when only plain files are picked', async () => {
+    installGoogleMock()
+    installFetchMock()
+    const onEmptyFolder = vi.fn()
+    await showDrivePicker({
+      ...baseArgs,
+      selectFolders: false,
+      onFilesPicked: () => {},
+      onEmptyFolder,
+    })
+    await capturedCallback!({
+      action: 'picked',
+      docs: [{ id: 'f1', name: 'a.pdf', mimeType: 'application/pdf' }],
+    })
+    expect(onEmptyFolder).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.ts
@@ -207,7 +207,9 @@ export async function showDrivePicker({
   token,
   apiKey,
   appId,
+  selectFolders,
   onFilesPicked,
+  onEmptyFolder,
   signal,
   onLoadingChange,
   onError,
@@ -215,7 +217,9 @@ export async function showDrivePicker({
   token: string
   apiKey: string
   appId: string
+  selectFolders: boolean
   onFilesPicked: (files: PickedItem[], accessToken: string) => void
+  onEmptyFolder: () => void
   signal: AbortSignal | undefined
   onLoadingChange: (loading: boolean) => void
   onError: (err: unknown) => void
@@ -320,6 +324,14 @@ export async function showDrivePicker({
           ...(await handleDocObjectRecursively({ doc, token, signal })),
         )
       }
+
+      const pickedAFolder = picked.docs.some(
+        (doc) => doc.mimeType === 'application/vnd.google-apps.folder',
+      )
+      if (pickedAFolder && results.length === 0) {
+        onEmptyFolder()
+      }
+
       onFilesPicked(results, token)
     } catch (err) {
       onError(err)
@@ -337,9 +349,7 @@ export async function showDrivePicker({
     .addView(
       new google.picker.DocsView(google.picker.ViewId.DOCS)
         .setIncludeFolders(true)
-        // Note: setEnableDrives doesn't seem to work
-        // .setEnableDrives(true)
-        .setSelectFolderEnabled(true)
+        .setSelectFolderEnabled(selectFolders)
         .setMode(google.picker.DocsViewMode.LIST),
     )
     // NOTE: photos is broken and results in an error being returned from Google

--- a/packages/@uppy/google-drive-picker/README.md
+++ b/packages/@uppy/google-drive-picker/README.md
@@ -13,6 +13,36 @@ Google Drive account using the new Picker API.
 Documentation for this plugin can be found on the
 [Uppy website](https://uppy.io/docs/google-drive-picker).
 
+## Options
+
+### `selectFolders` (default: `false`)
+
+Whether users can **select** folders in the picker. Defaults to `false`.
+Folders are always shown so users can navigate into them to reach files; this
+option only controls whether a folder itself can be picked.
+
+> **Note on the `drive.file` scope:** This plugin uses Google's narrow
+> `drive.file` OAuth scope (which avoids Google's CASA Tier 2 assessment).
+> Under this scope, an app can only access files the user explicitly picks.
+> When a user picks a _folder_, its contents are not "explicitly picked", so
+> Google returns only the files the app already had access to — often none.
+> For this reason folder selection is off by default. If you enable
+> `selectFolders: true` and a picked folder yields no accessible files, the
+> user is shown a warning, because "empty folder" and "no access to the
+> folder's contents" are indistinguishable under `drive.file`.
+
+```js
+import GoogleDrivePicker from '@uppy/google-drive-picker'
+
+uppy.use(GoogleDrivePicker, {
+  companionUrl: 'https://your-companion.example.com',
+  clientId: 'YOUR_CLIENT_ID',
+  apiKey: 'YOUR_API_KEY',
+  appId: 'YOUR_APP_ID',
+  selectFolders: false, // set true to allow folder selection (see note above)
+})
+```
+
 ## License
 
 The [MIT License](./LICENSE).

--- a/packages/@uppy/google-drive-picker/src/GoogleDrivePicker.tsx
+++ b/packages/@uppy/google-drive-picker/src/GoogleDrivePicker.tsx
@@ -1,4 +1,10 @@
-import type { AsyncStore, BaseProviderPlugin, Body, Meta } from '@uppy/core'
+import type {
+  AsyncStore,
+  BaseProviderPlugin,
+  Body,
+  DefinePluginOpts,
+  Meta,
+} from '@uppy/core'
 import { UIPlugin, type Uppy } from '@uppy/core'
 import {
   type CompanionPluginOptions,
@@ -25,11 +31,20 @@ export type GoogleDrivePickerOptions = CompanionPluginOptions & {
   clientId: string
   apiKey: string
   appId: string
+  selectFolders?: boolean
   locale?: LocaleStrings<typeof locale>
 }
 
+const defaultOptions = {
+  selectFolders: false,
+} satisfies Partial<GoogleDrivePickerOptions>
+
 export default class GoogleDrivePicker<M extends Meta, B extends Body>
-  extends UIPlugin<GoogleDrivePickerOptions, M, B>
+  extends UIPlugin<
+    DefinePluginOpts<GoogleDrivePickerOptions, keyof typeof defaultOptions>,
+    M,
+    B
+  >
   implements BaseProviderPlugin
 {
   static VERSION = packageJson.version
@@ -45,7 +60,7 @@ export default class GoogleDrivePicker<M extends Meta, B extends Body>
   defaultLocale = locale
 
   constructor(uppy: Uppy<M, B>, opts: GoogleDrivePickerOptions) {
-    super(uppy, opts)
+    super(uppy, { ...defaultOptions, ...opts })
     this.id = this.opts.id || 'GoogleDrivePicker'
     this.storage = this.opts.storage || tokenStorage
 
@@ -117,6 +132,7 @@ export default class GoogleDrivePicker<M extends Meta, B extends Body>
       clientId={this.opts.clientId}
       apiKey={this.opts.apiKey}
       appId={this.opts.appId}
+      selectFolders={this.opts.selectFolders}
       onFilesPicked={this.handleFilesPicked}
     />
   )


### PR DESCRIPTION
## Summary

The Google Drive Picker enables folder selection unconditionally, but the plugin uses the narrow `drive.file` OAuth scope. Under `drive.file`, an app can only access files the user *explicitly* picks, selecting a folder does **not** grant access to its contents. So when a user selects a folder, listing it returns only the files the app already had per-file access to (often none), and the selection appears to do nothing.

Reading arbitrary folder contents would require a restricted scope (`drive.readonly`/`drive`), which triggers Google's security assessment (CASA), something many integrators specifically use this picker to avoid.

This PR makes folder **selection** opt-in:

- Adds a `selectFolders` option (default `false`) to `@uppy/google-drive-picker`.
- Folders remain **visible** for navigation (`setIncludeFolders(true)` stays unconditional); only folder *selection* (`setSelectFolderEnabled`) is gated by the option.
- When `selectFolders: true` and a picked folder resolves to zero files, the user sees an ambiguity-aware warning — under `drive.file`, "empty folder" and "no access to the folder's contents" are indistinguishable.
- Keeps the `drive.file` scope unchanged.

## Behavior change

Folder selection previously defaulted on but couldn't work reliably under `drive.file`. It now defaults off; set `selectFolders: true` to re-enable it. Captured in the changeset (`@uppy/google-drive-picker` minor, `@uppy/core` patch).

## Testing

- Added unit tests for `showDrivePicker` (6 tests, all passing).
- `yarn workspace @uppy/core typecheck` and `@uppy/google-drive-picker typecheck` clean.
