### PR TITLE
ci: build and check every example, not just Angular

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,6 +42,7 @@ yarn build
 - `yarn dev:with-companion` - Start dev server with Companion for cloud integrations
 - `yarn start:companion` - Start only Companion server at http://localhost:3020
 - `yarn build:watch` - Build packages in watch mode
+- `yarn build:examples` - Build and type-check the examples and the dev playground
 - `yarn test` - Run tests for all packages
 - `yarn test:watch` - Run tests in watch mode
 - `yarn typecheck` - Run TypeScript type checking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,12 @@ jobs:
           COMPANION_PROTOCOL: http
           COMPANION_REDIS_URL: redis://localhost:6379
           VITE_MINIO_CONFIG: "test_user,test_password,http://localhost:9002/test-bucket,us-east-1"
-      # The Angular example isn't covered by `yarn build` (packages only) or
-      # `yarn test` (react/vue/sveltekit only), so build it explicitly.
-      - name: Build Angular example
-        run: corepack yarn workspace example-angular build
+      # The examples aren't covered by `yarn build` (packages only) or
+      # `yarn test` (react/vue/sveltekit only), so build and typecheck them
+      # explicitly. Run it after the unit tests so an example-only breakage
+      # doesn't mask the test results.
+      - name: Build and check examples
+        run: corepack yarn run build:examples
 
   types:
     name: Types

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -5,8 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,

--- a/examples/sveltekit/src/components/CustomDropzone.svelte
+++ b/examples/sveltekit/src/components/CustomDropzone.svelte
@@ -20,9 +20,10 @@ const { getButtonProps, getInputProps: getFileInputProps } = useFileInput()
   >
     <div class="flex items-center justify-center gap-4">
       <input {...getFileInputProps()} class="hidden" />
-      <button type="button"
+      <button
         {...getButtonProps()}
         class="hover:bg-gray-100 transition-colors p-2 rounded-md flex flex-col items-center gap-2 text-sm"
+        type="button"
       >
         <div class="bg-white shadow-md rounded-md p-1">
           <ProviderIcon provider="device" fill="#1269cf" />

--- a/examples/sveltekit/src/components/ImageEditor.svelte
+++ b/examples/sveltekit/src/components/ImageEditor.svelte
@@ -42,75 +42,86 @@ const editor = useImageEditor({ file })
   </div>
 
   <div class="flex gap-2 flex-wrap mb-4">
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getRotateButtonProps(-90)}
+      type="button"
     >
       ↶ -90°
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getRotateButtonProps(90)}
+      type="button"
     >
       ↷ +90°
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getFlipHorizontalButtonProps()}
+      type="button"
     >
       ⇆ Flip
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getZoomButtonProps(0.1)}
+      type="button"
     >
       + Zoom
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getZoomButtonProps(-0.1)}
+      type="button"
     >
       - Zoom
     </button>
   </div>
 
   <div class="flex gap-2 flex-wrap mb-4">
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getCropSquareButtonProps()}
+      type="button"
     >
       1:1
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getCropLandscapeButtonProps()}
+      type="button"
     >
       16:9
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getCropPortraitButtonProps()}
+      type="button"
     >
       9:16
     </button>
-    <button type="button"
+    <button
       class="bg-gray-200 px-3 py-1 rounded disabled:opacity-50"
       {...editor.getResetButtonProps()}
+      type="button"
     >
       Reset
     </button>
   </div>
 
   <div class="flex gap-4 justify-end">
-    <button type="button"
+    <button
       class="bg-gray-500 text-white px-4 py-2 rounded-md"
       {...editor.getCancelButtonProps({ onClick: close })}
+      type="button"
     >
       Cancel
     </button>
-    <button type="button"
+    <button
       class="bg-green-500 text-white px-4 py-2 rounded-md disabled:opacity-50 disabled:bg-green-300"
       {...editor.getSaveButtonProps({ onClick: close })}
+      type="button"
     >
       Save
     </button>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "turbo run --no-daemon build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
+    "build:examples": "turbo run --no-daemon build typecheck check --filter='./examples/*' --filter='./private/*'",
     "build:clean": "git clean -Xfd packages e2e .parcel-cache coverage .turbo .turbo -e '!node_modules' -e '!**/node_modules/**/*'",
     "build:watch": "yarn build && turbo watch build build:css --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "migrate:components": "yarn workspace @uppy/components migrate",

--- a/turbo.json
+++ b/turbo.json
@@ -36,8 +36,13 @@
     },
     "typecheck": {
       "outputLogs": "new-only",
-      "dependsOn": ["build"],
+      "dependsOn": ["build", "^build"],
       "inputs": ["src/**/*.{js,ts,jsx,tsx}", "tsconfig.json"]
+    },
+    "check": {
+      "outputLogs": "new-only",
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.{js,ts,jsx,tsx,svelte}", "tsconfig.json"]
     },
     "test": {
       "dependsOn": ["^test"],


### PR DESCRIPTION
`yarn build` only covers `./packages/@uppy/*` and `./packages/uppy`, and `yarn test` only runs the react/vue/sveltekit test suites. That left a number of workspaces with a build or type-check step that CI never ran:

- `example-nextjs` (`next build`)
- `example-react` (`tsc && vite build`)
- `example-vue` (`vite build`)
- `example-sveltekit` (`vite build`, plus `svelte-check`)
- `example-reactrouter` (`react-router typegen && tsc`)
- `@uppy-dev/dev`, the dev playground (`vite build`)

260810a8 papered over one of them by building the Angular example in a dedicated step; replace that with a `build:examples` script that runs `build`, `typecheck` and `check` across `./examples/*` and `./private/*`, so a new example (or a new script on an existing one) is picked up automatically.

Two regressions this immediately surfaced, both fixed here:

- `example-react` failed to build: TypeScript 6 rejects an explicit `esModuleInterop: false` (TS5107). Every other tsconfig in the repo sets it to `true`.
- `example-sveltekit` had 12 `svelte-check` errors where `type="button"` was written before a props spread that also sets `type`, so the attribute was silently overwritten. Moving it after the spread satisfies both svelte-check and Biome's `useButtonType`.

`typecheck` now also depends on `^build`, so it works for workspaces that type-check but have no build step of their own (reactrouter).

Not covered: `example-angular`'s `ng test` (needs a Karma/Chrome setup) and the examples that are plain HTML/node/php/python with nothing to build.


Claude-Session: https://claude.ai/code/session_01MThqEJ6BBy3YpdvvSx5MvG