### PR TITLE
Update remaining packages to TypeScript 6

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -30,6 +30,6 @@
     "@angular-devkit/build-angular": "^19.2.6",
     "@angular/cli": "^19.2.6",
     "@angular/compiler-cli": "^19.2.17",
-    "typescript": "~5.7.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/angular/package.json
+++ b/packages/@uppy/angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -33,6 +34,6 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
     "ng-packagr": "^21.2.3",
-    "typescript": "~5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/@uppy/angular/projects/uppy/angular/package.json
+++ b/packages/@uppy/angular/projects/uppy/angular/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.0",
   "license": "MIT",
   "homepage": "https://uppy.io",
+  "type": "module",
   "keywords": [
     "file uploader",
     "uppy",

--- a/packages/@uppy/angular/projects/uppy/angular/tsconfig.lib.json
+++ b/packages/@uppy/angular/projects/uppy/angular/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../out-tsc/lib",
-    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,

--- a/packages/@uppy/angular/tsconfig.json
+++ b/packages/@uppy/angular/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
+    "rootDir": "./projects/uppy/angular/src",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -13,12 +13,10 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "nodenext",
     "useDefineForClassFields": false,
     "lib": ["ES2022", "dom"],
     "allowSyntheticDefaultImports": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -13253,7 +13253,7 @@ __metadata:
     ng-packagr: "npm:^21.2.3"
     rxjs: "npm:~7.8.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:~5.9.3"
+    typescript: "npm:^6.0.3"
     zone.js: "npm:~0.16.2"
   languageName: unknown
   linkType: soft
@@ -16705,7 +16705,7 @@ __metadata:
     "@uppy/webcam": "workspace:*"
     rxjs: "npm:~7.8.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:~5.7.3"
+    typescript: "npm:^6.0.3"
     zone.js: "npm:~0.15.0"
   languageName: unknown
   linkType: soft
@@ -27136,26 +27136,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.7.3":
-  version: 5.7.3
-  resolution: "typescript@npm:5.7.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/6a7e556de91db3d34dc51cd2600e8e91f4c312acd8e52792f243c7818dfadb27bae677175fad6947f9c81efb6c57eb6b2d0c736f196a6ee2f1f7d57b74fc92fa
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
@@ -27163,26 +27143,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
-  version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/dc58d777eb4c01973f7fbf1fd808aad49a0efdf545528dab9b07d94fdcb65b8751742804c3057e9619a4627f2d9cc85547fdd49d9f4326992ad0181b49e61d81
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This means we no longer have multiple TypeScript instances in our `node_modules`.

This also sets `"type": "module"` in `@uppy/angular`.