### PR TITLE
docs: include README on the uppy npm package page

### DIFF
--- a/packages/uppy/build-bundle.mjs
+++ b/packages/uppy/build-bundle.mjs
@@ -75,12 +75,12 @@ const methods = [
   ),
 ]
 
-// Add BUNDLE-README.MD
+const bundleReadme = new URL('../../BUNDLE-README.md', import.meta.url)
+
+// Include the bundle instructions in both the downloadable archive and npm package page.
 methods.push(
-  fs.copyFile(
-    new URL('../../BUNDLE-README.md', import.meta.url),
-    new URL('./dist/README.md', import.meta.url),
-  ),
+  fs.copyFile(bundleReadme, new URL('./README.md', import.meta.url)),
+  fs.copyFile(bundleReadme, new URL('./dist/README.md', import.meta.url)),
 )
 
 await Promise.all(methods).then(

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
         "bundle.mjs",
         "build-bundle.mjs"
       ],
-      "outputs": ["lib/**", "dist/**"]
+      "outputs": ["lib/**", "dist/**", "README.md"]
     },
     "uppy#build:css": {
       "outputLogs": "new-only",


### PR DESCRIPTION
Summary:

- Copy the bundle README to the package root during the bundle build.
- Retain the existing copy in the downloadable dist archive.
- Let npm display installation and usage guidance instead of showing that the package has no README.

Verification:

- node --check packages/uppy/build-bundle.mjs
- git diff --check

A full bundle build could not run in this checkout because the Yarn install state is absent.