### PR TITLE
chore: add missing major changeset for @uppy/aws-s3 rewrite

### DIFF
--- a/.changeset/aws-s3-rewrite.md
+++ b/.changeset/aws-s3-rewrite.md
@@ -8,10 +8,10 @@ The plugin is now built on a standalone S3 client and configuration is reduced t
 mutually exclusive signing modes:
 
 - `getCredentials` — client-side SigV4 signing using temporary AWS credentials
-- `signRequest` — bring your own signer
-- `companionEndpoint` — Companion signing
+- `signRequest` — bring your own signer (client side or server side)
+- `companionEndpoint` — Companion signing (as before)
 
-Companion is no longer required in the data path, and any S3-compatible service (R2,
+It is now much easier to use the S3 plugin without relying on Companion. Any S3-compatible service (R2,
 MinIO, DigitalOcean Spaces, …) works.
 
 **Removed options:** `endpoint`, `getTemporarySecurityCredentials`, `getUploadParameters`,

--- a/.changeset/aws-s3-rewrite.md
+++ b/.changeset/aws-s3-rewrite.md
@@ -1,0 +1,26 @@
+---
+"@uppy/aws-s3": major
+---
+
+`@uppy/aws-s3` has been rewritten from scratch ([#6345](https://github.com/transloadit/uppy/pull/6345)).
+
+The plugin is now built on a standalone S3 client and configuration is reduced to three
+mutually exclusive signing modes:
+
+- `getCredentials` — client-side SigV4 signing with temporary credentials
+- `signRequest` — bring your own signer
+- `companionEndpoint` — Companion signing
+
+Companion is no longer required in the data path, and any S3-compatible service (R2,
+MinIO, DigitalOcean Spaces, …) works.
+
+**Removed options:** `endpoint`, `getTemporarySecurityCredentials`, `getUploadParameters`,
+`signPart`, `createMultipartUpload`, `listParts`, `abortMultipartUpload`,
+`completeMultipartUpload`, `uploadPartBytes`, `retryDelays`.
+
+**New options:** `s3Endpoint`, `region`, `getCredentials`, `signRequest`,
+`companionEndpoint`, `generateObjectKey`.
+
+**Unchanged:** `shouldUseMultipart`, `getChunkSize`, `allowedMetaFields`, `limit`.
+
+See the migration guide for before/after examples for each signing mode.

--- a/.changeset/aws-s3-rewrite.md
+++ b/.changeset/aws-s3-rewrite.md
@@ -11,11 +11,13 @@ mutually exclusive signing modes:
 - `signRequest` — bring your own signer (client side or server side)
 - `companionEndpoint` — Companion signing (as before)
 
-It is now much easier to use the S3 plugin without relying on Companion. Any S3-compatible service (R2,
-MinIO, DigitalOcean Spaces, …) works.
+It is now much easier to use the S3 plugin without relying on Companion. Any S3-compatible
+service (R2, MinIO, DigitalOcean Spaces) now works in every signing mode, including
+client-side signing, which previously hardcoded `*.amazonaws.com` and could only target AWS.
 
-**Removed options:** `endpoint`, `getTemporarySecurityCredentials`, `getUploadParameters`,
-`signPart`, `createMultipartUpload`, `listParts`, `abortMultipartUpload`,
+**Removed options:** `endpoint`, `headers`, `cookiesRule`,
+`getTemporarySecurityCredentials`, `getUploadParameters`, `signPart`,
+`createMultipartUpload`, `listParts`, `abortMultipartUpload`,
 `completeMultipartUpload`, `uploadPartBytes`, `retryDelays`.
 
 **New options:** `s3Endpoint`, `region`, `getCredentials`, `signRequest`,

--- a/.changeset/aws-s3-rewrite.md
+++ b/.changeset/aws-s3-rewrite.md
@@ -7,7 +7,7 @@
 The plugin is now built on a standalone S3 client and configuration is reduced to three
 mutually exclusive signing modes:
 
-- `getCredentials` — client-side SigV4 signing with temporary credentials
+- `getCredentials` — client-side SigV4 signing using temporary AWS credentials
 - `signRequest` — bring your own signer
 - `companionEndpoint` — Companion signing
 


### PR DESCRIPTION
The rewrite landed in #6345 without a changeset, so the pending release would have bumped @uppy/aws-s3 as a patch instead of a major.