### PR TITLE
Fix regressions in the TypeScript config restructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "yarn workspace @uppy-dev/dev dev",
     "dev:with-companion": "npm-run-all --parallel start:companion dev",
     "start:companion": "yarn workspace @uppy/companion start:dev",
-    "test": "turbo run test --concurrency=1 --filter='./packages/@uppy/*' --filter='./packages/uppy' --filter='./examples/{react,vue,sveltekit}' -- --browser.headless",
+    "test": "turbo run test --concurrency=1 --filter='./packages/@uppy/*' --filter='./packages/uppy' --filter='./private/tsconfig' --filter='./examples/{react,vue,sveltekit}' -- --browser.headless",
     "test:e2e": "turbo run test:e2e --concurrency=1 --filter='./packages/@uppy/*' --filter='./packages/uppy' --filter='./examples/{react,vue,sveltekit}' -- --browser.headless",
     "test:watch": "turbo watch test --filter='./packages/@uppy/*' --filter='./packages/uppy'",
     "typecheck": "turbo run typecheck --filter='./packages/@uppy/*' --filter='./packages/uppy'",

--- a/packages/@uppy/audio/tsconfig.build.json
+++ b/packages/@uppy/audio/tsconfig.build.json
@@ -1,4 +1,14 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/aws-s3/src/s3-client/types.ts
+++ b/packages/@uppy/aws-s3/src/s3-client/types.ts
@@ -119,7 +119,7 @@ export interface UploadPart {
 /** Parameters for {@link S3Client.putObject}. */
 export interface PutObjectParams {
   key: string
-  data: Blob | File | string
+  data: Blob | File
   fileType?: string
   metadata?: Record<string, unknown>
   onProgress?: OnProgressFn

--- a/packages/@uppy/aws-s3/test/s3-client/minio.test.ts
+++ b/packages/@uppy/aws-s3/test/s3-client/minio.test.ts
@@ -28,7 +28,7 @@ if (config) {
   const key_bin = 'test-multipart.bin'
 
   const large_buffer = randomBytes(EIGHT_MB * 3.2)
-  const content = 'some content'
+  const content = new Blob(['some content'])
   const key = 'first-test-object.txt'
   const key_list_parts = 'test-list-parts.bin'
   const key_abort_multipart = 'test-abort-multipart.bin'
@@ -93,7 +93,7 @@ if (config) {
 
       const result = await s3client.putObject({
         key,
-        data: 'Hello from pre-signed URL test.',
+        data: new Blob(['Hello from pre-signed URL test.']),
         fileType: 'text/plain',
       })
 
@@ -172,7 +172,7 @@ if (config) {
         try {
           const result = await s3.putObject({
             key: testKey,
-            data: 'Hello STS!',
+            data: new Blob(['Hello STS!']),
             fileType: 'text/plain',
           })
           expect(result.location).toBeDefined()
@@ -214,12 +214,12 @@ if (config) {
 
         await s3.putObject({
           key: `sts-cache-1-${Date.now()}.txt`,
-          data: 'File 1',
+          data: new Blob(['File 1']),
           fileType: 'text/plain',
         })
         await s3.putObject({
           key: `sts-cache-2-${Date.now()}.txt`,
-          data: 'File 2',
+          data: new Blob(['File 2']),
           fileType: 'text/plain',
         })
         expect(fetchCount).toBe(1)

--- a/packages/@uppy/aws-s3/tsconfig.build.json
+++ b/packages/@uppy/aws-s3/tsconfig.build.json
@@ -1,4 +1,14 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/aws-s3/tsconfig.json
+++ b/packages/@uppy/aws-s3/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig",
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/box/tsconfig.build.json
+++ b/packages/@uppy/box/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/companion/package.json
+++ b/packages/@uppy/companion/package.json
@@ -107,7 +107,7 @@
     "deploy": "kubectl apply -f infra/kube/companion-kube.yml",
     "start": "node ./dist/standalone/start-server.js",
     "start:dev": "bash start-dev",
-    "typecheck": "tsc",
+    "typecheck": "tsc --build",
     "check": "yarn typecheck && yarn test",
     "test": "vitest run --silent='passed-only'"
   },

--- a/packages/@uppy/companion/src/server/provider/credentials.ts
+++ b/packages/@uppy/companion/src/server/provider/credentials.ts
@@ -1,10 +1,7 @@
 import { htmlEscape } from 'escape-goat'
 import type { NextFunction, Request, Response } from 'express'
 import got from 'got'
-import type {
-  CredentialsFetchResponse,
-  ProviderOptions,
-} from '../../schemas/companion.js'
+import type { CredentialsFetchResponse } from '../../schemas/companion.js'
 import type { CompanionRuntimeOptions } from '../../types/companion-options.js'
 import type { CompanionExpressLocals } from '../../types/express.js'
 import * as tokenService from '../helpers/jwt.js'
@@ -56,8 +53,7 @@ async function fetchProviderKeys(
   companionOptions: CompanionRuntimeOptions,
   credentialRequestParams: unknown,
 ): Promise<CredentialsFetchResponse | null> {
-  let providerConfig: ProviderOptions | undefined =
-    companionOptions.providerOptions[providerName]
+  let providerConfig = companionOptions.providerOptions[providerName]
   if (!providerConfig) {
     providerConfig = companionOptions.customProviders?.[providerName]?.config
   }

--- a/packages/@uppy/companion/tsconfig.build.json
+++ b/packages/@uppy/companion/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "@uppy-dev/tsconfig/build",
   "compilerOptions": {
     "lib": ["esnext"],
+    "noEmitOnError": true,
     "outDir": "dist",
     "types": ["node"]
   }

--- a/packages/@uppy/companion/vitest.config.ts
+++ b/packages/@uppy/companion/vitest.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  test: {},
-})
+export default defineConfig({})

--- a/packages/@uppy/components/tsconfig.build.json
+++ b/packages/@uppy/components/tsconfig.build.json
@@ -1,11 +1,26 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../google-drive-picker/tsconfig.build.json" },
-    { "path": "../google-photos-picker/tsconfig.build.json" },
-    { "path": "../image-editor/tsconfig.build.json" },
-    { "path": "../screen-capture/tsconfig.build.json" },
-    { "path": "../webcam/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../google-drive-picker/tsconfig.build.json"
+    },
+    {
+      "path": "../google-photos-picker/tsconfig.build.json"
+    },
+    {
+      "path": "../image-editor/tsconfig.build.json"
+    },
+    {
+      "path": "../screen-capture/tsconfig.build.json"
+    },
+    {
+      "path": "../webcam/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false
+  }
 }

--- a/packages/@uppy/compressor/tsconfig.build.json
+++ b/packages/@uppy/compressor/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/compressor/tsconfig.json
+++ b/packages/@uppy/compressor/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig",
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/core/test/companion-client/RequestClient.test.ts
+++ b/packages/@uppy/core/test/companion-client/RequestClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import RequestClient from './RequestClient.js'
+import RequestClient from '../../lib/companion-client/RequestClient.js'
 
 describe('RequestClient', () => {
   it('has a hostname without trailing slash', () => {

--- a/packages/@uppy/core/test/companion-client/getAllowedHosts.test.ts
+++ b/packages/@uppy/core/test/companion-client/getAllowedHosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import getAllowedHosts from './getAllowedHosts.js'
+import getAllowedHosts from '../../lib/companion-client/getAllowedHosts.js'
 
 describe('getAllowedHosts', () => {
   it('can convert companionAllowedHosts', () => {

--- a/packages/@uppy/core/test/provider-views/utils/PartialTreeUtils/index.test.ts
+++ b/packages/@uppy/core/test/provider-views/utils/PartialTreeUtils/index.test.ts
@@ -5,15 +5,15 @@ import type {
   PartialTreeFolderNode,
   PartialTreeFolderRoot,
   PartialTreeId,
-} from '../../../index.js'
-import type { CompanionFile } from '../../../utils/index.js'
-import afterFill from './afterFill.js'
-import afterOpenFolder from './afterOpenFolder.js'
-import afterScrollFolder from './afterScrollFolder.js'
-import afterToggleCheckbox from './afterToggleCheckbox.js'
-import getBreadcrumbs from './getBreadcrumbs.js'
-import getCheckedFilesWithPaths from './getCheckedFilesWithPaths.js'
-import getNumberOfSelectedFiles from './getNumberOfSelectedFiles.js'
+} from '../../../../lib/index.js'
+import afterFill from '../../../../lib/provider-views/utils/PartialTreeUtils/afterFill.js'
+import afterOpenFolder from '../../../../lib/provider-views/utils/PartialTreeUtils/afterOpenFolder.js'
+import afterScrollFolder from '../../../../lib/provider-views/utils/PartialTreeUtils/afterScrollFolder.js'
+import afterToggleCheckbox from '../../../../lib/provider-views/utils/PartialTreeUtils/afterToggleCheckbox.js'
+import getBreadcrumbs from '../../../../lib/provider-views/utils/PartialTreeUtils/getBreadcrumbs.js'
+import getCheckedFilesWithPaths from '../../../../lib/provider-views/utils/PartialTreeUtils/getCheckedFilesWithPaths.js'
+import getNumberOfSelectedFiles from '../../../../lib/provider-views/utils/PartialTreeUtils/getNumberOfSelectedFiles.js'
+import type { CompanionFile } from '../../../../lib/utils/index.js'
 
 const _root = (id: string, options: any = {}): PartialTreeFolderRoot => ({
   type: 'root',

--- a/packages/@uppy/core/tsconfig.build.json
+++ b/packages/@uppy/core/tsconfig.build.json
@@ -1,6 +1,10 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "compilerOptions": {
-    "types": ["google.accounts", "google.picker", "gapi"]
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "types": ["google.accounts", "google.picker", "gapi"],
+    "useUnknownInCatchVariables": false
   }
 }

--- a/packages/@uppy/core/tsconfig.json
+++ b/packages/@uppy/core/tsconfig.json
@@ -1,4 +1,13 @@
 {
   "extends": "@uppy-dev/tsconfig",
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/dashboard/test/index.test.ts
+++ b/packages/@uppy/dashboard/test/index.test.ts
@@ -3,7 +3,7 @@ import GoogleDrivePlugin from '@uppy/google-drive'
 import Url from '@uppy/url'
 import WebcamPlugin from '@uppy/webcam'
 import { describe, expect, it } from 'vitest'
-import DashboardPlugin from './index.js'
+import DashboardPlugin from '../lib/index.js'
 
 describe('Dashboard', () => {
   it('works without any remote provider plugins', () => {

--- a/packages/@uppy/dashboard/test/utils/copyToClipboard.test.ts
+++ b/packages/@uppy/dashboard/test/utils/copyToClipboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import copyToClipboard from './copyToClipboard.js'
+import copyToClipboard from '../../lib/utils/copyToClipboard.js'
 
 describe('copyToClipboard', () => {
   it.skip('should copy the specified text to the clipboard', () => {

--- a/packages/@uppy/dashboard/test/utils/createSuperFocus.test.ts
+++ b/packages/@uppy/dashboard/test/utils/createSuperFocus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import createSuperFocus from './createSuperFocus.js'
+import createSuperFocus from '../../lib/utils/createSuperFocus.js'
 
 describe('createSuperFocus', () => {
   // superFocus.cancel() is used in dashboard

--- a/packages/@uppy/dashboard/tsconfig.build.json
+++ b/packages/@uppy/dashboard/tsconfig.build.json
@@ -1,11 +1,28 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dropbox/tsconfig.build.json" },
-    { "path": "../google-drive/tsconfig.build.json" },
-    { "path": "../thumbnail-generator/tsconfig.build.json" },
-    { "path": "../url/tsconfig.build.json" },
-    { "path": "../webcam/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dropbox/tsconfig.build.json"
+    },
+    {
+      "path": "../google-drive/tsconfig.build.json"
+    },
+    {
+      "path": "../thumbnail-generator/tsconfig.build.json"
+    },
+    {
+      "path": "../url/tsconfig.build.json"
+    },
+    {
+      "path": "../webcam/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/drag-drop/tsconfig.build.json
+++ b/packages/@uppy/drag-drop/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/drop-target/tsconfig.build.json
+++ b/packages/@uppy/drop-target/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/dropbox/tsconfig.build.json
+++ b/packages/@uppy/dropbox/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/facebook/tsconfig.build.json
+++ b/packages/@uppy/facebook/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/form/tsconfig.build.json
+++ b/packages/@uppy/form/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/golden-retriever/tsconfig.build.json
+++ b/packages/@uppy/golden-retriever/tsconfig.build.json
@@ -1,8 +1,18 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dashboard/tsconfig.build.json" },
-    { "path": "../xhr-upload/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dashboard/tsconfig.build.json"
+    },
+    {
+      "path": "../xhr-upload/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/google-drive-picker/tsconfig.build.json
+++ b/packages/@uppy/google-drive-picker/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/google-drive/tsconfig.build.json
+++ b/packages/@uppy/google-drive/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/google-photos-picker/tsconfig.build.json
+++ b/packages/@uppy/google-photos-picker/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/image-editor/tsconfig.build.json
+++ b/packages/@uppy/image-editor/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/image-generator/tsconfig.build.json
+++ b/packages/@uppy/image-generator/tsconfig.build.json
@@ -1,7 +1,16 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../transloadit/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../transloadit/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/onedrive/tsconfig.build.json
+++ b/packages/@uppy/onedrive/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/react/tsconfig.build.json
+++ b/packages/@uppy/react/tsconfig.build.json
@@ -1,14 +1,28 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "compilerOptions": {
-    "jsxImportSource": "react"
+    "exactOptionalPropertyTypes": false,
+    "jsxImportSource": "react",
+    "noImplicitOverride": false
   },
   "references": [
-    { "path": "../components/tsconfig.build.json" },
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dashboard/tsconfig.build.json" },
-    { "path": "../screen-capture/tsconfig.build.json" },
-    { "path": "../status-bar/tsconfig.build.json" },
-    { "path": "../webcam/tsconfig.build.json" }
+    {
+      "path": "../components/tsconfig.build.json"
+    },
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dashboard/tsconfig.build.json"
+    },
+    {
+      "path": "../screen-capture/tsconfig.build.json"
+    },
+    {
+      "path": "../status-bar/tsconfig.build.json"
+    },
+    {
+      "path": "../webcam/tsconfig.build.json"
+    }
   ]
 }

--- a/packages/@uppy/remote-sources/tsconfig.build.json
+++ b/packages/@uppy/remote-sources/tsconfig.build.json
@@ -1,15 +1,39 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../box/tsconfig.build.json" },
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dashboard/tsconfig.build.json" },
-    { "path": "../dropbox/tsconfig.build.json" },
-    { "path": "../facebook/tsconfig.build.json" },
-    { "path": "../google-drive/tsconfig.build.json" },
-    { "path": "../onedrive/tsconfig.build.json" },
-    { "path": "../unsplash/tsconfig.build.json" },
-    { "path": "../url/tsconfig.build.json" },
-    { "path": "../zoom/tsconfig.build.json" }
-  ]
+    {
+      "path": "../box/tsconfig.build.json"
+    },
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dashboard/tsconfig.build.json"
+    },
+    {
+      "path": "../dropbox/tsconfig.build.json"
+    },
+    {
+      "path": "../facebook/tsconfig.build.json"
+    },
+    {
+      "path": "../google-drive/tsconfig.build.json"
+    },
+    {
+      "path": "../onedrive/tsconfig.build.json"
+    },
+    {
+      "path": "../unsplash/tsconfig.build.json"
+    },
+    {
+      "path": "../url/tsconfig.build.json"
+    },
+    {
+      "path": "../zoom/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/screen-capture/tsconfig.build.json
+++ b/packages/@uppy/screen-capture/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/status-bar/tsconfig.build.json
+++ b/packages/@uppy/status-bar/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/thumbnail-generator/tsconfig.build.json
+++ b/packages/@uppy/thumbnail-generator/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noImplicitOverride": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/transloadit/tsconfig.build.json
+++ b/packages/@uppy/transloadit/tsconfig.build.json
@@ -1,7 +1,17 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../tus/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../tus/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/tus/tsconfig.build.json
+++ b/packages/@uppy/tus/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/unsplash/tsconfig.build.json
+++ b/packages/@uppy/unsplash/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/url/tsconfig.build.json
+++ b/packages/@uppy/url/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/url/tsconfig.json
+++ b/packages/@uppy/url/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig",
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/vue/tsconfig.build.json
+++ b/packages/@uppy/vue/tsconfig.build.json
@@ -1,11 +1,26 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../components/tsconfig.build.json" },
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dashboard/tsconfig.build.json" },
-    { "path": "../screen-capture/tsconfig.build.json" },
-    { "path": "../status-bar/tsconfig.build.json" },
-    { "path": "../webcam/tsconfig.build.json" }
-  ]
+    {
+      "path": "../components/tsconfig.build.json"
+    },
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dashboard/tsconfig.build.json"
+    },
+    {
+      "path": "../screen-capture/tsconfig.build.json"
+    },
+    {
+      "path": "../status-bar/tsconfig.build.json"
+    },
+    {
+      "path": "../webcam/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false
+  }
 }

--- a/packages/@uppy/webcam/test/Webcam.test.ts
+++ b/packages/@uppy/webcam/test/Webcam.test.ts
@@ -1,6 +1,6 @@
 import { Uppy } from '@uppy/core'
 import { describe, expect, it } from 'vitest'
-import Webcam from './index.js'
+import Webcam from '../lib/index.js'
 
 describe('Webcam', () => {
   describe('_getMediaRecorderOptions', () => {

--- a/packages/@uppy/webcam/test/formatSeconds.test.ts
+++ b/packages/@uppy/webcam/test/formatSeconds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import formatSeconds from './formatSeconds.js'
+import formatSeconds from '../lib/formatSeconds.js'
 
 describe('formatSeconds', () => {
   it("should return a value of '0:43' when an argument of 43 seconds is supplied", () => {

--- a/packages/@uppy/webcam/test/supportsMediaRecorder.test.ts
+++ b/packages/@uppy/webcam/test/supportsMediaRecorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import supportsMediaRecorder from './supportsMediaRecorder.js'
+import supportsMediaRecorder from '../lib/supportsMediaRecorder.js'
 
 describe('supportsMediaRecorder', () => {
   it('should return true if MediaRecorder is supported', () => {

--- a/packages/@uppy/webcam/tsconfig.build.json
+++ b/packages/@uppy/webcam/tsconfig.build.json
@@ -1,4 +1,14 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/webdav/tsconfig.build.json
+++ b/packages/@uppy/webdav/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/packages/@uppy/xhr-upload/tsconfig.build.json
+++ b/packages/@uppy/xhr-upload/tsconfig.build.json
@@ -1,7 +1,16 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
   "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../dashboard/tsconfig.build.json" }
-  ]
+    {
+      "path": "../core/tsconfig.build.json"
+    },
+    {
+      "path": "../dashboard/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false,
+    "useUnknownInCatchVariables": false
+  }
 }

--- a/packages/@uppy/xhr-upload/tsconfig.json
+++ b/packages/@uppy/xhr-upload/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "@uppy-dev/tsconfig",
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false
+  }
 }

--- a/packages/@uppy/zoom/tsconfig.build.json
+++ b/packages/@uppy/zoom/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "@uppy-dev/tsconfig/build",
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": false
+  }
 }

--- a/private/tsconfig/package.json
+++ b/private/tsconfig/package.json
@@ -2,10 +2,14 @@
   "name": "@uppy-dev/tsconfig",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "description": "TypeScript config presets that Uppy packages extend.",
   "exports": {
     ".": "./tsconfig.json",
     "./build": "./tsconfig.build.json"
+  },
+  "scripts": {
+    "test": "vitest run --silent='passed-only'"
   },
   "devDependencies": {
     "vitest": "^4.1.6"

--- a/private/tsconfig/test/tsconfig.test.ts
+++ b/private/tsconfig/test/tsconfig.test.ts
@@ -5,8 +5,13 @@ const ignore = ['angular', 'svelte']
 
 const projectRoot = new URL('../../../', import.meta.url)
 
-const packages = (await readdir(new URL('packages/@uppy/', projectRoot)))
-  .filter((name) => !ignore.includes(name))
+const packages = (
+  await readdir(new URL('packages/@uppy/', projectRoot), {
+    withFileTypes: true,
+  })
+)
+  .filter((entry) => entry.isDirectory() && !ignore.includes(entry.name))
+  .map((entry) => entry.name)
   .sort()
 
 async function readJSON(path: string): Promise<any> {
@@ -21,7 +26,7 @@ test('tsconfig.json', async () => {
       ...packages.map((name) => ({
         path: `./packages/@uppy/${name}/tsconfig.json`,
       })),
-      './packages/uppy/tsconfig.json',
+      { path: './packages/uppy/tsconfig.json' },
     ],
   })
 })
@@ -39,7 +44,7 @@ test.each(packages)('packages/@uppy/%s/tsconfig.build.json', async (name) => {
       ...pkg.devDependencies,
       ...pkg.peerDependencies,
     })
-      .filter((dep) => dep.startsWith('@uppy'))
+      .filter((dep) => dep.startsWith('@uppy/'))
       .sort()
 
     if (deps.length) {

--- a/private/tsconfig/tsconfig.build.json
+++ b/private/tsconfig/tsconfig.build.json
@@ -4,14 +4,17 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "nodenext",
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "outDir": "${configDir}/lib",
     "rootDir": "${configDir}/src",
     "skipLibCheck": true,
     "target": "esnext",
-    "useUnknownInCatchVariables": false,
     "verbatimModuleSyntax": true
   }
 }

--- a/private/tsconfig/tsconfig.json
+++ b/private/tsconfig/tsconfig.json
@@ -2,14 +2,17 @@
   "exclude": ["${configDir}/src", "${configDir}/lib", "${configDir}/dist"],
   "compilerOptions": {
     "composite": true,
-    "noEmit": true,
+    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "module": "preserve",
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "rootDir": "${configDir}",
     "skipLibCheck": true,
     "target": "esnext",
     "types": ["vite/client"],
-    "useUnknownInCatchVariables": false,
     "verbatimModuleSyntax": true
   }
 }

--- a/private/tsconfig/tsconfig.json
+++ b/private/tsconfig/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["${configDir}/src"],
+  "exclude": ["${configDir}/src", "${configDir}/lib", "${configDir}/dist"],
   "compilerOptions": {
     "composite": true,
     "noEmit": true,

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
+  "globalDependencies": ["private/tsconfig/tsconfig*.json"],
   "tasks": {
     "build": {
       "outputLogs": "new-only",
@@ -37,12 +38,20 @@
     "typecheck": {
       "outputLogs": "new-only",
       "dependsOn": ["build", "^build"],
-      "inputs": ["src/**/*.{js,ts,jsx,tsx}", "tsconfig.json"]
+      "inputs": [
+        "{src,test}/**/*.{js,ts,jsx,tsx}",
+        "tsconfig.json",
+        "tsconfig.build.json"
+      ]
     },
     "check": {
       "outputLogs": "new-only",
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.{js,ts,jsx,tsx,svelte}", "tsconfig.json"]
+      "inputs": [
+        "{src,test}/**/*.{js,ts,jsx,tsx,svelte}",
+        "tsconfig.json",
+        "tsconfig.build.json"
+      ]
     },
     "test": {
       "dependsOn": ["^test"],


### PR DESCRIPTION
Follow-up to #6508, targeting its `fixup-tsconfig` branch. The restructure itself is a clear improvement — one shared preset, a root solution file, `tsc --build` across the repo — but a few settings didn't survive the move, and the new consistency tests don't currently run. Each item below was verified against the branch before and after.

## Test files were being shipped in `lib/`

The old per-package `tsconfig.build.json` carried `"exclude": ["./src/**/*.test.ts"]`; `@uppy-dev/tsconfig/build` has no `exclude`, and nine test files were left behind in `src/`. After `yarn build` on the branch:

```
packages/@uppy/core/lib/companion-client/RequestClient.test.js       (+ .d.ts, .d.ts.map)
packages/@uppy/core/lib/companion-client/getAllowedHosts.test.js
packages/@uppy/core/lib/provider-views/utils/PartialTreeUtils/index.test.js
packages/@uppy/dashboard/lib/index.test.js
packages/@uppy/dashboard/lib/utils/{copyToClipboard,createSuperFocus}.test.js
packages/@uppy/webcam/lib/{Webcam,formatSeconds,supportsMediaRecorder}.test.js
```

All three packages list `lib` in `files`, so these would go out to npm.

**Fix:** moved the nine stragglers into `test/`, following the `@uppy/audio` pattern already established here (`../lib/*.js` imports). Also restored an `exclude` in the build preset so a test file dropped into `src/` can't silently ship again.

## The same tests ran twice

The vitest `include` globs were removed from several packages, and `lib/` is not part of vitest's default `exclude` (only `dist/` is). CI runs `yarn build` before `yarn test`, so `vitest list` in `packages/@uppy/webcam` reported:

```
[chromium] lib/Webcam.test.js         [chromium] src/Webcam.test.ts
[chromium] lib/formatSeconds.test.js  [chromium] src/formatSeconds.test.ts
...
```

Same in `dashboard` and `core`.

**Fix:** resolved by the move above — every file is now collected exactly once, all from `test/`. `packages/@uppy/url`'s browser project also got its `include` back, since without one it's a catch-all rather than a browser-only project.

## `strict` was switched off for the whole library

The deleted root `tsconfig.shared.json` set `"strict": true`. Neither new preset does — `tsc -p packages/@uppy/core/tsconfig.build.json --showConfig` confirms it's absent.

**Fix:** restored in both presets. `tsc --build tsconfig.json --force` reports **0 errors** with it on, so nothing was relying on the looser setting.

## Companion lost its own strictness settings

`packages/@uppy/companion/tsconfig.shared.json` was deleted without its options being carried over: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `erasableSyntaxOnly`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `forceConsistentCasingInFileNames`, `allowJs: false`, `checkJs: false`, `noEmitOnError: true`. The preset also flips `useUnknownInCatchVariables` from `true` to `false`.

**Fix:** all restored on both companion configs; the build is clean with them. The `credentials.ts` change (annotating `providerConfig: ProviderOptions | undefined`) was only needed *because* `noUncheckedIndexedAccess` had gone, so it's reverted along with it.

## The new consistency tests never ran, and 36 of 71 failed

`private/tsconfig/package.json` had no `scripts`, and `private/*` is outside the root `yarn test` filter. Run by hand against the branch, 36 of 71 tests failed:

- **All 35 `tsconfig.build.json` tests:** `dep.startsWith('@uppy')` also matches `@uppy-dev/tsconfig` — the devDependency this PR adds to every package — so each test expected a nonexistent `../@uppy-dev/tsconfig/tsconfig.build.json` reference.
- **The root `tsconfig.json` test:** the last expected reference was the bare string `'./packages/uppy/tsconfig.json'` instead of `{ path: … }`.

**Fix:** `startsWith('@uppy/')`, the missing `{ path }` wrapper, `readdir` with `withFileTypes` so a stray file (a `.DS_Store`, say) can't masquerade as a package, a `test` script on the package, and `--filter='./private/tsconfig'` in the root `test` script. All 71 now pass and run in CI.

## Turbo's cache inputs didn't match the new layout

`typecheck` and `check` still listed `src/**` as their only source input, so changes under the new `test/` directories didn't invalidate the cache, and nothing invalidated any cache when the shared preset itself changed.

**Fix:** added `{src,test}/**` and `tsconfig.build.json` to the `typecheck` and `check` inputs, and `private/tsconfig/tsconfig*.json` to `globalDependencies`.

## `PutObjectParams.data` widening reverted

`data` was widened from `Blob | File` to `Blob | File | string`. Those string call sites are pre-existing in the minio tests and only became visible once `test/` started being type-checked — they weren't new. Widening a public type is a separate decision worth making deliberately (and with a changeset), and `CompanionS3.putObject` does `formData.set('file', data)`, which posts a raw string as a plain form field rather than a file.

**Fix:** reverted the type; the five test call sites now pass `Blob`s.

## Smaller things

- `companion/vitest.config.ts` was left as `defineConfig({ test: {} })` — dropped the empty key.
- `companion`'s `typecheck` script was `tsc` while every other package uses `tsc --build`.
- The dev preset's `exclude` only covered `src`, so the whole built `lib/` was pulled into each project — 114 of 149 files for `@uppy/core`. `skipLibCheck` keeps it error-free, but it made results depend on whether a build had run. Added `lib` and `dist`.
- Added `"type": "module"` to `@uppy-dev/tsconfig` to silence a Vite config-loader warning.

## Verification

From a clean `lib/`/`dist/`, on this branch:

The full CI sequence, from a clean `lib/`/`dist/`:

- `yarn build` — clean
- `yarn test` — 20/20 tasks, all suites green (core 194, companion 159, dashboard 22, webcam 11, aws-s3 19, tsconfig 71, plus the rest), browser mode included
- `yarn build:examples` — clean apart from `example-angular`, which fails the same way on the base branch here for an unrelated reason (this machine's Node is 22.22.2; the Angular CLI wants 22.22.3)
- `yarn typecheck` — 75/75 tasks pass
- `yarn check:ci` — clean

Also spot-checked: no `*.test.*` left under any `src/` and none emitted into any `lib/`, and `vitest list` collects each test file exactly once. Every one of the eight commits builds and lints clean on its own.

## Two things left, not fixed here

**`yarn test` needs a prior `yarn build`.** Tests import from `lib/`, but Turbo's `test` task has no `build` dependency. CI is fine because it runs `yarn build` first; a fresh checkout running `yarn test` alone is not, and `turbo watch test` runs against stale output after a `src` edit.

I tried adding `build`/`^build` to the `test` task and had to back it out — it makes `yarn test` pull in `example-sveltekit#build`, which then fails on an unresolved `@uppy/svelte/css/style.css`. The cause is separate and pre-existing: `@uppy/svelte#build` declares `outputs: ["dist/**"]`, so every run of it wipes `dist/styles.css`, which `@uppy/svelte#build:css` had copied there. Worth fixing (narrow the `build` outputs, or fold the CSS copy into `build`), but it belongs in its own change rather than this one.

**No changeset.** Nothing here changes a public API any more, but moving tests out of `src/` does change what's in the published tarballs, so a patch changeset may still be warranted.
