### PR TITLE
fix(@uppy/image-editor): destroy cropper and clean up state on file re-open and removal #6223

### DIFF
--- a/.changeset/fix-image-editor-cleanup.md
+++ b/.changeset/fix-image-editor-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@uppy/image-editor": patch
+---
+
+Fix cropper not reinitializing after save/cancel by destroying previous instance in `start()` and cleaning up on file removal

--- a/packages/@uppy/image-editor/src/ImageEditor.tsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.tsx
@@ -350,6 +350,7 @@ export default class ImageEditor<
    */
   start = (file: UppyFile<M, B>): void => {
     // Clean up any previous editing session
+    this.destroyCropper()
     if (this.objectUrl) {
       URL.revokeObjectURL(this.objectUrl)
       this.objectUrl = null
@@ -480,8 +481,16 @@ export default class ImageEditor<
     return this.objectUrl
   }
 
+  handleFileRemoved = (file: UppyFile<M, B>): void => {
+    const { currentImage } = this.getPluginState()
+    if (currentImage && currentImage.id === file.id) {
+      this.stop()
+    }
+  }
+
   install(): void {
     this.resetEditorState(null)
+    this.uppy.on('file-removed', this.handleFileRemoved)
 
     const { target } = this.opts
     if (target) {
@@ -496,6 +505,7 @@ export default class ImageEditor<
       const file = this.uppy.getFile(currentImage.id)
       this.uppy.emit('file-editor:cancel', file)
     }
+    this.uppy.off('file-removed', this.handleFileRemoved)
     this.stop()
     this.unmount()
   }

--- a/packages/@uppy/image-editor/src/ImageEditor.tsx
+++ b/packages/@uppy/image-editor/src/ImageEditor.tsx
@@ -350,11 +350,7 @@ export default class ImageEditor<
    */
   start = (file: UppyFile<M, B>): void => {
     // Clean up any previous editing session
-    this.destroyCropper()
-    if (this.objectUrl) {
-      URL.revokeObjectURL(this.objectUrl)
-      this.objectUrl = null
-    }
+    this.stop()
 
     // Get file data - first try the passed file, then try fetching from Uppy state
     let fileData = file.data


### PR DESCRIPTION
alternative implementation:

Rather than duplicating `stop()`'s cleanup here, we can reuse it — `stop()` is a no-op when there's no previous session and emits no events. (It can't go inside `resetEditorState` itself because `reset()`/revert calls that while the cropper must stay alive.)

closes #6223
closes #6210
