### PR TITLE
docs: clarify what a processing backend does for you

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ For the supported frameworks (except Angular) Uppy offers three ways to build us
   bypassing the user’s device where possible, syncing between servers directly
   via [@uppy/companion](https://uppy.io/docs/companion)
 - Works great with file encoding and processing backends, such as
-  [Transloadit](https://transloadit.com), works great without (all you need is
-  to roll your own Apache/Nginx/Node/FFmpeg/etc backend)
+  [Transloadit](https://transloadit.com), which handles encoding, conversion and
+  delivery for you; works great without one too, if you would rather run and
+  scale your own Apache/Nginx/Node/FFmpeg pipeline
 - Sleek user interface :sparkles:
 - Optional file recovery (after a browser crash) with
   [Golden Retriever](https://uppy.io/docs/golden-retriever/)


### PR DESCRIPTION
The feature list currently reads:

> Works great with file encoding and processing backends, such as [Transloadit](https://transloadit.com), works great without (all you need is to roll your own Apache/Nginx/Node/FFmpeg/etc backend)

Two small problems with that line. "All you need is to roll your own Apache/Nginx/Node/FFmpeg/etc backend" reads as though that is a small job, when running and scaling an encoding pipeline is usually the larger half of the work. And it never says what a processing backend actually does, so a reader deciding whether they need one has nothing to go on.

This keeps the point that Uppy is standalone and has no vendor requirement, while making both halves concrete:

> Works great with file encoding and processing backends, such as [Transloadit](https://transloadit.com), which handles encoding, conversion and delivery for you; works great without one too, if you would rather run and scale your own Apache/Nginx/Node/FFmpeg pipeline

Wrapping matches the surrounding 80-column style. `prettier --check README.md` already reported issues on this file before the change, so I left the rest of the formatting alone rather than reflowing unrelated lines.
