### PR TITLE
Fix stale Turbo build config for @uppy/angular

### DIFF
--- a/packages/@uppy/angular/package.json
+++ b/packages/@uppy/angular/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/transloadit/uppy.git"
   },
   "scripts": {
-    "build": "ng-packagr && mv dist/fesm2022 ./ && mv dist/types ./"
+    "build": "ng-packagr && rm -rf fesm2022 types && mv dist/fesm2022 ./ && mv dist/types ./"
   },
   "main": "./fesm2022/uppy-angular.mjs",
   "types": "./types/uppy-angular.d.ts",

--- a/packages/@uppy/angular/turbo.json
+++ b/packages/@uppy/angular/turbo.json
@@ -2,16 +2,19 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["@uppy/core#build", "@uppy/dashboard#build"],
-      "inputs": [
-        "projects/uppy/angular/src/**/*.{js,ts,jsx,tsx}",
-        "package.json",
-        "angular.json",
-        "projects/uppy/angular/ng-package.json",
-        "projects/uppy/angular/tsconfig.lib.json",
-        "projects/uppy/angular/tsconfig.lib.prod.json"
+      "dependsOn": [
+        "@uppy/core#build",
+        "@uppy/dashboard#build",
+        "@uppy/status-bar#build"
       ],
-      "outputs": ["dist/uppy/angular/**"]
+      "inputs": [
+        "src/**/*.{js,ts,jsx,tsx}",
+        "package.json",
+        "ng-package.json",
+        "tsconfig.lib.json",
+        "tsconfig.lib.prod.json"
+      ],
+      "outputs": ["dist/**", "fesm2022/**", "types/**"]
     }
   }
 }


### PR DESCRIPTION
When `@uppy/angular` was restructured (`projects/uppy/angular/src/` → `src/`, no more `angular.json`), its `turbo.json` was left pointing at the old layout.

## Stale cache

None of the declared `inputs` existed any more except `package.json`, so the cache key for `@uppy/angular#build` did not depend on the sources at all. Editing anything under `src/` produced the same hash and Turbo replayed a stale build:

```
--- before, baseline run ---
@uppy/angular:build: cache miss, executing 1a05a853156d4c8f
--- before, after editing src/utils/wrapper.ts ---
@uppy/angular:build: cache hit, suppressing logs 1a05a853156d4c8f
```

The `outputs` were equally dead. `ng-package.json` has `"dest": "dist"`, and the build script then moves `dist/fesm2022` and `dist/types` up to the package root (that is what `main`/`types`/`files` point at), so nothing ever landed in `dist/uppy/angular/**`. A cache hit therefore restored nothing and left the package with no build artifacts at all.

## Changes

- `inputs` → `src/**/*.{js,ts,jsx,tsx}`, `package.json`, `ng-package.json`, `tsconfig.lib.json`, `tsconfig.lib.prod.json`.
- `outputs` → `dist/**`, `fesm2022/**`, `types/**`.
- `dependsOn` gains `@uppy/status-bar#build` — `status-bar.component.ts` imports from `@uppy/status-bar`, so it has to be built first. It was only working by luck of build ordering.
- **`packages/@uppy/angular/package.json`**: `rm -rf fesm2022 types` before the moves. Making the Turbo task re-run correctly exposed that the build script is not idempotent — `mv dist/fesm2022 ./` fails with `Directory not empty` on BSD `mv` (and silently nests the directory on GNU coreutils) whenever a previous build left `fesm2022/` in place:

  ```
  @uppy/angular:build: mv: rename dist/fesm2022 to ./fesm2022: Directory not empty
  @uppy/angular:build: ERROR: command finished with error
  ```

  This was masked until now precisely because the broken inputs meant the task almost never re-ran.

## Verification

`yarn turbo run build --filter=@uppy/angular`:

| case | result |
| --- | --- |
| first run | cache miss, builds |
| immediate re-run | `cache hit … >>> FULL TURBO` |
| after editing `src/utils/wrapper.ts` | cache miss, new hash |
| after reverting that edit | cache hit on the original hash |
| outputs deleted, then run | cache hit, `dist/`, `fesm2022/` and `types/` all restored |
| `--force` twice in a row | both succeed (script is now idempotent) |

Built artifacts unchanged: `fesm2022/uppy-angular.mjs(.map)` and `types/uppy-angular.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
