### PR TITLE
Git ignore all .tgz files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ examples/dev/bundle.js
 examples/aws-php/vendor/*
 test/endtoend/create-react-app/build/
 test/endtoend/create-react-app/coverage/
-uppy-*.tgz
+*.tgz
 generatedLocale.d.ts
 packages/@uppy/locales/src/en_US.js
 


### PR DESCRIPTION
Running `yarn pack` generates `.tgz` files. These should never be committed, regardless of their file name.