### PR TITLE
Remove whatwg-fetch dev dependency

### DIFF
--- a/packages/@uppy/aws-s3/package.json
+++ b/packages/@uppy/aws-s3/package.json
@@ -46,8 +46,7 @@
     "@vitest/browser-playwright": "^4.1.6",
     "playwright": "1.61.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6",
-    "whatwg-fetch": "3.6.20"
+    "vitest": "^4.1.6"
   },
   "peerDependencies": {
     "@uppy/core": "workspace:^"

--- a/packages/@uppy/aws-s3/tests/index.test.ts
+++ b/packages/@uppy/aws-s3/tests/index.test.ts
@@ -1,7 +1,6 @@
+import Core, { type Meta, type UppyFile } from '@uppy/core'
 import { HttpResponse, http } from 'msw'
 import type { SetupWorker } from 'msw/browser'
-import 'whatwg-fetch'
-import Core, { type Meta, type UppyFile } from '@uppy/core'
 import { describe, expect, vi } from 'vitest'
 import AwsS3, { type AwsBody, type AwsS3Options } from '../src/index.js'
 import { test } from './test-utils/test-extend.js'

--- a/packages/@uppy/transloadit/package.json
+++ b/packages/@uppy/transloadit/package.json
@@ -55,7 +55,6 @@
     "msw": "^2.10.4",
     "playwright": "1.61.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6",
-    "whatwg-fetch": "^3.6.2"
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/@uppy/transloadit/src/index.test.js
+++ b/packages/@uppy/transloadit/src/index.test.js
@@ -3,7 +3,6 @@ import { HttpResponse, http } from 'msw'
 import { describe, expect, vi } from 'vitest'
 import Transloadit from './index.ts'
 import { it } from './test-extend.ts'
-import 'whatwg-fetch'
 
 // The `websocket_url` in these tests points at nothing, and MSW cannot
 // intercept server-sent events, so a real EventSource would keep retrying the

--- a/yarn.lock
+++ b/yarn.lock
@@ -6920,7 +6920,6 @@ __metadata:
     playwright: "npm:1.61.1"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
-    whatwg-fetch: "npm:3.6.20"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -7445,7 +7444,6 @@ __metadata:
     playwright: "npm:1.61.1"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
-    whatwg-fetch: "npm:^3.6.2"
   peerDependencies:
     "@uppy/core": "workspace:^"
   languageName: unknown
@@ -19731,13 +19729,6 @@ __metadata:
   version: 0.1.4
   resolution: "websocket-extensions@npm:0.1.4"
   checksum: 10/b5399b487d277c78cdd2aef63764b67764aa9899431e3a2fa272c6ad7236a0fb4549b411d89afa76d5afd664c39d62fc19118582dc937e5bb17deb694f42a0d1
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:3.6.20, whatwg-fetch@npm:^3.6.2":
-  version: 3.6.20
-  resolution: "whatwg-fetch@npm:3.6.20"
-  checksum: 10/2b4ed92acd6a7ad4f626a6cb18b14ec982bbcaf1093e6fe903b131a9c6decd14d7f9c9ca3532663c2759d1bdf01d004c77a0adfb2716a5105465c20755a8c57c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The fetch API is available in all modern browsers. We don’t need to stub polyfill this in our tests.