### PR TITLE
Review fixes for #6423: drop nock 15, make Google Picker fields optional

### DIFF
--- a/.changeset/google-picker-optional-fields.md
+++ b/.changeset/google-picker-optional-fields.md
@@ -1,0 +1,14 @@
+---
+"@uppy/core": patch
+---
+
+Type `name` and `mimeType` on `PickedItemBase` as optional, matching what the
+Google Picker actually returns. `@types/google.picker` v0.0.52 corrected these
+to be optional because views other than Drive documents may omit them. Files
+picked without a name or mime type are passed through and resolved by Companion
+rather than failing the whole selection.
+
+`name` is now also optional on `MinimalRequiredUppyFile` (the type accepted by
+`uppy.addFile()`/`addFiles()`), which matches the existing runtime behaviour —
+`getFileName` already falls back to the mime type or `noname` when a file
+descriptor has no name.

--- a/.changeset/google-picker-response-validation.md
+++ b/.changeset/google-picker-response-validation.md
@@ -1,8 +1,0 @@
----
-"@uppy/core": patch
----
-
-Validate Google Picker responses before importing them. `@types/google.picker`
-v0.0.52 correctly types `docs`, `name` and `mimeType` as optional, so the picker
-now throws a descriptive error instead of importing a file with an undefined
-name or mime type. Shortcut metadata on the picked document is preserved.

--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -45,7 +45,6 @@
     "@uppy/core": "workspace:^",
     "@vitest/browser-playwright": "^4.1.6",
     "jsdom": "^29.1.1",
-    "nock": "^15.0.0",
     "playwright": "1.61.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6",

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -101,7 +101,7 @@
     "@types/ws": "8.18.1",
     "execa": "10.0.0",
     "http-proxy": "1.18.1",
-    "nock": "^15.0.0",
+    "nock": "^14.0.16",
     "supertest": "7.2.2",
     "typescript": "^6.0.3",
     "vitest": "4.1.6"

--- a/packages/@uppy/companion/test/credentials.test.ts
+++ b/packages/@uppy/companion/test/credentials.test.ts
@@ -41,11 +41,8 @@ describe('providers requests with remote oauth keys', () => {
     // mocking request module used to fetch custom oauth credentials
     nock('http://localhost:2111')
       .post('/zoom-keys')
-      .reply(async (request) => {
-        const { provider, parameters } = (await request.json()) as {
-          provider?: string
-          parameters?: string
-        }
+      // @ts-expect-error
+      .reply((uri, { provider, parameters }) => {
         if (provider !== 'zoom' || parameters !== 'ZOOM-CREDENTIALS-PARAMS')
           return [400]
 

--- a/packages/@uppy/companion/test/fixtures/zoom.ts
+++ b/packages/@uppy/companion/test/fixtures/zoom.ts
@@ -59,9 +59,10 @@ export const nockZoomRevoke = ({
 }) => {
   nock('https://zoom.us')
     .post('/oauth/revoke?token=token+value')
-    .reply((request) => {
+    .reply(function () {
+      const { headers } = this.req
       const expected = getBasicAuthHeader(key, secret)
-      const success = request.headers.get('authorization') === expected
+      const success = headers['authorization'] === expected
       return success ? [200, { status: 'success' }] : [400]
     })
 }

--- a/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/core/src/provider-views/GooglePicker/googlePicker.ts
@@ -73,8 +73,12 @@ export interface PickingSession {
 
 export interface PickedItemBase {
   id: string
-  mimeType: string
-  name: string
+  // The Google Picker only guarantees these for some view types (Drive documents have them,
+  // but e.g. the Photos, Upload and YouTube views don't), so treat them as optional and let
+  // Uppy/Companion fall back when they're missing.
+  // https://developers.google.com/workspace/drive/picker/reference/picker.documentobject.mimetype
+  mimeType?: string
+  name?: string
 }
 
 export interface PickedDriveItem extends PickedItemBase {
@@ -233,8 +237,8 @@ export async function showDrivePicker({
   }: {
     doc: {
       id: string
-      name: string
-      mimeType: string
+      name?: string
+      mimeType?: string
       shortcutDetails?: { targetMimeType: string }
     }
     token: string
@@ -314,28 +318,10 @@ export async function showDrivePicker({
     try {
       onLoadingChange(true)
 
-      if (!picked.docs) {
-        throw new Error('Google Picker returned no selected documents')
-      }
-
       const results: PickedDriveItem[] = []
-      for (const doc of picked.docs) {
-        if (!doc.name || !doc.mimeType) {
-          throw new Error(
-            `Google Picker returned an incomplete document (${doc.id})`,
-          )
-        }
+      for (const doc of picked.docs ?? []) {
         results.push(
-          ...(await handleDocObjectRecursively({
-            doc: {
-              ...doc,
-              id: doc.id,
-              name: doc.name,
-              mimeType: doc.mimeType,
-            },
-            token,
-            signal,
-          })),
+          ...(await handleDocObjectRecursively({ doc, token, signal })),
         )
       }
       onFilesPicked(results, token)

--- a/packages/@uppy/core/src/utils/UppyFile.ts
+++ b/packages/@uppy/core/src/utils/UppyFile.ts
@@ -81,11 +81,11 @@ export type UppyFileNonGhost<M extends Meta, B extends Body> =
 /*
  * The user facing type for UppyFile used in uppy.addFile() and uppy.setOptions()
  */
-export type MinimalRequiredUppyFile<M extends Meta, B extends Body> = Required<
-  Pick<UppyFile<M, B>, 'name'>
-> & { data: NonNullable<UppyFile<M, B>['data']> } & Partial<
-    Omit<UppyFile<M, B>, 'name' | 'meta' | 'data'>
-    // We want to omit the 'meta' from UppyFile because of internal metadata
-    // (see InternalMetadata in `UppyFile.js`), as when adding a new file
-    // that is not required.
-  > & { meta?: M }
+export type MinimalRequiredUppyFile<M extends Meta, B extends Body> = {
+  data: NonNullable<UppyFile<M, B>['data']>
+} & Partial<
+  Omit<UppyFile<M, B>, 'meta' | 'data'>
+  // We want to omit the 'meta' from UppyFile because of internal metadata
+  // (see InternalMetadata in `UppyFile.js`), as when adding a new file
+  // that is not required.
+> & { meta?: M }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7638,21 +7638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mswjs/interceptors@npm:^0.39.5":
-  version: 0.39.8
-  resolution: "@mswjs/interceptors@npm:0.39.8"
-  dependencies:
-    "@open-draft/deferred-promise": "npm:^2.2.0"
-    "@open-draft/logger": "npm:^0.3.0"
-    "@open-draft/until": "npm:^2.0.0"
-    is-node-process: "npm:^1.2.0"
-    outvariant: "npm:^1.4.3"
-    strict-event-emitter: "npm:^0.5.1"
-  checksum: 10/d92546cf9bf670ddb927c53f5fa19f0554b7475a264ead4e1ae2339874f4312fe4ada5d42588f27eea3577bee29fa8f46889d398f0e7ecb3f7a4c1d3e0b71bdc
-  languageName: node
-  linkType: hard
-
-"@mswjs/interceptors@npm:^0.41.3":
+"@mswjs/interceptors@npm:^0.41.0, @mswjs/interceptors@npm:^0.41.3":
   version: 0.41.9
   resolution: "@mswjs/interceptors@npm:0.41.9"
   dependencies:
@@ -11832,7 +11818,6 @@ __metadata:
     "@uppy/core": "workspace:^"
     "@vitest/browser-playwright": "npm:^4.1.6"
     jsdom: "npm:^29.1.1"
-    nock: "npm:^15.0.0"
     playwright: "npm:1.61.1"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
@@ -11912,7 +11897,7 @@ __metadata:
     moment-timezone: "npm:0.6.2"
     morgan: "npm:1.11.0"
     ms: "npm:2.1.3"
-    nock: "npm:^15.0.0"
+    nock: "npm:^14.0.16"
     node-schedule: "npm:2.1.1"
     p-map: "npm:7.0.5"
     prom-client: "npm:15.1.3"
@@ -21592,13 +21577,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "nock@npm:15.0.0"
+"nock@npm:^14.0.16":
+  version: 14.0.16
+  resolution: "nock@npm:14.0.16"
   dependencies:
-    "@mswjs/interceptors": "npm:^0.39.5"
+    "@mswjs/interceptors": "npm:^0.41.0"
     json-stringify-safe: "npm:^5.0.1"
-  checksum: 10/316daf308fef834b57455cf65e4d08d5f0507ca7207a82b23d23117eb2941598910c0422d4f52ec635b66701eb80cf5da1d426dbf264960d42f793031c7102b9
+    propagate: "npm:^2.0.0"
+  checksum: 10/75f0d98d022bbe65b4a9e7667bde0ddb0fc27ad6db09b9969ebdc217700b50b7725da647878f07359cc05301bcedf684f10004b07012e45311cd1dabc7f93cdf
   languageName: node
   linkType: hard
 
@@ -23762,6 +23748,13 @@ __metadata:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
   checksum: 10/96e1a82453c6c96eef53a37a1d6134c9f2482f94068f98a59145d0986ca4e497bf110a410adf73857e588165eab3899f0ebcf7b3890c1b3ce802abc0d65967d4
+  languageName: node
+  linkType: hard
+
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: 10/8c761c16e8232f82f6d015d3e01e8bd4109f47ad804f904d950f6fe319813b448ca112246b6bfdc182b400424b155b0b7c4525a9bb009e6fa950200157569c14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stacked on #6423 — review follow-ups, so the diff here reads as "what changes about that PR".

## nock 15 is a deprecated, accidental release

`npm view nock@15.0.0 deprecated`:

> v15.0.0 was released accidentally and is unstable. Please use v14.x until v15 is officially ready.

Supporting signals:

- `dist-tags`: `latest` → 14.0.17, `beta` → 15.0.0-beta.14. The 15.0.0 tarball is behind the beta line in intent, and nothing on `latest` points at it.
- Upstream is still shipping 14.x: 15.0.0-beta.14 (2026-07-22) → 14.0.17 (2026-07-30).
- This is what the Socket bot's -46 Maintenance score drop on nock was flagging — the only red signal in that whole scan.
- nock 15.0.0 depends on `@mswjs/interceptors@^0.39.5`, a *downgrade* from nock 14's `^0.41.0`, which added a duplicate copy (0.39.8 alongside 0.41.9) to the lockfile.

Our `npmMinimalAgeGate: "1w"` did not catch this, because it gates on publish age rather than deprecation and 15.0.0 is old enough to pass.

Changes:

- `@uppy/companion`: `nock` `^15.0.0` → `^14.0.16`. I wanted `^14.0.17`, but it shipped 5 days ago and is still inside the age gate; `^14.0.16` is still a bump over main's `^14.0.15`.
- Reverted both reply-callback rewrites (`credentials.test.ts`, `fixtures/zoom.ts`) — they existed only to match nock 15's `Request`-based signature.
- `@uppy/aws-s3`: dropped `nock` entirely rather than bumping it. Nothing in the package imports it; the only nock usages in the repo are under `packages/@uppy/companion/test/`.

## Google Picker: optional types instead of throwing

Per @mifi's review comment on the original PR.

The per-doc `throw` sat inside the loop over `picked.docs`, so a single doc with a missing `mimeType` aborted the entire selection — pick 20 files, get zero plus an error. It also guarded a case this builder can't produce: only `DocsView` is registered, and Drive documents always populate both fields. The `@types/google.picker` v0.0.52 fields went optional to cover other view types (Photos, Upload, YouTube), not because DocsView regressed.

So: `name` and `mimeType` are optional on `PickedItemBase` and on the internal `doc` param, both throws are gone, and `picked.docs ?? []` replaces the empty-docs throw. `handleDocObjectRecursively` already treats an unknown mimeType as a regular file for Companion to resolve.

### One thing worth a look

Making `name` optional forced a change to a public type. `MinimalRequiredUppyFile` declared `name` as `Required<Pick<UppyFile, 'name'>>`, so `string | undefined` wouldn't pass through `addFiles` in `GoogleDrivePicker.tsx`. I widened it to optional.

For it: `getFileName` already accepts `{ name?: string }` and falls back to the mime type or `'noname'`, so the runtime always supported this — the type was stricter than the code. It's a widening on an input type, so callers passing a name still compile.

Against it: it's a public `@uppy/core` type being touched from a deps PR. The alternative was inventing a fallback name at the picker boundary (`name ?? id`), which seemed worse. Easy to swap if you'd rather.

The changeset is rewritten to describe the optional types instead of the removed validation behaviour.

## Not touched

The react-router 7.12 → 7.18.1 bump and the Next.js tsconfig change both hold up and are left alone. react-router in particular is load-bearing, not cosmetic: `@react-router/dev@7.12` declares `vite: ^5 || ^6 || ^7`, while 7.18.1 widens to `|| ^8`, which the stacked vite-8 work needs.

## Verification

- Full `turbo run typecheck`: 63 tasks pass. Two failures (`@uppy-dev/dev`, `example-vue`) are missing-CSS-artifact errors that reproduce identically on the unmodified #6423 head — pre-existing and unrelated.
- `@uppy/companion`: 118 tests pass on nock 14.
- `@uppy/core`: 199 pass, 3 skipped.
- `yarn check:ci` clean.
- Lockfile regenerated: nock 15.0.0 and the duplicate `@mswjs/interceptors@0.39.8` are out, `propagate` is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)