### PR TITLE
Deprecate hasProperty

### DIFF
--- a/.changeset/huge-sloths-fry.md
+++ b/.changeset/huge-sloths-fry.md
@@ -1,0 +1,5 @@
+---
+"@uppy/core": patch
+---
+
+Deprecate `hasProperty`. Use `Object.hasOwn` instead.

--- a/packages/@uppy/core/src/utils/AbortController.ts
+++ b/packages/@uppy/core/src/utils/AbortController.ts
@@ -1,5 +1,3 @@
-import hasProperty from './hasProperty.js'
-
 /**
  * @deprecated
  *   Use the global [`AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController).
@@ -21,7 +19,7 @@ export const createAbortError = (
   options?: Parameters<typeof Error>[1],
 ): DOMException => {
   const err = new DOMException(message, 'AbortError')
-  if (options != null && hasProperty(options, 'cause')) {
+  if (options != null && Object.hasOwn(options, 'cause')) {
     Object.defineProperty(err, 'cause', {
       // @ts-expect-error TS is drunk
       __proto__: null,

--- a/packages/@uppy/core/src/utils/ErrorWithCause.ts
+++ b/packages/@uppy/core/src/utils/ErrorWithCause.ts
@@ -1,4 +1,3 @@
-import hasProperty from './hasProperty.js'
 import type NetworkError from './NetworkError.js'
 
 class ErrorWithCause extends Error {
@@ -12,7 +11,7 @@ class ErrorWithCause extends Error {
   ) {
     super(message)
     this.cause = options?.cause
-    if (this.cause && hasProperty(this.cause, 'isNetworkError')) {
+    if (this.cause && Object.hasOwn(this.cause, 'isNetworkError')) {
       this.isNetworkError = (this.cause as NetworkError).isNetworkError
     } else {
       this.isNetworkError = false

--- a/packages/@uppy/core/src/utils/hasProperty.ts
+++ b/packages/@uppy/core/src/utils/hasProperty.ts
@@ -1,6 +1,7 @@
-export default function hasProperty(
-  object: Parameters<typeof Object.hasOwn>[0],
-  key: Parameters<typeof Object.hasOwn>[1],
-): ReturnType<typeof Object.hasOwn> {
-  return Object.hasOwn(object, key)
-}
+/**
+ * @deprecated
+ *   Use [`Object.hasOwn`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn).
+ */
+const hasProperty = Object.hasOwn
+
+export default hasProperty

--- a/packages/@uppy/transloadit/src/Assembly.ts
+++ b/packages/@uppy/transloadit/src/Assembly.ts
@@ -2,11 +2,7 @@ import type {
   RateLimitedQueue,
   WrapPromiseFunctionType,
 } from '@uppy/core/utils'
-import {
-  fetchWithNetworkError,
-  hasProperty as has,
-  NetworkError,
-} from '@uppy/core/utils'
+import { fetchWithNetworkError, NetworkError } from '@uppy/core/utils'
 import Emitter from 'component-emitter'
 import {
   type AssemblyFile,
@@ -281,7 +277,7 @@ class TransloaditAssembly extends Emitter {
     const nextUploads = next.uploads
     if (nextUploads != null && prevUploads != null) {
       Object.keys(nextUploads)
-        .filter((upload) => !has(prevUploads, upload))
+        .filter((upload) => !Object.hasOwn(prevUploads, upload))
         .forEach((upload) => {
           // This is a bit confusing. Not sure why Object.keys was chosen here, because nextUploads is an Array. Object.keys returns strings for array keys ("0", "1", etc.). Typescript expects arrays to be indexed with a number, not a string nextUploads[0], even though JavaScript is fine with it, so we need to type assert here:
           this.emit('upload', nextUploads[upload as unknown as number])

--- a/packages/@uppy/transloadit/src/index.ts
+++ b/packages/@uppy/transloadit/src/index.ts
@@ -15,7 +15,6 @@ import type {
 import { BasePlugin } from '@uppy/core'
 import {
   ErrorWithCause,
-  hasProperty,
   RateLimitedQueue,
   type RemoteUppyFile,
 } from '@uppy/core/utils'
@@ -936,7 +935,7 @@ export default class Transloadit<
       }
 
       const incompleteFiles = files.filter(
-        (file) => !hasProperty(this.completedFiles, file.id),
+        (file) => !Object.hasOwn(this.completedFiles, file.id),
       )
       incompleteFiles.forEach((file) => {
         this.uppy.emit('postprocess-progress', file, {

--- a/packages/@uppy/tus/src/index.ts
+++ b/packages/@uppy/tus/src/index.ts
@@ -12,7 +12,6 @@ import {
   filterFilesToEmitUploadStarted,
   filterFilesToUpload,
   getAllowedMetaFields,
-  hasProperty,
   isNetworkError,
   type LocalUppyFile,
   NetworkError,
@@ -271,7 +270,7 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
           userProvidedPromise = onBeforeRequest(req, file)
         }
 
-        if (hasProperty(queuedRequest, 'shouldBeRequeued')) {
+        if (Object.hasOwn(queuedRequest, 'shouldBeRequeued')) {
           if (!queuedRequest.shouldBeRequeued) return Promise.reject()
           // TODO: switch to `Promise.withResolvers` on the next major if available.
           let done: () => void
@@ -457,7 +456,7 @@ export default class Tus<M extends Meta, B extends Body> extends BasePlugin<
         srcProp: string,
         destProp: string,
       ) => {
-        if (hasProperty(obj, srcProp) && !hasProperty(obj, destProp)) {
+        if (Object.hasOwn(obj, srcProp) && !Object.hasOwn(obj, destProp)) {
           obj[destProp] = obj[srcProp]
         }
       }


### PR DESCRIPTION
This function just calls `Object.hasOwn()` under the hood.