### PR TITLE
fix(@uppy/angular): apply initial `open` value after the plugin mounts

### DIFF
--- a/.changeset/angular-dashboard-modal-initial-open.md
+++ b/.changeset/angular-dashboard-modal-initial-open.md
@@ -1,0 +1,5 @@
+---
+"@uppy/angular": patch
+---
+
+Fix `<uppy-dashboard-modal [open]="true">` throwing `Cannot read properties of undefined (reading 'openModal')` on the first render. Angular runs `ngOnChanges` before `ngOnInit`, so the initial `open` value is now applied after the plugin is mounted.

--- a/packages/@uppy/angular/src/components/dashboard-modal/dashboard-modal.component.ts
+++ b/packages/@uppy/angular/src/components/dashboard-modal/dashboard-modal.component.ts
@@ -30,6 +30,8 @@ export class DashboardModalComponent<M extends Meta, B extends Body>
 	@Input() props: DashboardOptions<M, B> = {};
 	@Input() open: boolean = false;
 
+	private mounted = false;
+
 	/** Inserted by Angular inject() migration for backwards compatibility */
 	constructor(...args: unknown[]);
 
@@ -46,9 +48,22 @@ export class DashboardModalComponent<M extends Meta, B extends Body>
 			},
 			Dashboard,
 		);
+		this.mounted = true;
+		// Angular runs `ngOnChanges` before `ngOnInit`, so the initial value of
+		// `open` — which only ever shows up in that first `SimpleChanges` — has to
+		// be applied here, once the plugin actually exists.
+		if (this.open) {
+			this.plugin!.openModal();
+		}
 	}
 
 	ngOnChanges(changes: SimpleChanges): void {
+		// The first `ngOnChanges` runs before `ngOnInit`, when there is no plugin
+		// to talk to yet. Every input still carries `previousValue: undefined` at
+		// that point, so nothing is lost by skipping it: `ngOnInit` mounts the
+		// plugin with the current `props` and applies the current `open` value.
+		if (!this.mounted) return;
+
 		this.handleChanges(changes, Dashboard);
 		// Handle dashboard-modal specific changes
 		if (changes["open"] && this.open !== changes["open"].previousValue) {


### PR DESCRIPTION
Note: I have no angular experience and cannot verify this:

Angular runs `ngOnChanges` before `ngOnInit`, and `this.plugin` is only assigned in `ngOnInit` -> `onMount`. So `<uppy-dashboard-modal [open]="true">` threw `TypeError: Cannot read properties of undefined (reading 'openModal')` on the very first change detection pass.

Apply the current `open` value in `ngOnInit`, right after the plugin is mounted — the initial value only ever appears in that first `SimpleChanges`, so guarding the call alone would silently drop it. `ngOnChanges` now bails out until the plugin exists and handles only post-mount transitions; on that first pass every input still carries `previousValue: undefined`, so all of its branches were no-ops anyway.


Claude-Session: https://claude.ai/code/session_01MKvGt7BTgQQ6MxHUWBDWpP