### PR TITLE
docs: connect packages to Uppy + Transloadit framework guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ server-side component, is needed for a plugin to work.
 
 ### File Processing
 
-- [`Transloadit`](https://uppy.io/docs/transloadit/) — support for
+- [`Transloadit`](https://uppy.io/docs/guides/uppy-transloadit/) — signed
+  JavaScript, React, Next.js, Vue, and Angular examples for
   [Transloadit](http://transloadit.com)’s robust file uploading and encoding
   backend
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ server-side component, is needed for a plugin to work.
 
 ### File Processing
 
-- [`Transloadit`](https://uppy.io/docs/guides/uppy-transloadit/) — signed
-  JavaScript, React, Next.js, Vue, and Angular examples for
-  [Transloadit](http://transloadit.com)’s robust file uploading and encoding
-  backend
+- [`Transloadit`](https://uppy.io/docs/guides/uppy-transloadit/) — JavaScript,
+  React, Next.js, Vue, and Angular examples that use server-signed Assembly
+  options for [Transloadit](http://transloadit.com)’s robust file uploading and
+  encoding backend
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ server-side component, is needed for a plugin to work.
 
 ### File Processing
 
-- [`Transloadit`](https://uppy.io/docs/guides/uppy-transloadit/) — JavaScript,
-  React, Next.js, Vue, and Angular examples that use server-signed Assembly
-  options for [Transloadit](http://transloadit.com)’s robust file uploading and
-  encoding backend
+- [`Transloadit`](https://uppy.io/docs/transloadit/) — creates Assemblies that
+  upload files to [Transloadit](http://transloadit.com)’s encoding backend. See
+  the [integration guide](https://uppy.io/docs/guides/uppy-transloadit/) for
+  JavaScript, React, Next.js, Vue, and Angular examples with server-signed
+  Assembly options
 
 ### Miscellaneous
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -3,9 +3,9 @@
 This example exercises Uppy upload destinations in a Next.js App Router
 application, including Transloadit. For the focused production integration,
 follow the canonical [Next.js + Uppy + Transloadit
-guide](https://uppy.io/docs/guides/uppy-transloadit/#nextjs). It keeps the
-Transloadit Auth Secret on the server and returns signed Assembly options to
-the browser.
+guide](https://uppy.io/docs/guides/uppy-transloadit/#nextjs). That Next.js
+integration keeps the Transloadit Auth Secret on the server and returns signed
+Assembly options to the browser.
 
 This is a [Next.js](https://nextjs.org) project bootstrapped with
 [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,4 +1,14 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Uppy with Next.js
+
+This example exercises Uppy upload destinations in a Next.js App Router
+application, including Transloadit. For the focused production integration,
+follow the canonical [Next.js + Uppy + Transloadit
+guide](https://uppy.io/docs/guides/uppy-transloadit/#nextjs). It keeps the
+Transloadit Auth Secret on the server and returns signed Assembly options to
+the browser.
+
+This is a [Next.js](https://nextjs.org) project bootstrapped with
+[`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -3,9 +3,9 @@
 This example exercises Uppy upload destinations in a Next.js App Router
 application, including Transloadit. For the focused production integration,
 follow the canonical [Next.js + Uppy + Transloadit
-guide](https://uppy.io/docs/guides/uppy-transloadit/#nextjs). That Next.js
-integration keeps the Transloadit Auth Secret on the server and returns signed
-Assembly options to the browser.
+guide](https://uppy.io/docs/guides/uppy-transloadit/#nextjs). The guide's
+Next.js integration keeps the Transloadit Auth Secret on the server and returns
+signed Assembly options to the browser.
 
 This is a [Next.js](https://nextjs.org) project bootstrapped with
 [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).

--- a/examples/nextjs/src/components/UppyDashboard.tsx
+++ b/examples/nextjs/src/components/UppyDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Uppy from '@uppy/core'
-import { Dashboard } from '@uppy/react'
+import Dashboard from '@uppy/react/dashboard'
 import Transloadit from '@uppy/transloadit'
 import Tus from '@uppy/tus'
 import Xhr from '@uppy/xhr-upload'

--- a/examples/transloadit/README.md
+++ b/examples/transloadit/README.md
@@ -1,7 +1,15 @@
 # Transloadit example
 
-This example shows how to make advantage of Uppy API to upload files to
-[Transloadit](https://transloadit.com/).
+This runnable JavaScript example uses Uppy for the browser upload experience
+and Transloadit as the managed backend that processes the uploaded files.
+
+For smaller production examples with server-side Signature Authentication,
+follow the canonical guides for
+[JavaScript](https://uppy.io/docs/guides/uppy-transloadit/#javascript),
+[React](https://uppy.io/docs/guides/uppy-transloadit/#react),
+[Next.js](https://uppy.io/docs/guides/uppy-transloadit/#nextjs),
+[Vue](https://uppy.io/docs/guides/uppy-transloadit/#vue), and
+[Angular](https://uppy.io/docs/guides/uppy-transloadit/#angular).
 
 ## Run it
 

--- a/examples/transloadit/README.md
+++ b/examples/transloadit/README.md
@@ -3,8 +3,10 @@
 This runnable JavaScript example uses Uppy for the browser upload experience
 and Transloadit as the managed backend that processes the uploaded files.
 
-For smaller production examples with server-side Signature Authentication,
-follow the canonical guides for
+This runnable demo uses a public demo Auth Key and unsigned Assembly options in
+the browser for local exploration only. It is not production-safe. For focused,
+production-ready examples with server-side Signature Authentication, follow the
+canonical guides for
 [JavaScript](https://uppy.io/docs/guides/uppy-transloadit/#javascript),
 [React](https://uppy.io/docs/guides/uppy-transloadit/#react),
 [Next.js](https://uppy.io/docs/guides/uppy-transloadit/#nextjs),
@@ -26,5 +28,5 @@ That will also install the dependencies for this example.
 Then, again in the **repository root**, start this example by doing:
 
 ```sh
-corepack yarn workspace @uppy-example/transloadit start
+corepack yarn workspace example-transloadit start
 ```

--- a/packages/@uppy/angular/README.md
+++ b/packages/@uppy/angular/README.md
@@ -26,6 +26,9 @@ Alternatively, you can also use this plugin in a pre-built bundle from Transload
 
 Documentation for this plugin can be found on the [Uppy website](https://uppy.io/docs/).
 
+For a managed processing backend, follow the canonical
+[Angular + Uppy + Transloadit guide](https://uppy.io/docs/guides/uppy-transloadit/#angular).
+
 ## License
 
 [The MIT License](./LICENSE).

--- a/packages/@uppy/angular/README.md
+++ b/packages/@uppy/angular/README.md
@@ -11,7 +11,23 @@ Uppy is being developed by the folks at [Transloadit](https://transloadit.com), 
 ## Example
 
 ```ts
-// TODO
+import { Component, type OnDestroy } from '@angular/core'
+import { DashboardComponent } from '@uppy/angular'
+import Uppy from '@uppy/core'
+
+@Component({
+  selector: 'app-uploader',
+  standalone: true,
+  imports: [DashboardComponent],
+  template: '<uppy-dashboard [uppy]="uppy"></uppy-dashboard>',
+})
+export class UploaderComponent implements OnDestroy {
+  readonly uppy = new Uppy()
+
+  ngOnDestroy(): void {
+    this.uppy.destroy()
+  }
+}
 ```
 
 ## Installation

--- a/packages/@uppy/react/README.md
+++ b/packages/@uppy/react/README.md
@@ -57,6 +57,9 @@ global `window.Uppy` object. See the
 Documentation for this plugin can be found on the
 [Uppy website](https://uppy.io/docs/react).
 
+For a managed processing backend, follow the canonical
+[React + Uppy + Transloadit guide](https://uppy.io/docs/guides/uppy-transloadit/#react).
+
 ## License
 
 [The MIT License](./LICENSE).

--- a/packages/@uppy/react/README.md
+++ b/packages/@uppy/react/README.md
@@ -20,7 +20,7 @@ a versatile file encoding service.
 /** @jsx React */
 import React from 'react'
 import Uppy from '@uppy/core'
-import { DashboardModal } from '@uppy/react'
+import DashboardModal from '@uppy/react/dashboard-modal'
 
 const uppy = new Uppy()
 

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -16,8 +16,7 @@ backend that receives those uploads and runs the processing workflow. This
 plugin connects the two; Uppy can also be used with other upload destinations.
 
 [Run the unsigned local demo →](https://github.com/transloadit/uppy/tree/main/examples/transloadit)
-(test use only). For production, follow the server-signed integration guide
-above.
+(test use only). For production, follow the server-signed integration guide.
 
 Uppy is being developed by the folks at [Transloadit](https://transloadit.com),
 a versatile file encoding service.

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -11,7 +11,11 @@ The Transloadit plugin can be used to upload files to Transloadit for all kinds
 of processing, such as transcoding video, resizing images, zipping/unzipping,
 [and more](https://transloadit.com/services/).
 
-[Try it live →](https://uppy.io/examples/transloadit/)
+Uppy owns the open-source browser upload experience. Transloadit is the managed
+backend that receives those uploads and runs the processing workflow. This
+plugin connects the two; Uppy can also be used with other upload destinations.
+
+[Run the example →](https://github.com/transloadit/uppy/tree/main/examples/transloadit)
 
 Uppy is being developed by the folks at [Transloadit](https://transloadit.com),
 a versatile file encoding service.
@@ -22,11 +26,21 @@ a versatile file encoding service.
 import Uppy from '@uppy/core'
 import Transloadit from '@uppy/transloadit'
 
-const uppy = new Uppy()
-uppy.use(Transloadit, {
-  // Plugins
+const uppy = new Uppy().use(Transloadit, {
+  async assemblyOptions() {
+    const response = await fetch('/api/transloadit-params', { method: 'POST' })
+    if (!response.ok) {
+      throw new Error(`Could not prepare the upload (${response.status})`)
+    }
+    return response.json()
+  },
 })
 ```
+
+Generate the returned `params` and `signature` on your server. Never include
+your Transloadit Auth Secret in browser code. See the canonical
+[JavaScript, React, Next.js, Vue, and Angular guide](https://uppy.io/docs/guides/uppy-transloadit/)
+for complete examples.
 
 ## Installation
 

--- a/packages/@uppy/transloadit/README.md
+++ b/packages/@uppy/transloadit/README.md
@@ -15,7 +15,9 @@ Uppy owns the open-source browser upload experience. Transloadit is the managed
 backend that receives those uploads and runs the processing workflow. This
 plugin connects the two; Uppy can also be used with other upload destinations.
 
-[Run the example →](https://github.com/transloadit/uppy/tree/main/examples/transloadit)
+[Run the unsigned local demo →](https://github.com/transloadit/uppy/tree/main/examples/transloadit)
+(test use only). For production, follow the server-signed integration guide
+above.
 
 Uppy is being developed by the folks at [Transloadit](https://transloadit.com),
 a versatile file encoding service.

--- a/packages/@uppy/vue/README.md
+++ b/packages/@uppy/vue/README.md
@@ -27,7 +27,7 @@ a versatile file encoding service.
 
 <script>
 import Uppy from '@uppy/core'
-import { DashboardModal } from '@uppy/vue'
+import DashboardModal from '@uppy/vue/dashboard-modal'
 
 export default {
   components: {

--- a/packages/@uppy/vue/README.md
+++ b/packages/@uppy/vue/README.md
@@ -66,6 +66,9 @@ global `window.Uppy` object. See the
 Documentation for this plugin can be found on the
 [Uppy website](https://uppy.io/docs/vue).
 
+For a managed processing backend, follow the canonical
+[Vue + Uppy + Transloadit guide](https://uppy.io/docs/guides/uppy-transloadit/#vue).
+
 ## License
 
 [The MIT License](./LICENSE).


### PR DESCRIPTION
## Summary

- make the @uppy/transloadit README state the Uppy/Transloadit ownership boundary explicitly
- replace its placeholder with the production client-side signed-options pattern
- link the React, Vue, Angular, Next.js, and runnable Transloadit examples to the canonical framework sections
- replace the package README's broken live-demo URL with the runnable repository example
- correct legacy Uppy 5 framework imports found during review

The canonical guide is introduced by transloadit/uppy.io#453. This PR keeps package documentation concise and sends readers to that maintained source rather than duplicating five full integrations.

## Merge order

Depends on transloadit/uppy.io#453. Merge this PR only after https://uppy.io/docs/guides/uppy-transloadit/ returns 200 and its JavaScript, React, Next.js, Vue, and Angular anchors have been verified. Do not publish the affected package READMEs before that deployment.

Svelte is intentionally outside the requested five-framework canonical scope.

## Verification

- yarn check:ci
- yarn typecheck (75 tasks across 38 packages)
- git diff --check