### PR TITLE
deps upgrade v2: upgrade TypeScript to 6

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -30,6 +30,6 @@
     "@angular-devkit/build-angular": "^19.2.6",
     "@angular/cli": "^19.2.6",
     "@angular/compiler-cli": "^19.2.17",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -26,6 +26,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -28,7 +28,7 @@
     "@vitest/browser-playwright": "^4.1.6",
     "msw": "^2.10.4",
     "playwright": "1.61.1",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vitest": "^4.1.6",
     "vitest-browser-react": "^2.2.0"

--- a/examples/reactrouter/package.json
+++ b/examples/reactrouter/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "tsx": "^4.0.0",
-    "typescript": "^5.1.6",
+    "typescript": "^6.0.3",
     "vite": "^6.3.6"
   },
   "engines": {

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -33,7 +33,7 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.3",
     "vite": "^6.2.5",
     "vitest": "^4.1.6",
     "vitest-browser-svelte": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.5#~/.yarn/patches/@changesets-cli-npm-2.29.5-68d8030bf3.patch",
     "npm-run-all": "^4.1.5",
     "turbo": "^2.5.4",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
   "engines": {

--- a/packages/@uppy/angular/package.json
+++ b/packages/@uppy/angular/package.json
@@ -33,6 +33,6 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
     "ng-packagr": "^21.2.3",
-    "typescript": "~5.9.0"
+    "typescript": "~5.9.3"
   }
 }

--- a/packages/@uppy/audio/package.json
+++ b/packages/@uppy/audio/package.json
@@ -48,7 +48,7 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^29.1.1",
     "nock": "^13.1.0",
     "playwright": "1.61.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6",
     "whatwg-fetch": "3.6.20"
   },

--- a/packages/@uppy/box/package.json
+++ b/packages/@uppy/box/package.json
@@ -44,6 +44,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -103,7 +103,7 @@
     "http-proxy": "1.18.1",
     "nock": "^14.0.15",
     "supertest": "7.2.2",
-    "typescript": "6.0.3",
+    "typescript": "^6.0.3",
     "vitest": "4.1.6"
   },
   "files": [

--- a/packages/@uppy/components/package.json
+++ b/packages/@uppy/components/package.json
@@ -53,7 +53,7 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "tailwindcss": "^4.0.6",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@uppy/core": "workspace:^",

--- a/packages/@uppy/compressor/package.json
+++ b/packages/@uppy/compressor/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^20.19.0",
     "jsdom": "^29.1.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "scripts": {

--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -73,7 +73,7 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }
 }

--- a/packages/@uppy/dashboard/package.json
+++ b/packages/@uppy/dashboard/package.json
@@ -67,7 +67,7 @@
     "postcss-cli": "^11.0.1",
     "resize-observer-polyfill": "^1.5.0",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/dashboard/src/css.d.ts
+++ b/packages/@uppy/dashboard/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/packages/@uppy/drag-drop/package.json
+++ b/packages/@uppy/drag-drop/package.json
@@ -55,6 +55,6 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/drop-target/package.json
+++ b/packages/@uppy/drop-target/package.json
@@ -54,6 +54,6 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/dropbox/package.json
+++ b/packages/@uppy/dropbox/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/facebook/package.json
+++ b/packages/@uppy/facebook/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/form/package.json
+++ b/packages/@uppy/form/package.json
@@ -40,6 +40,6 @@
     "@uppy/core": "workspace:^"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/golden-retriever/package.json
+++ b/packages/@uppy/golden-retriever/package.json
@@ -54,7 +54,7 @@
     "@vitest/browser": "^4.1.6",
     "@vitest/browser-playwright": "^4.1.6",
     "playwright": "1.61.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }
 }

--- a/packages/@uppy/golden-retriever/src/css.d.ts
+++ b/packages/@uppy/golden-retriever/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/packages/@uppy/google-drive-picker/package.json
+++ b/packages/@uppy/google-drive-picker/package.json
@@ -43,6 +43,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/google-drive/package.json
+++ b/packages/@uppy/google-drive/package.json
@@ -42,6 +42,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/google-photos-picker/package.json
+++ b/packages/@uppy/google-photos-picker/package.json
@@ -43,6 +43,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/image-editor/package.json
+++ b/packages/@uppy/image-editor/package.json
@@ -60,6 +60,6 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/locales/package.json
+++ b/packages/@uppy/locales/package.json
@@ -37,6 +37,6 @@
     "chalk": "^5.0.0",
     "dedent": "^1.0.0",
     "glob": "^13.0.6",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/onedrive/package.json
+++ b/packages/@uppy/onedrive/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/react/package.json
+++ b/packages/@uppy/react/package.json
@@ -49,7 +49,7 @@
     "jsdom": "^29.1.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "exports": {

--- a/packages/@uppy/remote-sources/package.json
+++ b/packages/@uppy/remote-sources/package.json
@@ -60,7 +60,7 @@
     "@uppy/core": "workspace:^",
     "jsdom": "^29.1.1",
     "resize-observer-polyfill": "^1.5.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }
 }

--- a/packages/@uppy/screen-capture/package.json
+++ b/packages/@uppy/screen-capture/package.json
@@ -57,6 +57,6 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/status-bar/package.json
+++ b/packages/@uppy/status-bar/package.json
@@ -58,6 +58,6 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/svelte/package.json
+++ b/packages/@uppy/svelte/package.json
@@ -65,7 +65,7 @@
     "svelte": "^5.55.8",
     "svelte-check": "^4.4.8",
     "tslib": "^2.8.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.13"
   },
   "peerDependencies": {

--- a/packages/@uppy/thumbnail-generator/package.json
+++ b/packages/@uppy/thumbnail-generator/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "jsdom": "^29.1.1",
     "namespace-emitter": "2.0.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -53,7 +53,7 @@
     "@uppy/core": "workspace:^",
     "jsdom": "^29.1.1",
     "msw": "^2.10.4",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6",
     "whatwg-fetch": "^3.6.2"
   }

--- a/packages/@uppy/tus/package.json
+++ b/packages/@uppy/tus/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@uppy/core": "workspace:^",
     "jsdom": "^29.1.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/unsplash/package.json
+++ b/packages/@uppy/unsplash/package.json
@@ -44,6 +44,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/url/package.json
+++ b/packages/@uppy/url/package.json
@@ -60,7 +60,7 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }
 }

--- a/packages/@uppy/vue/package.json
+++ b/packages/@uppy/vue/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vue": "^3.5.14"
   },
   "exports": {

--- a/packages/@uppy/webcam/package.json
+++ b/packages/@uppy/webcam/package.json
@@ -56,7 +56,7 @@
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/webdav/package.json
+++ b/packages/@uppy/webdav/package.json
@@ -45,6 +45,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/xhr-upload/package.json
+++ b/packages/@uppy/xhr-upload/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^29.1.1",
     "msw": "^2.10.4",
     "playwright": "1.61.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
   "peerDependencies": {

--- a/packages/@uppy/xhr-upload/src/css.d.ts
+++ b/packages/@uppy/xhr-upload/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/packages/@uppy/zoom/package.json
+++ b/packages/@uppy/zoom/package.json
@@ -44,6 +44,6 @@
   },
   "devDependencies": {
     "@uppy/core": "workspace:^",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/uppy/package.json
+++ b/packages/uppy/package.json
@@ -90,6 +90,6 @@
     "postcss-cli": "^11.0.1",
     "sass": "^1.89.2",
     "tar": "^7.5.7",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11833,7 +11833,7 @@ __metadata:
     "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.5#~/.yarn/patches/@changesets-cli-npm-2.29.5-68d8030bf3.patch"
     npm-run-all: "npm:^4.1.5"
     turbo: "npm:^2.5.4"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -11875,7 +11875,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -11895,7 +11895,7 @@ __metadata:
     jsdom: "npm:^29.1.1"
     nock: "npm:^13.1.0"
     playwright: "npm:1.61.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
     whatwg-fetch: "npm:3.6.20"
   peerDependencies:
@@ -11909,7 +11909,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -11982,7 +11982,7 @@ __metadata:
     supertest: "npm:7.2.2"
     supports-color: "npm:10.2.2"
     tus-js-client: "npm:4.3.1"
-    typescript: "npm:6.0.3"
+    typescript: "npm:^6.0.3"
     validator: "npm:13.15.35"
     vitest: "npm:4.1.6"
     webdav: "npm:5.10.0"
@@ -12007,7 +12007,7 @@ __metadata:
     preact: "npm:^10.29.2"
     pretty-bytes: "npm:^7.1.0"
     tailwindcss: "npm:^4.0.6"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
     "@uppy/image-editor": "workspace:^"
@@ -12033,7 +12033,7 @@ __metadata:
     jsdom: "npm:^29.1.1"
     preact: "npm:^10.29.2"
     promise-queue: "npm:^2.2.5"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12065,7 +12065,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   languageName: unknown
   linkType: soft
@@ -12095,7 +12095,7 @@ __metadata:
     resize-observer-polyfill: "npm:^1.5.0"
     sass: "npm:^1.89.2"
     shallow-equal: "npm:^3.1.0"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12111,7 +12111,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12125,7 +12125,7 @@ __metadata:
     postcss: "npm:^8.5.15"
     postcss-cli: "npm:^11.0.1"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12137,7 +12137,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12149,7 +12149,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12160,7 +12160,7 @@ __metadata:
   resolution: "@uppy/form@workspace:packages/@uppy/form"
   dependencies:
     get-form-data: "npm:^3.0.0"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12177,7 +12177,7 @@ __metadata:
     "@vitest/browser-playwright": "npm:^4.1.6"
     lodash: "npm:^4.18.1"
     playwright: "npm:1.61.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12190,7 +12190,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12202,7 +12202,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12214,7 +12214,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12230,7 +12230,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12260,7 +12260,7 @@ __metadata:
     chalk: "npm:^5.0.0"
     dedent: "npm:^1.0.0"
     glob: "npm:^13.0.6"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -12270,7 +12270,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12291,7 +12291,7 @@ __metadata:
     preact: "npm:^10.29.2"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     use-sync-external-store: "npm:^1.6.0"
     vitest: "npm:^4.1.6"
   peerDependencies:
@@ -12330,7 +12330,7 @@ __metadata:
     "@uppy/zoom": "workspace:^"
     jsdom: "npm:^29.1.1"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12346,7 +12346,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12363,7 +12363,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12383,7 +12383,7 @@ __metadata:
     svelte: "npm:^5.55.8"
     svelte-check: "npm:^4.4.8"
     tslib: "npm:^2.8.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.13"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12411,7 +12411,7 @@ __metadata:
     exifr: "npm:^7.1.3"
     jsdom: "npm:^29.1.1"
     namespace-emitter: "npm:2.0.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12428,7 +12428,7 @@ __metadata:
     component-emitter: "npm:^2.0.0"
     jsdom: "npm:^29.1.1"
     msw: "npm:^2.10.4"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
     whatwg-fetch: "npm:^3.6.2"
   peerDependencies:
@@ -12443,7 +12443,7 @@ __metadata:
     "@uppy/core": "workspace:^"
     jsdom: "npm:^29.1.1"
     tus-js-client: "npm:^4.3.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12456,7 +12456,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12476,7 +12476,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12491,7 +12491,7 @@ __metadata:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
     shallow-equal: "npm:^3.1.0"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vue: "npm:^3.5.14"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12523,7 +12523,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     preact: "npm:^10.29.2"
     sass: "npm:^1.89.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12536,7 +12536,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -12553,7 +12553,7 @@ __metadata:
     jsdom: "npm:^29.1.1"
     msw: "npm:^2.10.4"
     playwright: "npm:1.61.1"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
     "@uppy/core": "workspace:^"
@@ -12566,7 +12566,7 @@ __metadata:
   dependencies:
     "@uppy/core": "workspace:^"
     preact: "npm:^10.29.2"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -13326,7 +13326,7 @@ __metadata:
     ng-packagr: "npm:^21.2.3"
     rxjs: "npm:~7.8.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:~5.9.0"
+    typescript: "npm:~5.9.3"
     zone.js: "npm:~0.16.2"
   languageName: unknown
   linkType: soft
@@ -16794,7 +16794,7 @@ __metadata:
     "@uppy/webcam": "workspace:*"
     rxjs: "npm:~7.8.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:~5.7.2"
+    typescript: "npm:~5.7.3"
     zone.js: "npm:~0.15.0"
   languageName: unknown
   linkType: soft
@@ -16917,7 +16917,7 @@ __metadata:
     react: "npm:19.2.7"
     react-dom: "npm:19.2.7"
     tailwindcss: "npm:^4"
-    typescript: "npm:^5"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -16942,7 +16942,7 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     tailwindcss: "npm:^4.0.9"
-    typescript: "npm:^5.7.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
     vitest: "npm:^4.1.6"
     vitest-browser-react: "npm:^2.2.0"
@@ -16973,7 +16973,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-router: "npm:^7.12.0"
     tsx: "npm:^4.0.0"
-    typescript: "npm:^5.1.6"
+    typescript: "npm:^6.0.3"
     vite: "npm:^6.3.6"
   languageName: unknown
   linkType: soft
@@ -17000,7 +17000,7 @@ __metadata:
     svelte: "npm:^5.0.0"
     svelte-check: "npm:^4.0.0"
     tailwindcss: "npm:^4.0.0"
-    typescript: "npm:^5.0.0"
+    typescript: "npm:^6.0.3"
     vite: "npm:^6.2.5"
     vitest: "npm:^4.1.6"
     vitest-browser-svelte: "npm:^2.1.1"
@@ -27242,7 +27242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.3":
+"typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -27252,17 +27252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5, typescript@npm:^5.0.0, typescript@npm:^5.1.6, typescript@npm:^5.7.3, typescript@npm:^5.8.3":
-  version: 5.9.2
-  resolution: "typescript@npm:5.9.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/cc2fe6c822819de5d453fa25aa9f32096bf70dde215d481faa1ad84a283dfb264e33988ed8f6d36bc803dd0b16dbe943efa311a798ef76d5b3892a05dfbfd628
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.7.2":
+"typescript@npm:~5.7.3":
   version: 5.7.3
   resolution: "typescript@npm:5.7.3"
   bin:
@@ -27272,7 +27262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.9.0":
+"typescript@npm:~5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -27282,7 +27272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
@@ -27292,17 +27282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.0.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.1.6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
-  version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/bd810ab13e8e557225a8b5122370385440b933e4e077d5c7641a8afd207fdc8be9c346e3c678adba934b64e0e70b0acf5eef9493ea05170a48ce22bef845fdc7
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.7.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
@@ -27312,7 +27292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.9.0#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -27578,7 +27558,7 @@ __metadata:
     postcss-cli: "npm:^11.0.1"
     sass: "npm:^1.89.2"
     tar: "npm:^7.5.7"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Moves all 43 workspaces to typescript ^6.0.3 (@uppy/companion was already pinned to 6.0.3). The two Angular workspaces stay on their own lines, ~5.7.3 and ~5.9.3, because the Angular compiler pins its supported range.

TypeScript 6 reports TS2882 for side-effect imports of files it has no declarations for, which the browser tests in @uppy/dashboard, @uppy/golden-retriever and @uppy/xhr-upload hit when importing plugin CSS. Each gets a one-line ambient declaration.

Nothing else changed: no source, no config, no lockfile churn beyond the compiler itself.

