### PR TITLE
ci: check for duplicate dependencies in lockfile

### DIFF
--- a/.github/workflows/lockfile_check.yml
+++ b/.github/workflows/lockfile_check.yml
@@ -39,3 +39,5 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: corepack yarn install --immutable --mode=skip-build
+      - name: Check for duplicate dependencies
+        run: corepack yarn dedupe --check

--- a/yarn.lock
+++ b/yarn.lock
@@ -7198,16 +7198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^19, @types/react-dom@npm:^19.0.4":
-  version: 19.2.3
-  resolution: "@types/react-dom@npm:19.2.3"
-  peerDependencies:
-    "@types/react": ^19.2.0
-  checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
-  languageName: node
-  linkType: hard
-
-"@types/react-dom@npm:^19.2.3":
+"@types/react-dom@npm:^19, @types/react-dom@npm:^19.0.4, @types/react-dom@npm:^19.2.3":
   version: 19.2.4
   resolution: "@types/react-dom@npm:19.2.4"
   peerDependencies:
@@ -11281,14 +11272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "es-module-lexer@npm:2.1.0"
-  checksum: 10/554c4374e78a812a1fa3673871ce7d42236438c414ea80c2ec35521cd9bb26d1d9155287529057d07431fd91df50d6a26d9bee5afd755fb7f6f7c81905a03956
-  languageName: node
-  linkType: hard
-
-"es-module-lexer@npm:^2.1.0":
+"es-module-lexer@npm:^2.0.0, es-module-lexer@npm:^2.1.0":
   version: 2.3.1
   resolution: "es-module-lexer@npm:2.3.1"
   checksum: 10/15bd9f6d70ec7f046a308b7fbeb56a1fd4bde09e6a46df0015caee58bd5888fc114029754e922ca68577b761890ac95cc450683424209464530cfe54f69b8566
@@ -16672,7 +16656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:7.0.5, p-map@npm:^7.0.2":
+"p-map@npm:7.0.5":
   version: 7.0.5
   resolution: "p-map@npm:7.0.5"
   checksum: 10/1061b8ac47088f5f6c665d4ff99991c296b7fd5d622bcb8dad5e7c863ef991a181c54c54c5167513c427fd67751c75f1b96c59c9fd9853dc2d5fb5f9c8abeb14
@@ -16695,7 +16679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.4":
+"p-map@npm:^7.0.2, p-map@npm:^7.0.4":
   version: 7.0.6
   resolution: "p-map@npm:7.0.6"
   checksum: 10/207bcdd33eb927d8490384bd48221e55b62097eb2d606ae75882b90e7f66b8eb9f0283c373d73139fccbdfbfc869fc47862a74e63eb54de42f440a2fe0840e74
@@ -18001,7 +17985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:19.2.7, react-dom@npm:^19.0.0, react-dom@npm:^19.2.6":
+"react-dom@npm:19.2.7":
   version: 19.2.7
   resolution: "react-dom@npm:19.2.7"
   dependencies:
@@ -18012,7 +17996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^19.2.7":
+"react-dom@npm:^19.0.0, react-dom@npm:^19.2.6, react-dom@npm:^19.2.7":
   version: 19.2.8
   resolution: "react-dom@npm:19.2.8"
   dependencies:
@@ -18052,14 +18036,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:19.2.7, react@npm:^19.0.0, react@npm:^19.2.6":
+"react@npm:19.2.7":
   version: 19.2.7
   resolution: "react@npm:19.2.7"
   checksum: 10/2939997e87d7f0ee0d9d2bb556866b616b999dfb7916283647034eda867a045a39c4f7a736c8ea6beffffcd78397fc30f63a7a3aaf8425b683c3060670859560
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.7":
+"react@npm:^19.0.0, react@npm:^19.2.6, react@npm:^19.2.7":
   version: 19.2.8
   resolution: "react@npm:19.2.8"
   checksum: 10/a3c697798035e295ca9e51591d3a8700824535cb8c070fac1f8abbe69717ceb99108cbc4ba7b31a606806f336b1eba705705f63b9d39ace198fe51e8990ac843


### PR DESCRIPTION
...until we get [auto support in yarn](https://github.com/yarnpkg/berry/issues/4976):

Adds `yarn dedupe --check` to the existing lockfile workflow, so PRs that introduce duplicate dependency ranges get flagged.

It runs in the `Lint yarn.lock` job, which already only triggers when `yarn.lock` changes — so there's no cost on unrelated PRs, and it reuses that job's install.

The lockfile wasn't deduped, so the check failed as-is. This also runs `yarn dedupe`, collapsing 8 duplicate ranges:

- `@types/react-dom` 19.2.3 → 19.2.4
- `es-module-lexer` 2.1.0 → 2.3.1
- `p-map` 7.0.5 → 7.0.6
- `react` / `react-dom` 19.2.7 → 19.2.8

Heads up: this will make dependency-bot PRs fail whenever they introduce a dupe, and the fix requires someone to run `yarn dedupe` and push. If that friction isn't wanted, we can add `continue-on-error: true` to the step so it reports without blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)