### PR TITLE
ci: build the Angular example in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
           COMPANION_PROTOCOL: http
           COMPANION_REDIS_URL: redis://localhost:6379
           VITE_MINIO_CONFIG: "test_user,test_password,http://localhost:9002/test-bucket,us-east-1"
+      # The Angular example isn't covered by `yarn build` (packages only) or
+      # `yarn test` (react/vue/sveltekit only), so build it explicitly.
+      - name: Build Angular example
+        run: corepack yarn workspace example-angular build
 
   types:
     name: Types


### PR DESCRIPTION
The Angular example is currently never built in CI:

- root `yarn build` filters to `./packages/@uppy/*` and `./packages/uppy`
- root `yarn test` only covers `./examples/{react,vue,sveltekit}`

So `examples/angular` has no coverage at all, and a regression there (e.g. from the recent Angular 21 upgrade in #6448) would go unnoticed.

This adds an explicit `corepack yarn workspace example-angular build` step to the `Tests` job, which already runs `yarn install` + `yarn build`, so the `@uppy/*` `lib/` output the example needs is present.

Notes:

- The step is placed **after** `Run tests` so an example-only breakage doesn't mask unit test results.
- The example resolves `@uppy/angular` via a tsconfig `paths` mapping straight to `projects/uppy/angular/src/public-api.ts`, so it doesn't need the `@uppy/angular` library `dist/` — only the core packages, which the existing `Build` step covers.
- Running this against current `main` locally succeeds today (only the usual "not ESM" optimization-bailout warnings for `namespace-emitter`, `is-mobile`, `classnames`, `lodash/debounce`, `retry`, `url-parse`), so this is about closing a coverage gap rather than fixing a current failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
