### PR TITLE
Fix Uppy instance leak in Angular components

### DIFF
--- a/.changeset/angular-uppy-instance-leak.md
+++ b/.changeset/angular-uppy-instance-leak.md
@@ -1,0 +1,14 @@
+---
+"@uppy/angular": patch
+---
+
+Fix a memory leak in `DashboardComponent`, `DashboardModalComponent` and `StatusBarComponent`.
+Their `uppy` input defaulted to `new Uppy()`, and since Uppy registers `online`/`offline`
+listeners on `window` in its constructor and only removes them in `destroy()`, every one of
+those default instances stayed reachable from `window` for the lifetime of the page - including
+the ones that were immediately replaced by a `[uppy]` binding and never used.
+
+The components no longer create a default eagerly. The wrapper creates an instance in `onMount`
+only when nothing was passed in, and destroys that one (and only that one) on teardown; instances
+passed in from the outside remain the caller's responsibility. Note that reading `component.uppy`
+before `ngOnInit` now returns `undefined` instead of a throwaway instance.

--- a/packages/@uppy/angular/src/components/dashboard-modal/dashboard-modal.component.ts
+++ b/packages/@uppy/angular/src/components/dashboard-modal/dashboard-modal.component.ts
@@ -8,10 +8,9 @@ import {
 	type OnDestroy,
 	type SimpleChanges,
 } from "@angular/core";
-import { Uppy } from "@uppy/core";
+import type { Body, Meta, Uppy } from "@uppy/core";
 import type { DashboardOptions } from "@uppy/dashboard";
 import Dashboard from "@uppy/dashboard";
-import type { Body, Meta } from "@uppy/core";
 import { UppyAngularWrapper } from "../../utils/wrapper";
 
 @Component({
@@ -26,7 +25,9 @@ export class DashboardModalComponent<M extends Meta, B extends Body>
 {
 	el = inject(ElementRef);
 
-	@Input() uppy: Uppy<M, B> = new Uppy();
+	// Left unset on purpose: the wrapper creates (and destroys) its own instance in
+	// `onMount` when nothing is passed in, so we never build one just to throw it away.
+	@Input() uppy!: Uppy<M, B>;
 	@Input() props: DashboardOptions<M, B> = {};
 	@Input() open: boolean = false;
 

--- a/packages/@uppy/angular/src/components/dashboard/dashboard.component.ts
+++ b/packages/@uppy/angular/src/components/dashboard/dashboard.component.ts
@@ -8,10 +8,9 @@ import {
 	type OnDestroy,
 	type SimpleChanges,
 } from "@angular/core";
-import { Uppy } from "@uppy/core";
+import type { Body, Meta, Uppy } from "@uppy/core";
 import type { DashboardOptions } from "@uppy/dashboard";
 import Dashboard from "@uppy/dashboard";
-import type { Body, Meta } from "@uppy/core";
 import { UppyAngularWrapper } from "../../utils/wrapper";
 
 @Component({
@@ -26,7 +25,9 @@ export class DashboardComponent<M extends Meta, B extends Body>
 {
 	el = inject(ElementRef);
 
-	@Input() uppy: Uppy<M, B> = new Uppy();
+	// Left unset on purpose: the wrapper creates (and destroys) its own instance in
+	// `onMount` when nothing is passed in, so we never build one just to throw it away.
+	@Input() uppy!: Uppy<M, B>;
 	@Input() props: DashboardOptions<M, B> = {};
 
 	/** Inserted by Angular inject() migration for backwards compatibility */

--- a/packages/@uppy/angular/src/components/status-bar/status-bar.component.ts
+++ b/packages/@uppy/angular/src/components/status-bar/status-bar.component.ts
@@ -8,10 +8,9 @@ import {
 	type OnDestroy,
 	type SimpleChanges,
 } from "@angular/core";
-import { Uppy } from "@uppy/core";
+import type { Body, Meta, Uppy } from "@uppy/core";
 import type { StatusBarOptions } from "@uppy/status-bar";
 import StatusBar from "@uppy/status-bar";
-import type { Body, Meta } from "@uppy/core";
 import { UppyAngularWrapper } from "../../utils/wrapper";
 
 @Component({
@@ -26,7 +25,9 @@ export class StatusBarComponent<M extends Meta, B extends Body>
 {
 	el = inject(ElementRef);
 
-	@Input() uppy: Uppy<M, B> = new Uppy();
+	// Left unset on purpose: the wrapper creates (and destroys) its own instance in
+	// `onMount` when nothing is passed in, so we never build one just to throw it away.
+	@Input() uppy!: Uppy<M, B>;
 	@Input() props: StatusBarOptions = {};
 
 	/** Inserted by Angular inject() migration for backwards compatibility */

--- a/packages/@uppy/angular/src/utils/wrapper.ts
+++ b/packages/@uppy/angular/src/utils/wrapper.ts
@@ -1,5 +1,11 @@
 import type { ElementRef, SimpleChanges } from "@angular/core";
-import type { UIPlugin, UIPluginOptions, Uppy, Body, Meta } from "@uppy/core";
+import {
+	type Body,
+	type Meta,
+	type UIPlugin,
+	type UIPluginOptions,
+	Uppy,
+} from "@uppy/core";
 import type { DashboardOptions } from "@uppy/dashboard";
 
 export abstract class UppyAngularWrapper<
@@ -14,29 +20,48 @@ export abstract class UppyAngularWrapper<
 	private options: any;
 	plugin: PluginType | undefined;
 
+	// The instance we created ourselves because no `uppy` was passed in. We own it, so we
+	// have to destroy it - otherwise it keeps the `online`/`offline` listeners that Uppy
+	// registers on `window` alive forever, which leaks the whole instance.
+	private ownUppy: Uppy<M, B> | undefined;
+
+	// The instance the plugin is currently installed on. This is what we have to compare
+	// against when `uppy` changes; `changes['uppy'].previousValue` is `undefined` for the
+	// first change and therefore cannot tell us what we are actually mounted on.
+	private mountedUppy: Uppy<M, B> | undefined;
+
 	onMount(
 		defaultOptions: Partial<Opts>,
 		plugin: new (uppy: any, opts?: Opts) => UIPlugin<Opts, M, B>,
 	) {
+		// Angular always runs `ngOnChanges` before `ngOnInit`, so a bound `uppy` is already
+		// set by the time we get here and we never create an instance we'd have to throw away.
+		if (!this.uppy) {
+			this.ownUppy = new Uppy<M, B>();
+			this.uppy = this.ownUppy;
+		}
+
 		this.options = {
 			...defaultOptions,
 			...this.props,
 		};
 
 		this.uppy.use(plugin, this.options);
+		this.mountedUppy = this.uppy;
 		this.plugin = this.uppy.getPlugin(this.options.id) as PluginType;
 	}
 
 	handleChanges(changes: SimpleChanges, plugin: any): void {
-		// Without the last part of this conditional, it tries to uninstall before the plugin is mounted
-		if (
-			changes["uppy"] &&
-			this.uppy !== changes["uppy"].previousValue &&
-			changes["uppy"].previousValue !== undefined
-		) {
-			this.uninstall(changes["uppy"].previousValue);
+		const { mountedUppy } = this;
+		// `ngOnChanges` runs before `ngOnInit`, so there is nothing to reconcile until
+		// `onMount` has installed the plugin.
+		if (mountedUppy === undefined) return;
+
+		if (changes["uppy"] && this.uppy !== mountedUppy) {
+			this.uninstall(mountedUppy);
 			// @ts-expect-error The options correspond to the plugin, I swear
 			this.uppy.use(plugin, this.options);
+			this.mountedUppy = this.uppy;
 		}
 		this.options = { ...this.options, ...this.props };
 		this.plugin = this.uppy.getPlugin(this.options.id) as PluginType;
@@ -49,7 +74,21 @@ export abstract class UppyAngularWrapper<
 		}
 	}
 
-	uninstall(uppy = this.uppy): void {
-		uppy.removePlugin(this.plugin!);
+	// Defaults to the instance we are actually mounted on rather than to `this.uppy`, so that
+	// we still clean up correctly if `uppy` was swapped without Angular reporting a change.
+	uninstall(uppy: Uppy<M, B> = this.mountedUppy ?? this.uppy): void {
+		if (this.plugin !== undefined) {
+			uppy.removePlugin(this.plugin);
+			this.plugin = undefined;
+		}
+		if (uppy === this.mountedUppy) {
+			this.mountedUppy = undefined;
+		}
+		if (this.ownUppy !== undefined && uppy === this.ownUppy) {
+			// We created this one, so we are the ones who have to destroy it. Instances that
+			// were passed in stay the caller's responsibility.
+			this.ownUppy.destroy();
+			this.ownUppy = undefined;
+		}
 	}
 }


### PR DESCRIPTION
**Note to self**: use squash merge, so that attributions get included.

Alternative to #6374, which reports and fixes the same leak. Thanks @costescuandrei for the diagnosis in #6265 - this takes a slightly different route to the same place, so please close whichever of the two is less useful.

Closes #6265
closes #6374

## The leak

`DashboardComponent`, `DashboardModalComponent` and `StatusBarComponent` all default their `uppy` `@Input` to `new Uppy()`. Uppy registers `online`/`offline` listeners on `window` in its constructor and only removes them in `destroy()`:

https://github.com/transloadit/uppy/blob/main/packages/@uppy/core/src/Uppy.ts#L1885-L1888

Nothing ever destroyed those defaults, so each one stayed reachable from `window` for the lifetime of the page - including the (very common) case where the default is immediately replaced by a `[uppy]` binding and never used at all.

## The fix

Rather than creating an instance and then destroying it again, don't create it unless it is needed. Angular always runs `ngOnChanges` before `ngOnInit`, so by the time `onMount` runs a bound `uppy` is already in place:

```ts
@Input() uppy!: Uppy<M, B>;   // no eager default
```

```ts
onMount(defaultOptions, plugin) {
  if (!this.uppy) {
    this.ownUppy = new Uppy<M, B>()
    this.uppy = this.ownUppy
  }
  …
}

uninstall(uppy = this.mountedUppy ?? this.uppy) {
  …
  if (this.ownUppy !== undefined && uppy === this.ownUppy) {
    this.ownUppy.destroy()
    this.ownUppy = undefined
  }
}
```

An instance passed in from the outside is never destroyed - that stays the caller's responsibility.

Two knock-on cleanups fall out of this:

- **`handleChanges` now compares against the instance the plugin is actually installed on** (`mountedUppy`) instead of `changes['uppy'].previousValue`. `previousValue` is `undefined` for the first change, which is exactly what the `changes['uppy'].previousValue !== undefined` workaround was papering over. It also meant that binding `[uppy]` to a property that only gets its value asynchronously left the plugin installed on a stale instance and leaked it. Angular's own lifecycle ordering now handles the "don't uninstall before the plugin is mounted" case via an early return.
- **`uninstall()` defaults to `mountedUppy`**, so cleanup still works if `uppy` was swapped without Angular reporting a change (e.g. assigned imperatively through a `ViewChild`).

## Compatibility

`uppy` keeps its declared type `Uppy<M, B>` and stays optional, so no consumer code changes. The one observable difference is that reading `component.uppy` *before* `ngOnInit` now returns `undefined` instead of a throwaway instance - and that instance was never the one the component ended up using anyway.

## Verification

Typechecked, and driven through the component lifecycle by hand (construct → `ngOnChanges` → `ngOnInit` → … → `ngOnDestroy`) for:

| scenario | result |
| --- | --- |
| no `[uppy]` binding | own instance created lazily, destroyed on `ngOnDestroy` |
| `[uppy]` bound | zero throwaway instances constructed; passed-in instance not destroyed |
| `[uppy]` swapped between two instances | plugin moved across, neither instance destroyed |
| `[uppy]` bound to a value that arrives asynchronously | own fallback destroyed, plugin re-installed on the late instance |
| `uppy` replaced imperatively (no `ngOnChanges`) | own instance still destroyed |
| `uninstall()` twice / destroyed before `ngOnInit` | no throw |

`@uppy/angular` has no test runner wired up (no `test` script, and the three `*.spec.ts` files are Angular-CLI boilerplate still using `async()`, removed back in Angular 12), so there is no regression test here. Happy to add vitest plus a real test for the wrapper in a follow-up if that is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Andrei Costescu <costescuandrei@gmail.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
