### PR TITLE
Remove supports-color dependency from companion

### DIFF
--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -66,7 +66,6 @@
     "prom-client": "15.1.3",
     "serialize-error": "13.0.1",
     "serialize-javascript": "7.0.7",
-    "supports-color": "10.2.2",
     "tus-js-client": "4.3.1",
     "validator": "13.15.35",
     "webdav": "5.10.0",

--- a/packages/@uppy/companion/src/server/logger.ts
+++ b/packages/@uppy/companion/src/server/logger.ts
@@ -1,12 +1,7 @@
-import util from 'node:util'
+import { inspect, styleText } from 'node:util'
 import escapeStringRegexp from 'escape-string-regexp'
-import supportsColors from 'supports-color'
 
-type StyleTextFn = (
-  style: Parameters<NonNullable<typeof util.styleText>>[0],
-  text: string,
-) => string
-type Colors = Parameters<StyleTextFn>[0]
+type Colors = Parameters<typeof styleText>[0]
 type LogLevel = 'error' | 'info' | 'warn' | 'debug'
 
 let valuesToMask: string[] = []
@@ -36,11 +31,6 @@ let processName = 'companion'
 export function setProcessName(newProcessName: string): void {
   processName = newProcessName
 }
-
-const styleText: StyleTextFn =
-  typeof util.styleText === 'function' && supportsColors.stderr
-    ? (style, text) => util.styleText(style, text)
-    : (_style, text) => text
 
 /**
  * Logs a message.
@@ -77,7 +67,7 @@ function log(params: {
       return arg.message
     }
     if (typeof arg === 'string') return arg
-    return util.inspect(arg)
+    return inspect(arg)
   }
 
   const msgString = msgToString()

--- a/packages/@uppy/companion/src/types/shims.d.ts
+++ b/packages/@uppy/companion/src/types/shims.d.ts
@@ -10,19 +10,3 @@ declare module 'express-interceptor' {
     fn: (req: Request, res: Response) => InterceptorConfig,
   ): RequestHandler
 }
-
-declare module 'supports-color' {
-  type ColorSupport = {
-    level: number
-    hasBasic: boolean
-    has256: boolean
-    has16m: boolean
-  }
-
-  const supportsColor: {
-    stdout: ColorSupport | false
-    stderr: ColorSupport | false
-  }
-
-  export default supportsColor
-}

--- a/packages/@uppy/companion/test/logger.test.ts
+++ b/packages/@uppy/companion/test/logger.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
-// We don't care about colors in our tests, so force `supports-color` to disable colors.
+// We don't care about colors in our tests, so force `util.styleText` to disable colors.
 process.env['FORCE_COLOR'] = 'false'
 
 import logger from '../src/server/logger.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6992,7 +6992,6 @@ __metadata:
     serialize-error: "npm:13.0.1"
     serialize-javascript: "npm:7.0.7"
     supertest: "npm:7.2.2"
-    supports-color: "npm:10.2.2"
     tus-js-client: "npm:4.3.1"
     typescript: "npm:^6.0.3"
     validator: "npm:13.15.35"
@@ -18388,13 +18387,6 @@ __metadata:
     methods: "npm:^1.1.2"
     superagent: "npm:^10.3.0"
   checksum: 10/41b29e005b7f0fec8e062df1e43037d5a29b40c1172331d1b448e8b39ed3cc020d2aac342aad6d6e75c1e07b2f08c32bff6472cd726ab4fc9b3f10969937979d
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:10.2.2":
-  version: 10.2.2
-  resolution: "supports-color@npm:10.2.2"
-  checksum: 10/bd132705fc07213a4024131fb061f0a46a48b49ecaf434bb029c0a5aa0339b969236d496d63969e3c248a90fdcac16d4f9c5bf187e7be0bfb5e804ed13bef6b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`util.styleText` already supports color support detection. We don’t need an external library for that.