### PR TITLE
extend dependency update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@
 
 version: 2
 updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,6 @@ initScope: uppy
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: '7d'
+npmMinimalAgeGate: 10080
 
 npmPublishAccess: public

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,6 @@ initScope: uppy
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 10080
+npmMinimalAgeGate: "1w"
 
 npmPublishAccess: public

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,6 @@ initScope: uppy
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 2880
+npmMinimalAgeGate: '7d'
 
 npmPublishAccess: public


### PR DESCRIPTION
Security Meassure , as discussed in uppy call

- Yarn package age gate increased to seven days
- Weekly npm Dependabot updates enabled with a seven-day cooldown

Note: Dependabot security-update PRs intentionally bypass the seven-day cooldown, ensuring security fixes remain available immediately.