### PR TITLE
Fix file-removed listener leak in createUppyEventAdapter

### DIFF
--- a/.changeset/components-event-adapter-cleanup.md
+++ b/.changeset/components-event-adapter-cleanup.md
@@ -1,0 +1,8 @@
+---
+"@uppy/components": patch
+---
+
+Fix a listener leak in `createUppyEventAdapter`: the `file-removed` event was
+subscribed but never unsubscribed in `cleanup()`, so framework wrappers
+(React, Vue, Svelte) leaked a `file-removed` handler every time a component
+using the adapter was unmounted.

--- a/packages/@uppy/components/src/uppyEventAdapter.ts
+++ b/packages/@uppy/components/src/uppyEventAdapter.ts
@@ -61,6 +61,7 @@ export function createUppyEventAdapter({
   return {
     cleanup: () => {
       uppy.off('file-added', onFileAdded)
+      uppy.off('file-removed', onFileRemoved)
       uppy.off('progress', onProgress)
       uppy.off('upload', onUploadStarted)
       uppy.off('complete', onComplete)


### PR DESCRIPTION
`createUppyEventAdapter` in `@uppy/components` subscribes to nine Uppy events, but its `cleanup()` function only unsubscribed eight of them — the `file-removed` handler was never removed. As a result, every framework wrapper that uses the adapter (React, Vue, Svelte hooks) leaked a `file-removed` listener each time a component was unmounted, with stale handlers still firing against the old `onStatusChange` callback.

This adds the missing `uppy.off('file-removed', onFileRemoved)` call, plus a patch changeset for `@uppy/components`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)