### PR TITLE
@uppy/core: upgrade p-retry to v8

### DIFF
--- a/packages/@uppy/core/package.json
+++ b/packages/@uppy/core/package.json
@@ -57,7 +57,7 @@
     "namespace-emitter": "^2.0.1",
     "nanoid": "^5.1.11",
     "p-queue": "^9.3.3",
-    "p-retry": "^6.1.0",
+    "p-retry": "^8.0.0",
     "preact": "^10.29.2"
   },
   "devDependencies": {

--- a/packages/@uppy/core/src/companion-client/RequestClient.ts
+++ b/packages/@uppy/core/src/companion-client/RequestClient.ts
@@ -293,8 +293,11 @@ export default class RequestClient<M extends Meta, B extends Body> {
         {
           retries: retryCount,
           signal,
-          onFailedAttempt: (err) =>
-            this.uppy.log(`Retrying upload due to: ${err.message}`, 'warning'),
+          onFailedAttempt: ({ error }) =>
+            this.uppy.log(
+              `Retrying upload due to: ${error.message}`,
+              'warning',
+            ),
         },
       )
     } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7077,7 +7077,7 @@ __metadata:
     namespace-emitter: "npm:^2.0.1"
     nanoid: "npm:^5.1.11"
     p-queue: "npm:^9.3.3"
-    p-retry: "npm:^6.1.0"
+    p-retry: "npm:^8.0.0"
     playwright: "npm:1.61.1"
     postcss: "npm:^8.5.23"
     postcss-cli: "npm:^11.0.1"
@@ -12768,10 +12768,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-network-error@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "is-network-error@npm:1.1.0"
-  checksum: 10/b2fe6aac07f814a9de275efd05934c832c129e7ba292d27614e9e8eec9e043b7a0bbeaeca5d0916b0f462edbec2aa2eaee974ee0a12ac095040e9515c222c251
+"is-network-error@npm:^1.0.0, is-network-error@npm:^1.3.0":
+  version: 1.3.2
+  resolution: "is-network-error@npm:1.3.2"
+  checksum: 10/6d5c0663f476acf7fd5894b5bdce14284aec6b595ad34484d430249b736372e46c345249fd1688bddb2c1380d72c28741838926d1d078264e37e779e970f9d93
   languageName: node
   linkType: hard
 
@@ -15398,7 +15398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-retry@npm:^6.1.0, p-retry@npm:^6.2.0":
+"p-retry@npm:^6.2.0":
   version: 6.2.0
   resolution: "p-retry@npm:6.2.0"
   dependencies:
@@ -15406,6 +15406,15 @@ __metadata:
     is-network-error: "npm:^1.0.0"
     retry: "npm:^0.13.1"
   checksum: 10/1a5ac16828c96c03c354f78d643dfc7aa8f8b998e1b60e27533da2c75e5cabfb1c7f88ce312e813e09a80b056011fbb372d384132e9c92d27d052bd7c282a978
+  languageName: node
+  linkType: hard
+
+"p-retry@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "p-retry@npm:8.0.0"
+  dependencies:
+    is-network-error: "npm:^1.3.0"
+  checksum: 10/73be38cb0854b2b54740e14402937e15062fd6a3b13605c92a73b19080c92148f9d6937a8f30ddd073df004e676167fdbe560b77cd0495680fc58ba726c8d523
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See https://github.com/transloadit/uppy/issues/6297#issuecomment-5397902374

p-retry v6 depends on the unmaintained CJS-only `retry` package, which prevents some bundler optimizations. v7 dropped that dependency (and improved stack traces as a result); v8 is the current major and matches the repo's Node >=22 engines requirement.

The only API change affecting us is `onFailedAttempt`, which now receives a `RetryContext` object instead of the error itself.


Claude-Session: https://claude.ai/code/session_01CZpX3U67tstF1tiMANykeK