### PR TITLE
Replace chalk with styleText

### DIFF
--- a/packages/@uppy/locales/package.json
+++ b/packages/@uppy/locales/package.json
@@ -35,7 +35,6 @@
     "@uppy/core": "workspace:^"
   },
   "devDependencies": {
-    "chalk": "^5.0.0",
     "glob": "^13.0.6",
     "typescript": "^6.0.3"
   }

--- a/packages/@uppy/locales/script/test.mjs
+++ b/packages/@uppy/locales/script/test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import chalk from 'chalk'
+import { styleText } from 'node:util'
 import { globSync } from 'glob'
 
 import {
@@ -106,7 +106,7 @@ function warnings({ leadingLocale, followerLocales }) {
 
     summary.push(
       [
-        chalk.cyan(name.padEnd(16)),
+        styleText('cyan', name.padEnd(16)),
         `${String(missing.length).padStart(3)} missing`,
         `${String(excess.length).padStart(3)} excess`,
         `(of ${total} keys in ${leadingLocaleName})`,
@@ -127,9 +127,9 @@ function warnings({ leadingLocale, followerLocales }) {
 
       details.push(
         [
-          `${chalk.cyan(name)} locale has missing string: '${chalk.red(key)}'`,
-          `that is present in ${chalk.cyan(leadingLocaleName)}`,
-          `with value: ${chalk.yellow(value)}`,
+          `${styleText('cyan', name)} locale has missing string: '${styleText('red', key)}'`,
+          `that is present in ${styleText('cyan', leadingLocaleName)}`,
+          `with value: ${styleText('yellow', value)}`,
         ].join(' '),
       )
     }
@@ -141,9 +141,9 @@ function warnings({ leadingLocale, followerLocales }) {
     for (const key of excess) {
       details.push(
         [
-          `${chalk.cyan(name)} locale has excess string:`,
-          `'${chalk.yellow(key)}' that is not present`,
-          `in ${chalk.cyan(leadingLocaleName)}.`,
+          `${styleText('cyan', name)} locale has excess string:`,
+          `'${styleText('yellow', key)}' that is not present`,
+          `in ${styleText('cyan', leadingLocaleName)}.`,
         ].join(' '),
       )
     }
@@ -157,14 +157,16 @@ function warnings({ leadingLocale, followerLocales }) {
   console.log(`--> Locale coverage relative to ${leadingLocaleName}\n`)
   console.log(summary.join('\n'))
   console.log(
-    `\n${chalk.bold(`${entries.length} locales`)}: ${chalk.red(
+    `\n${styleText('bold', `${entries.length} locales`)}: ${styleText(
+      'red',
       `${missingTotal} missing`,
-    )}, ${chalk.yellow(`${excessTotal} excess`)} string(s) in total.`,
+    )}, ${styleText('yellow', `${excessTotal} excess`)} string(s) in total.`,
   )
 
   if (!verbose && missingTotal + excessTotal > 0) {
     console.log(
-      chalk.dim(
+      styleText(
+        'dim',
         'Re-run with --verbose to list the individual keys. This check is advisory and does not fail the build.',
       ),
     )
@@ -223,8 +225,8 @@ function placeholders({ leadingLocale, followerLocales }) {
 
       for (const [form, string] of getForms(value)) {
         const where = [
-          chalk.cyan(name),
-          `→ ${chalk.yellow(key)}${form == null ? '' : `['${form}']`}`,
+          styleText('cyan', name),
+          `→ ${styleText('yellow', key)}${form == null ? '' : `['${form}']`}`,
         ].join(' ')
         const found = getPlaceholders(string)
 
@@ -235,16 +237,16 @@ function placeholders({ leadingLocale, followerLocales }) {
           if (malformed) {
             errors.push(
               [
-                `${where}: malformed placeholder ${chalk.red(malformed)},`,
-                `expected ${chalk.green(`%{${placeholder}}`)}.`,
+                `${where}: malformed placeholder ${styleText('red', malformed)},`,
+                `expected ${styleText('green', `%{${placeholder}}`)}.`,
                 `It will not interpolate and is rendered as-is:\n    ${string}`,
               ].join(' '),
             )
           } else {
             logs.push(
               [
-                `${where}: missing placeholder ${chalk.red(`%{${placeholder}}`)}`,
-                `that ${chalk.cyan(leadingLocaleName)} has:\n    ${string}`,
+                `${where}: missing placeholder ${styleText('red', `%{${placeholder}}`)}`,
+                `that ${styleText('cyan', leadingLocaleName)} has:\n    ${string}`,
               ].join(' '),
             )
           }
@@ -255,8 +257,8 @@ function placeholders({ leadingLocale, followerLocales }) {
 
           logs.push(
             [
-              `${where}: unknown placeholder ${chalk.red(`%{${placeholder}}`)}`,
-              `that ${chalk.cyan(leadingLocaleName)} does not have,`,
+              `${where}: unknown placeholder ${styleText('red', `%{${placeholder}}`)}`,
+              `that ${styleText('cyan', leadingLocaleName)} does not have,`,
               `so no value is passed for it and it is rendered as-is:\n    ${string}`,
             ].join(' '),
           )
@@ -267,7 +269,9 @@ function placeholders({ leadingLocale, followerLocales }) {
 
   if (logs.length) {
     console.log(logs.join('\n'))
-    console.log(`\n${chalk.yellow(`${logs.length} placeholder warning(s).`)}`)
+    console.log(
+      `\n${styleText('yellow', `${logs.length} placeholder warning(s).`)}`,
+    )
   }
 
   if (errors.length) {

--- a/packages/uppy/build-bundle.mjs
+++ b/packages/uppy/build-bundle.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs/promises'
-import chalk from 'chalk'
+import { styleText } from 'node:util'
 
 import esbuild from 'esbuild'
 
@@ -30,13 +30,13 @@ function buildBundle(
     .then(() => {
       if (minify) {
         console.info(
-          chalk.green(`✓ Built Minified Bundle [${standalone}]:`),
-          chalk.magenta(bundleFile),
+          styleText('green', `✓ Built Minified Bundle [${standalone}]:`),
+          styleText('magenta', bundleFile),
         )
       } else {
         console.info(
-          chalk.green(`✓ Built Bundle [${standalone}]:`),
-          chalk.magenta(bundleFile),
+          styleText('green', `✓ Built Bundle [${standalone}]:`),
+          styleText('magenta', bundleFile),
         )
       }
     })
@@ -85,9 +85,9 @@ methods.push(
 
 await Promise.all(methods).then(
   () => {
-    console.info(chalk.yellow('✓ JS bundles 🎉'))
+    console.info(styleText('yellow', '✓ JS bundles 🎉'))
   },
   (err) => {
-    console.error(chalk.red('✗ Error:'), chalk.red(err.message))
+    console.error(styleText('red', '✗ Error:'), styleText('red', err.message))
   },
 )

--- a/packages/uppy/package.json
+++ b/packages/uppy/package.json
@@ -79,7 +79,6 @@
     "@aws-sdk/client-s3": "^3.338.0",
     "@npmcli/arborist": "^10.0.1",
     "adm-zip": "^0.6.0",
-    "chalk": "^5.0.0",
     "concat-stream": "^2.0.0",
     "cssnano": "^8.0.1",
     "esbuild": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7274,7 +7274,6 @@ __metadata:
   resolution: "@uppy/locales@workspace:packages/@uppy/locales"
   dependencies:
     "@uppy/core": "workspace:^"
-    chalk: "npm:^5.0.0"
     glob: "npm:^13.0.6"
     typescript: "npm:^6.0.3"
   languageName: unknown
@@ -8954,7 +8953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.0.0, chalk@npm:^5.6.2":
+"chalk@npm:^5.6.2":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10/1b2f48f6fba1370670d5610f9cd54c391d6ede28f4b7062dd38244ea5768777af72e5be6b74fb6c6d54cb84c4a2dff3f3afa9b7cb5948f7f022cfd3d087989e0
@@ -19149,7 +19148,6 @@ __metadata:
     "@uppy/xhr-upload": "workspace:*"
     "@uppy/zoom": "workspace:*"
     adm-zip: "npm:^0.6.0"
-    chalk: "npm:^5.0.0"
     concat-stream: "npm:^2.0.0"
     cssnano: "npm:^8.0.1"
     esbuild: "npm:^0.28.1"


### PR DESCRIPTION
This change replaces the `chalk` library with the builtin Node.js function `util.styleText`. This only affects dev dependencies.