### PR TITLE
Update release.yml to use github-api for commit mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           publish: corepack yarn run release
           commit: "[ci] release"
           title: "[ci] release"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
try to fix broken release job. e.g: https://github.com/transloadit/uppy/actions/runs/30944294577/job/92110667032

```
/usr/bin/git push origin HEAD:changeset-release/main --force
remote: error: GH013: Repository rule violations found for refs/heads/changeset-release/main.        
remote: Review all repository rules at https://github.com/transloadit/uppy/rules?ref=refs%2Fheads%2Fchangeset-release%2Fmain        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation:        
remote: 
remote:   881bbb3d511baa101fc127a2ad906e42ca7f80ed        
remote: 
To https://github.com/transloadit/uppy
 ! [remote rejected] HEAD -> changeset-release/main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/transloadit/uppy'
Error: Error: The process '/usr/bin/git' failed with exit code 1
Error: The process '/usr/bin/git' failed with exit code 1
```