### PR TITLE
Remove JSX from tsconfig presets

### DIFF
--- a/packages/@uppy/audio/tsconfig.build.json
+++ b/packages/@uppy/audio/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false,
     "useUnknownInCatchVariables": false

--- a/packages/@uppy/box/tsconfig.build.json
+++ b/packages/@uppy/box/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/companion/src/server/Uploader.ts
+++ b/packages/@uppy/companion/src/server/Uploader.ts
@@ -8,7 +8,6 @@ import { pipeline } from 'node:stream/promises'
 import type { PutObjectCommandInput, S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import type { Request } from 'express'
-import type { FormDataLike } from 'form-data-encoder'
 import { FormData } from 'formdata-node'
 import type { OptionsOfTextResponseBody, Response } from 'got'
 import got from 'got'
@@ -823,7 +822,8 @@ export default class Uploader {
         },
       })
 
-      reqOptions.body = formData as unknown as FormDataLike
+      // @ts-expect-error This type error will be resolved by updating to the latest `got`.
+      reqOptions.body = formData
     } else {
       if (this.size != null) {
         reqOptions.headers = {

--- a/packages/@uppy/components/tsconfig.build.json
+++ b/packages/@uppy/components/tsconfig.build.json
@@ -21,6 +21,8 @@
     }
   ],
   "compilerOptions": {
-    "exactOptionalPropertyTypes": false
+    "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
   }
 }

--- a/packages/@uppy/core/tsconfig.build.json
+++ b/packages/@uppy/core/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "@uppy-dev/tsconfig/build",
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false,
     "types": ["google.accounts", "google.picker", "gapi"],

--- a/packages/@uppy/dashboard/tsconfig.build.json
+++ b/packages/@uppy/dashboard/tsconfig.build.json
@@ -22,6 +22,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false
   }

--- a/packages/@uppy/drag-drop/tsconfig.build.json
+++ b/packages/@uppy/drag-drop/tsconfig.build.json
@@ -6,6 +6,8 @@
     }
   ],
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/dropbox/tsconfig.build.json
+++ b/packages/@uppy/dropbox/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/facebook/tsconfig.build.json
+++ b/packages/@uppy/facebook/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/google-drive-picker/tsconfig.build.json
+++ b/packages/@uppy/google-drive-picker/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/google-drive/tsconfig.build.json
+++ b/packages/@uppy/google-drive/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/google-photos-picker/tsconfig.build.json
+++ b/packages/@uppy/google-photos-picker/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/image-editor/tsconfig.build.json
+++ b/packages/@uppy/image-editor/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false
   }

--- a/packages/@uppy/image-generator/tsconfig.build.json
+++ b/packages/@uppy/image-generator/tsconfig.build.json
@@ -10,6 +10,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false
   }

--- a/packages/@uppy/onedrive/tsconfig.build.json
+++ b/packages/@uppy/onedrive/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/react/tsconfig.build.json
+++ b/packages/@uppy/react/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "@uppy-dev/tsconfig/build",
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
-    "jsxImportSource": "react",
+    "jsx": "react-jsx",
     "noImplicitOverride": false
   },
   "references": [

--- a/packages/@uppy/react/tsconfig.json
+++ b/packages/@uppy/react/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@uppy-dev/tsconfig",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsx": "react-jsx"
   },
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/@uppy/screen-capture/tsconfig.build.json
+++ b/packages/@uppy/screen-capture/tsconfig.build.json
@@ -6,6 +6,8 @@
     }
   ],
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false,
     "useUnknownInCatchVariables": false

--- a/packages/@uppy/status-bar/tsconfig.build.json
+++ b/packages/@uppy/status-bar/tsconfig.build.json
@@ -6,6 +6,8 @@
     }
   ],
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false
   }

--- a/packages/@uppy/unsplash/tsconfig.build.json
+++ b/packages/@uppy/unsplash/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/url/tsconfig.build.json
+++ b/packages/@uppy/url/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "useUnknownInCatchVariables": false
   }

--- a/packages/@uppy/webcam/tsconfig.build.json
+++ b/packages/@uppy/webcam/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false,
     "noUncheckedIndexedAccess": false,
     "useUnknownInCatchVariables": false

--- a/packages/@uppy/webdav/tsconfig.build.json
+++ b/packages/@uppy/webdav/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/packages/@uppy/zoom/tsconfig.build.json
+++ b/packages/@uppy/zoom/tsconfig.build.json
@@ -7,6 +7,8 @@
   ],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "noImplicitOverride": false
   }
 }

--- a/private/tsconfig/tsconfig.build.json
+++ b/private/tsconfig/tsconfig.build.json
@@ -6,8 +6,6 @@
     "declarationMap": true,
     "erasableSyntaxOnly": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "preact",
     "module": "nodenext",
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
The `preact` JSX import source pulls in DOM types. However, in some packages we don’t want DOM types. To avoid this, JSX configurations are removed from the preset. JSX is now configured explicitly in every package that needs it.